### PR TITLE
feat(cli): add backward-compatible poetry support to deploy command

### DIFF
--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -410,8 +410,8 @@ def deploy(zip_file: str, output_dir: str | None, force: bool):
 
     This command:
     1. Unpacks the zip file to the specified output directory
-    2. Creates a Poetry virtual environment in the .venv folder
-    3. Installs dependencies from the poetry.lock file
+    2. Creates a uv virtual environment in the .venv folder
+    3. Installs dependencies from the uv.lock file
 
     If no output directory is specified, the zip file is unpacked in the same directory
     as the zip file, in a folder with the same name as the zip file (without the .zip extension).
@@ -523,7 +523,7 @@ def init(
     - Package structure for proper imports
 
     The generated strategy can be run immediately with:
-    poetry run qubx run --config config.yml --paper
+    uv run qubx run --config config.yml --paper
     """
     from qubx.templates import TemplateError, TemplateManager
 
@@ -558,7 +558,7 @@ def init(
         click.echo()
         click.echo("To run your strategy:")
         click.echo(f"  cd {strategy_path}")
-        click.echo("  poetry run qubx run config.yml --paper")
+        click.echo("  uv run qubx run config.yml --paper")
         click.echo()
         click.echo("To run in Jupyter mode:")
         click.echo("  ./jpaper.sh")

--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -410,8 +410,10 @@ def deploy(zip_file: str, output_dir: str | None, force: bool):
 
     This command:
     1. Unpacks the zip file to the specified output directory
-    2. Creates a uv virtual environment in the .venv folder
-    3. Installs dependencies from the uv.lock file
+    2. Auto-detects the package manager (uv or legacy poetry) from the lock file
+    3. Creates a virtual environment and installs dependencies
+
+    Supports both uv-based releases (uv.lock) and legacy Poetry-based releases (poetry.lock).
 
     If no output directory is specified, the zip file is unpacked in the same directory
     as the zip file, in a folder with the same name as the zip file (without the .zip extension).

--- a/src/qubx/cli/deploy.py
+++ b/src/qubx/cli/deploy.py
@@ -199,8 +199,8 @@ def deploy_strategy(zip_file: str, output_dir: str | None, force: bool) -> bool:
 
     This function:
     1. Unpacks the zip file to the specified output directory
-    2. Creates a Poetry virtual environment in the .venv folder
-    3. Installs dependencies from the poetry.lock file
+    2. Creates a uv virtual environment in the .venv folder
+    3. Installs dependencies from the uv.lock file
 
     Args:
         zip_file: Path to the zip file to deploy

--- a/src/qubx/cli/deploy.py
+++ b/src/qubx/cli/deploy.py
@@ -94,6 +94,19 @@ def extract_zip_file(zip_file: str, output_dir: str) -> bool:
         return False
 
 
+def _detect_package_manager(output_dir: str) -> str:
+    """Detect whether the release was built with uv or poetry.
+
+    Returns "uv" or "poetry" based on which lock file is present.
+    Defaults to "uv" if neither is found.
+    """
+    if os.path.exists(os.path.join(output_dir, "uv.lock")):
+        return "uv"
+    if os.path.exists(os.path.join(output_dir, "poetry.lock")):
+        return "poetry"
+    return "uv"
+
+
 def ensure_lock_exists(output_dir: str) -> bool:
     """
     Ensures that a uv.lock file exists in the output directory.
@@ -170,11 +183,80 @@ def setup_uv_environment(output_dir: str) -> bool:
         return False
 
 
-def create_strategy_runners(output_dir: str):
+# --- Legacy Poetry support (temporary) ---
+# TODO: Remove Poetry deploy functions once all old releases are re-released with uv
+
+
+def _ensure_poetry_lock_exists(output_dir: str) -> bool:
+    """Ensures that a poetry.lock file exists in the output directory.
+
+    Legacy support for old Poetry-based releases.
+    """
+    poetry_lock_path = os.path.join(output_dir, "poetry.lock")
+    if not os.path.exists(poetry_lock_path):
+        logger.warning("poetry.lock not found in the zip file. Attempting to generate it.")
+        try:
+            subprocess.run(["poetry", "lock"], cwd=output_dir, check=True, capture_output=True, text=True)
+            return True
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to generate poetry.lock: {e.stderr}")
+            return False
+    return True
+
+
+def _setup_poetry_environment(output_dir: str) -> bool:
+    """Sets up the Poetry virtual environment in the output directory.
+
+    Legacy support for old Poetry-based releases.
+    """
+    logger.info("Creating Poetry virtual environment")
+    try:
+        subprocess.run(
+            ["poetry", "config", "virtualenvs.in-project", "true", "--local"],
+            cwd=output_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        in_poetry_env = "POETRY_ACTIVE" in os.environ or "VIRTUAL_ENV" in os.environ
+
+        logger.info("Installing dependencies")
+
+        install_cmd = ["poetry", "install"]
+        if in_poetry_env:
+            env = os.environ.copy()
+            for var in ["POETRY_ACTIVE", "VIRTUAL_ENV"]:
+                if var in env:
+                    del env[var]
+            subprocess.run(install_cmd, cwd=output_dir, check=True, capture_output=False, text=True, env=env)
+        else:
+            subprocess.run(install_cmd, cwd=output_dir, check=True, capture_output=False, text=True)
+
+        venv_path = os.path.join(output_dir, ".venv")
+        if not os.path.exists(venv_path):
+            logger.warning(
+                "Virtual environment directory (.venv) not found. "
+                "You may need to run 'cd %s && poetry env use python' to create it manually.",
+                output_dir,
+            )
+
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to set up Poetry environment: {e.stderr}")
+        return False
+
+
+# --- End legacy Poetry support ---
+
+
+def create_strategy_runners(output_dir: str, pkg_manager: str = "uv"):
     """
     Creates a strategy runner script in the output_dir
     """
     import sys
+
+    run_prefix = "uv run" if pkg_manager == "uv" else "poetry run"
 
     if sys.platform == "win32":
         _pfx = ""
@@ -187,7 +269,7 @@ def create_strategy_runners(output_dir: str):
 
     try:
         with open(_f_name, "w") as f:
-            f.write(f"{_pfx}uv run qubx run config.yml --paper -j")
+            f.write(f"{_pfx}{run_prefix} qubx run config.yml --paper -j")
         os.chmod(_f_name, 0o755)
     except Exception as e:
         logger.error(f"Failed to create strategy paper runner script: {e}")
@@ -199,8 +281,10 @@ def deploy_strategy(zip_file: str, output_dir: str | None, force: bool) -> bool:
 
     This function:
     1. Unpacks the zip file to the specified output directory
-    2. Creates a uv virtual environment in the .venv folder
-    3. Installs dependencies from the uv.lock file
+    2. Auto-detects the package manager (uv or poetry) based on the lock file
+    3. Creates a virtual environment and installs dependencies
+
+    Supports both new uv-based releases and legacy Poetry-based releases.
 
     Args:
         zip_file: Path to the zip file to deploy
@@ -225,16 +309,33 @@ def deploy_strategy(zip_file: str, output_dir: str | None, force: bool) -> bool:
     if not extract_zip_file(zip_file, resolved_output_dir):
         return False
 
-    # Ensure uv.lock exists
-    if not ensure_lock_exists(resolved_output_dir):
-        return False
+    # Detect package manager
+    pkg_manager = _detect_package_manager(resolved_output_dir)
+    logger.info(f"Detected package manager: {pkg_manager}")
+    if pkg_manager == "poetry":
+        logger.warning(
+            "This is a legacy Poetry-based release. "
+            "Consider re-releasing with the latest qubx version (uv-based)."
+        )
 
-    # Set up the uv environment
-    if not setup_uv_environment(resolved_output_dir):
-        return False
+    # Ensure lock file exists
+    if pkg_manager == "uv":
+        if not ensure_lock_exists(resolved_output_dir):
+            return False
+    else:
+        if not _ensure_poetry_lock_exists(resolved_output_dir):
+            return False
+
+    # Set up environment
+    if pkg_manager == "uv":
+        if not setup_uv_environment(resolved_output_dir):
+            return False
+    else:
+        if not _setup_poetry_environment(resolved_output_dir):
+            return False
 
     # Create the strategy runners
-    create_strategy_runners(resolved_output_dir)
+    create_strategy_runners(resolved_output_dir, pkg_manager)
 
     # Success messages
     logger.info(f"Strategy deployed successfully to {resolved_output_dir}")

--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -814,6 +814,47 @@ def _create_metadata(stg_name: str, git_info: ReleaseInfo, release_dir: str) -> 
         fs.write(f"Commit: {git_info.commit}\n")
 
 
+def _clean_pyproject_for_release(pyproject_data: dict) -> dict:
+    """
+    Remove dev-only and local-path-dependent sections from pyproject.toml for release.
+
+    Removes:
+    - [tool.uv.sources] - local editable paths won't work in release
+    - [dependency-groups] - dev dependencies not needed in release
+    - [project.optional-dependencies] - may reference local-only packages
+    - Dev tool configs ([tool.pytest], [tool.ruff], etc.)
+
+    Preserves:
+    - [[tool.uv.index]] - needed for private registry access
+    - [build-system] - needed for package building
+    - [tool.poetry] - needed for poetry build backend
+    """
+    # Remove [tool.uv.sources] (local paths won't work in release)
+    if "tool" in pyproject_data and "uv" in pyproject_data["tool"]:
+        if "sources" in pyproject_data["tool"]["uv"]:
+            del pyproject_data["tool"]["uv"]["sources"]
+            logger.debug("Removed [tool.uv.sources] from release pyproject.toml")
+
+    # Remove [dependency-groups] (dev deps not needed in release)
+    if "dependency-groups" in pyproject_data:
+        del pyproject_data["dependency-groups"]
+        logger.debug("Removed [dependency-groups] from release pyproject.toml")
+
+    # Remove [project.optional-dependencies] (may reference local-only packages)
+    if "project" in pyproject_data and "optional-dependencies" in pyproject_data["project"]:
+        del pyproject_data["project"]["optional-dependencies"]
+        logger.debug("Removed [project.optional-dependencies] from release pyproject.toml")
+
+    # Remove dev tool configs
+    if "tool" in pyproject_data:
+        for key in ["pytest", "ruff", "semantic_release"]:
+            if key in pyproject_data["tool"]:
+                del pyproject_data["tool"][key]
+                logger.debug(f"Removed [tool.{key}] from release pyproject.toml")
+
+    return pyproject_data
+
+
 def _modify_pyproject_toml(pyproject_path: str, package_name: str) -> None:
     """
     Modify the pyproject.toml file to include the project package as a dependency.
@@ -830,6 +871,9 @@ def _modify_pyproject_toml(pyproject_path: str, package_name: str) -> None:
         # Read the existing pyproject.toml
         with open(pyproject_path, "r") as f:
             pyproject_data = toml.load(f)
+
+        # Clean up dev-only and local-path-dependent sections
+        pyproject_data = _clean_pyproject_for_release(pyproject_data)
 
         # Handle PEP 621 format
         if "project" in pyproject_data:
@@ -936,6 +980,9 @@ def _configure_pyproject_for_external_deps(pyproject_path: str, packages: list[s
         # Read existing pyproject.toml
         with open(pyproject_path, "r") as f:
             pyproject_data = toml.load(f)
+
+        # Clean up dev-only and local-path-dependent sections
+        pyproject_data = _clean_pyproject_for_release(pyproject_data)
 
         # Handle PEP 621 format
         if "project" in pyproject_data:

--- a/tests/qubx/cli/deploy_test.py
+++ b/tests/qubx/cli/deploy_test.py
@@ -266,9 +266,9 @@ class TestStrategy:
     def test_deploy_strategy_missing_uv_lock(self, mock_subprocess, mock_exists, temp_dir, mock_zip_file):
         """Test deploy_strategy with missing uv.lock file."""
 
-        # Mock os.path.exists to return False for uv.lock and True for everything else
+        # Mock os.path.exists to return False for lock files and True for everything else
         def mock_exists_side_effect(path):
-            if path.endswith("uv.lock"):
+            if path.endswith("uv.lock") or path.endswith("poetry.lock"):
                 return False
             return True
 
@@ -292,9 +292,9 @@ class TestStrategy:
     def test_deploy_strategy_uv_lock_error(self, mock_subprocess, mock_exists, temp_dir, mock_zip_file):
         """Test deploy_strategy with an error during uv lock generation."""
 
-        # Mock os.path.exists to return False for uv.lock and True for everything else
+        # Mock os.path.exists to return False for lock files and True for everything else
         def mock_exists_side_effect(path):
-            if path.endswith("uv.lock"):
+            if path.endswith("uv.lock") or path.endswith("poetry.lock"):
                 return False
             return True
 
@@ -322,7 +322,7 @@ class TestStrategy:
 
         # Mock os.path.exists for different paths
         def mock_exists_side_effect(path):
-            if path.endswith("uv.lock"):
+            if path.endswith("uv.lock") or path.endswith("poetry.lock"):
                 return False
             elif path.endswith(Path(mock_zip_file).stem):  # Output directory
                 return False
@@ -366,7 +366,7 @@ class TestStrategy:
 
         # Mock os.path.exists for different paths
         def mock_exists_side_effect(path):
-            if path.endswith("uv.lock"):
+            if path.endswith("uv.lock") or path.endswith("poetry.lock"):
                 return False
             elif path.endswith(Path(mock_zip_file).stem):  # Output directory
                 return False


### PR DESCRIPTION
Auto-detect package manager (uv vs poetry) from lock file in release
zip and route to the appropriate deploy flow. This allows deploying
old Poetry-based releases alongside new uv-based ones.