### PR TITLE
Exporters: added leverages initialization for redis exporter

### DIFF
--- a/src/qubx/exporters/formatters/incremental.py
+++ b/src/qubx/exporters/formatters/incremental.py
@@ -13,7 +13,12 @@ class IncrementalFormatter(DefaultFormatter):
     based on leverage changes.
     """
 
-    def __init__(self, alert_name: str, exchange_mapping: Optional[Dict[str, str]] = None):
+    def __init__(
+            self, 
+            alert_name: str, 
+            exchange_mapping: Optional[Dict[str, str]] = None,
+            account: Optional[IAccountViewer] = None
+    ):
         """
         Initialize the IncrementalFormatter.
 
@@ -21,11 +26,15 @@ class IncrementalFormatter(DefaultFormatter):
             alert_name: The name of the alert to include in the messages
             exchange_mapping: Optional mapping of exchange names to use in messages.
                              If an exchange is not in the mapping, the instrument's exchange is used.
+            account: The account viewer to get account information like total capital, leverage, etc.
         """
         super().__init__()
         self.alert_name = alert_name
         self.exchange_mapping = exchange_mapping or {}
         self.instrument_leverages: Dict[Instrument, float] = {}
+
+        if account:
+            self.instrument_leverages = dict(account.get_leverages())
 
     def format_position_change(
         self, time: dt_64, instrument: Instrument, price: float, account: IAccountViewer

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -261,9 +261,6 @@ def create_strategy_context(
 
     _aux_reader = construct_reader(config.aux) if config.aux else None
 
-    # Create exporters if configured
-    _exporter = create_exporters(config.exporters, stg_name)
-
     # Create metric emitters
     _metric_emitter = create_metric_emitters(config.emission, stg_name) if config.emission else None
 
@@ -334,6 +331,9 @@ def create_strategy_context(
         else _exchange_to_account[exchanges[0]]
     )
     _initializer = BasicStrategyInitializer(simulation=_exchange_to_data_provider[exchanges[0]].is_simulation)
+
+    # Create exporters if configured
+    _exporter = create_exporters(config.exporters, stg_name, _account)
 
     logger.info(f"- Strategy: <blue>{stg_name}</blue>\n- Mode: {_run_mode}\n- Parameters: {config.parameters}")
     ctx = StrategyContext(


### PR DESCRIPTION
After restart previous leverages information for redis restorer is empty, leading to first incorrect position change export. Added leverages fetching during initialization