### PR TITLE
fix(cli): clean uv-specific sections from pyproject.toml during release

### DIFF
--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -410,8 +410,8 @@ def deploy(zip_file: str, output_dir: str | None, force: bool):
 
     This command:
     1. Unpacks the zip file to the specified output directory
-    2. Creates a Poetry virtual environment in the .venv folder
-    3. Installs dependencies from the poetry.lock file
+    2. Creates a uv virtual environment in the .venv folder
+    3. Installs dependencies from the uv.lock file
 
     If no output directory is specified, the zip file is unpacked in the same directory
     as the zip file, in a folder with the same name as the zip file (without the .zip extension).
@@ -523,7 +523,7 @@ def init(
     - Package structure for proper imports
 
     The generated strategy can be run immediately with:
-    poetry run qubx run --config config.yml --paper
+    uv run qubx run --config config.yml --paper
     """
     from qubx.templates import TemplateError, TemplateManager
 
@@ -558,7 +558,7 @@ def init(
         click.echo()
         click.echo("To run your strategy:")
         click.echo(f"  cd {strategy_path}")
-        click.echo("  poetry run qubx run config.yml --paper")
+        click.echo("  uv run qubx run config.yml --paper")
         click.echo()
         click.echo("To run in Jupyter mode:")
         click.echo("  ./jpaper.sh")

--- a/src/qubx/cli/deploy.py
+++ b/src/qubx/cli/deploy.py
@@ -199,8 +199,8 @@ def deploy_strategy(zip_file: str, output_dir: str | None, force: bool) -> bool:
 
     This function:
     1. Unpacks the zip file to the specified output directory
-    2. Creates a Poetry virtual environment in the .venv folder
-    3. Installs dependencies from the poetry.lock file
+    2. Creates a uv virtual environment in the .venv folder
+    3. Installs dependencies from the uv.lock file
 
     Args:
         zip_file: Path to the zip file to deploy

--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -814,6 +814,47 @@ def _create_metadata(stg_name: str, git_info: ReleaseInfo, release_dir: str) -> 
         fs.write(f"Commit: {git_info.commit}\n")
 
 
+def _clean_pyproject_for_release(pyproject_data: dict) -> dict:
+    """
+    Remove dev-only and local-path-dependent sections from pyproject.toml for release.
+
+    Removes:
+    - [tool.uv.sources] - local editable paths won't work in release
+    - [dependency-groups] - dev dependencies not needed in release
+    - [project.optional-dependencies] - may reference local-only packages
+    - Dev tool configs ([tool.pytest], [tool.ruff], etc.)
+
+    Preserves:
+    - [[tool.uv.index]] - needed for private registry access
+    - [build-system] - needed for package building
+    - [tool.poetry] - needed for poetry build backend
+    """
+    # Remove [tool.uv.sources] (local paths won't work in release)
+    if "tool" in pyproject_data and "uv" in pyproject_data["tool"]:
+        if "sources" in pyproject_data["tool"]["uv"]:
+            del pyproject_data["tool"]["uv"]["sources"]
+            logger.debug("Removed [tool.uv.sources] from release pyproject.toml")
+
+    # Remove [dependency-groups] (dev deps not needed in release)
+    if "dependency-groups" in pyproject_data:
+        del pyproject_data["dependency-groups"]
+        logger.debug("Removed [dependency-groups] from release pyproject.toml")
+
+    # Remove [project.optional-dependencies] (may reference local-only packages)
+    if "project" in pyproject_data and "optional-dependencies" in pyproject_data["project"]:
+        del pyproject_data["project"]["optional-dependencies"]
+        logger.debug("Removed [project.optional-dependencies] from release pyproject.toml")
+
+    # Remove dev tool configs
+    if "tool" in pyproject_data:
+        for key in ["pytest", "ruff", "semantic_release"]:
+            if key in pyproject_data["tool"]:
+                del pyproject_data["tool"][key]
+                logger.debug(f"Removed [tool.{key}] from release pyproject.toml")
+
+    return pyproject_data
+
+
 def _modify_pyproject_toml(pyproject_path: str, package_name: str) -> None:
     """
     Modify the pyproject.toml file to include the project package as a dependency.
@@ -830,6 +871,9 @@ def _modify_pyproject_toml(pyproject_path: str, package_name: str) -> None:
         # Read the existing pyproject.toml
         with open(pyproject_path, "r") as f:
             pyproject_data = toml.load(f)
+
+        # Clean up dev-only and local-path-dependent sections
+        pyproject_data = _clean_pyproject_for_release(pyproject_data)
 
         # Handle PEP 621 format
         if "project" in pyproject_data:
@@ -936,6 +980,9 @@ def _configure_pyproject_for_external_deps(pyproject_path: str, packages: list[s
         # Read existing pyproject.toml
         with open(pyproject_path, "r") as f:
             pyproject_data = toml.load(f)
+
+        # Clean up dev-only and local-path-dependent sections
+        pyproject_data = _clean_pyproject_for_release(pyproject_data)
 
         # Handle PEP 621 format
         if "project" in pyproject_data:


### PR DESCRIPTION
Strip [tool.uv.sources], [dependency-groups], [project.optional-dependencies], and dev tool configs from the released pyproject.toml so that local editable paths don't break uv lock in the release archive. Also update stale Poetry references to uv in deploy/init command docs.