### PR TITLE
Improved state restoring from mongodb

### DIFF
--- a/src/qubx/core/lookups.py
+++ b/src/qubx/core/lookups.py
@@ -297,7 +297,7 @@ class InstrumentsLookup:
             path,
             "bitmex",
             {"bitmex": "bitmex"},
-            query_exchanges=False,
+            query_exchanges=query_exchanges,
         )
 
     def _update_deribit(self, path: str, query_exchanges: bool = False):

--- a/src/qubx/core/lookups.py
+++ b/src/qubx/core/lookups.py
@@ -289,7 +289,7 @@ class InstrumentsLookup:
             "bitfinex.f",
             {"bitfinex.f": "bitfinex"},
             keep_types=[MarketType.SWAP],
-            query_exchanges=query_exchanges,
+            query_exchanges=False,
         )
 
     def _update_bitmex(self, path: str, query_exchanges: bool = False):
@@ -297,7 +297,7 @@ class InstrumentsLookup:
             path,
             "bitmex",
             {"bitmex": "bitmex"},
-            query_exchanges=query_exchanges,
+            query_exchanges=False,
         )
 
     def _update_deribit(self, path: str, query_exchanges: bool = False):

--- a/src/qubx/core/lookups.py
+++ b/src/qubx/core/lookups.py
@@ -283,6 +283,7 @@ class InstrumentsLookup:
             query_exchanges=query_exchanges,
         )
 
+    #todo: temporaty disabled ccxt call to exchange, due to conectivity issues. Revert for bitfinex live usage
     def _update_bitfinex(self, path: str, query_exchanges: bool = False):
         self._ccxt_update(
             path,

--- a/tests/qubx/restorers/test_restorers.py
+++ b/tests/qubx/restorers/test_restorers.py
@@ -17,6 +17,7 @@ import pandas as pd
 import pytest
 import mongomock
 
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from qubx.core.basics import AssetBalance, RestoredState
@@ -242,9 +243,11 @@ class TestMongoDBPositionRestorer:
     def _insert_test_data(self, mongo_client):
         db = mongo_client["default_logs_db"]
         collection = db["qubx_logs"]
+        now = datetime.now()
+        log_timestamp = now - timedelta(days=1)
 
         collection.insert_one({
-            "timestamp": "2025-01-01T00:00:00.000Z",
+            "timestamp": log_timestamp,
             "symbol": "BTCUSDT",
             "exchange": "BINANCE.UM",
             "market_type": "SWAP",
@@ -369,9 +372,11 @@ class TestMongoDbSignalRestorer:
     def _insert_test_data(self, mongo_client):
         db = mongo_client["default_logs_db"]
         collection = db["qubx_logs"]
+        now = datetime.now()
+        log_timestamp = now - timedelta(days=1)
 
         collection.insert_one({
-		  "timestamp": "2025-01-01T00:00:00.000Z",
+		  "timestamp": log_timestamp,
 		  "symbol": "BTCUSDT",
 		  "exchange": "BINANCE.UM",
 		  "market_type": "SWAP",
@@ -470,9 +475,11 @@ class TestMongoDBBalanceRestorer:
     def _insert_test_data(self, mongo_client):
         db = mongo_client["default_logs_db"]
         collection = db["qubx_logs"]
+        now = datetime.now()
+        log_timestamp = now - timedelta(days=1)
 
         collection.insert_one({
-		  "timestamp": "2025-01-01T00:00:00.000Z",
+		  "timestamp": log_timestamp,
 		  "currency": "USDT",
 		  "total": 10000,
 		  "locked": 1000,
@@ -614,8 +621,10 @@ class TestMongoDBStateRestorer:
     def _insert_test_data(self, mongo_client):
         db = mongo_client["default_logs_db"]
 
+        now = datetime.now()
+        log_timestamp = now - timedelta(days=1)
         db["qubx_logs_positions"].insert_one({
-            "timestamp": "2025-01-01T00:00:00.000Z",
+            "timestamp": log_timestamp,
             "symbol": "BTCUSDT",
             "exchange": "BINANCE.UM",
             "market_type": "SWAP",
@@ -630,7 +639,7 @@ class TestMongoDBStateRestorer:
         })
 
         db["qubx_logs_signals"].insert_one({
-            "timestamp": "2025-01-01T00:00:00.000Z",
+            "timestamp": log_timestamp,
             "symbol": "BTCUSDT",
             "exchange": "BINANCE.UM",
             "market_type": "SWAP",
@@ -643,7 +652,7 @@ class TestMongoDBStateRestorer:
         })
 
         db["qubx_logs_balance"].insert_one({
-            "timestamp": "2025-01-01T00:00:00.000Z",
+            "timestamp": log_timestamp,
             "currency": "USDT",
             "total": 10000,
             "locked": 1000,


### PR DESCRIPTION
Fixed and optimized mongodb state restorers:
- for positions: fetching last info by symbol
- for balances: last by currency
- for signals: last 20 by symbol

Temporary disabled bitfinex ccxt instruments refresh job.