### PR TITLE
feat: redesign of simulated exchange

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "Qubx"
-version = "0.6.19"
+version = "0.6.22"
 description = "Qubx - Quantitative Trading Framework"
 authors = [ "Dmitry Marienko <dmitry.marienko@xlydian.com>", "Yuriy Arabskyy <yuriy.arabskyy@xlydian.com>",]
 readme = "README.md"

--- a/src/qubx/backtester/account.py
+++ b/src/qubx/backtester/account.py
@@ -1,5 +1,4 @@
-from qubx import logger
-from qubx.backtester.simulated_exchange import BasicSimulatedExchange
+from qubx.backtester.simulated_exchange import ISimulatedExchange
 from qubx.core.account import BasicAccountProcessor
 from qubx.core.basics import (
     CtrlChannel,
@@ -15,12 +14,12 @@ from qubx.restorers import RestoredState
 
 class SimulatedAccountProcessor(BasicAccountProcessor):
     _channel: CtrlChannel
-    _exchange: BasicSimulatedExchange
+    _exchange: ISimulatedExchange
 
     def __init__(
         self,
         account_id: str,
-        exchange: BasicSimulatedExchange,
+        exchange: ISimulatedExchange,
         channel: CtrlChannel,
         base_currency: str,
         initial_capital: float,

--- a/src/qubx/backtester/account.py
+++ b/src/qubx/backtester/account.py
@@ -1,54 +1,41 @@
 from qubx import logger
-from qubx.backtester.ome import OrdersManagementEngine
+from qubx.backtester.simulated_exchange import BasicSimulatedExchange
 from qubx.core.account import BasicAccountProcessor
 from qubx.core.basics import (
-    ZERO_COSTS,
     CtrlChannel,
     Instrument,
     Order,
     Position,
     Timestamped,
-    TransactionCostsCalculator,
     dt_64,
 )
-from qubx.core.interfaces import ITimeProvider
-from qubx.core.series import Bar, OrderBook, Quote, Trade, TradeArray
+from qubx.core.series import OrderBook, Quote, Trade, TradeArray
 from qubx.restorers import RestoredState
 
 
 class SimulatedAccountProcessor(BasicAccountProcessor):
-    ome: dict[Instrument, OrdersManagementEngine]
-    order_to_instrument: dict[str, Instrument]
-
     _channel: CtrlChannel
-    _fill_stop_order_at_price: bool
-    _half_tick_size: dict[Instrument, float]
+    _exchange: BasicSimulatedExchange
 
     def __init__(
         self,
         account_id: str,
+        exchange: BasicSimulatedExchange,
         channel: CtrlChannel,
         base_currency: str,
         initial_capital: float,
-        time_provider: ITimeProvider,
-        tcc: TransactionCostsCalculator = ZERO_COSTS,
-        accurate_stop_orders_execution: bool = False,
         restored_state: RestoredState | None = None,
     ) -> None:
         super().__init__(
             account_id=account_id,
-            time_provider=time_provider,
+            time_provider=exchange.get_time_provider(),
             base_currency=base_currency,
-            tcc=tcc,
+            tcc=exchange.get_transaction_costs_calculator(),
             initial_capital=initial_capital,
         )
-        self.ome = {}
-        self.order_to_instrument = {}
+
+        self._exchange = exchange
         self._channel = channel
-        self._half_tick_size = {}
-        self._fill_stop_order_at_price = accurate_stop_orders_execution
-        if self._fill_stop_order_at_price:
-            logger.info(f"[<y>{self.__class__.__name__}</y>] :: emulates stop orders executions at exact price")
 
         if restored_state is not None:
             self._balances.update(restored_state.balances)
@@ -57,42 +44,25 @@ class SimulatedAccountProcessor(BasicAccountProcessor):
                 _pos.reset_by_position(position)
 
     def get_orders(self, instrument: Instrument | None = None) -> dict[str, Order]:
-        if instrument is not None:
-            ome = self.ome.get(instrument)
-            if ome is None:
-                raise ValueError(f"ExchangeService:get_orders :: No OME configured for '{instrument}'!")
-
-            return {o.id: o for o in ome.get_open_orders()}
-
-        return {o.id: o for ome in self.ome.values() for o in ome.get_open_orders()}
+        return self._exchange.get_open_orders(instrument)
 
     def get_position(self, instrument: Instrument) -> Position:
         if instrument in self.positions:
             return self.positions[instrument]
 
-        # - initiolize OME for this instrument
-        self.ome[instrument] = OrdersManagementEngine(
-            instrument=instrument,
-            time_provider=self.time_provider,
-            tcc=self._tcc,  # type: ignore
-            fill_stop_order_at_price=self._fill_stop_order_at_price,
-        )
-
-        # - initiolize empty position
+        # - initialize empty position
         position = Position(instrument)  # type: ignore
-        self._half_tick_size[instrument] = instrument.tick_size / 2  # type: ignore
         self.attach_positions(position)
         return self.positions[instrument]
 
     def update_position_price(self, time: dt_64, instrument: Instrument, update: float | Timestamped) -> None:
+        self.get_position(instrument)
+
         super().update_position_price(time, instrument, update)
 
-        # - first we need to update OME with new quote.
-        # - if update is not a quote we need 'emulate' it.
-        # - actually if SimulatedExchangeService is used in backtesting mode it will recieve only quotes
-        # - case when we need that - SimulatedExchangeService is used for paper trading and data provider configured to listen to OHLC or TAS.
-        # - probably we need to subscribe to quotes in real data provider in any case and then this emulation won't be needed.
-        quote = update if isinstance(update, Quote) else self.emulate_quote_from_data(instrument, time, update)
+        quote = (
+            update if isinstance(update, Quote) else self._exchange.emulate_quote_from_data(instrument, time, update)
+        )
         if quote is None:
             return
 
@@ -106,56 +76,9 @@ class SimulatedAccountProcessor(BasicAccountProcessor):
 
         super().process_market_data(time, instrument, update)
 
-    def process_order(self, order: Order, update_locked_value: bool = True) -> None:
-        _new = order.status == "NEW"
-        _open = order.status == "OPEN"
-        _cancel = order.status == "CANCELED"
-        _closed = order.status == "CLOSED"
-        if _new or _open:
-            self.order_to_instrument[order.id] = order.instrument
-        if (_cancel or _closed) and order.id in self.order_to_instrument:
-            self.order_to_instrument.pop(order.id)
-        return super().process_order(order, update_locked_value)
-
-    def emulate_quote_from_data(
-        self, instrument: Instrument, timestamp: dt_64, data: float | Timestamped
-    ) -> Quote | None:
-        if instrument not in self._half_tick_size:
-            _ = self.get_position(instrument)
-
-        if isinstance(data, Quote):
-            return data
-
-        elif isinstance(data, Trade):
-            _ts2 = self._half_tick_size[instrument]
-            if data.side == 1:  # type: ignore
-                return Quote(timestamp, data.price - _ts2 * 2, data.price, 0, 0)  # type: ignore
-            else:
-                return Quote(timestamp, data.price, data.price + _ts2 * 2, 0, 0)  # type: ignore
-
-        elif isinstance(data, Bar):
-            _ts2 = self._half_tick_size[instrument]
-            return Quote(timestamp, data.close - _ts2, data.close + _ts2, 0, 0)  # type: ignore
-
-        elif isinstance(data, OrderBook):
-            return data.to_quote()
-
-        elif isinstance(data, float):
-            _ts2 = self._half_tick_size[instrument]
-            return Quote(timestamp, data - _ts2, data + _ts2, 0, 0)
-
-        else:
-            return None
-
     def _process_new_data(self, instrument: Instrument, data: Quote | OrderBook | Trade | TradeArray) -> None:
-        ome = self.ome.get(instrument)
-        if ome is None:
-            logger.warning(f"ExchangeService:update :: No OME configured for '{instrument}' yet !")
-            return
-        for r in ome.process_market_data(data):
+        for r in self._exchange.process_market_data(instrument, data):
             if r.exec is not None:
-                if r.order.id in self.order_to_instrument:
-                    self.order_to_instrument.pop(r.order.id)
                 # - process methods will be called from stg context
                 self._channel.send((instrument, "order", r.order, False))
                 self._channel.send((instrument, "deals", [r.exec], False))

--- a/src/qubx/backtester/broker.py
+++ b/src/qubx/backtester/broker.py
@@ -1,5 +1,5 @@
 from qubx.backtester.ome import OmeReport
-from qubx.backtester.simulated_exchange import BasicSimulatedExchange
+from qubx.backtester.simulated_exchange import ISimulatedExchange
 from qubx.core.basics import (
     CtrlChannel,
     Instrument,
@@ -14,13 +14,13 @@ class SimulatedBroker(IBroker):
     channel: CtrlChannel
 
     _account: SimulatedAccountProcessor
-    _exchange: BasicSimulatedExchange
+    _exchange: ISimulatedExchange
 
     def __init__(
         self,
         channel: CtrlChannel,
         account: SimulatedAccountProcessor,
-        simulated_exchange: BasicSimulatedExchange,
+        simulated_exchange: ISimulatedExchange,
     ) -> None:
         self.channel = channel
         self._account = account

--- a/src/qubx/backtester/broker.py
+++ b/src/qubx/backtester/broker.py
@@ -1,4 +1,4 @@
-from qubx.backtester.ome import OmeReport
+from qubx.backtester.ome import SimulatedExecutionReport
 from qubx.backtester.simulated_exchange import ISimulatedExchange
 from qubx.core.basics import (
     CtrlChannel,
@@ -72,7 +72,7 @@ class SimulatedBroker(IBroker):
     def update_order(self, order_id: str, price: float | None = None, amount: float | None = None) -> Order:
         raise NotImplementedError("Not implemented yet")
 
-    def _send_execution_report(self, report: OmeReport | None):
+    def _send_execution_report(self, report: SimulatedExecutionReport | None):
         if report is None:
             return
 

--- a/src/qubx/backtester/broker.py
+++ b/src/qubx/backtester/broker.py
@@ -1,4 +1,5 @@
 from qubx.backtester.ome import OmeReport
+from qubx.backtester.simulated_exchange import BasicSimulatedExchange
 from qubx.core.basics import (
     CtrlChannel,
     Instrument,
@@ -13,16 +14,17 @@ class SimulatedBroker(IBroker):
     channel: CtrlChannel
 
     _account: SimulatedAccountProcessor
+    _exchange: BasicSimulatedExchange
 
     def __init__(
         self,
         channel: CtrlChannel,
         account: SimulatedAccountProcessor,
-        exchange_id: str = "simulated",
+        simulated_exchange: BasicSimulatedExchange,
     ) -> None:
         self.channel = channel
         self._account = account
-        self._exchange_id = exchange_id
+        self._exchange = simulated_exchange
 
     @property
     def is_simulated_trading(self) -> bool:
@@ -39,22 +41,12 @@ class SimulatedBroker(IBroker):
         time_in_force: str = "gtc",
         **options,
     ) -> Order:
-        ome = self._account.ome.get(instrument)
-        if ome is None:
-            raise ValueError(f"ExchangeService:send_order :: No OME configured for '{instrument.symbol}'!")
-
-        # - try to place order in OME
-        report = ome.place_order(
-            order_side.upper(),  # type: ignore
-            order_type.upper(),  # type: ignore
-            amount,
-            price,
-            client_id,
-            time_in_force,
-            **options,
+        # - place order at exchange and send exec report to data channel
+        self._send_execution_report(
+            report := self._exchange.place_order(
+                instrument, order_side, order_type, amount, price, client_id, time_in_force, **options
+            )
         )
-
-        self._send_exec_report(instrument, report)
         return report.order
 
     def send_order_async(
@@ -71,22 +63,8 @@ class SimulatedBroker(IBroker):
         self.send_order(instrument, order_side, order_type, amount, price, client_id, time_in_force, **optional)
 
     def cancel_order(self, order_id: str) -> Order | None:
-        instrument = self._account.order_to_instrument.get(order_id)
-        if instrument is None:
-            raise ValueError(f"ExchangeService:cancel_order :: can't find order with id = '{order_id}'!")
-
-        ome = self._account.ome.get(instrument)
-        if ome is None:
-            raise ValueError(f"ExchangeService:send_order :: No OME configured for '{instrument}'!")
-
-        # - cancel order in OME and remove from the map to free memory
-        order_update = ome.cancel_order(order_id)
-        if order_update is None:
-            return None
-
-        self._send_exec_report(instrument, order_update)
-
-        return order_update.order
+        self._send_execution_report(order_update := self._exchange.cancel_order(order_id))
+        return order_update.order if order_update is not None else None
 
     def cancel_orders(self, instrument: Instrument) -> None:
         raise NotImplementedError("Not implemented yet")
@@ -94,10 +72,13 @@ class SimulatedBroker(IBroker):
     def update_order(self, order_id: str, price: float | None = None, amount: float | None = None) -> Order:
         raise NotImplementedError("Not implemented yet")
 
-    def _send_exec_report(self, instrument: Instrument, report: OmeReport):
-        self.channel.send((instrument, "order", report.order, False))
+    def _send_execution_report(self, report: OmeReport | None):
+        if report is None:
+            return
+
+        self.channel.send((report.instrument, "order", report.order, False))
         if report.exec is not None:
-            self.channel.send((instrument, "deals", [report.exec], False))
+            self.channel.send((report.instrument, "deals", [report.exec], False))
 
     def exchange(self) -> str:
-        return self._exchange_id.upper()
+        return self._exchange.exchange_id

--- a/src/qubx/backtester/ome.py
+++ b/src/qubx/backtester/ome.py
@@ -28,6 +28,7 @@ from qubx.core.series import OrderBook, Quote, Trade, TradeArray
 
 @dataclass
 class OmeReport:
+    instrument: Instrument
     timestamp: dt_64
     order: Order
     exec: Deal | None
@@ -273,12 +274,13 @@ class OrdersManagementEngine:
             self.active_orders[order.id] = order
 
         self._dbg(f"registered {order.id} {order.type} {order.side} {order.quantity} {order.price}")
-        return OmeReport(timestamp, order, None)
+        return OmeReport(self.instrument, timestamp, order, None)
 
     def _execute_order(self, timestamp: dt_64, exec_price: float, order: Order, taker: bool) -> OmeReport:
         order.status = "CLOSED"
         self._dbg(f"<red>{order.id}</red> {order.type} {order.side} {order.quantity} executed at {exec_price}")
         return OmeReport(
+            self.instrument,
             timestamp,
             order,
             Deal(
@@ -346,7 +348,7 @@ class OrdersManagementEngine:
 
         order.status = "CANCELED"
         self._dbg(f"{order.id} {order.type} {order.side} {order.quantity} canceled")
-        return OmeReport(self.time_service.time(), order, None)
+        return OmeReport(self.instrument, self.time_service.time(), order, None)
 
     def __str__(self) -> str:
         _a, _b = True, True

--- a/src/qubx/backtester/ome.py
+++ b/src/qubx/backtester/ome.py
@@ -27,7 +27,7 @@ from qubx.core.series import OrderBook, Quote, Trade, TradeArray
 
 
 @dataclass
-class OmeReport:
+class SimulatedExecutionReport:
     instrument: Instrument
     timestamp: dt_64
     order: Order
@@ -92,7 +92,7 @@ class OrdersManagementEngine:
     def get_open_orders(self) -> list[Order]:
         return list(self.active_orders.values()) + list(self.stop_orders.values())
 
-    def process_market_data(self, mdata: Quote | OrderBook | Trade | TradeArray) -> list[OmeReport]:
+    def process_market_data(self, mdata: Quote | OrderBook | Trade | TradeArray) -> list[SimulatedExecutionReport]:
         """
         Processes the new market data (quote, trade or trades array) and simulates the execution of pending orders.
         """
@@ -174,7 +174,7 @@ class OrdersManagementEngine:
         client_id: str | None = None,
         time_in_force: str = "gtc",
         **options,
-    ) -> OmeReport:
+    ) -> SimulatedExecutionReport:
         if self.bbo is None:
             raise ExchangeError(f"Simulator is not ready for order management - no quote for {self.instrument.symbol}")
 
@@ -201,7 +201,7 @@ class OrdersManagementEngine:
     def _dbg(self, message, **kwargs) -> None:
         logger.debug(f"    [<y>OME</y>(<g>{self.instrument}</g>)] :: {message}", **kwargs)
 
-    def _process_order(self, timestamp: dt_64, order: Order) -> OmeReport:
+    def _process_order(self, timestamp: dt_64, order: Order) -> SimulatedExecutionReport:
         if order.status in ["CLOSED", "CANCELED"]:
             raise InvalidOrder(f"Order {order.id} is already closed or canceled.")
 
@@ -274,12 +274,14 @@ class OrdersManagementEngine:
             self.active_orders[order.id] = order
 
         self._dbg(f"registered {order.id} {order.type} {order.side} {order.quantity} {order.price}")
-        return OmeReport(self.instrument, timestamp, order, None)
+        return SimulatedExecutionReport(self.instrument, timestamp, order, None)
 
-    def _execute_order(self, timestamp: dt_64, exec_price: float, order: Order, taker: bool) -> OmeReport:
+    def _execute_order(
+        self, timestamp: dt_64, exec_price: float, order: Order, taker: bool
+    ) -> SimulatedExecutionReport:
         order.status = "CLOSED"
         self._dbg(f"<red>{order.id}</red> {order.type} {order.side} {order.quantity} executed at {exec_price}")
-        return OmeReport(
+        return SimulatedExecutionReport(
             self.instrument,
             timestamp,
             order,
@@ -324,7 +326,7 @@ class OrdersManagementEngine:
                     f"Stop price would trigger immediately: STOP_MARKET {order_side} {amount} of {self.instrument.symbol} at {price} | market: {c_ask} / {c_bid}"
                 )
 
-    def cancel_order(self, order_id: str) -> OmeReport | None:
+    def cancel_order(self, order_id: str) -> SimulatedExecutionReport | None:
         # - check limit orders
         if order_id in self.active_orders:
             order = self.active_orders.pop(order_id)
@@ -348,7 +350,7 @@ class OrdersManagementEngine:
 
         order.status = "CANCELED"
         self._dbg(f"{order.id} {order.type} {order.side} {order.quantity} canceled")
-        return OmeReport(self.instrument, self.time_service.time(), order, None)
+        return SimulatedExecutionReport(self.instrument, self.time_service.time(), order, None)
 
     def __str__(self) -> str:
         _a, _b = True, True

--- a/src/qubx/backtester/simulated_exchange.py
+++ b/src/qubx/backtester/simulated_exchange.py
@@ -1,0 +1,193 @@
+from collections.abc import Generator
+
+from qubx import logger
+from qubx.backtester.ome import OmeReport, OrdersManagementEngine
+from qubx.core.basics import (
+    ZERO_COSTS,
+    Instrument,
+    ITimeProvider,
+    Order,
+    Timestamped,
+    TransactionCostsCalculator,
+    dt_64,
+)
+from qubx.core.series import Bar, OrderBook, Quote, Trade, TradeArray
+
+
+class BasicSimulatedExchange:
+    """
+    Basic emulation of generic exchange.
+    """
+
+    exchange_id: str
+    _ome: dict[Instrument, OrdersManagementEngine]
+    _order_to_instrument: dict[str, Instrument]
+    _half_tick_size: dict[Instrument, float]
+    _fill_stop_order_at_price: bool
+    _time_provider: ITimeProvider
+    _tcc: TransactionCostsCalculator
+
+    def __init__(
+        self,
+        exchange_id: str,
+        time_provider: ITimeProvider,
+        tcc: TransactionCostsCalculator = ZERO_COSTS,
+        accurate_stop_orders_execution: bool = False,
+    ):
+        self.exchange_id = exchange_id.upper()
+        self._ome = {}
+        self._order_to_instrument = {}
+        self._half_tick_size = {}
+        self._fill_stop_order_at_price = accurate_stop_orders_execution
+        self._time_provider = time_provider
+        self._tcc = tcc
+        if self._fill_stop_order_at_price:
+            logger.info(
+                f"[<y>{self.__class__.__name__}</y>] :: emulation of stop orders executions at exact price is ON"
+            )
+
+    def get_time_provider(self) -> ITimeProvider:
+        return self._time_provider
+
+    def get_transaction_costs_calculator(self) -> TransactionCostsCalculator:
+        return self._tcc
+
+    def place_order(
+        self,
+        instrument: Instrument,
+        order_side: str,
+        order_type: str,
+        amount: float,
+        price: float | None = None,
+        client_id: str | None = None,
+        time_in_force: str = "gtc",
+        **options,
+    ) -> OmeReport:
+        # - try to place order in OME
+        return self._get_ome(instrument).place_order(
+            order_side.upper(),  # type: ignore
+            order_type.upper(),  # type: ignore
+            amount,
+            price,
+            client_id,
+            time_in_force,
+            **options,
+        )
+
+    def cancel_order(self, order_id: str) -> OmeReport | None:
+        # - first check in active orders
+        instrument = self._order_to_instrument.get(order_id)
+
+        if instrument is None:
+            # - if not found in active orders, check in each OME
+            for o in self._ome.values():
+                for order in o.get_open_orders():
+                    if order.id == order_id:
+                        return self._process_ome_response(o.cancel_order(order_id))
+
+            logger.error(
+                f"[<y>{self.__class__.__name__}</y>] :: cancel_order :: can't find order with id = 'ValueError{order_id}'!"
+            )
+            return None
+
+        ome = self._ome.get(instrument)
+        if ome is None:
+            raise ValueError(
+                f"{self.__class__.__name__}</y>] :: cancel_order :: No OME created for '{instrument}' - fatal error!"
+            )
+
+        # - cancel order in OME and remove from the map to free memory
+        return self._process_ome_response(ome.cancel_order(order_id))
+
+    def _process_ome_response(self, report: OmeReport | None) -> OmeReport | None:
+        if report is not None:
+            _order = report.order
+            _new = _order.status == "NEW"
+            _open = _order.status == "OPEN"
+            _cancel = _order.status == "CANCELED"
+            _closed = _order.status == "CLOSED"
+
+            if _new or _open:
+                self._order_to_instrument[_order.id] = _order.instrument
+
+            if (_cancel or _closed) and _order.id in self._order_to_instrument:
+                self._order_to_instrument.pop(_order.id)
+
+        return report
+
+    def get_open_orders(self, instrument: Instrument | None = None) -> dict[str, Order]:
+        if instrument is not None:
+            ome = self._get_ome(instrument)
+            return {o.id: o for o in ome.get_open_orders()}
+
+        return {o.id: o for ome in self._ome.values() for o in ome.get_open_orders()}
+
+    def emulate_quote_from_data(
+        self, instrument: Instrument, timestamp: dt_64, data: float | Timestamped
+    ) -> Quote | None:
+        if instrument not in self._half_tick_size:
+            self._half_tick_size[instrument] = instrument.tick_size / 2  # type: ignore
+
+        if isinstance(data, Quote):
+            return data
+
+        elif isinstance(data, Trade):
+            _ts2 = self._half_tick_size[instrument]
+            if data.side == 1:  # type: ignore
+                return Quote(timestamp, data.price - _ts2 * 2, data.price, 0, 0)  # type: ignore
+            else:
+                return Quote(timestamp, data.price, data.price + _ts2 * 2, 0, 0)  # type: ignore
+
+        elif isinstance(data, Bar):
+            _ts2 = self._half_tick_size[instrument]
+            return Quote(timestamp, data.close - _ts2, data.close + _ts2, 0, 0)  # type: ignore
+
+        elif isinstance(data, OrderBook):
+            return data.to_quote()
+
+        elif isinstance(data, float):
+            _ts2 = self._half_tick_size[instrument]
+            return Quote(timestamp, data - _ts2, data + _ts2, 0, 0)
+
+        else:
+            return None
+
+    def _get_ome(self, instrument: Instrument) -> OrdersManagementEngine:
+        if (ome := self._ome.get(instrument)) is None:
+            self._half_tick_size[instrument] = instrument.tick_size / 2  # type: ignore
+            # - create order management engine for instrument
+            self._ome[instrument] = (
+                ome := OrdersManagementEngine(
+                    instrument=instrument,
+                    time_provider=self._time_provider,
+                    tcc=self._tcc,  # type: ignore
+                    fill_stop_order_at_price=self._fill_stop_order_at_price,
+                )
+            )
+        return ome
+
+    def process_market_data(
+        self, instrument: Instrument, data: Quote | OrderBook | Trade | TradeArray
+    ) -> Generator[OmeReport]:
+        ome = self._get_ome(instrument)
+
+        for r in ome.process_market_data(data):
+            if r.exec is not None:
+                if r.order.id in self._order_to_instrument:
+                    self._order_to_instrument.pop(r.order.id)
+                yield r
+
+
+def get_simulated_exchange(
+    exchange_name: str,
+    time_provider: ITimeProvider,
+    tcc: TransactionCostsCalculator,
+    accurate_stop_orders_execution=False,
+):
+    """
+    Factory function to create different types of simulated exchanges based on it's name etc
+    Now it supports only basic exchange that fits for most cases of crypto trading.
+    """
+    return BasicSimulatedExchange(
+        exchange_name, time_provider, tcc, accurate_stop_orders_execution=accurate_stop_orders_execution
+    )

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -14,7 +14,7 @@ This module includes:
 
 import traceback
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Protocol, Set, Tuple
+from typing import Any, Literal, Protocol
 
 import numpy as np
 import pandas as pd
@@ -49,24 +49,24 @@ RemovalPolicy = Literal["close", "wait_for_close", "wait_for_change"]
 class ITradeDataExport:
     """Interface for exporting trading data to external systems."""
 
-    def export_signals(self, time: dt_64, signals: List[Signal], account: "IAccountViewer") -> None:
+    def export_signals(self, time: dt_64, signals: list[Signal], account: "IAccountViewer") -> None:
         """
         Export signals to an external system.
 
         Args:
             time: Timestamp when the signals were generated
-            signals: List of signals to export
+            signals: list of signals to export
             account: Account viewer to get account information like total capital, leverage, etc.
         """
         pass
 
-    def export_target_positions(self, time: dt_64, targets: List[TargetPosition], account: "IAccountViewer") -> None:
+    def export_target_positions(self, time: dt_64, targets: list[TargetPosition], account: "IAccountViewer") -> None:
         """
         Export target positions to an external system.
 
         Args:
             time: Timestamp when the target positions were generated
-            targets: List of target positions to export
+            targets: list of target positions to export
             account: Account viewer to get account information like total capital, leverage, etc.
         """
         pass
@@ -377,7 +377,7 @@ class IDataProvider:
     def subscribe(
         self,
         subscription_type: str,
-        instruments: Set[Instrument],
+        instruments: set[Instrument],
         reset: bool = False,
     ) -> None:
         """
@@ -390,7 +390,7 @@ class IDataProvider:
         """
         ...
 
-    def unsubscribe(self, subscription_type: str | None, instruments: Set[Instrument]) -> None:
+    def unsubscribe(self, subscription_type: str | None, instruments: set[Instrument]) -> None:
         """
         Unsubscribe from market data for a list of instruments.
 
@@ -413,7 +413,7 @@ class IDataProvider:
         """
         ...
 
-    def get_subscriptions(self, instrument: Instrument | None = None) -> List[str]:
+    def get_subscriptions(self, instrument: Instrument | None = None) -> list[str]:
         """
         Get all subscriptions for an instrument.
 
@@ -421,11 +421,11 @@ class IDataProvider:
             instrument (optional): Instrument to get subscriptions for. If None, all subscriptions are returned.
 
         Returns:
-            List[str]: List of subscriptions
+            list[str]: list of subscriptions
         """
         ...
 
-    def get_subscribed_instruments(self, subscription_type: str | None = None) -> List[Instrument]:
+    def get_subscribed_instruments(self, subscription_type: str | None = None) -> list[Instrument]:
         """
         Get a list of instruments that are subscribed to a specific subscription type.
 
@@ -433,11 +433,11 @@ class IDataProvider:
             subscription_type: Type of subscription to filter by (optional)
 
         Returns:
-            List[Instrument]: List of subscribed instruments
+            list[Instrument]: list of subscribed instruments
         """
         ...
 
-    def warmup(self, configs: Dict[Tuple[str, Instrument], str]) -> None:
+    def warmup(self, configs: dict[tuple[str, Instrument], str]) -> None:
         """
         Run warmup for subscriptions.
 
@@ -522,7 +522,7 @@ class IMarketManager(ITimeProvider):
             sub_type: The subscription type of data to get
 
         Returns:
-            List[Any]: The data
+            list[Any]: The data
         """
         ...
 
@@ -542,7 +542,7 @@ class IMarketManager(ITimeProvider):
         """Get list of subscribed instruments.
 
         Returns:
-            list[Instrument]: List of subscribed instruments
+            list[Instrument]: list of subscribed instruments
         """
         ...
 
@@ -683,9 +683,9 @@ class IUniverseManager:
         """Set the trading universe.
 
         Args:
-            instruments: List of instruments in the universe
-            skip_callback: Skip callback to the strategy
-            if_has_position_then: What to do if the instrument has a position
+            instruments: list of instruments in the universe
+            skip_callback: skip callback to the strategy
+            if_has_position_then: what to do if the instrument has a position
                 - "close" (default) - close position immediatelly and remove (unsubscribe) instrument from strategy
                 - "wait_for_close" - keep instrument and it's position until it's closed from strategy (or risk management), then remove instrument from strategy
                 - "wait_for_change" - keep instrument and position until strategy would try to change it - then close position and remove instrument
@@ -752,7 +752,7 @@ class IUniverseManager:
 class ISubscriptionManager:
     """Manages subscriptions."""
 
-    def subscribe(self, subscription_type: str, instruments: List[Instrument] | Instrument | None = None) -> None:
+    def subscribe(self, subscription_type: str, instruments: list[Instrument] | Instrument | None = None) -> None:
         """Subscribe to market data for an instrument.
 
         Args:
@@ -761,7 +761,7 @@ class ISubscriptionManager:
         """
         ...
 
-    def unsubscribe(self, subscription_type: str, instruments: List[Instrument] | Instrument | None = None) -> None:
+    def unsubscribe(self, subscription_type: str, instruments: list[Instrument] | Instrument | None = None) -> None:
         """Unsubscribe from market data for an instrument.
 
         Args:
@@ -799,7 +799,7 @@ class ISubscriptionManager:
         """
         ...
 
-    def get_subscriptions(self, instrument: Instrument | None = None) -> List[str]:
+    def get_subscriptions(self, instrument: Instrument | None = None) -> list[str]:
         """
         Get all subscriptions for an instrument.
 
@@ -807,11 +807,11 @@ class ISubscriptionManager:
             instrument: Instrument to get subscriptions for (optional)
 
         Returns:
-            List[str]: List of subscriptions
+            list[str]: list of subscriptions
         """
         ...
 
-    def get_subscribed_instruments(self, subscription_type: str | None = None) -> List[Instrument]:
+    def get_subscribed_instruments(self, subscription_type: str | None = None) -> list[Instrument]:
         """
         Get a list of instruments that are subscribed to a specific subscription type.
 
@@ -819,7 +819,7 @@ class ISubscriptionManager:
             subscription_type: Type of subscription to filter by (optional)
 
         Returns:
-            List[Instrument]: List of subscribed instruments
+            list[Instrument]: list of subscribed instruments
         """
         ...
 
@@ -963,7 +963,7 @@ class IAccountProcessor(IAccountViewer):
         """
         ...
 
-    def add_active_orders(self, orders: Dict[str, Order]) -> None:
+    def add_active_orders(self, orders: dict[str, Order]) -> None:
         """Add active orders to the account.
 
         Warning only use in the beginning for state restoration because it does not update locked balances.
@@ -1115,8 +1115,8 @@ class IPositionGathering:
     def alter_position_size(self, ctx: IStrategyContext, target: TargetPosition) -> float: ...
 
     def alter_positions(
-        self, ctx: IStrategyContext, targets: List[TargetPosition] | TargetPosition
-    ) -> Dict[Instrument, float]:
+        self, ctx: IStrategyContext, targets: list[TargetPosition] | TargetPosition
+    ) -> dict[Instrument, float]:
         if not isinstance(targets, list):
             targets = [targets]
 
@@ -1194,7 +1194,7 @@ class PositionsTracker:
 
     def update(
         self, ctx: IStrategyContext, instrument: Instrument, update: Timestamped
-    ) -> List[TargetPosition] | TargetPosition:
+    ) -> list[TargetPosition] | TargetPosition:
         """
         Tracker is being updated by new market data.
         It may require to change position size or create new position because of interior tracker's logic (risk management for example).
@@ -1521,7 +1521,7 @@ class IStrategy(metaclass=Mixable):
         """
         return None
 
-    def on_event(self, ctx: IStrategyContext, event: TriggerEvent) -> List[Signal] | Signal | None:
+    def on_event(self, ctx: IStrategyContext, event: TriggerEvent) -> list[Signal] | Signal | None:
         """Called on strategy events.
 
         Args:
@@ -1533,7 +1533,7 @@ class IStrategy(metaclass=Mixable):
         """
         return None
 
-    def on_market_data(self, ctx: IStrategyContext, data: MarketEvent) -> List[Signal] | Signal | None:
+    def on_market_data(self, ctx: IStrategyContext, data: MarketEvent) -> list[Signal] | Signal | None:
         """
         Called when new market data is received.
 

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -13,6 +13,7 @@ from qubx.backtester.account import SimulatedAccountProcessor
 from qubx.backtester.broker import SimulatedBroker
 from qubx.backtester.optimization import variate
 from qubx.backtester.runner import SimulationRunner
+from qubx.backtester.simulated_exchange import get_simulated_exchange
 from qubx.backtester.utils import (
     SetupTypes,
     SimulatedLogFormatter,
@@ -437,12 +438,15 @@ def _create_account_processor(
 ) -> IAccountProcessor:
     if paper:
         settings = account_manager.get_exchange_settings(exchange_name)
+
+        # - TODO: here we can create  different types of simulated exchanges based on it's name etc
+        simulated_exchange = get_simulated_exchange(exchange_name, time_provider, tcc)
+
         return SimulatedAccountProcessor(
             account_id=exchange_name,
+            exchange=simulated_exchange,
             channel=channel,
             base_currency=settings.base_currency,
-            time_provider=time_provider,
-            tcc=tcc,
             initial_capital=settings.initial_capital,
             restored_state=restored_state,
         )
@@ -477,7 +481,7 @@ def _create_broker(
 ) -> IBroker:
     if paper:
         assert isinstance(account, SimulatedAccountProcessor)
-        return SimulatedBroker(channel=channel, account=account, exchange_id=exchange_name)
+        return SimulatedBroker(channel=channel, account=account, simulated_exchange=account._exchange)
 
     creds = account_manager.get_exchange_credentials(exchange_name)
 

--- a/tests/qubx/core/context_test.py
+++ b/tests/qubx/core/context_test.py
@@ -1,12 +1,7 @@
-from typing import Any
-
 from qubx import logger
-from qubx.backtester.broker import SimulatedAccountProcessor
 from qubx.backtester.simulator import simulate
-from qubx.backtester.utils import SimulatedScheduler, SimulatedTimeProvider, recognize_simulation_data_config
-from qubx.core.basics import DataType, Instrument, ITimeProvider, Signal, TriggerEvent, dt_64
+from qubx.core.basics import Instrument, Signal, TriggerEvent
 from qubx.core.interfaces import IStrategy, IStrategyContext
-from qubx.core.lookups import lookup
 from qubx.data.helpers import loader
 
 


### PR DESCRIPTION
- now all code related to orders simulation is moved to BasicSimulatedExchange class (OME is there too and it just one of possible implementations)
- it's possible to create any custom exchanges simulators (like for stocks, futures) which could emulate some particular features: custom order flags, rejections, latencies etc