### PR TITLE
Lighter fixes

### DIFF
--- a/src/qubx/connectors/ccxt/utils.py
+++ b/src/qubx/connectors/ccxt/utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import re
 from collections import defaultdict
-from typing import Any, Awaitable, Callable, Dict, List, Set
+from typing import Any, Awaitable, Callable, Dict, List, Set, cast
 
 import numpy as np
 import pandas as pd
@@ -287,7 +287,7 @@ def ccxt_convert_orderbook(
 
 def ccxt_convert_liquidation(liq: dict[str, Any]) -> Liquidation:
     try:
-        _dt = to_utc_naive(pd.Timestamp(liq["datetime"])).asm8
+        _dt = to_utc_naive(cast(pd.Timestamp, pd.Timestamp(liq["datetime"]))).asm8.item()
         return Liquidation(
             time=_dt,
             price=liq["price"],
@@ -308,7 +308,7 @@ def ccxt_convert_ticker(ticker: dict[str, Any]) -> Quote:
         Quote: The converted Quote object.
     """
     return Quote(
-        time=to_utc_naive(pd.Timestamp(ticker["datetime"])).asm8,
+        time=to_utc_naive(cast(pd.Timestamp, pd.Timestamp(ticker["datetime"]))).asm8.item(),
         bid=ticker["bid"],
         ask=ticker["ask"],
         bid_size=ticker["bidVolume"],
@@ -318,7 +318,7 @@ def ccxt_convert_ticker(ticker: dict[str, Any]) -> Quote:
 
 def ccxt_convert_funding_rate(info: dict[str, Any]) -> FundingRate:
     return FundingRate(
-        time=pd.Timestamp(info["timestamp"], unit="ms").asm8,
+        time=pd.Timestamp(info["timestamp"], unit="ms").asm8.item(),
         rate=info["fundingRate"],
         interval=info["interval"],
         next_funding_time=pd.Timestamp(info["nextFundingTime"], unit="ms").asm8,

--- a/src/qubx/connectors/xlighter/client.py
+++ b/src/qubx/connectors/xlighter/client.py
@@ -220,7 +220,7 @@ class LighterClient:
                 return market
         return None
 
-    @rate_limited("rest", weight=WEIGHT_CANDLESTICKS * 2)
+    @rate_limited("rest", weight=WEIGHT_CANDLESTICKS * 1.2)
     async def get_candlesticks(
         self,
         market_id: int,
@@ -285,7 +285,7 @@ class LighterClient:
             logger.error(f"Failed to get candlesticks for market {market_id}: {e}")
             raise
 
-    @rate_limited("rest", weight=WEIGHT_FUNDING * 2)
+    @rate_limited("rest", weight=WEIGHT_FUNDING * 1.2)
     async def get_fundings(
         self,
         market_id: int,
@@ -339,7 +339,7 @@ class LighterClient:
             logger.error(f"Failed to get funding data for market {market_id}: {e}")
             raise
 
-    @rate_limited("rest", weight=WEIGHT_DEFAULT * 2)
+    @rate_limited("rest", weight=WEIGHT_DEFAULT * 1.2)
     async def get_funding_rates(self) -> dict[int, float]:
         """
         Get current funding rates for all markets.

--- a/src/qubx/connectors/xlighter/data.py
+++ b/src/qubx/connectors/xlighter/data.py
@@ -9,6 +9,7 @@ Provides market data subscriptions via WebSocket with support for:
 """
 
 import asyncio
+import time
 from collections import defaultdict
 from typing import Any, Literal, Optional, cast
 
@@ -37,6 +38,15 @@ class LighterDataProvider(IDataProvider):
     Architecture:
         WebSocket → Router → Handler → CtrlChannel → Strategy
     """
+
+    SUPPORTED_SUBSCRIPTIONS = [
+        DataType.ORDERBOOK,
+        DataType.TRADE,
+        DataType.QUOTE,
+        DataType.FUNDING_RATE,
+        DataType.FUNDING_PAYMENT,
+        DataType.OPEN_INTEREST,
+    ]
 
     def __init__(
         self,
@@ -90,20 +100,17 @@ class LighterDataProvider(IDataProvider):
         # Track if reconnection callback has been registered
         self._reconnection_callback_registered: bool = False
 
-        logger.info("LighterDataProvider initialized")
+        self._info("Data provider initialized")
 
     @property
     def is_simulation(self) -> bool:
-        """Check if provider is in simulation mode (always False for live)"""
         return False
 
     @property
     def ws_manager(self) -> LighterWebSocketManager:
-        """Get WebSocket manager (shared across components)"""
         return self._ws_manager
 
     def exchange(self) -> str:
-        """Return exchange name"""
         return "LIGHTER"
 
     def subscribe(
@@ -112,61 +119,182 @@ class LighterDataProvider(IDataProvider):
         instruments: set[Instrument],
         reset: bool = False,
     ) -> None:
-        """
-        Subscribe to market data for instruments.
-
-        Args:
-            subscription_type: Type of subscription (e.g., "orderbook", "trade", "quote")
-            instruments: Set of instruments to subscribe to
-            reset: If True, replace existing subscriptions; if False, add to existing
-
-        Supported types:
-            - "orderbook" - L2 orderbook with stateful updates
-            - "trade" - Trade feed (including liquidations)
-            - "quote" - Best bid/ask (derived from orderbook if not subscribed)
-
-        Example:
-            provider.subscribe("orderbook", {btc_instrument, eth_instrument})
-            provider.subscribe("trade", {btc_instrument})
-        """
         if not instruments:
-            logger.debug(f"No instruments provided for subscription type: {subscription_type}")
             return
 
-        # Parse subscription type
         sub_type, params = DataType.from_str(subscription_type)
-
-        # Validate subscription type
-        if sub_type not in [
-            "orderbook",
-            "trade",
-            "quote",
-            DataType.FUNDING_RATE,
-            DataType.FUNDING_PAYMENT,
-            DataType.OPEN_INTEREST,
-        ]:
+        if sub_type not in self.SUPPORTED_SUBSCRIPTIONS:
             raise ValueError(f"Unsupported subscription type: {sub_type}")
 
-        # Ensure WebSocket is connected (wait if needed)
         try:
             self._ensure_websocket_connected(timeout=5.0)
         except (TimeoutError, ConnectionError) as e:
-            logger.error(f"Cannot subscribe: {e}")
+            self._error(f"Cannot subscribe: {e}")
             raise
 
-        # Update subscription tracking
+        current_subscriptions = self._subscriptions.get(subscription_type, set())
+        new_subscriptions = instruments.difference(current_subscriptions)
+
         if reset:
             self._subscriptions[subscription_type] = set(instruments)
         else:
             self._subscriptions[subscription_type].update(instruments)
 
-        # Subscribe to each instrument (connection guaranteed at this point)
         for instrument in instruments:
             self._subscribe_instrument(sub_type, instrument, **params)
 
-        logger.info(
-            f"Subscribed to {subscription_type} for {len(instruments)} instruments: {[i.symbol for i in instruments]}"
+        if new_subscriptions:
+            self._info(
+                f"Subscribed to {subscription_type} for {len(new_subscriptions)} new instruments: {[i.symbol for i in new_subscriptions]}"
+            )
+
+    def unsubscribe(self, subscription_type: str | None, instruments: set[Instrument]) -> None:
+        if subscription_type is None:
+            # Unsubscribe from all types
+            for sub_type in list(self._subscriptions.keys()):
+                self.unsubscribe(sub_type, instruments)
+            return
+
+        # Remove from tracking
+        if subscription_type in self._subscriptions:
+            self._subscriptions[subscription_type] -= instruments
+
+            # If no instruments left, remove subscription type
+            if not self._subscriptions[subscription_type]:
+                del self._subscriptions[subscription_type]
+
+        # Unsubscribe from WebSocket
+        sub_type, _ = DataType.from_str(subscription_type)
+
+        # Special handling for market stats subscriptions
+        if sub_type in [DataType.OPEN_INTEREST, DataType.FUNDING_RATE, DataType.FUNDING_PAYMENT]:
+            # Check if ALL market stats subscriptions are now empty
+            has_market_stats_subs = (
+                bool(self._subscriptions.get(DataType.FUNDING_RATE))
+                or bool(self._subscriptions.get(DataType.FUNDING_PAYMENT))
+                or bool(self._subscriptions.get(DataType.OPEN_INTEREST))
+            )
+
+            # If no more market stats subscriptions, unsubscribe from WebSocket
+            if not has_market_stats_subs and self._market_stats_subscribed:
+                if self._ws_manager is not None:
+                    self._async_loop.submit(self._ws_manager.unsubscribe_market_stats("all"))
+
+                # Remove shared handler
+                handler_key = ("market_stats", 0)
+                if handler_key in self._handlers:
+                    del self._handlers[handler_key]
+
+                self._market_stats_subscribed = False
+                self._info("Unsubscribed from market_stats:all (no more market stats subscriptions)")
+
+        # Normal unsubscribe flow for non-market-stats types
+        else:
+            for instrument in instruments:
+                market_id = self.instrument_loader.get_market_id(instrument.symbol)
+                if market_id is not None:
+                    # Remove handler
+                    handler_key = (sub_type, market_id)
+                    if handler_key in self._handlers:
+                        del self._handlers[handler_key]
+
+                    # Unsubscribe from WebSocket (if connected)
+                    if self._ws_manager is not None:
+                        if sub_type == "orderbook":
+                            self._async_loop.submit(self._ws_manager.unsubscribe_orderbook(market_id))
+                        elif sub_type == "trade":
+                            self._async_loop.submit(self._ws_manager.unsubscribe_trades(market_id))
+                        elif sub_type == "quote":
+                            self._async_loop.submit(self._ws_manager.unsubscribe_orderbook(market_id))
+
+        self._info(
+            f"Unsubscribed from {subscription_type} for {len(instruments)} instruments: {[i.symbol for i in instruments]}"
         )
+
+    def has_subscription(self, instrument: Instrument, subscription_type: str) -> bool:
+        base_type = DataType.from_str(subscription_type)[0]
+        return any(
+            DataType.from_str(stored_sub_type)[0] == base_type and instrument in instruments
+            for stored_sub_type, instruments in self._subscriptions.items()
+        )
+
+    def get_subscriptions(self, instrument: Instrument | None = None) -> list[str]:
+        if instrument is None:
+            return list(self._subscriptions.keys())
+        return [sub_type for sub_type, instrs in self._subscriptions.items() if instrument in instrs]
+
+    def get_subscribed_instruments(self, subscription_type: str | None = None) -> list[Instrument]:
+        if subscription_type is None:
+            # Return all subscribed instruments across all types
+            all_instruments = set()
+            for instruments in self._subscriptions.values():
+                all_instruments.update(instruments)
+            return list(all_instruments)
+
+        return list(self._subscriptions.get(subscription_type, set()))
+
+    def warmup(self, configs: dict[tuple[str, Instrument], str]) -> None:
+        if not configs:
+            self._debug("No warmup configs provided")
+            return
+
+        self._info(f"Starting warmup for {len(configs)} configurations")
+
+        for (sub_type, instrument), period in configs.items():
+            try:
+                self._warmup_instrument(sub_type, instrument, period)
+            except Exception as e:
+                self._error(f"Warmup failed for {sub_type}/{instrument.symbol}: {e}")
+
+        self._info("Warmup complete")
+
+    def get_ohlc(self, instrument: Instrument, timeframe: str, nbarsback: int) -> list[Bar]:
+        market_id = self.instrument_loader.get_market_id(instrument.symbol)
+        if market_id is None:
+            raise ValueError(f"Market ID not found for {instrument.symbol}")
+
+        # Fetch candlesticks via REST API
+        async def _fetch():
+            return await self.client.get_candlesticks(market_id=market_id, resolution=timeframe, count_back=nbarsback)
+
+        try:
+            future = self._async_loop.submit(_fetch())
+            candlesticks = future.result(timeout=30)
+
+            # Convert to Bar objects
+            bars = []
+            for candle in candlesticks:
+                ts = pd.Timestamp(candle["timestamp"], unit="ms")
+                time_ns = time_as_nsec(ts.asm8)
+
+                bar = Bar(
+                    time=time_ns,
+                    open=float(candle["open"]),
+                    high=float(candle["high"]),
+                    low=float(candle["low"]),
+                    close=float(candle["close"]),
+                    volume=float(candle.get("volume0", 0.0)),
+                    volume_quote=float(candle.get("volume1", 0.0)),
+                )
+                bars.append(bar)
+
+            return bars
+
+        except Exception as e:
+            self._error(f"Failed to fetch OHLC data for {instrument.symbol}: {e}")
+            return []
+
+    def get_quote(self, instrument: Instrument) -> Quote | None:
+        return self._last_quotes.get(instrument, None)
+
+    def close(self) -> None:
+        if self._ws_manager:
+            future = self._async_loop.submit(self._ws_manager.disconnect())
+            try:
+                future.result(timeout=5)
+            except Exception as e:
+                self._error(f"Error disconnecting WebSocket: {e}")
+            self._info("LighterDataProvider closed")
 
     async def _on_reconnected(self) -> None:
         """
@@ -176,36 +304,22 @@ class LighterDataProvider(IDataProvider):
         This is particularly important for stateful handlers like OrderbookHandler
         which maintain incremental state that becomes invalid after disconnection.
         """
-        logger.info("WebSocket reconnected, resetting all handler states")
+        self._info("WebSocket reconnected, resetting all handler states")
 
         # Reset all handlers (stateless handlers have empty reset() implementation)
         for handler in self._handlers.values():
             try:
                 handler.reset()
             except Exception as e:
-                logger.error(f"Error resetting handler {handler.__class__.__name__}: {e}")
+                self._error(f"Error resetting handler {handler.__class__.__name__}: {e}")
 
-        logger.debug(f"Reset {len(self._handlers)} handlers after reconnection")
+        self._debug(f"Reset {len(self._handlers)} handlers after reconnection")
 
     def _ensure_websocket_connected(self, timeout: float = 5.0) -> None:
-        """
-        Ensure WebSocket is connected, wait if necessary.
-
-        Args:
-            timeout: Maximum time to wait for connection (seconds)
-
-        Raises:
-            TimeoutError: If connection not established within timeout
-            ConnectionError: If connection fails
-        """
-        # Already connected
         if self._ws_manager.is_connected:
             return
 
-        # Connection in progress, wait for it
         if self._ws_connected:
-            import time
-
             max_wait = int(timeout * 10)  # Check every 0.1s
             for _ in range(max_wait):
                 if self._ws_manager.is_connected:
@@ -213,7 +327,6 @@ class LighterDataProvider(IDataProvider):
                 time.sleep(0.1)
             raise TimeoutError(f"WebSocket connection not ready after {timeout}s")
 
-        # Need to initiate connection
         async def _connect():
             assert self._ws_manager is not None
             await self._ws_manager.connect()
@@ -223,29 +336,17 @@ class LighterDataProvider(IDataProvider):
             if not self._reconnection_callback_registered:
                 self._ws_manager.on_reconnected(self._on_reconnected)
                 self._reconnection_callback_registered = True
-                logger.debug("Registered reconnection callback for handler state reset")
+                self._debug("Registered reconnection callback for handler state reset")
 
-        # Submit and WAIT for connection
         future = self._async_loop.submit(_connect())
         try:
             future.result(timeout=timeout)
-            logger.info("WebSocket connection established")
+            self._info("WebSocket connection established")
         except Exception as e:
             self._ws_connected = False
             raise ConnectionError(f"Failed to connect WebSocket: {e}") from e
 
     def _subscribe_instrument(self, sub_type: str, instrument: Instrument, **params) -> None:
-        """
-        Subscribe single instrument to a data type.
-
-        Creates handler if needed and subscribes via WebSocket.
-
-        Args:
-            sub_type: Data type (orderbook, trade, quote, funding_rate, funding_payment, open_interest)
-            instrument: Instrument to subscribe
-            **params: Additional parameters (e.g., depth for orderbook)
-        """
-        # Get market_id for this instrument
         market_id = self.instrument_loader.get_market_id(instrument.symbol)
         if market_id is None:
             raise ValueError(f"Market ID not found for {instrument.symbol}")
@@ -274,7 +375,7 @@ class LighterDataProvider(IDataProvider):
                 # Submit to event loop via AsyncThreadLoop
                 self._async_loop.submit(_subscribe_market_stats())
                 self._market_stats_subscribed = True
-                logger.info("Subscribed to market_stats:all (shared for all instruments)")
+                self._info("Subscribed to market_stats:all (shared for all instruments)")
 
             return  # Don't proceed with normal subscription flow
 
@@ -375,10 +476,10 @@ class LighterDataProvider(IDataProvider):
 
         async def callback():
             if self._ws_manager is None:
-                logger.warning(f"Cannot resubscribe for market {market_id}: WebSocket manager not initialized")
+                self._warning(f"Cannot resubscribe for market {market_id}: WebSocket manager not initialized")
                 return
 
-            logger.info(f"Resubscribing to orderbook for market {market_id} ({instrument.symbol})")
+            self._info(f"Resubscribing to orderbook for market {market_id} ({instrument.symbol})")
 
             try:
                 # Unsubscribe from current orderbook
@@ -404,13 +505,13 @@ class LighterDataProvider(IDataProvider):
                         break
                     except Exception as e:
                         sleep_timeout = min(count * WS_RESUBSCRIBE_DELAY, 60.0)
-                        logger.warning(
+                        self._warning(
                             f"Failed to resubscribe for market {market_id}: {e} retrying in {sleep_timeout} seconds"
                         )
                         await asyncio.sleep(sleep_timeout)
 
             except Exception as e:
-                logger.error(f"Failed to resubscribe for market {market_id}: {e}")
+                self._error(f"Failed to resubscribe for market {market_id}: {e}")
 
         return callback
 
@@ -490,152 +591,6 @@ class LighterDataProvider(IDataProvider):
 
         return callback
 
-    def unsubscribe(self, subscription_type: str | None, instruments: set[Instrument]) -> None:
-        """
-        Unsubscribe from market data.
-
-        Args:
-            subscription_type: Type of subscription to unsubscribe from (or None for all)
-            instruments: Set of instruments to unsubscribe
-        """
-        if subscription_type is None:
-            # Unsubscribe from all types
-            for sub_type in list(self._subscriptions.keys()):
-                self.unsubscribe(sub_type, instruments)
-            return
-
-        # Remove from tracking
-        if subscription_type in self._subscriptions:
-            self._subscriptions[subscription_type] -= instruments
-
-            # If no instruments left, remove subscription type
-            if not self._subscriptions[subscription_type]:
-                del self._subscriptions[subscription_type]
-
-        # Unsubscribe from WebSocket
-        sub_type, _ = DataType.from_str(subscription_type)
-
-        # Special handling for market stats subscriptions
-        if sub_type in [DataType.OPEN_INTEREST, DataType.FUNDING_RATE, DataType.FUNDING_PAYMENT]:
-            # Check if ALL market stats subscriptions are now empty
-            has_market_stats_subs = (
-                bool(self._subscriptions.get(DataType.FUNDING_RATE))
-                or bool(self._subscriptions.get(DataType.FUNDING_PAYMENT))
-                or bool(self._subscriptions.get(DataType.OPEN_INTEREST))
-            )
-
-            # If no more market stats subscriptions, unsubscribe from WebSocket
-            if not has_market_stats_subs and self._market_stats_subscribed:
-                if self._ws_manager is not None:
-                    self._async_loop.submit(self._ws_manager.unsubscribe_market_stats("all"))
-
-                # Remove shared handler
-                handler_key = ("market_stats", 0)
-                if handler_key in self._handlers:
-                    del self._handlers[handler_key]
-
-                self._market_stats_subscribed = False
-                logger.info("Unsubscribed from market_stats:all (no more market stats subscriptions)")
-
-        # Normal unsubscribe flow for non-market-stats types
-        else:
-            for instrument in instruments:
-                market_id = self.instrument_loader.get_market_id(instrument.symbol)
-                if market_id is not None:
-                    # Remove handler
-                    handler_key = (sub_type, market_id)
-                    if handler_key in self._handlers:
-                        del self._handlers[handler_key]
-
-                    # Unsubscribe from WebSocket (if connected)
-                    if self._ws_manager is not None:
-                        if sub_type == "orderbook":
-                            self._async_loop.submit(self._ws_manager.unsubscribe_orderbook(market_id))
-                        elif sub_type == "trade":
-                            self._async_loop.submit(self._ws_manager.unsubscribe_trades(market_id))
-                        elif sub_type == "quote":
-                            self._async_loop.submit(self._ws_manager.unsubscribe_orderbook(market_id))
-
-        logger.info(f"Unsubscribed from {subscription_type} for {len(instruments)} instruments")
-
-    def has_subscription(self, instrument: Instrument, subscription_type: str) -> bool:
-        """
-        Check if instrument has a subscription.
-
-        Args:
-            instrument: Instrument to check
-            subscription_type: Subscription type
-
-        Returns:
-            True if subscribed
-        """
-        return instrument in self._subscriptions.get(subscription_type, set())
-
-    def get_subscriptions(self, instrument: Instrument | None = None) -> list[str]:
-        """
-        Get all subscription types.
-
-        Args:
-            instrument: Filter by instrument (or None for all)
-
-        Returns:
-            List of subscription type strings
-        """
-        if instrument is None:
-            return list(self._subscriptions.keys())
-
-        # Return subscriptions for specific instrument
-        return [sub_type for sub_type, instrs in self._subscriptions.items() if instrument in instrs]
-
-    def get_subscribed_instruments(self, subscription_type: str | None = None) -> list[Instrument]:
-        """
-        Get subscribed instruments.
-
-        Args:
-            subscription_type: Filter by subscription type (or None for all)
-
-        Returns:
-            List of subscribed instruments
-        """
-        if subscription_type is None:
-            # Return all subscribed instruments across all types
-            all_instruments = set()
-            for instruments in self._subscriptions.values():
-                all_instruments.update(instruments)
-            return list(all_instruments)
-
-        return list(self._subscriptions.get(subscription_type, set()))
-
-    def warmup(self, configs: dict[tuple[str, Instrument], str]) -> None:
-        """
-        Run warmup for subscriptions using historical data.
-
-        Args:
-            configs: Dict mapping (subscription_type, instrument) to warmup period
-
-        Example:
-            warmup({
-                ("trade", btc_instrument): "1h",
-                ("orderbook", eth_instrument): "10min",
-            })
-
-        Note: Lighter's REST API has limited historical data support.
-        Warmup primarily useful for trades (recent history).
-        """
-        if not configs:
-            logger.debug("No warmup configs provided")
-            return
-
-        logger.info(f"Starting warmup for {len(configs)} configurations")
-
-        for (sub_type, instrument), period in configs.items():
-            try:
-                self._warmup_instrument(sub_type, instrument, period)
-            except Exception as e:
-                logger.error(f"Warmup failed for {sub_type}/{instrument.symbol}: {e}")
-
-        logger.info("Warmup complete")
-
     def _warmup_instrument(self, sub_type: str, instrument: Instrument, period: str) -> None:
         """
         Warmup single instrument.
@@ -658,10 +613,10 @@ class LighterDataProvider(IDataProvider):
             # Get market ID
             market_id = self.instrument_loader.get_market_id(instrument.symbol)
             if market_id is None:
-                logger.warning(f"Market ID not found for {instrument.symbol}, skipping OHLC warmup")
+                self._warning(f"Market ID not found for {instrument.symbol}, skipping OHLC warmup")
                 return
 
-            logger.debug(f"OHLC warmup for {instrument.symbol}: fetching {nbarsback} {timeframe} bars")
+            self._debug(f"OHLC warmup for {instrument.symbol}: fetching {nbarsback} {timeframe} bars")
 
             # Fetch historical OHLC data via REST API using AsyncThreadLoop
             async def _fetch_ohlc():
@@ -708,108 +663,39 @@ class LighterDataProvider(IDataProvider):
                     )
                     self.channel.send((instrument, DataType.QUOTE, quote, False))
                 else:
-                    logger.warning(f"No OHLC data returned for {instrument.symbol}")
+                    self._warning(f"No OHLC data returned for {instrument.symbol}")
 
             except Exception as e:
-                logger.error(f"Failed to fetch OHLC data for {instrument.symbol}: {e}")
+                self._error(f"Failed to fetch OHLC data for {instrument.symbol}: {e}")
 
         elif data_type == "trade":
             # Fetch recent trades from REST API
             market_id = self.instrument_loader.get_market_id(instrument.symbol)
             if market_id is None:
-                logger.warning(f"Market ID not found for {instrument.symbol}, skipping warmup")
+                self._warning(f"Market ID not found for {instrument.symbol}, skipping warmup")
                 return
 
             # TODO: Implement trade history fetching via REST API
-            logger.debug(f"Trade warmup for {instrument.symbol} (period: {period})")
+            self._debug(f"Trade warmup for {instrument.symbol} (period: {period})")
             # trades = self.client.get_trades(market_id, limit=100)
             # for trade in trades:
             #     self.channel.send((instrument, "trade", trade, True))  # is_warmup=True
 
         elif data_type == "orderbook":
             # Orderbook is realtime state, no historical warmup needed
-            logger.debug(f"Orderbook warmup skipped for {instrument.symbol} (realtime data only)")
+            self._debug(f"Orderbook warmup skipped for {instrument.symbol} (realtime data only)")
 
         else:
-            logger.warning(f"Warmup not supported for {data_type}")
+            self._warning(f"Warmup not supported for {data_type}")
 
-    def get_ohlc(self, instrument: Instrument, timeframe: str, nbarsback: int) -> list[Bar]:
-        """
-        Get historical OHLC data for an instrument.
+    def _info(self, message: str) -> None:
+        logger.info(f"<yellow>[Lighter]</yellow> {message}")
 
-        Args:
-            instrument: Instrument to get OHLC data for
-            timeframe: Timeframe for bars (e.g., "1m", "5m", "1h")
-            nbarsback: Number of bars to retrieve
+    def _warning(self, message: str) -> None:
+        logger.warning(f"<yellow>[Lighter]</yellow> {message}")
 
-        Returns:
-            List of Bar objects, oldest first
+    def _error(self, message: str) -> None:
+        logger.error(f"<yellow>[Lighter]</yellow> {message}")
 
-        Note:
-            This method fetches data synchronously via REST API.
-            For realtime data, use OHLC subscription instead.
-        """
-        # Get market ID
-        market_id = self.instrument_loader.get_market_id(instrument.symbol)
-        if market_id is None:
-            raise ValueError(f"Market ID not found for {instrument.symbol}")
-
-        # Fetch candlesticks via REST API
-        async def _fetch():
-            return await self.client.get_candlesticks(market_id=market_id, resolution=timeframe, count_back=nbarsback)
-
-        try:
-            future = self._async_loop.submit(_fetch())
-            candlesticks = future.result(timeout=30)
-
-            # Convert to Bar objects
-            bars = []
-            for candle in candlesticks:
-                ts = pd.Timestamp(candle["timestamp"], unit="ms")
-                time_ns = time_as_nsec(ts.asm8)
-
-                bar = Bar(
-                    time=time_ns,
-                    open=float(candle["open"]),
-                    high=float(candle["high"]),
-                    low=float(candle["low"]),
-                    close=float(candle["close"]),
-                    volume=float(candle.get("volume0", 0.0)),
-                    volume_quote=float(candle.get("volume1", 0.0)),
-                )
-                bars.append(bar)
-
-            return bars
-
-        except Exception as e:
-            logger.error(f"Failed to fetch OHLC data for {instrument.symbol}: {e}")
-            return []
-
-    def get_quote(self, instrument: Instrument) -> Quote | None:
-        """
-        Get the latest quote for an instrument.
-
-        Returns cached quote from last orderbook update or quote subscription.
-        If no quote is available, raises ValueError.
-
-        Args:
-            instrument: Instrument to get quote for
-
-        Returns:
-            Quote object with bid/ask prices and sizes
-
-        Returns:
-            Quote object with bid/ask prices and sizes or None if no quote is available
-        """
-        return self._last_quotes.get(instrument, None)
-
-    def close(self) -> None:
-        """Close WebSocket connections and cleanup"""
-        if self._ws_manager:
-            # Submit disconnect to event loop and wait for completion
-            future = self._async_loop.submit(self._ws_manager.disconnect())
-            try:
-                future.result(timeout=5)
-            except Exception as e:
-                logger.error(f"Error disconnecting WebSocket: {e}")
-            logger.info("LighterDataProvider closed")
+    def _debug(self, message: str) -> None:
+        logger.debug(f"<yellow>[Lighter]</yellow> {message}")

--- a/src/qubx/connectors/xlighter/handlers/stats.py
+++ b/src/qubx/connectors/xlighter/handlers/stats.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from qubx import logger
 from qubx.core.basics import FundingPayment, FundingRate, Instrument, OpenInterest, dt_64
+from qubx.utils.time import floor_t64
 
 from .base import BaseHandler
 
@@ -257,7 +258,9 @@ class MarketStatsHandler(BaseHandler[dict[Instrument, list[FundingRate | OpenInt
                     funding_timestamp_ns = int(funding_timestamp * 1_000_000)
 
                     payment = FundingPayment(
-                        time=dt_64(funding_timestamp_ns, "ns"),  # When payment occurred
+                        time=floor_t64(
+                            dt_64(funding_timestamp_ns, "ns"), self.FUNDING_INTERVAL_HOURS
+                        ),  # When payment occurred
                         funding_rate=funding_rate_paid,  # Rate that was paid
                         funding_interval_hours=self.FUNDING_INTERVAL_HOURS,
                     )
@@ -319,8 +322,6 @@ class MarketStatsHandler(BaseHandler[dict[Instrument, list[FundingRate | OpenInt
         Returns:
             (should_emit, emission_timestamp, data_to_emit)
         """
-        from qubx.utils.time import floor_t64
-
         # Floor current message time to interval
         current_boundary = floor_t64(msg_time, interval)
 

--- a/src/qubx/connectors/xlighter/handlers/stats.py
+++ b/src/qubx/connectors/xlighter/handlers/stats.py
@@ -179,7 +179,7 @@ class MarketStatsHandler(BaseHandler[dict[Instrument, list[FundingRate | OpenInt
 
                 # Prepare data for buffering
                 funding_rate_data = {
-                    "rate": current_funding_rate,
+                    "rate": current_funding_rate / 100.0,  # Convert from percentage to decimal
                     "next_funding_time": dt_64(next_funding_ns, "ns"),
                     "mark_price": mark_price,
                     "index_price": index_price,
@@ -261,7 +261,7 @@ class MarketStatsHandler(BaseHandler[dict[Instrument, list[FundingRate | OpenInt
                         time=floor_t64(
                             dt_64(funding_timestamp_ns, "ns"), self.FUNDING_INTERVAL_HOURS
                         ),  # When payment occurred
-                        funding_rate=funding_rate_paid,  # Rate that was paid
+                        funding_rate=funding_rate_paid / 100.0,  # Convert from percentage to decimal
                         funding_interval_hours=self.FUNDING_INTERVAL_HOURS,
                     )
                     objects.append(payment)

--- a/src/qubx/connectors/xlighter/reader.py
+++ b/src/qubx/connectors/xlighter/reader.py
@@ -423,9 +423,13 @@ class LighterReader(DataReader):
                 if timestamp > stop:
                     continue
 
+                side = funding_item.get("direction", None)
+                if side is None:
+                    continue
+
                 # Extract funding rate - Lighter uses 'rate' field
                 # The rate is in percentage, so we need to divide by 100.0 to get the actual rate
-                funding_rate = float(funding_item.get("rate", 0.0)) / 100.0
+                funding_rate = float(funding_item.get("rate", 0.0)) / 100.0 * (1 if side == "long" else -1)
 
                 funding_data.append(
                     (

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -109,6 +109,7 @@ class StrategyContext(IStrategyContext):
     _strategy_name: str
     _delisting_detector: DelistingDetector
     _notifier: IStrategyNotifier
+    _aux: DataReader | None
 
     _thread_data_loop: Thread | None = None  # market data loop
     _is_initialized: bool = False
@@ -175,6 +176,7 @@ class StrategyContext(IStrategyContext):
         self._strategy_state = strategy_state if strategy_state is not None else StrategyState()
         self._strategy_name = strategy_name if strategy_name is not None else strategy.__class__.__name__
         self._restored_state = restored_state
+        self._aux = aux_data_provider
 
         self._health_monitor = health_monitor or DummyHealthMonitor()
         self.health = self._health_monitor
@@ -322,6 +324,10 @@ class StrategyContext(IStrategyContext):
     @property
     def strategy_name(self) -> str:
         return self._strategy_name or self.strategy.__class__.__name__
+
+    @property
+    def aux(self) -> DataReader | None:
+        return self._aux
 
     def start(self, blocking: bool = False):
         if self._is_initialized:

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -15,7 +15,7 @@ This module includes:
 import inspect
 import traceback
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import pandas as pd
@@ -45,6 +45,9 @@ from qubx.core.basics import (
 from qubx.core.errors import BaseErrorEvent
 from qubx.core.helpers import set_parameters_to_object
 from qubx.core.series import OHLCV, Bar, Quote
+
+if TYPE_CHECKING:
+    from qubx.data.readers import DataReader
 
 RemovalPolicy = Literal["close", "wait_for_close", "wait_for_change"]
 
@@ -1453,6 +1456,7 @@ class IStrategyContext(
     health: "IHealthReader"
     notifier: "IStrategyNotifier"
     strategy_name: str
+    aux: "DataReader | None"
 
     _strategy_state: StrategyState
 

--- a/src/qubx/data/composite.py
+++ b/src/qubx/data/composite.py
@@ -1,7 +1,7 @@
 import math
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterator
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 
 import numpy as np
 import pandas as pd
@@ -677,9 +677,9 @@ class CompositeReader(DataReader):
         # Combine all symbols back together
         if deduplicated_parts:
             final_result = pd.concat(deduplicated_parts, axis=0)
-            removed_count = len(df) - len(final_result)
-            if removed_count > 0:
-                logger.debug(f"Removed {removed_count} near-duplicate records (tolerance={tolerance}) for '{data_id}'")
+            # removed_count = len(df) - len(final_result)
+            # if removed_count > 0:
+            #     logger.debug(f"Removed {removed_count} near-duplicate records (tolerance={tolerance}) for '{data_id}'")
             return final_result.sort_index()
         else:
             return pd.DataFrame(columns=df.columns)
@@ -693,7 +693,7 @@ class CompositeReader(DataReader):
         if len(data) <= 1:
             return data
 
-        tolerance_delta = pd.Timedelta(tolerance)
+        tolerance_delta = cast(pd.Timedelta, pd.Timedelta(tolerance))
         timestamps = data.index
 
         # Find groups of timestamps within tolerance
@@ -701,9 +701,9 @@ class CompositeReader(DataReader):
 
         # Keep only the selected records - convert to numpy boolean array for iloc
         result = data.iloc[dedupe_mask.values]
-        removed_count = len(data) - len(result)
-        if removed_count > 0:
-            logger.debug(f"Removed {removed_count} near-duplicate records (tolerance={tolerance}) for '{data_id}'")
+        # removed_count = len(data) - len(result)
+        # if removed_count > 0:
+        #     logger.debug(f"Removed {removed_count} near-duplicate records (tolerance={tolerance}) for '{data_id}'")
 
         return result.sort_index()
 

--- a/src/qubx/data/readers.py
+++ b/src/qubx/data/readers.py
@@ -1780,7 +1780,7 @@ class QuestDBSqlFundingBuilder(QuestDBSqlBuilder):
         where_clause = "WHERE " + " AND ".join(where_clauses) if where_clauses else ""
 
         return f"""
-        SELECT timestamp, symbol, funding_rate, funding_interval_hours
+        SELECT timestamp, funding_rate, funding_interval_hours
         FROM {table_name}
         {where_clause}
         ORDER BY timestamp ASC

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -52,7 +52,6 @@ class PrefetchConfig(StrictBaseModel):
 class WarmupConfig(StrictBaseModel):
     readers: list[TypedReaderConfig] = Field(default_factory=list)
     restorer: RestorerConfig | None = None
-    prefetch: PrefetchConfig | None = None
     enable_funding: bool = False
 
 
@@ -125,6 +124,7 @@ class LiveConfig(StrictBaseModel):
     health: HealthConfig = Field(default_factory=HealthConfig)
     throttling: ThrottlingConfig | None = None
     aux: list[ReaderConfig] | ReaderConfig | None = None
+    prefetch: PrefetchConfig = Field(default_factory=PrefetchConfig)
 
 
 class SimulationConfig(StrictBaseModel):

--- a/tests/qubx/connectors/xlighter/test_market_stats_handler.py
+++ b/tests/qubx/connectors/xlighter/test_market_stats_handler.py
@@ -130,7 +130,7 @@ class TestIntervalBasedEmissionFundingRate:
 
         # But buffer should be populated
         assert 0 in handler._funding_rate_buffer
-        assert handler._funding_rate_buffer[0]["data"]["rate"] == 0.0005
+        assert handler._funding_rate_buffer[0]["data"]["rate"] == 5e-06  # 0.0005 / 100
 
     def test_same_interval_updates_buffer_no_emission(self, handler):
         """Test that messages in same interval update buffer without emission."""
@@ -154,7 +154,7 @@ class TestIntervalBasedEmissionFundingRate:
         assert result2 is None or len(result2) == 0
 
         # Buffer should have latest value
-        assert handler._funding_rate_buffer[0]["data"]["rate"] == 0.0006
+        assert handler._funding_rate_buffer[0]["data"]["rate"] == pytest.approx(6e-06)  # 0.0006 / 100
 
     def test_boundary_crossing_emits_buffered_data(self, handler):
         """Test that crossing interval boundary emits buffered data."""
@@ -190,8 +190,8 @@ class TestIntervalBasedEmissionFundingRate:
         assert len(funding_rates) == 1
 
         fr = funding_rates[0]
-        # Check that emitted data is from msg1 (0.0005, not 0.0006)
-        assert fr.rate == 0.0005
+        # Check that emitted data is from msg1 (0.0005 / 100, not 0.0006 / 100)
+        assert fr.rate == 5e-06  # 0.0005 / 100
         assert fr.mark_price == 4000.00
         assert fr.index_price == 4001.00
 
@@ -224,7 +224,7 @@ class TestIntervalBasedEmissionFundingRate:
         assert btc in result
         funding_rates = [obj for obj in result[btc] if isinstance(obj, FundingRate)]
         assert len(funding_rates) == 1
-        assert funding_rates[0].rate == 0.0005
+        assert funding_rates[0].rate == 5e-06  # 0.0005 / 100
 
         # Timestamp should be 18:05:00 (current boundary, not 18:01:00)
         expected_time = dt_64(int(1000 * (18 * 3600 + 5 * 60 + 0) * 1_000_000), "ns")
@@ -363,7 +363,7 @@ class TestFundingPaymentEmission:
         assert len(payments) == 1
 
         payment = payments[0]
-        assert payment.funding_rate == 0.0003  # Rate from msg2
+        assert payment.funding_rate == pytest.approx(3e-06)  # 0.0003 / 100 (Rate from msg2)
         assert payment.funding_interval_hours == 1
 
         # Timestamp should be the new funding_timestamp


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds funding payment read support (CCXT/XLighter), fixes Lighter funding rate units and payment time flooring, enhances XLighter provider APIs, and wires aux prefetch/cache into live and warmup flows.
> 
> - **Data Readers (CCXT/XLighter)**:
>   - CCXT `CcxtDataReader`: support `funding_payment` via `_fetch_data`, async funding-history fetch (bulk/individual), per-exchange funding-interval caching, and error/warn helpers; floor timestamps to funding interval.
>   - XLighter `LighterReader`: funding payments now signed by `direction`, handle second-based timestamps; OHLC/funding batch fetch helpers.
>   - QuestDB funding SQL: return `timestamp, funding_rate, funding_interval_hours` (no `symbol`) to match transformer.
> - **XLighter Data Provider**:
>   - Add supported subscription list, robust subscribe/unsubscribe (incl. shared `market_stats:all`), introspection (`has_subscription`, `get_*`), warmup, OHLC fetch, quote cache, graceful close, and reconnection/reset; unify logging helpers.
>   - Orderbook resubscribe/backoff flow improved.
> - **XLighter Client**:
>   - Reduce REST rate-limiter weights for candlesticks/funding/default to 1.2; enforce timeframe bounds and counts.
> - **Funding Stats Handler**:
>   - Convert funding rates from percent to decimal and floor `FundingPayment` time to hourly boundary.
>   - Update tests to new scaling and flooring.
> - **Core/Runner/Config**:
>   - Expose `ctx.aux` (DataReader) on `StrategyContext`/interfaces.
>   - Add `live.prefetch` config and wrap aux reader with `CachedPrefetchReader`; pass `ctx.aux` into warmup `SimulationRunner`.
> - **Misc**:
>   - Minor type casts, timestamp fixes (`.asm8.item()`), and deduplication helper cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b57ebe79824b551740de1a420aac272f14970059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->