### PR TITLE
feat: platform integration - release fix, Docker, health, logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.venv
+__pycache__
+*.pyc
+*.so
+*.pyd
+build/
+dist/
+*.egg-info
+.ruff_cache
+.pytest_cache
+tests/
+docs/
+examples/
+research/
+scripts/
+.github/

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -213,9 +213,40 @@ jobs:
         if: steps.check_version.outputs.exists != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  build-docker:
+    name: Build and push Docker image
+    needs: [publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          build-args: QUBX_VERSION=${{ steps.get_version.outputs.VERSION }}
+          tags: |
+            ghcr.io/xlydiansoftware/qubx:${{ steps.get_version.outputs.VERSION }}
+            ghcr.io/xlydiansoftware/qubx:latest
+
   github-release:
     name: Create GitHub Release
-    needs: [publish-pypi]
+    needs: [publish-pypi, build-docker]
     # Only create releases for stable versions (no rc/dev in tag)
     if: ${{ !contains(github.ref, 'rc') && !contains(github.ref, 'dev') }}
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+ARG QUBX_VERSION
+
+# Install qubx with k8 extra (prometheus-client) and uv for strategy dep management
+RUN pip install --no-cache-dir "qubx[k8]==${QUBX_VERSION}" uv boto3
+
+WORKDIR /app
+
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+STRATEGY_DIR="/app/strategy"
+
+# 1. Download strategy artifact if URL is set
+if [ -n "$STRATEGY_ARTIFACT_URL" ]; then
+    echo "Downloading strategy from $STRATEGY_ARTIFACT_URL"
+    ARTIFACT_FILE="/tmp/strategy.zip"
+
+    if [[ "$STRATEGY_ARTIFACT_URL" == s3://* ]]; then
+        python -c "
+import boto3
+url = '$STRATEGY_ARTIFACT_URL'
+bucket = url.split('/')[2]
+key = '/'.join(url.split('/')[3:])
+boto3.client('s3').download_file(bucket, key, '$ARTIFACT_FILE')
+print(f'Downloaded from s3://{bucket}/{key}')
+"
+    elif [[ "$STRATEGY_ARTIFACT_URL" == http* ]]; then
+        python -c "
+import urllib.request
+urllib.request.urlretrieve('$STRATEGY_ARTIFACT_URL', '$ARTIFACT_FILE')
+print('Downloaded from $STRATEGY_ARTIFACT_URL')
+"
+    elif [ -f "$STRATEGY_ARTIFACT_URL" ]; then
+        ARTIFACT_FILE="$STRATEGY_ARTIFACT_URL"
+    else
+        echo "ERROR: Cannot handle artifact URL: $STRATEGY_ARTIFACT_URL"
+        exit 1
+    fi
+
+    # 2. Deploy using qubx deploy (unzip + uv sync + env setup)
+    echo "Deploying strategy..."
+    qubx deploy "$ARTIFACT_FILE" -o "$STRATEGY_DIR"
+fi
+
+# 3. Build run command
+CONFIG="${STRATEGY_CONFIG_PATH:-$STRATEGY_DIR/config.yml}"
+ARGS="run $CONFIG"
+
+if [ "$QUBX_PAPER" = "true" ]; then
+    ARGS="$ARGS --paper"
+fi
+
+if [ -f /app/overrides.yml ]; then
+    ARGS="$ARGS --override /app/overrides.yml"
+fi
+
+# 4. Run from strategy dir so uv activates the deployed venv
+echo "Starting: qubx $ARGS"
+cd "$STRATEGY_DIR"
+exec uv run qubx $ARGS

--- a/src/qubx/__init__.py
+++ b/src/qubx/__init__.py
@@ -38,9 +38,21 @@ def formatter(record):
     if record["level"].name in {"WARNING", "SNAKY"}:
         fmt = "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - %s" % fmt
 
+    # Platform identity prefix (bot_id / instance_id if bound)
+    identity = ""
+    bot_id = record["extra"].get("bot_id")
+    instance_id = record["extra"].get("instance_id")
+    if bot_id or instance_id:
+        parts = []
+        if bot_id:
+            parts.append(f"bot={bot_id}")
+        if instance_id:
+            parts.append(f"inst={instance_id}")
+        identity = "<magenta>[%s]</magenta> " % " ".join(parts)
+
     prefix = (
-        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> [ <level>%s</level> ] <cyan>({module})</cyan> "
-        % record["level"].icon
+        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> [ <level>%s</level> ] %s<cyan>({module})</cyan> "
+        % (record["level"].icon, identity)
     )
 
     if record["exception"] is not None:
@@ -95,6 +107,18 @@ class QubxLogConfig:
             diagnose=True,
         )
         logger = logger.opt(colors=colorize)
+
+    @staticmethod
+    def bind_platform_identity(bot_id: str | None = None, instance_id: str | None = None):
+        """Bind platform identity fields (bot_id, instance_id) to all subsequent log messages."""
+        global logger
+        extra = {}
+        if bot_id:
+            extra["bot_id"] = bot_id
+        if instance_id:
+            extra["instance_id"] = instance_id
+        if extra:
+            logger = logger.bind(**extra)
 
 
 QubxLogConfig.setup_logger()

--- a/src/qubx/__init__.py
+++ b/src/qubx/__init__.py
@@ -32,14 +32,8 @@ def runtime_env():
         return "python"  # Probably standard Python interpreter
 
 
-def formatter(record):
-    end = record["extra"].get("end", "\n")
-    fmt = "<lvl>{message}</lvl>%s" % end
-    if record["level"].name in {"WARNING", "SNAKY"}:
-        fmt = "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - %s" % fmt
-
-    # Platform identity prefix (bot_id / instance_id if bound)
-    identity = ""
+def format_platform_identity(record) -> str:
+    """Return a colored identity prefix from record extras (bot_id / instance_id)."""
     bot_id = record["extra"].get("bot_id")
     instance_id = record["extra"].get("instance_id")
     if bot_id or instance_id:
@@ -48,8 +42,17 @@ def formatter(record):
             parts.append(f"bot={bot_id}")
         if instance_id:
             parts.append(f"inst={instance_id}")
-        identity = "<magenta>[%s]</magenta> " % " ".join(parts)
+        return "<magenta>[%s]</magenta> " % " ".join(parts)
+    return ""
 
+
+def formatter(record):
+    end = record["extra"].get("end", "\n")
+    fmt = "<lvl>{message}</lvl>%s" % end
+    if record["level"].name in {"WARNING", "SNAKY"}:
+        fmt = "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - %s" % fmt
+
+    identity = format_platform_identity(record)
     prefix = (
         "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> [ <level>%s</level> ] %s<cyan>({module})</cyan> "
         % (record["level"].icon, identity)
@@ -110,15 +113,14 @@ class QubxLogConfig:
 
     @staticmethod
     def bind_platform_identity(bot_id: str | None = None, instance_id: str | None = None):
-        """Bind platform identity fields (bot_id, instance_id) to all subsequent log messages."""
-        global logger
-        extra = {}
-        if bot_id:
-            extra["bot_id"] = bot_id
-        if instance_id:
-            extra["instance_id"] = instance_id
-        if extra:
-            logger = logger.bind(**extra)
+        """Bind platform identity fields (bot_id, instance_id) to all log messages globally."""
+        def patcher(record):
+            if bot_id:
+                record["extra"]["bot_id"] = bot_id
+            if instance_id:
+                record["extra"]["instance_id"] = instance_id
+
+        logger.configure(patcher=patcher)
 
 
 QubxLogConfig.setup_logger()

--- a/src/qubx/__init__.py
+++ b/src/qubx/__init__.py
@@ -1,3 +1,4 @@
+import json as _json
 import os
 import sys
 from typing import Callable
@@ -85,6 +86,38 @@ class QubxLogConfig:
         os.environ["QUBX_LOG_LEVEL"] = level
         QubxLogConfig.setup_logger(level)
 
+    _COLOR_TAG_RE = None
+
+    @staticmethod
+    def _strip_color_tags(text: str) -> str:
+        """Remove loguru color markup tags like <yellow>...</yellow> from text."""
+        import re
+
+        if QubxLogConfig._COLOR_TAG_RE is None:
+            QubxLogConfig._COLOR_TAG_RE = re.compile(r"</?[a-z_]+>")
+        return QubxLogConfig._COLOR_TAG_RE.sub("", text)
+
+    @staticmethod
+    def _json_sink(message):
+        """Emit one JSON line per log record for Loki/Promtail ingestion."""
+        record = message.record
+        entry = {
+            "timestamp": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "level": record["level"].name,
+            "module": record["module"],
+            "function": record["function"],
+            "line": record["line"],
+            "message": QubxLogConfig._strip_color_tags(record["message"]),
+        }
+        # Merge platform identity and any other extras (skip internal loguru keys)
+        for key, val in record["extra"].items():
+            if key not in ("user", "end", "stack"):
+                entry[key] = val
+        if record["exception"] is not None:
+            entry["exception"] = stackprinter.format(record["exception"], style="plaintext")
+        sys.stdout.write(_json.dumps(entry, default=str) + "\n")
+        sys.stdout.flush()
+
     @staticmethod
     def setup_logger(level: str | None = None, custom_formatter: Callable | None = None, colorize: bool = True):
         global logger
@@ -99,7 +132,21 @@ class QubxLogConfig:
         logger.remove(None)
 
         level = level or QubxLogConfig.get_log_level()
-        # Add stdout handler with enqueue=True for thread/process safety
+
+        # Check if JSON format is requested (for Loki/container deployments)
+        log_format = os.getenv("QUBX_LOG_FORMAT", "text").lower()
+        if log_format == "json":
+            logger.add(
+                QubxLogConfig._json_sink,
+                level=level,
+                enqueue=True,
+                backtrace=True,
+                diagnose=True,
+            )
+            # No colorize opt needed for JSON
+            return
+
+        # Default: human-readable text format
         logger.add(
             sys.stdout,
             format=custom_formatter or formatter,

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -133,8 +133,10 @@ class SimulatedLogFormatter:
         else:
             now = self.time_provider.time().astype("datetime64[us]").item().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
-        # prefix = "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> [ <level>%s</level> ] " % record["level"].icon
-        prefix = f"<lc>{now}</lc> [<level>{record['level'].icon}</level>] <cyan>({{module}})</cyan> "
+        from qubx import format_platform_identity
+
+        identity = format_platform_identity(record)
+        prefix = f"<lc>{now}</lc> [<level>{record['level'].icon}</level>] {identity}<cyan>({{module}})</cyan> "
 
         if record["exception"] is not None:
             record["extra"]["stack"] = stackprinter.format(record["exception"], style="darkbg3")

--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -109,6 +109,7 @@ def main(debug: bool, debug_port: int, log_level: str):
 @click.option("--no-emission", is_flag=True, default=False, help="Disable metric emission.", show_default=True)
 @click.option("--no-notifiers", is_flag=True, default=False, help="Disable lifecycle notifiers.", show_default=True)
 @click.option("--no-exporters", is_flag=True, default=False, help="Disable trade exporters.", show_default=True)
+@click.option("--override", type=Path, default=None, help="Sparse YAML file to deep-merge on top of config.", show_default=False)
 def run(
     config_file: Path,
     account_file: Path | None,
@@ -127,6 +128,7 @@ def run(
     no_emission: bool,
     no_notifiers: bool,
     no_exporters: bool,
+    override: Path | None,
 ):
     """
     Starts the strategy with the given configuration file. If paper mode is enabled, account is not required.
@@ -210,6 +212,7 @@ def run(
             no_emission=no_emission,
             no_notifiers=no_notifiers,
             no_exporters=no_exporters,
+            config_overrides=override,
         )
 
 

--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -534,9 +534,9 @@ def release_strategy(
             config_file=config_file,
         )
     except ValueError as e:
-        logger.error(f"<r>{str(e)}</r>")
+        logger.error(f"<r>{str(e).replace('<', chr(92) + '<')}</r>")
     except Exception as e:
-        logger.error(f"<r>Error releasing strategy: {e}</r>")
+        logger.error(f"<r>Error releasing strategy: {str(e).replace('<', chr(92) + '<')}</r>")
 
 
 def create_released_pack(
@@ -814,7 +814,217 @@ def _create_metadata(stg_name: str, git_info: ReleaseInfo, release_dir: str) -> 
         fs.write(f"Commit: {git_info.commit}\n")
 
 
-def _clean_pyproject_for_release(pyproject_data: dict) -> dict:
+def _version_exists_on_pypi(pkg_name: str, version: str) -> bool:
+    """Check if a specific package version is available on public PyPI."""
+    import urllib.request
+
+    try:
+        url = f"https://pypi.org/pypi/{pkg_name}/{version}/json"
+        with urllib.request.urlopen(url, timeout=5) as response:
+            return response.status == 200
+    except Exception:
+        return False
+
+
+def _get_index_url(index_name: str, pyproject_data: dict) -> str | None:
+    """Get URL for a named uv index from [[tool.uv.index]] entries."""
+    indexes = pyproject_data.get("tool", {}).get("uv", {}).get("index", [])
+    for idx in indexes:
+        if idx.get("name") == index_name:
+            return idx.get("url")
+    return None
+
+
+def _find_version_in_pyproject(pkg_name: str, pyproject_data: dict) -> str | None:
+    """
+    Find a package's pinned version from pyproject.toml deps (regular + optional).
+    Returns the version string (e.g. "0.1.0") or None if not found.
+    """
+    all_deps: list[str] = list(pyproject_data.get("project", {}).get("dependencies", []))
+    for group_deps in pyproject_data.get("project", {}).get("optional-dependencies", {}).values():
+        all_deps.extend(group_deps)
+
+    for dep in all_deps:
+        dep_pkg = dep.split(">=")[0].split("==")[0].split("<")[0].strip()
+        if dep_pkg.lower() == pkg_name.lower():
+            if "==" in dep:
+                return dep.split("==")[1].strip()
+            if ">=" in dep:
+                return dep.split(">=")[1].split(",")[0].strip()
+    return None
+
+
+def _bundle_source_overrides(
+    pyproject_data: dict,
+    pyproject_root: str,
+    release_dir: str,
+    required_packages: set[str],
+) -> list[str]:
+    """
+    For each [tool.uv.sources] entry that is required by this release:
+    - path source + installed version on public PyPI → skip (will resolve from PyPI)
+    - path source + NOT on public PyPI → build wheel from local path and bundle in wheels/
+    - index source (private registry) → download wheel from that index and bundle in wheels/
+
+    Returns list of bundled package names (lowercase).
+    """
+    import subprocess
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as get_version
+
+    sources = pyproject_data.get("tool", {}).get("uv", {}).get("sources", {})
+    if not sources:
+        return []
+
+    wheels_dir = os.path.join(release_dir, "wheels")
+    bundled: list[str] = []
+
+    for pkg_name, source in sources.items():
+        if pkg_name.lower() not in required_packages:
+            continue
+
+        if "path" in source:
+            local_path = os.path.normpath(os.path.join(pyproject_root, source["path"]))
+
+            try:
+                installed_ver = get_version(pkg_name)
+            except PackageNotFoundError:
+                logger.warning(f"  {pkg_name} not installed, skipping bundle")
+                continue
+
+            if _version_exists_on_pypi(pkg_name, installed_ver):
+                logger.info(f"  {pkg_name}=={installed_ver} found on public PyPI, will resolve from registry")
+                continue
+
+            logger.info(f"  Bundling {pkg_name}=={installed_ver} from local path {local_path} ...")
+            os.makedirs(wheels_dir, exist_ok=True)
+            try:
+                # Run from the package's own directory so uv reads its [tool.uv.sources]
+                # (needed when the package has local-path build deps like qubx)
+                subprocess.run(
+                    ["uv", "build", "--wheel", ".", "--out-dir", wheels_dir],
+                    cwd=local_path,
+                    check=True, capture_output=True, text=True,
+                )
+                # Warn if the wheel is platform-specific (compiled extensions)
+                for whl in os.listdir(wheels_dir):
+                    if whl.lower().startswith(pkg_name.lower().replace("-", "_")) and "none-any" not in whl:
+                        logger.warning(
+                            f"  {whl} is platform-specific. "
+                            "Ensure the container architecture matches the build machine."
+                        )
+                bundled.append(pkg_name.lower())
+                logger.info(f"  Bundled {pkg_name}")
+            except subprocess.CalledProcessError as e:
+                err_msg = (e.stderr or str(e)).replace("<", r"\<")
+                logger.warning(f"  Failed to build wheel for {pkg_name}: {err_msg}")
+
+        elif "index" in source:
+            index_name = source["index"]
+            index_url = _get_index_url(index_name, pyproject_data)
+            if not index_url:
+                logger.warning(f"  Index '{index_name}' not found in [[tool.uv.index]] (needed for {pkg_name})")
+                continue
+
+            try:
+                installed_ver = get_version(pkg_name)
+            except PackageNotFoundError:
+                # Package not installed (e.g. optional dep not synced) — fall back to
+                # the version declared in pyproject optional-deps or regular deps
+                installed_ver = _find_version_in_pyproject(pkg_name, pyproject_data)
+                if not installed_ver:
+                    logger.warning(
+                        f"  {pkg_name} not installed and no version found in pyproject deps, skipping bundle"
+                    )
+                    continue
+                logger.info(f"  {pkg_name} not installed; using declared version {installed_ver} from pyproject")
+
+            if _version_exists_on_pypi(pkg_name, installed_ver):
+                logger.info(f"  {pkg_name}=={installed_ver} found on public PyPI, will resolve from registry")
+                continue
+
+            logger.info(f"  Downloading {pkg_name}=={installed_ver} from private index '{index_name}' ...")
+            os.makedirs(wheels_dir, exist_ok=True)
+            try:
+                import shutil
+
+                pip_exe = shutil.which("pip") or shutil.which("pip3")
+                if not pip_exe:
+                    raise RuntimeError("pip not found — cannot download wheel from private index")
+                subprocess.run(
+                    [
+                        pip_exe, "download",
+                        f"{pkg_name}=={installed_ver}",
+                        "--index-url", index_url,
+                        "--dest", wheels_dir,
+                        "--no-deps",
+                        "--quiet",
+                    ],
+                    check=True, capture_output=True, text=True,
+                )
+                bundled.append(pkg_name.lower())
+                logger.info(f"  Downloaded {pkg_name}=={installed_ver}")
+            except subprocess.CalledProcessError as e:
+                err_msg = (e.stderr or str(e)).replace("<", r"\<")
+                logger.warning(f"  Failed to download wheel for {pkg_name}: {err_msg}")
+
+    return bundled
+
+
+def _get_plugin_deps(stg_config: "StrategyConfig", pyproject_data: dict) -> list[str]:
+    """
+    Extract package dependency specs for plugin modules listed in the strategy config.
+
+    Maps plugin module names (e.g. qubx_lighter) to package specs
+    (e.g. qubx-lighter==0.1.0) by looking in [project.optional-dependencies].
+    Falls back to the installed version if not found there.
+
+    Returns list of dep specs like ["qubx-lighter==0.1.0"].
+    """
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as get_version
+
+    if not stg_config.plugins or not stg_config.plugins.modules:
+        return []
+
+    optional_deps: dict[str, list[str]] = pyproject_data.get("project", {}).get("optional-dependencies", {})
+
+    plugin_deps: list[str] = []
+    for module_name in stg_config.plugins.modules:
+        pkg_name = module_name.replace("_", "-")
+
+        # Search in optional-dependency groups first
+        found = False
+        for group_name, group_deps in optional_deps.items():
+            for dep in group_deps:
+                dep_pkg = dep.split(">=")[0].split("==")[0].split("<")[0].strip()
+                if dep_pkg.lower() == pkg_name.lower():
+                    plugin_deps.append(dep)
+                    logger.info(f"  Plugin '{module_name}' -> adding '{dep}' (from optional-deps [{group_name}])")
+                    found = True
+                    break
+            if found:
+                break
+
+        if not found:
+            try:
+                ver = get_version(pkg_name)
+                spec = f"{pkg_name}>={ver}"
+                plugin_deps.append(spec)
+                logger.warning(
+                    f"  Plugin '{module_name}' not in optional-deps; "
+                    f"adding '{spec}' from installed packages"
+                )
+            except PackageNotFoundError:
+                logger.warning(
+                    f"  Plugin '{module_name}' ({pkg_name}) not found in "
+                    "optional-deps or installed packages - skipping"
+                )
+
+    return plugin_deps
+
+
+def _clean_pyproject_for_release(pyproject_data: dict, bundled_packages: list[str] | None = None) -> dict:
     """
     Remove dev-only and local-path-dependent sections from pyproject.toml for release.
 
@@ -852,10 +1062,24 @@ def _clean_pyproject_for_release(pyproject_data: dict) -> dict:
                 del pyproject_data["tool"][key]
                 logger.debug(f"Removed [tool.{key}] from release pyproject.toml")
 
+    # If any wheels were bundled, add find-links so uv can resolve them
+    if bundled_packages:
+        if "tool" not in pyproject_data:
+            pyproject_data["tool"] = {}
+        if "uv" not in pyproject_data["tool"]:
+            pyproject_data["tool"]["uv"] = {}
+        pyproject_data["tool"]["uv"]["find-links"] = ["./wheels"]
+        logger.debug("Added find-links = ['./wheels'] to [tool.uv]")
+
     return pyproject_data
 
 
-def _modify_pyproject_toml(pyproject_path: str, package_name: str) -> None:
+def _modify_pyproject_toml(
+    pyproject_path: str,
+    package_name: str,
+    bundled_packages: list[str] | None = None,
+    plugin_deps: list[str] | None = None,
+) -> None:
     """
     Modify the pyproject.toml file to include the project package as a dependency.
 
@@ -873,7 +1097,7 @@ def _modify_pyproject_toml(pyproject_path: str, package_name: str) -> None:
             pyproject_data = toml.load(f)
 
         # Clean up dev-only and local-path-dependent sections
-        pyproject_data = _clean_pyproject_for_release(pyproject_data)
+        pyproject_data = _clean_pyproject_for_release(pyproject_data, bundled_packages)
 
         # Handle PEP 621 format
         if "project" in pyproject_data:
@@ -895,6 +1119,18 @@ def _modify_pyproject_toml(pyproject_path: str, package_name: str) -> None:
                         deps[i] = f"{dep_name}>={version(dep_name)}"
                     except Exception:
                         pass
+
+            # Add plugin dependencies (from config's plugins.modules)
+            if plugin_deps:
+                for pdep in plugin_deps:
+                    pdep_pkg = pdep.split(">=")[0].split("==")[0].split("<")[0].strip().lower()
+                    already_present = any(
+                        d.split(">=")[0].split("==")[0].split("<")[0].strip().lower() == pdep_pkg
+                        for d in deps
+                    )
+                    if not already_present:
+                        deps.append(pdep)
+                        logger.debug(f"Added plugin dep: {pdep}")
 
             # Check if build-system section exists
             if "build-system" not in pyproject_data:
@@ -1095,13 +1331,10 @@ def _handle_project_files(
 ) -> None:
     """
     Handle project files like pyproject.toml and generate lock file.
-
-    Args:
-        pyproject_root: Root directory containing pyproject.toml
-        release_dir: Destination directory for release
-        stg_info: Strategy info with config (optional, for dependency extraction)
     """
-    # Copy pyproject.toml if it exists
+    import toml
+
+    # Copy pyproject.toml
     pyproject_src = os.path.join(pyproject_root, "pyproject.toml")
     if not os.path.exists(pyproject_src):
         raise FileNotFoundError(f"pyproject.toml not found in {pyproject_root}")
@@ -1110,25 +1343,51 @@ def _handle_project_files(
     logger.debug(f"Copying pyproject.toml from {pyproject_src} to {pyproject_dest}")
     shutil.copy2(pyproject_src, pyproject_dest)
 
-    # If no classes exist, configure pyproject.toml for external dependencies only
+    # Read original data once for analysis (before any modifications)
+    with open(pyproject_dest, "r") as f:
+        pyproject_data = toml.load(f)
+
+    # --- Plugin deps from config ---
+    plugin_deps: list[str] = []
+    if stg_info and stg_info.config:
+        plugin_deps = _get_plugin_deps(stg_info.config, pyproject_data)
+        if plugin_deps:
+            logger.info(f"Plugin dependencies from config: {plugin_deps}")
+
+    # --- Build required_packages set for targeted bundling ---
+    # Start from declared project deps
+    required_packages: set[str] = set()
+    for dep in pyproject_data.get("project", {}).get("dependencies", []):
+        name = dep.split(">=")[0].split("==")[0].split("<")[0].strip().lower()
+        required_packages.add(name)
+    # Add plugin packages
+    for pdep in plugin_deps:
+        name = pdep.split(">=")[0].split("==")[0].split("<")[0].strip().lower()
+        required_packages.add(name)
+
+    # --- Bundle private/local wheels ---
+    bundled_packages: list[str] = []
+    if required_packages:
+        logger.info("Resolving private/local source dependencies...")
+        bundled_packages = _bundle_source_overrides(pyproject_data, pyproject_root, release_dir, required_packages)
+        if bundled_packages:
+            logger.info(f"Bundled {len(bundled_packages)} package(s): {', '.join(bundled_packages)}")
+
+    # --- Handle external-deps-only configs (no custom strategy classes) ---
     if stg_info and not stg_info.classes:
         current_package = get_project_package_name(pyproject_root)
         external_deps = extract_external_dependencies(stg_info.config, current_package)
-
         if external_deps:
             logger.info(f"Configuring pyproject.toml for external dependencies: {external_deps}")
             _configure_pyproject_for_external_deps(pyproject_dest, external_deps)
 
-    # Copy build.py if it exists
+    # --- Copy build.py ---
     build_src = os.path.join(pyproject_root, "build.py")
     if not os.path.exists(build_src):
         logger.info(f"build.py not found in {pyproject_root} using default one")
         build_src = load_qubx_resources_as_text("_build.py")
-
-        # - setup project's name in default build.py
         prj_name = os.path.basename(pyproject_root)
         build_src = build_src.replace("<<PROJECT_NAME>>", prj_name)
-
         with open(os.path.join(release_dir, "build.py"), "wt") as fs:
             fs.write(build_src)
     else:
@@ -1136,13 +1395,11 @@ def _handle_project_files(
         logger.debug(f"Copying build.py from {build_src} to {build_dest}")
         shutil.copy2(build_src, build_dest)
 
-    # Get the basename of the pyproject_root as the package name
+    # --- Modify pyproject: clean sources, pin versions, add find-links + plugin deps ---
     package_name = os.path.basename(pyproject_root)
+    _modify_pyproject_toml(pyproject_dest, package_name, bundled_packages=bundled_packages, plugin_deps=plugin_deps)
 
-    # Modify the pyproject.toml to include the project package
-    _modify_pyproject_toml(pyproject_dest, package_name)
-
-    # Generate the uv.lock file
+    # --- Generate lock file ---
     _generate_lock_file(release_dir)
 
 

--- a/src/qubx/config.py
+++ b/src/qubx/config.py
@@ -86,6 +86,14 @@ class QubxSettings(BaseSettings):
     instrument_lookup: LookupConfig = LookupConfig()
     fees_lookup: LookupConfig = LookupConfig()
 
+    # Platform integration (all settable via QUBX_* env vars or ~/.qubx/config.json)
+    account_file: str | None = None
+    bot_id: str | None = None
+    instance_id: str | None = None
+    metrics_port: int | None = None
+    health_port: int | None = None
+    log_format: str = "text"  # "text" or "json"
+
     model_config = {"env_prefix": "QUBX_", "env_nested_delimiter": "__"}
 
     @classmethod

--- a/src/qubx/health/__init__.py
+++ b/src/qubx/health/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseHealthMonitor
 from .dummy import DummyHealthMonitor
+from .server import HealthServer
 
-__all__ = ["BaseHealthMonitor", "DummyHealthMonitor"]
+__all__ = ["BaseHealthMonitor", "DummyHealthMonitor", "HealthServer"]

--- a/src/qubx/health/server.py
+++ b/src/qubx/health/server.py
@@ -1,0 +1,67 @@
+"""Lightweight HTTP health/readiness server for k8s probes.
+
+Activated by QUBX_HEALTH_PORT env var or --health-port CLI flag.
+Runs in a daemon thread, no external dependencies.
+
+Endpoints:
+    GET /health → 200 if process alive (liveness probe)
+    GET /ready  → 200 after on_warmup_finished; 503 during warmup (readiness probe)
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from qubx import logger
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler for /health and /ready."""
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._respond(200, {"status": "ok"})
+        elif self.path == "/ready":
+            if self.server.ready_check():
+                self._respond(200, {"status": "ready"})
+            else:
+                self._respond(503, {"status": "not_ready"})
+        else:
+            self._respond(404, {"error": "not_found"})
+
+    def _respond(self, code: int, body: dict):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def log_message(self, format, *args):
+        # Silence default stderr logging from BaseHTTPRequestHandler
+        pass
+
+
+class HealthServer:
+    """Runs /health + /ready endpoints in a background daemon thread."""
+
+    def __init__(self, port: int, ready_check: callable = lambda: False):
+        """
+        Args:
+            port: TCP port to listen on
+            ready_check: Callable that returns True when the strategy is ready
+        """
+        self._port = port
+        self._ready_check = ready_check
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self):
+        self._server = HTTPServer(("0.0.0.0", self._port), _HealthHandler)
+        self._server.ready_check = self._ready_check
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        logger.info(f"Health server started on port {self._port} (/health, /ready)")
+
+    def stop(self):
+        if self._server:
+            self._server.shutdown()
+            logger.debug("Health server stopped")

--- a/src/qubx/utils/runner/accounts.py
+++ b/src/qubx/utils/runner/accounts.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import toml
@@ -72,10 +71,10 @@ class AccountConfigurationManager:
         self._config_paths = [Path("~/.qubx/accounts.toml").expanduser()] if search_qubx_dir else []
         if strategy_dir:
             self._config_paths.append(strategy_dir / "accounts.toml")
-        # QUBX_ACCOUNT_FILE env var — between strategy_dir and explicit CLI flag
-        env_account_file = os.environ.get("QUBX_ACCOUNT_FILE")
-        if env_account_file:
-            self._config_paths.append(Path(env_account_file).expanduser())
+        # QUBX_ACCOUNT_FILE from unified settings (env var or config.json)
+        from qubx.config import settings
+        if settings.account_file:
+            self._config_paths.append(Path(settings.account_file).expanduser())
         if account_config:
             self._config_paths.append(account_config)
         self._config_paths = [config for config in self._config_paths if config.exists()]

--- a/src/qubx/utils/runner/accounts.py
+++ b/src/qubx/utils/runner/accounts.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import toml
@@ -71,6 +72,10 @@ class AccountConfigurationManager:
         self._config_paths = [Path("~/.qubx/accounts.toml").expanduser()] if search_qubx_dir else []
         if strategy_dir:
             self._config_paths.append(strategy_dir / "accounts.toml")
+        # QUBX_ACCOUNT_FILE env var — between strategy_dir and explicit CLI flag
+        env_account_file = os.environ.get("QUBX_ACCOUNT_FILE")
+        if env_account_file:
+            self._config_paths.append(Path(env_account_file).expanduser())
         if account_config:
             self._config_paths.append(account_config)
         self._config_paths = [config for config in self._config_paths if config.exists()]

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -264,7 +264,22 @@ def resolve_aux_config(
         return normalize_aux_config(global_aux)
 
 
-def load_strategy_config_from_yaml(path: Path | str, key: str | None = None) -> StrategyConfig:
+def _deep_merge(base: dict, overrides: dict) -> dict:
+    """Deep-merge overrides into base. Dicts merge recursively, everything else replaces."""
+    merged = dict(base)
+    for key, val in overrides.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(val, dict):
+            merged[key] = _deep_merge(merged[key], val)
+        else:
+            merged[key] = val
+    return merged
+
+
+def load_strategy_config_from_yaml(
+    path: Path | str,
+    key: str | None = None,
+    overrides_path: Path | str | None = None,
+) -> StrategyConfig:
     """
     Loads a strategy configuration from a YAML file.
 
@@ -277,6 +292,7 @@ def load_strategy_config_from_yaml(path: Path | str, key: str | None = None) -> 
     Args:
         path (str | Path): The path to the YAML file.
         key (str | None): The key to extract from the YAML file.
+        overrides_path: Optional sparse YAML file to deep-merge on top of base config.
 
     Returns:
         StrategyConfig: The parsed configuration with env vars resolved.
@@ -288,6 +304,15 @@ def load_strategy_config_from_yaml(path: Path | str, key: str | None = None) -> 
         config_dict = yaml.safe_load(f)
         if key:
             config_dict = config_dict[key]
+
+        # Deep-merge overrides if provided
+        if overrides_path:
+            overrides_path = Path(os.path.expanduser(overrides_path))
+            if overrides_path.exists():
+                with overrides_path.open("r") as of:
+                    overrides_dict = yaml.safe_load(of) or {}
+                config_dict = _deep_merge(config_dict, overrides_dict)
+
         config_dict = resolve_env_vars_recursive(config_dict)
         return StrategyConfig(**config_dict)
 

--- a/src/qubx/utils/runner/factory.py
+++ b/src/qubx/utils/runner/factory.py
@@ -80,7 +80,10 @@ def construct_storage(storage_config: StorageConfig | None) -> IStorage | None:
 
 
 def create_metric_emitters(
-    emission_config: EmissionConfig, strategy_name: str, run_id: str | None = None
+    emission_config: EmissionConfig,
+    strategy_name: str,
+    run_id: str | None = None,
+    extra_tags: dict[str, str] | None = None,
 ) -> IMetricEmitter | None:
     """
     Create metric emitters from the configuration.
@@ -89,6 +92,7 @@ def create_metric_emitters(
         emission_config: Configuration for metric emission
         strategy_name: Name of the strategy to be included in tags
         run_id: Optional run ID to be included in tags
+        extra_tags: Additional tags to merge (e.g. bot_id, instance_id from platform)
 
     Returns:
         IMetricEmitter or None if no metric emitters are configured
@@ -132,6 +136,8 @@ def create_metric_emitters(
             tags["strategy"] = strategy_name
             if run_id is not None:
                 tags["run_id"] = run_id
+            if extra_tags:
+                tags.update(extra_tags)
 
             # Add tags if the emitter supports it
             if "tags" in inspect.signature(emitter_class).parameters:

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -262,6 +262,22 @@ def run_strategy(
         colorize=not no_color,
     )
 
+    # Start health server early so liveness probe works during init/warmup
+    from qubx.config import settings as _qubx_settings
+
+    _health_server = None
+    _health_ctx_ref: list[IStrategyContext | None] = [None]  # mutable ref for closure
+
+    if _qubx_settings.health_port:
+        from qubx.health import HealthServer
+
+        def _ready_check() -> bool:
+            c = _health_ctx_ref[0]
+            return c is not None and c._strategy_state.is_on_warmup_finished_called
+
+        _health_server = HealthServer(_qubx_settings.health_port, ready_check=_ready_check)
+        _health_server.start()
+
     # Restore state if configured
     restored_state = _restore_state(config.live.warmup.restorer if config.live.warmup else None) if restore else None
 
@@ -282,6 +298,7 @@ def run_strategy(
         no_notifiers=no_notifiers,
         no_exporters=no_exporters,
     )
+    _health_ctx_ref[0] = ctx  # expose to health server ready_check
 
     try:
         _run_warmup(
@@ -313,6 +330,8 @@ def run_strategy(
             logger.info("Stopped by user")
         finally:
             ctx.stop()
+            if _health_server:
+                _health_server.stop()
             _cleanup_event_loop(loop)
     else:
         ctx.start()

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -375,14 +375,42 @@ def create_strategy_context(
 
     _logging = _setup_strategy_logging(stg_name, config.live.logging, simulated_formatter, run_id)
 
+    # --- Platform identity from unified settings ---
+    from qubx.config import settings as qubx_settings
+
+    _bot_id = qubx_settings.bot_id
+    _instance_id = qubx_settings.instance_id or socket.gethostname()
+    _platform_tags: dict[str, str] = {}
+    if _bot_id:
+        _platform_tags["bot_id"] = _bot_id
+    _platform_tags["instance_id"] = _instance_id
+
+    # Bind platform identity to all log messages
+    QubxLogConfig.bind_platform_identity(_bot_id, _instance_id)
+
     # Create metric emitters with run_id as a tag
     if no_emission:
         logger.info("Metric emission disabled via CLI flag")
         _metric_emitter = None
     else:
         _metric_emitter = (
-            create_metric_emitters(config.live.emission, stg_name, run_id) if config.live.emission else None
+            create_metric_emitters(config.live.emission, stg_name, run_id, extra_tags=_platform_tags)
+            if config.live.emission
+            else None
         )
+
+        # Auto-enable Prometheus from QUBX_METRICS_PORT if no emitter was configured
+        if _metric_emitter is None and qubx_settings.metrics_port:
+            from qubx.emitters.prometheus import PrometheusMetricEmitter
+
+            _prom_tags = {"strategy": stg_name, "run_id": run_id or "", **_platform_tags}
+            _metric_emitter = PrometheusMetricEmitter(
+                strategy_name=stg_name,
+                expose_http=True,
+                http_port=qubx_settings.metrics_port,
+                tags=_prom_tags,
+            )
+            logger.info(f"Auto-enabled Prometheus metrics on port {qubx_settings.metrics_port} (QUBX_METRICS_PORT)")
 
     # Create lifecycle notifiers
     if no_notifiers:

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -113,6 +113,7 @@ def run_strategy_yaml(
     no_emission: bool = False,
     no_notifiers: bool = False,
     no_exporters: bool = False,
+    config_overrides: Path | None = None,
 ) -> IStrategyContext:
     """
     Run the strategy with the given configuration file.
@@ -133,7 +134,7 @@ def run_strategy_yaml(
     from qubx.plugins import load_plugins  # noqa: I001
 
     acc_manager = AccountConfigurationManager(account_file, config_file.parent, search_qubx_dir=True)
-    stg_config = load_strategy_config_from_yaml(config_file)
+    stg_config = load_strategy_config_from_yaml(config_file, overrides_path=config_overrides)
 
     # Load plugins from configuration
     load_plugins(stg_config.plugins)


### PR DESCRIPTION
## Summary

Complete platform integration for containerized k8s deployment. Fixes the broken release flow after the uv migration and adds all infrastructure needed for the bot container model.

### Changes

- **fix(release)**: Bundle private/local deps as wheels in release zip. Packages not on public PyPI (e.g. QuantKit from local path, qubx-lighter from private registry) are built/downloaded and placed in `wheels/` dir with `find-links` configured. Plugin modules from config are auto-detected and promoted from optional to required deps.

- **feat(accounts)**: `QUBX_ACCOUNT_FILE` env var support via unified `QubxSettings` (pydantic-settings). Resolution order: CLI flag > env var > config dir > ~/.qubx/.

- **feat(platform)**: `QUBX_METRICS_PORT` auto-enables PrometheusMetricEmitter with HTTP scrape endpoint. `QUBX_BOT_ID` / `QUBX_INSTANCE_ID` injected into all log lines and Prometheus tags.

- **feat(logging)**: `QUBX_LOG_FORMAT=json` switches all output to structured JSON lines for Loki/Promtail. Color tags stripped from messages.

- **feat(health)**: `/health` + `/ready` HTTP endpoints on `QUBX_HEALTH_PORT`. Liveness returns 200 immediately; readiness returns 503 until `on_warmup_finished` completes. Zero external deps (stdlib http.server).

- **feat(config)**: `--override overrides.yml` flag for deep-merging sparse YAML on top of base config. Dicts merge recursively, lists replace.

- **feat(docker)**: `Dockerfile` (python:3.12-slim + qubx[k8] + uv + boto3), `entrypoint.sh` (download artifact → qubx deploy → uv run qubx run), CI job in build-publish.yml pushes `ghcr.io/xlydiansoftware/qubx:{version}` on tag.

### All new env vars (via QubxSettings)

| Env Var | Purpose |
|---------|---------|
| `QUBX_ACCOUNT_FILE` | Path to accounts.toml |
| `QUBX_BOT_ID` | Bot identity in logs + metrics |
| `QUBX_INSTANCE_ID` | Instance identity (defaults to hostname) |
| `QUBX_METRICS_PORT` | Auto-enable Prometheus HTTP endpoint |
| `QUBX_HEALTH_PORT` | Enable /health + /ready endpoints |
| `QUBX_LOG_FORMAT` | `text` (default) or `json` |

## Test plan

- [x] `qubx release` on OKX config (no plugins) — bundles QuantKit wheel, uv lock succeeds
- [x] `qubx release` on Lighter config (with qubx_lighter plugin) — bundles both QuantKit + qubx-lighter wheels
- [x] `qubx deploy` on both release zips — installs successfully
- [x] Strategy run with `QUBX_BOT_ID` / `QUBX_INSTANCE_ID` — identity in all log lines
- [x] Strategy run with `QUBX_METRICS_PORT` — Prometheus auto-enabled, /metrics serves
- [x] Strategy run with `QUBX_HEALTH_PORT` — /health=200, /ready=503→200 lifecycle
- [x] Strategy run with `QUBX_LOG_FORMAT=json` — clean JSON lines
- [x] Docker build + container run with release zip — full deploy flow works
- [x] `--override` deep-merge — dicts merge, lists replace, missing keys preserved
- [x] Backwards compatible — no env vars set = identical behavior to before