### PR TITLE
set_universe removable policies 

### DIFF
--- a/src/qubx/backtester/account.py
+++ b/src/qubx/backtester/account.py
@@ -48,14 +48,15 @@ class SimulatedAccountProcessor(BasicAccountProcessor):
         if self._fill_stop_order_at_price:
             logger.info(f"[<y>{self.__class__.__name__}</y>] :: emulates stop orders executions at exact price")
 
-    def get_orders(self, instrument: Instrument | None = None) -> list[Order]:
+    def get_orders(self, instrument: Instrument | None = None) -> dict[str, Order]:
         if instrument is not None:
             ome = self.ome.get(instrument)
             if ome is None:
                 raise ValueError(f"ExchangeService:get_orders :: No OME configured for '{instrument}'!")
-            return ome.get_open_orders()
 
-        return [o for ome in self.ome.values() for o in ome.get_open_orders()]
+            return {o.id: o for o in ome.get_open_orders()}
+
+        return {o.id: o for ome in self.ome.values() for o in ome.get_open_orders()}
 
     def get_position(self, instrument: Instrument) -> Position:
         if instrument in self.positions:

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -144,6 +144,7 @@ class StrategyContext(IStrategyContext):
             account=self.account,
             position_tracker=__position_tracker,
             position_gathering=__position_gathering,
+            universe_manager=self._universe_manager,
             cache=self._cache,
             scheduler=self._scheduler,
             is_simulation=self._data_provider.is_simulation,

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -34,6 +34,7 @@ from qubx.core.interfaces import (
     ITradingManager,
     IUniverseManager,
     PositionsTracker,
+    RemovalPolicy,
 )
 from qubx.core.loggers import StrategyLogging
 from qubx.data.readers import DataReader
@@ -326,8 +327,10 @@ class StrategyContext(IStrategyContext):
         return self._trading_manager.cancel_orders(instrument)
 
     # IUniverseManager delegation
-    def set_universe(self, instruments: list[Instrument], skip_callback: bool = False):
-        return self._universe_manager.set_universe(instruments, skip_callback)
+    def set_universe(
+        self, instruments: list[Instrument], skip_callback: bool = False, if_has_position_then: RemovalPolicy = "close"
+    ):
+        return self._universe_manager.set_universe(instruments, skip_callback, if_has_position_then)
 
     def add_instruments(self, instruments: list[Instrument]):
         return self._universe_manager.add_instruments(instruments)

--- a/src/qubx/core/helpers.py
+++ b/src/qubx/core/helpers.py
@@ -271,21 +271,20 @@ def process_schedule_spec(spec_str: str | None) -> dict[str, Any]:
                     if croniter.is_valid(_S):
                         config = dict(type="cron", schedule=_S, spec=_S)
                     else:
-                        if _has_intervals:
-                            _F = (
-                                convert_seconds_to_str(int(_s_pos.as_unit("s").to_timedelta64().item().total_seconds()))
-                                if not _F
-                                else _F
-                            )
-                            config = dict(type="bar", schedule=None, timeframe=_F, delay=_s_neg, spec=_S)
-                        else:
-                            # - try convert to cron
-                            _S = interval_to_cron(_S)
-                            if not croniter.is_valid(_S):
-                                raise ValueError(f"Wrong specification for cron: {spec_str}")
-
+                        # - try convert to cron
+                        _S = interval_to_cron(_S)
+                        if croniter.is_valid(_S):
                             config = dict(type="cron", schedule=_S, spec=_S)
-
+                        else:
+                            if _has_intervals:
+                                _F = (
+                                    convert_seconds_to_str(
+                                        int(_s_pos.as_unit("s").to_timedelta64().item().total_seconds())
+                                    )
+                                    if not _F
+                                    else _F
+                                )
+                                config = dict(type="bar", schedule=None, timeframe=_F, delay=_s_neg, spec=_S)
         case _:
             config = dict(type=_T, schedule=None, timeframe=_F, delay=_shift, spec=_S)
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -579,6 +579,9 @@ class IUniverseManager:
             instruments: List of instruments in the universe
             skip_callback: Skip callback to the strategy
             if_has_position_then: What to do if the instrument has a position
+                - “close” (default) - close position immediatelly and remove (unsubscribe) instrument from strategy
+                - “wait_for_close” - keep instrument and it’s position until it’s closed from strategy (or risk management), then remove instrument from strategy
+                - “wait_for_change” - keep instrument and position until strategy would try to change it - then close position and remove instrument
         """
         ...
 
@@ -590,11 +593,15 @@ class IUniverseManager:
         """
         ...
 
-    def remove_instruments(self, instruments: list[Instrument]):
+    def remove_instruments(self, instruments: list[Instrument], if_has_position_then: RemovalPolicy = "close"):
         """Remove instruments from the trading universe.
 
         Args:
             instruments: List of instruments to remove
+            if_has_position_then: What to do if the instrument has a position
+                - “close” (default) - close position immediatelly and remove (unsubscribe) instrument from strategy
+                - “wait_for_close” - keep instrument and it’s position until it’s closed from strategy (or risk management), then remove instrument from strategy
+                - “wait_for_change” - keep instrument and position until strategy would try to change it - then close position and remove instrument
         """
         ...
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -10,7 +10,7 @@ This module includes:
 """
 
 import traceback
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Literal, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -35,6 +35,8 @@ from qubx.core.basics import (
 )
 from qubx.core.helpers import set_parameters_to_object
 from qubx.core.series import OHLCV, Bar, Quote
+
+RemovalPolicy = Literal["close", "wait_for_close", "wait_for_change"]
 
 
 class IAccountViewer:
@@ -568,11 +570,15 @@ class ITradingManager:
 class IUniverseManager:
     """Manages universe updates."""
 
-    def set_universe(self, instruments: list[Instrument], skip_callback: bool = False):
+    def set_universe(
+        self, instruments: list[Instrument], skip_callback: bool = False, if_has_position_then: RemovalPolicy = "close"
+    ):
         """Set the trading universe.
 
         Args:
             instruments: List of instruments in the universe
+            skip_callback: Skip callback to the strategy
+            if_has_position_then: What to do if the instrument has a position
         """
         ...
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -599,6 +599,19 @@ class IUniverseManager:
         """
         ...
 
+    def on_alter_position(self, instrument: Instrument) -> None:
+        """
+        Called when the position of an instrument changes.
+        It can be used for postponed unsubscribed events
+        """
+        ...
+
+    def is_trading_allowed(self, instrument: Instrument) -> bool:
+        """
+        Check if trading is allowed for an instrument because of the instrument's trading policy.
+        """
+        ...
+
 
 class ISubscriptionManager:
     """Manages subscriptions."""

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -232,8 +232,13 @@ class ProcessingManager(IProcessingManager):
     ) -> list[TargetPosition]:
         if target_positions is None:
             return []
+
         if isinstance(target_positions, TargetPosition):
             target_positions = [target_positions]
+
+        # - check if trading is allowed for each target position
+        target_positions = [t for t in target_positions if self._universe_manager.is_trading_allowed(t.instrument)]
+
         self._logging.save_signals_targets(target_positions)
         return target_positions
 

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -13,10 +13,9 @@ from qubx.core.interfaces import (
     ITimeProvider,
     ITradingManager,
     IUniverseManager,
+    RemovalPolicy,
 )
 from qubx.core.loggers import StrategyLogging
-
-RemovalPolicy = Literal["close", "wait_for_close", "wait_for_change"]
 
 
 class UniverseManager(IUniverseManager):
@@ -63,8 +62,8 @@ class UniverseManager(IUniverseManager):
 
     def _has_position(self, instrument: Instrument) -> bool:
         return (
-            instrument.symbol in self._account.positions
-            and abs(self._account.positions[instrument.symbol].quantity) > instrument.min_size
+            instrument in self._account.positions
+            and abs(self._account.positions[instrument].quantity) > instrument.min_size
         )
 
     def set_universe(

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -72,6 +72,12 @@ class UniverseManager(IUniverseManager):
         skip_callback: bool = False,
         if_has_position_then: RemovalPolicy = "close",
     ) -> None:
+        assert if_has_position_then in (
+            "close",
+            "wait_for_close",
+            "wait_for_change",
+        ), "Invalid if_has_position_then policy"
+
         new_set = set(instruments)
         prev_set = set(self._instruments)
 
@@ -130,6 +136,12 @@ class UniverseManager(IUniverseManager):
         instruments: list[Instrument],
         if_has_position_then: RemovalPolicy = "close",
     ):
+        assert if_has_position_then in (
+            "close",
+            "wait_for_close",
+            "wait_for_change",
+        ), "Invalid if_has_position_then policy"
+
         # - split instruments into removable and keepable
         to_remove, to_keep = self._get_what_can_be_removed_or_kept(instruments, False, if_has_position_then)
 

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -1,4 +1,6 @@
-from qubx.core.basics import DataType, Instrument, TargetPosition
+from typing import Literal
+
+from qubx.core.basics import DataType, Instrument, Position, TargetPosition
 from qubx.core.helpers import CachedMarketDataHolder
 from qubx.core.interfaces import (
     IAccountProcessor,
@@ -14,6 +16,8 @@ from qubx.core.interfaces import (
 )
 from qubx.core.loggers import StrategyLogging
 
+RemovalPolicy = Literal["close", "wait_for_close", "wait_for_change"]
+
 
 class UniverseManager(IUniverseManager):
     _context: IStrategyContext
@@ -27,6 +31,7 @@ class UniverseManager(IUniverseManager):
     _time_provider: ITimeProvider
     _account: IAccountProcessor
     _position_gathering: IPositionGathering
+    _removal_queue: dict[Instrument, tuple[RemovalPolicy, bool]]
 
     def __init__(
         self,
@@ -54,56 +59,94 @@ class UniverseManager(IUniverseManager):
         self._account = account
         self._position_gathering = position_gathering
         self._instruments = []
+        self._removal_queue = {}
 
-    def set_universe(self, instruments: list[Instrument], skip_callback: bool = False) -> None:
+    def _has_position(self, instrument: Instrument) -> bool:
+        return (
+            instrument.symbol in self._account.positions
+            and abs(self._account.positions[instrument.symbol].quantity) > instrument.min_size
+        )
+
+    def set_universe(
+        self,
+        instruments: list[Instrument],
+        skip_callback: bool = False,
+        if_has_position_then: RemovalPolicy = "close",
+    ) -> None:
         new_set = set(instruments)
         prev_set = set(self._instruments)
-        rm_instr = list(prev_set - new_set)
-        add_instr = list(new_set - prev_set)
 
-        self.__add_instruments(add_instr)
-        self.__remove_instruments(rm_instr)
+        # - determine instruments to remove depending on if_has_position_then policy
+        may_be_removed = list(prev_set - new_set)
+        immediately_close = if_has_position_then == "close"
+        to_remove, to_keep = [], []
+        for instr in may_be_removed:
+            if immediately_close:
+                to_remove.append(instr)
+            else:
+                if self._has_position(instr):
+                    self._removal_queue[instr] = (if_has_position_then, skip_callback)
+                    to_keep.append(instr)
 
-        if not skip_callback and (add_instr or rm_instr):
-            self._strategy.on_universe_change(self._context, add_instr, rm_instr)
+        to_add = list(new_set - prev_set)
+        self.__do_add_instruments(to_add)
+        self.__do_remove_instruments(to_remove)
+
+        if not skip_callback and (to_add or to_remove):
+            self._strategy.on_universe_change(self._context, to_add, to_remove)
 
         self._subscription_manager.commit()  # apply pending changes
 
         # set new instruments
         self._instruments.clear()
         self._instruments.extend(instruments)
+        self._instruments.extend(to_keep)
 
     def add_instruments(self, instruments: list[Instrument]):
-        self.__add_instruments(instruments)
+        self.__do_add_instruments(instruments)
         self._strategy.on_universe_change(self._context, instruments, [])
         self._subscription_manager.commit()
         self._instruments.extend(instruments)
 
-    def remove_instruments(self, instruments: list[Instrument]):
-        self.__remove_instruments(instruments)
-        self._strategy.on_universe_change(self._context, [], instruments)
+    def remove_instruments(
+        self,
+        instruments: list[Instrument],
+        if_has_position_then: RemovalPolicy = "close",
+    ):
+        # TODO: implement removal logic dependent on if_has_position_then policy !
+        actually_removed_instr = instruments
+        self.__do_remove_instruments(instruments)
+
+        self._strategy.on_universe_change(self._context, [], actually_removed_instr)
         self._subscription_manager.commit()
-        self._instruments = list(set(self._instruments) - set(instruments))
+        self._instruments = list(set(self._instruments) - set(actually_removed_instr))
 
     @property
     def instruments(self) -> list[Instrument]:
         return self._instruments
 
-    def __remove_instruments(self, instruments: list[Instrument]) -> None:
+    def __do_remove_instruments(self, instruments: list[Instrument]):
         """
         Remove symbols from universe. Steps:
-        - close all open positions
-        - unsubscribe from market data
-        - remove from data cache
+        - [v] cancel all open orders
+        - [v] close all open positions
+        - [v] unsubscribe from market data
+        - [v] remove from data cache
 
         We are still keeping the symbols in the positions dictionary.
         """
+        if not instruments:
+            return
+
+        # - cancel all open orders
+        for instr in instruments:
+            self._trading_manager.cancel_orders(instr)
+
         # - close all open positions
         exit_targets = [
             TargetPosition.zero(self._context, instr.signal(0, group="Universe", comment="Universe change"))
             for instr in instruments
-            if instr.symbol in self._account.positions
-            and abs(self._account.positions[instr.symbol].quantity) > instr.min_size
+            if self._has_position(instr)
         ]
         self._position_gathering.alter_positions(self._context, exit_targets)
 
@@ -121,12 +164,15 @@ class UniverseManager(IUniverseManager):
         for instr in instruments:
             self._cache.remove(instr)
 
-    def __add_instruments(self, instruments: list[Instrument]) -> None:
+    def __do_add_instruments(self, instruments: list[Instrument]) -> None:
         # - create positions for instruments
         self._create_and_update_positions(instruments)
 
         # - get actual positions from exchange
         for instr in instruments:
+            # - if it's still in the removal queue, remove it
+            if instr in self._removal_queue:
+                self._removal_queue.pop(instr)
             self._cache.init_ohlcv(instr)
 
         # - subscribe to market data
@@ -153,3 +199,27 @@ class UniverseManager(IUniverseManager):
             #     instrument._aux_instrument = aux
             #     instruments.append(aux)
             #     _ = self._trading_service.get_position(aux)
+
+    def on_alter_position(self, instrument: Instrument) -> None:
+        """
+        Called when the position of an instrument changes.
+        It can be used for postponed unsubscribed events
+        """
+        # - check if need to remove instrument from the universe
+        if instrument in self._removal_queue:
+            _, skip_callback = self._removal_queue[instrument]
+
+            # - if no position, remove instrument from the universe
+            if not self._has_position(instrument):
+                self.__do_remove_instruments([instrument])
+
+                if not skip_callback:
+                    self._strategy.on_universe_change(self._context, [], [instrument])
+
+                # - commit changes and remove instrument from the universe
+                self._subscription_manager.commit()
+                self._instruments.remove(instrument)
+                self._removal_queue.pop(instrument)
+
+    def is_trading_allowed(self, instrument: Instrument) -> bool:
+        return True

--- a/tests/qubx/backtester/simulation_set_universe_test.py
+++ b/tests/qubx/backtester/simulation_set_universe_test.py
@@ -151,7 +151,7 @@ class TestSetUniverseInSimulator:
             {"ohlc(1d)": ld},
             capital=100_000, instruments=["BINANCE.UM:BTCUSDT"], commissions="vip0_usdt",
             start="2023-06-01", stop="+10d",
-            debug="DEBUG", silent=True, n_jobs=1,
+            debug="DEBUG", silent=True, n_jobs=-1,
         )
         # fmt: on
         for ri in r:

--- a/tests/qubx/backtester/simulation_set_universe_test.py
+++ b/tests/qubx/backtester/simulation_set_universe_test.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Any
 
 import pandas as pd
 
@@ -18,20 +17,19 @@ from qubx.data import loader
 
 
 class Test_SetUniverseLogic(IStrategy):
-    _U: list[list[Instrument]] = []
     commands = [
         ("fit", "nope", None, None),  # - skip 1'st fit
         ("fit", "set", 0, "close"),
         ("event", "trade", 0, 0.25),
         ("fit", "set", 1, "close"),
     ]
+    asserts = []
 
     def on_init(self, ctx: IStrategyContext) -> None:
+        self.asserts = []
         ctx.set_fit_schedule("3D @ 23:59")
-        self._U = [
-            [i for s in ["BTCUSDT", "ETHUSDT"] if (i := ctx.query_instrument(s)) is not None],
-            [i for s in ["ETHUSDT", "LTCUSDT"] if (i := ctx.query_instrument(s)) is not None],
-        ]
+
+        self.commands.insert(0, ("fit", "nope", None, None))  # - skip 1'st fit
 
     def on_fit(self, ctx: IStrategyContext):
         logger.info(f" - <r>FIT</r> at {ctx.time()} -")
@@ -47,22 +45,35 @@ class Test_SetUniverseLogic(IStrategy):
                 return i
         raise ValueError(f"Instrument {symbol} not found")
 
+    def query_instruments(self, ctx: IStrategyContext, symbols: list[str]) -> list[Instrument]:
+        return [i for s in symbols if (i := ctx.query_instrument(s)) is not None]
+
     def run_cmd(self, scope: str, ctx: IStrategyContext) -> list[Signal]:
         if self.commands and scope == self.commands[0][0]:
             _, c, a0, a1 = self.commands.pop(0)
-            logger.info(f"\t<r>COMMAND</r> for {scope} ::: <r>{c}</r> ({a0}, {a1})")
+            # logger.info(f"\t<r>COMMAND</r> for {scope} ::: <r>{c}</r> ({a0}, {a1})")
+
             match c:
                 case "set":
-                    logger.info(f"\t\t>>> <cyan>SET UNIVERSE: {','.join([i.symbol for i in self._U[a0]])}</cyan>")
-                    ctx.set_universe(self._U[a0], if_has_position_then=a1)
-                    return []
+                    n_universe = self.query_instruments(ctx, a0)
+                    logger.info(
+                        f"\t\t>>> <r>COMMAND</r> <cyan>SET UNIVERSE: {','.join([i.symbol for i in n_universe])}</cyan>"
+                    )
+                    ctx.set_universe(n_universe, if_has_position_then=a1)
 
                 case "trade":
+                    logger.info(f"\t\t>>> <r>COMMAND</r> <cyan>TRADE: {a0} -> {a1}</cyan>")
                     return self._i_by_symbol(ctx, a0).signal(a1)
 
                 case "show-universe":
-                    logger.info(f"\t\t>>> <cyan>UNIVERSE: {','.join([i.symbol for i in ctx.instruments])}</cyan>")
-                    return []
+                    logger.info(
+                        f"\t\t>>> <r>COMMAND</r> <cyan>SHOW UNIVERSE: {','.join([i.symbol for i in ctx.instruments])}</cyan>"
+                    )
+
+                case "check-universe":
+                    logger.info(f"\t\t>>> <r>COMMAND</r> <cyan>CHECK UNIVERSE: {','.join(a0)}</cyan>")
+                    self.asserts.append(a := set(a0) == set([i.symbol for i in ctx.instruments]))
+                    assert a, f"Universe mismatch: {a0} != {','.join([i.symbol for i in ctx.instruments])}"
 
         return []
 
@@ -70,23 +81,69 @@ class Test_SetUniverseLogic(IStrategy):
 class TestSetUniverseInSimulator:
     def test_set_universe_1(self):
         ld = loader("BINANCE.UM", "1h", source="csv::tests/data/csv_1h/", n_jobs=1)
+        s0, s1, s2, s3 = None, None, None, None
 
         # fmt: off
         r = simulate(
             {
+                "SetUniverse0": (
+                    s0 := Test_SetUniverseLogic(
+                        commands=[
+                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),
+                            ("event", "show-universe", None, None),
+                            ("event", "trade", "BTCUSDT", 0.25),
+                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "close"),  # - this must close BTC position
+                            ("event", "show-universe", None, None),
+                            ("event", "check-universe", ["ETHUSDT", "LTCUSDT"], None),
+                        ]
+                    )
+                ),
+
                 "SetUniverse1": (
                     s1 := Test_SetUniverseLogic(
                         commands=[
-                            ("fit", "nope", None, None),  # - skip 1'st fit
-                            ("fit", "set", 0, "close"),
+                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),
                             ("event", "show-universe", None, None),
                             ("event", "trade", "BTCUSDT", 0.25),
-                            ("fit", "set", 1, "wait_for_close"),
-                            # ("event", "nope", None, None),
-                            # ("fit", "set", 1, "close"),
+                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "wait_for_close"), # - wait before closing BTC position
                             ("event", "show-universe", None, None),
-                            ("event", "trade", "BTCUSDT", 0),
+                            ("event", "check-universe", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
+                            ("event", "trade", "BTCUSDT", 0), # - close BTC position
                             ("event", "show-universe", None, None),
+                            ("event", "check-universe", ["ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
+                        ]
+                    )
+                ),
+
+                "SetUniverse2": (
+                    s2 := Test_SetUniverseLogic(
+                        commands=[
+                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),
+                            ("event", "show-universe", None, None),
+                            ("event", "trade", "BTCUSDT", 0.25),
+                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "wait_for_change"), # - wait before try to change BTC position somehow
+                            ("event", "show-universe", None, None),
+                            ("event", "check-universe", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
+                            ("event", "trade", "BTCUSDT", -2), # - try to change BTC position
+                            ("event", "show-universe", None, None),
+                            ("event", "check-universe", ["ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
+                        ]
+                    )
+                ),
+
+                "SetUniverse3": (
+                    s3 := Test_SetUniverseLogic(
+                        commands=[
+                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),
+                            ("event", "show-universe", None, None),
+                            ("event", "trade", "BTCUSDT", 0.25),
+                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "wait_for_close"),             # - wait before try to change BTC position somehow
+                            ("event", "show-universe", None, None),
+                            ("event", "check-universe", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
+                            ("fit", "set", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], "close"),           # - this should reset BTC removal as we want to add it again 
+                            ("event", "trade", "BTCUSDT", 0), # - try to change BTC position
+                            ("event", "show-universe", None, None),
+                            ("event", "check-universe", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], None),  # - universe must be unchanged
                         ]
                     )
                 ),
@@ -97,5 +154,11 @@ class TestSetUniverseInSimulator:
             debug="DEBUG", silent=True, n_jobs=1,
         )
         # fmt: on
-        logger.info("Executions\n" + r[0].executions_log.to_string())
-        logger.info("Signals\n" + r[0].signals_log.to_string())
+        for ri in r:
+            logger.info(f"Executions {ri.name}\n" + ri.executions_log.to_string())
+            logger.info(f"Signals {ri.name}\n" + ri.signals_log.to_string())
+
+        assert all(s0.asserts) if s0 else True
+        assert all(s1.asserts) if s1 else True
+        assert all(s2.asserts) if s2 else True
+        assert all(s3.asserts) if s3 else True

--- a/tests/qubx/backtester/simulation_set_universe_test.py
+++ b/tests/qubx/backtester/simulation_set_universe_test.py
@@ -89,7 +89,7 @@ class TestSetUniverseInSimulator:
                 "SetUniverse0": (
                     s0 := Test_SetUniverseLogic(
                         commands=[
-                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),
+                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),  # - set initial universe
                             ("event", "show-universe", None, None),
                             ("event", "trade", "BTCUSDT", 0.25),
                             ("fit", "set", ["ETHUSDT", "LTCUSDT"], "close"),  # - this must close BTC position
@@ -102,15 +102,15 @@ class TestSetUniverseInSimulator:
                 "SetUniverse1": (
                     s1 := Test_SetUniverseLogic(
                         commands=[
-                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),
+                            ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),                      # - set initial universe
                             ("event", "show-universe", None, None),
-                            ("event", "trade", "BTCUSDT", 0.25),
-                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "wait_for_close"), # - wait before closing BTC position
+                            ("event", "trade", "BTCUSDT", 0.25),                                  # - open BTC position
+                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "wait_for_close"),             # - wait before closing BTC position
                             ("event", "show-universe", None, None),
-                            ("event", "check-universe", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
-                            ("event", "trade", "BTCUSDT", 0), # - close BTC position
+                            ("event", "check-universe", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged as it waits for BTC position to be closed
+                            ("event", "trade", "BTCUSDT", 0),                                     # - close BTC position
                             ("event", "show-universe", None, None),
-                            ("event", "check-universe", ["ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
+                            ("event", "check-universe", ["ETHUSDT", "LTCUSDT"], None),            # - universe must be changed as BTC position is closed
                         ]
                     )
                 ),
@@ -121,12 +121,12 @@ class TestSetUniverseInSimulator:
                             ("fit", "set", ["BTCUSDT", "ETHUSDT"], "close"),
                             ("event", "show-universe", None, None),
                             ("event", "trade", "BTCUSDT", 0.25),
-                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "wait_for_change"), # - wait before try to change BTC position somehow
+                            ("fit", "set", ["ETHUSDT", "LTCUSDT"], "wait_for_change"),            # - wait before try to change BTC position somehow
                             ("event", "show-universe", None, None),
                             ("event", "check-universe", ["BTCUSDT", "ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
-                            ("event", "trade", "BTCUSDT", -2), # - try to change BTC position
+                            ("event", "trade", "BTCUSDT", -2),                                    # - try to change BTC position somehow
                             ("event", "show-universe", None, None),
-                            ("event", "check-universe", ["ETHUSDT", "LTCUSDT"], None), # - universe must be unchanged
+                            ("event", "check-universe", ["ETHUSDT", "LTCUSDT"], None),            # - universe must be changed as BTC position is closed
                         ]
                     )
                 ),

--- a/tests/qubx/backtester/simulation_set_universe_test.py
+++ b/tests/qubx/backtester/simulation_set_universe_test.py
@@ -1,0 +1,101 @@
+from collections import defaultdict
+from typing import Any
+
+import pandas as pd
+
+from qubx import logger, lookup
+from qubx.backtester import simulate
+from qubx.core.basics import DataType
+from qubx.core.interfaces import (
+    OHLCV,
+    Instrument,
+    IStrategy,
+    IStrategyContext,
+    Signal,
+    TriggerEvent,
+)
+from qubx.data import loader
+
+
+class Test_SetUniverseLogic(IStrategy):
+    _U: list[list[Instrument]] = []
+    commands = [
+        ("fit", "nope", None, None),  # - skip 1'st fit
+        ("fit", "set", 0, "close"),
+        ("event", "trade", 0, 0.25),
+        ("fit", "set", 1, "close"),
+    ]
+
+    def on_init(self, ctx: IStrategyContext) -> None:
+        ctx.set_fit_schedule("3D @ 23:59")
+        self._U = [
+            [i for s in ["BTCUSDT", "ETHUSDT"] if (i := ctx.query_instrument(s)) is not None],
+            [i for s in ["ETHUSDT", "LTCUSDT"] if (i := ctx.query_instrument(s)) is not None],
+        ]
+
+    def on_fit(self, ctx: IStrategyContext):
+        logger.info(f" - <r>FIT</r> at {ctx.time()} -")
+        self.run_cmd("fit", ctx)
+
+    def on_event(self, ctx: IStrategyContext, event: TriggerEvent) -> list[Signal]:
+        logger.info(f" - <g>EVENT</g> at {ctx.time()} -")
+        return self.run_cmd("event", ctx)
+
+    def _i_by_symbol(self, ctx: IStrategyContext, symbol: str) -> Instrument:
+        for i in ctx.instruments:
+            if i.symbol == symbol:
+                return i
+        raise ValueError(f"Instrument {symbol} not found")
+
+    def run_cmd(self, scope: str, ctx: IStrategyContext) -> list[Signal]:
+        if self.commands and scope == self.commands[0][0]:
+            _, c, a0, a1 = self.commands.pop(0)
+            logger.info(f"\t<r>COMMAND</r> for {scope} ::: <r>{c}</r> ({a0}, {a1})")
+            match c:
+                case "set":
+                    logger.info(f"\t\t>>> <cyan>SET UNIVERSE: {','.join([i.symbol for i in self._U[a0]])}</cyan>")
+                    ctx.set_universe(self._U[a0], if_has_position_then=a1)
+                    return []
+
+                case "trade":
+                    return self._i_by_symbol(ctx, a0).signal(a1)
+
+                case "show-universe":
+                    logger.info(f"\t\t>>> <cyan>UNIVERSE: {','.join([i.symbol for i in ctx.instruments])}</cyan>")
+                    return []
+
+        return []
+
+
+class TestSetUniverseInSimulator:
+    def test_set_universe_1(self):
+        ld = loader("BINANCE.UM", "1h", source="csv::tests/data/csv_1h/", n_jobs=1)
+
+        # fmt: off
+        r = simulate(
+            {
+                "SetUniverse1": (
+                    s1 := Test_SetUniverseLogic(
+                        commands=[
+                            ("fit", "nope", None, None),  # - skip 1'st fit
+                            ("fit", "set", 0, "close"),
+                            ("event", "show-universe", None, None),
+                            ("event", "trade", "BTCUSDT", 0.25),
+                            ("fit", "set", 1, "wait_for_close"),
+                            # ("event", "nope", None, None),
+                            # ("fit", "set", 1, "close"),
+                            ("event", "show-universe", None, None),
+                            ("event", "trade", "BTCUSDT", 0),
+                            ("event", "show-universe", None, None),
+                        ]
+                    )
+                ),
+            },
+            {"ohlc(1d)": ld},
+            capital=100_000, instruments=["BINANCE.UM:BTCUSDT"], commissions="vip0_usdt",
+            start="2023-06-01", stop="+10d",
+            debug="DEBUG", silent=True, n_jobs=1,
+        )
+        # fmt: on
+        logger.info("Executions\n" + r[0].executions_log.to_string())
+        logger.info("Signals\n" + r[0].signals_log.to_string())

--- a/tests/qubx/core/universe_manager_test.py
+++ b/tests/qubx/core/universe_manager_test.py
@@ -96,7 +96,7 @@ def test_set_universe_with_position_close(universe_manager, mock_dependencies, m
             ltc := mocker.Mock(spec=Instrument, symbol="LTCUSDT", min_size=0.0),
         ]
     )
-    mock_dependencies["account"].positions = {btc.symbol: mocker.Mock(quantity=1.0)}
+    mock_dependencies["account"].positions = {btc: mocker.Mock(quantity=1.0)}
 
     # - set new universe with close policy
     universe_manager.set_universe([eth, ltc, sol], if_has_position_then="close")
@@ -129,7 +129,7 @@ def test_set_universe_with_position_wait_for_close(universe_manager, mock_depend
         ]
     )
     # - set position for btc
-    account.positions = {btc.symbol: mocker.Mock(quantity=1.0)}
+    account.positions = {btc: mocker.Mock(quantity=1.0)}
 
     # - set new universe with wait for close policy
     universe_manager.set_universe([eth, ltc, sol], if_has_position_then="wait_for_close")
@@ -138,7 +138,7 @@ def test_set_universe_with_position_wait_for_close(universe_manager, mock_depend
     strategy.on_universe_change.assert_any_call(ctx, [sol], [])
 
     # - emulate position close - it should remove btc from universe
-    account.positions = {btc.symbol: mocker.Mock(quantity=0.0)}
+    account.positions = {btc: mocker.Mock(quantity=0.0)}
     universe_manager.on_alter_position(btc)
     strategy.on_universe_change.assert_any_call(ctx, [], [btc])
 
@@ -160,7 +160,7 @@ def test_set_universe_with_position_wait_for_change(universe_manager, mock_depen
         ]
     )
     # - set position for btc
-    account.positions = {btc.symbol: mocker.Mock(quantity=1.0)}
+    account.positions = {btc: mocker.Mock(quantity=1.0)}
 
     # - set new universe with wait for close policy
     universe_manager.set_universe([eth, ltc, sol], if_has_position_then="wait_for_change")
@@ -173,7 +173,7 @@ def test_set_universe_with_position_wait_for_change(universe_manager, mock_depen
     assert universe_manager.is_trading_allowed(btc) is False
 
     # - emulate position close - it should remove btc from universe
-    account.positions = {btc.symbol: mocker.Mock(quantity=0.0)}
+    account.positions = {btc: mocker.Mock(quantity=0.0)}
 
     mock_dependencies["position_gathering"].alter_positions.assert_called_once_with(
         ctx,

--- a/tests/qubx/core/universe_manager_test.py
+++ b/tests/qubx/core/universe_manager_test.py
@@ -1,0 +1,146 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from qubx.core.basics import DataType, Instrument, TargetPosition
+from qubx.core.mixins.universe import UniverseManager
+
+
+@pytest.fixture
+def mock_dependencies(mocker: MockerFixture):
+    return {
+        "context": mocker.Mock(),
+        "strategy": mocker.Mock(),
+        "broker": mocker.Mock(),
+        "trading_service": mocker.Mock(),
+        "cache": mocker.Mock(),
+        "logging": mocker.Mock(),
+        "subscription_manager": mocker.Mock(),
+        "trading_manager": mocker.Mock(),
+        "time_provider": mocker.Mock(),
+        "account": mocker.Mock(),
+        "position_gathering": mocker.Mock(),
+    }
+
+
+@pytest.fixture
+def universe_manager(mock_dependencies):
+    return UniverseManager(
+        context=mock_dependencies["context"],
+        strategy=mock_dependencies["strategy"],
+        broker=mock_dependencies["broker"],
+        trading_service=mock_dependencies["trading_service"],
+        cache=mock_dependencies["cache"],
+        logging=mock_dependencies["logging"],
+        subscription_manager=mock_dependencies["subscription_manager"],
+        trading_manager=mock_dependencies["trading_manager"],
+        time_provider=mock_dependencies["time_provider"],
+        account=mock_dependencies["account"],
+        position_gathering=mock_dependencies["position_gathering"],
+    )
+
+
+def test_set_universe_adds_new_instruments(universe_manager, mock_dependencies, mocker: MockerFixture):
+    instruments = list(
+        set(
+            [
+                mocker.Mock(spec=Instrument, symbol="BTCUSDT"),
+                mocker.Mock(spec=Instrument, symbol="ETHUSDT"),
+            ]
+        )
+    )
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    universe_manager.set_universe(instruments)
+
+    assert set(universe_manager.instruments) == set(instruments)
+    mock_dependencies["subscription_manager"].subscribe.assert_called_once()
+    mock_dependencies["subscription_manager"].commit.assert_called_once()
+    mock_dependencies["strategy"].on_universe_change.assert_called_once_with(
+        mock_dependencies["context"], instruments, []
+    )
+
+
+def test_set_universe_removes_instruments(universe_manager, mock_dependencies, mocker: MockerFixture):
+    initial_instruments = [
+        mocker.Mock(spec=Instrument, symbol="BTCUSDT"),
+        mocker.Mock(spec=Instrument, symbol="ETHUSDT"),
+    ]
+    new_instruments = [initial_instruments[0]]  # Remove second instrument
+
+    universe_manager._instruments = initial_instruments.copy()
+    mock_dependencies["account"].positions = {}
+
+    universe_manager.set_universe(new_instruments)
+
+    assert universe_manager.instruments == new_instruments
+    mock_dependencies["subscription_manager"].unsubscribe.assert_called_with(DataType.ALL, initial_instruments[1])
+    mock_dependencies["strategy"].on_universe_change.assert_called_once_with(
+        mock_dependencies["context"], [], [initial_instruments[1]]
+    )
+
+
+def test_set_universe_with_skip_callback(universe_manager, mock_dependencies, mocker: MockerFixture):
+    instruments = [mocker.Mock(spec=Instrument)]
+    universe_manager.set_universe(instruments, skip_callback=True)
+    mock_dependencies["strategy"].on_universe_change.assert_not_called()
+
+
+def test_set_universe_with_position_close(universe_manager, mock_dependencies, mocker: MockerFixture):
+    ctx = mock_dependencies["context"]
+
+    sol = (mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0),)
+    universe_manager.set_universe(
+        [
+            btc := mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0),
+            eth := mocker.Mock(spec=Instrument, symbol="ETHUSDT", min_size=0.0),
+            ltc := mocker.Mock(spec=Instrument, symbol="LTCUSDT", min_size=0.0),
+        ]
+    )
+    mock_dependencies["account"].positions = {btc.symbol: mocker.Mock(quantity=1.0)}
+
+    # - set new universe with close policy
+    universe_manager.set_universe([eth, ltc, sol], if_has_position_then="close")
+
+    # - should close position through alter_positions
+    mock_dependencies["position_gathering"].alter_positions.assert_called_once_with(
+        ctx,
+        [
+            TargetPosition.zero(
+                ctx,
+                btc.signal(0, group="Universe", comment="Universe change"),
+            )
+        ],
+    )
+
+    assert set(universe_manager.instruments) == set([eth, ltc, sol])
+
+
+def test_set_universe_with_position_wait_for_close(universe_manager, mock_dependencies, mocker: MockerFixture):
+    ctx = mock_dependencies["context"]
+    account = mock_dependencies["account"]
+    strategy = mock_dependencies["strategy"]
+
+    sol = mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0)
+    universe_manager.set_universe(
+        [
+            btc := mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0),
+            eth := mocker.Mock(spec=Instrument, symbol="ETHUSDT", min_size=0.0),
+            ltc := mocker.Mock(spec=Instrument, symbol="LTCUSDT", min_size=0.0),
+        ]
+    )
+    # - set position for btc
+    account.positions = {btc.symbol: mocker.Mock(quantity=1.0)}
+
+    # - set new universe with wait for close policy
+    universe_manager.set_universe([eth, ltc, sol], if_has_position_then="wait_for_close")
+
+    assert set(universe_manager.instruments) == set([btc, eth, ltc, sol])
+    strategy.on_universe_change.assert_any_call(ctx, [sol], [])
+
+    # - emulate position close - it should remove btc from universe
+    account.positions = {btc.symbol: mocker.Mock(quantity=0.0)}
+    universe_manager.on_alter_position(btc)
+    strategy.on_universe_change.assert_any_call(ctx, [], [btc])
+
+    assert set(universe_manager.instruments) == set([eth, ltc, sol])
+    assert universe_manager._removal_queue == {}


### PR DESCRIPTION
Add different policies to set_univers in case when removable instrument has open position.

Accepts additional parameter if_has_position_then  

It describe what to do with assets requested to remove when they have open position.

It can have 3 possible values:

“close” (default) - close position immediatelly and remove (unsubscribe) instrument from strategy

“wait_for_close” - keep instrument and it’s position until it’s closed from strategy (or risk management), then remove instrument from strategy

“wait_for_change” - keep instrument and position until strategy would try to change it - then close position and remove instrument