### PR TITLE
Fix bitfinex optional import, ipywidgets to core, drop private index from release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "textual-serve>=1.0.0,<2",
     "jupyter-client>=8.0.0,<9",
     "ipykernel>=6.29.0,<7",
+    "ipywidgets>=8.1.5,<9",
     # Production monitoring & cloud
     "prometheus-client>=0.21.1,<1",
     "boto3>=1.34.0,<2",
@@ -94,7 +95,6 @@ viz = [
 jupyter = [
     "jupyter>=1.1.1,<2",
     "jupyter-console>=6.6.3,<7",
-    "ipywidgets>=8.1.5,<9",
 ]
 
 # ============================================================
@@ -160,7 +160,6 @@ dev = [
     "py-spy>=0.4.1,<1",
     # Jupyter / notebooks
     "ipykernel>=6.29.4,<7",
-    "iprogress>=0.4,<1",
     "nbformat>=5.10.4,<6",
     # Documentation
     "markdown==3.7",

--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -898,12 +898,6 @@ def _generate_release_pyproject(
         },
     }
 
-    # Preserve [[tool.uv.index]] from original pyproject (needed for private registry)
-    if pyproject_data:
-        indexes = pyproject_data.get("tool", {}).get("uv", {}).get("index", [])
-        if indexes:
-            release_pyproject["tool"]["uv"]["index"] = indexes
-
     pyproject_path = os.path.join(release_dir, "pyproject.toml")
     with open(pyproject_path, "w") as f:
         toml.dump(release_pyproject, f)

--- a/src/qubx/connectors/ccxt/exchanges/__init__.py
+++ b/src/qubx/connectors/ccxt/exchanges/__init__.py
@@ -9,8 +9,6 @@ import ccxt.pro as cxp
 from ..broker import CcxtBroker
 from .binance.broker import BinanceCcxtBroker
 from .binance.exchange import BINANCE_UM_MM, BinancePortfolioMargin, BinanceQV, BinanceQVUSDM
-from .bitfinex.bitfinex import BitfinexF
-from .bitfinex.bitfinex_account import BitfinexAccountProcessor
 from .gateio.gateio import GateioFutures
 from .hyperliquid.account import HyperliquidAccountProcessor
 from .hyperliquid.broker import HyperliquidCcxtBroker
@@ -19,6 +17,15 @@ from .kraken.kraken import CustomKrakenFutures
 from .okx.account import OkxAccountProcessor
 from .okx.broker import OkxCcxtBroker
 from .okx.okx import OkxFutures
+
+# Bitfinex requires optional qubx-bitfinex-api package
+try:
+    from .bitfinex.bitfinex import BitfinexF
+    from .bitfinex.bitfinex_account import BitfinexAccountProcessor
+
+    _HAS_BITFINEX = True
+except ImportError:
+    _HAS_BITFINEX = False
 
 
 @dataclass
@@ -59,7 +66,7 @@ CUSTOM_BROKERS: dict[str, BrokerConfig] = {
     "binance.um": BrokerConfig(BinanceCcxtBroker, {"enable_create_order_ws": True, "enable_cancel_order_ws": True}),
     "binance.cm": BrokerConfig(BinanceCcxtBroker, {"enable_create_order_ws": True, "enable_cancel_order_ws": False}),
     "binance.pm": BrokerConfig(BinanceCcxtBroker, {"enable_create_order_ws": False, "enable_cancel_order_ws": False}),
-    "bitfinex.f": BrokerConfig(CcxtBroker, {"enable_create_order_ws": True, "enable_cancel_order_ws": True}),
+    **({"bitfinex.f": BrokerConfig(CcxtBroker, {"enable_create_order_ws": True, "enable_cancel_order_ws": True})} if _HAS_BITFINEX else {}),
     "hyperliquid": BrokerConfig(
         HyperliquidCcxtBroker,
         {"enable_create_order_ws": True, "enable_cancel_order_ws": False, "enable_edit_order_ws": True},
@@ -72,7 +79,7 @@ CUSTOM_BROKERS: dict[str, BrokerConfig] = {
 }
 
 CUSTOM_ACCOUNTS = {
-    "bitfinex.f": BitfinexAccountProcessor,
+    **({"bitfinex.f": BitfinexAccountProcessor} if _HAS_BITFINEX else {}),
     "hyperliquid": HyperliquidAccountProcessor,
     "hyperliquid.f": HyperliquidAccountProcessor,
     "okx.f": OkxAccountProcessor,
@@ -98,7 +105,8 @@ cxp.binanceqv_usdm = BinanceQVUSDM  # type: ignore
 cxp.binancepm = BinancePortfolioMargin  # type: ignore
 cxp.binance_um_mm = BINANCE_UM_MM  # type: ignore
 cxp.custom_krakenfutures = CustomKrakenFutures  # type: ignore
-cxp.bitfinex_f = BitfinexF  # type: ignore
+if _HAS_BITFINEX:
+    cxp.bitfinex_f = BitfinexF  # type: ignore
 cxp.hyperliquid = Hyperliquid  # type: ignore
 cxp.hyperliquid_f = HyperliquidF  # type: ignore
 cxp.gateio_futures = GateioFutures  # type: ignore
@@ -110,7 +118,8 @@ cxp.exchanges.append("binancepm")
 cxp.exchanges.append("binancepm_usdm")
 cxp.exchanges.append("binance_um_mm")
 cxp.exchanges.append("custom_krakenfutures")
-cxp.exchanges.append("bitfinex_f")
+if _HAS_BITFINEX:
+    cxp.exchanges.append("bitfinex_f")
 cxp.exchanges.append("hyperliquid")
 cxp.exchanges.append("hyperliquid_f")
 cxp.exchanges.append("gateio_futures")

--- a/uv.lock
+++ b/uv.lock
@@ -1236,18 +1236,6 @@ wheels = [
 ]
 
 [[package]]
-name = "iprogress"
-version = "0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/34/01dd785348674d9a056966a4bbadb602a74b01c3422b988376480d3631a1/IProgress-0.4.tar.gz", hash = "sha256:55c6bce8ad4401889330fb1125c0bf7810bfbfe0105c058f861ae91e962d51eb", size = 10209, upload-time = "2016-06-22T07:00:37.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/92/46acb3eccee1d0e5581dea18455ebc2d25ec8da77d6c45d395882d4b9dd4/IProgress-0.4-py3-none-any.whl", hash = "sha256:098ba92780bf0eb3f2f3a0d4109e48d1f3c8ba57d821c6838f9ccb73e4fdc576", size = 11709, upload-time = "2016-06-22T07:00:41.816Z" },
-]
-
-[[package]]
 name = "ipykernel"
 version = "6.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3627,6 +3615,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "importlib-metadata" },
     { name = "ipykernel" },
+    { name = "ipywidgets" },
     { name = "jinja2" },
     { name = "joblib" },
     { name = "jupyter-client" },
@@ -3675,7 +3664,6 @@ connectors = [
     { name = "ccxt" },
 ]
 jupyter = [
-    { name = "ipywidgets" },
     { name = "jupyter" },
     { name = "jupyter-console" },
 ]
@@ -3691,7 +3679,6 @@ dev = [
     { name = "cython" },
     { name = "debugpy" },
     { name = "git-cliff" },
-    { name = "iprogress" },
     { name = "ipykernel" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -3730,7 +3717,7 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.44,<4" },
     { name = "importlib-metadata" },
     { name = "ipykernel", specifier = ">=6.29.0,<7" },
-    { name = "ipywidgets", marker = "extra == 'jupyter'", specifier = ">=8.1.5,<9" },
+    { name = "ipywidgets", specifier = ">=8.1.5,<9" },
     { name = "jinja2", specifier = ">=3.1.0,<4" },
     { name = "joblib", specifier = ">=1.3.0,<2" },
     { name = "jupyter", marker = "extra == 'jupyter'", specifier = ">=1.1.1,<2" },
@@ -3780,7 +3767,6 @@ dev = [
     { name = "cython", specifier = "==3.0.8" },
     { name = "debugpy", specifier = ">=1.8.12,<2" },
     { name = "git-cliff", specifier = ">=2.0.0" },
-    { name = "iprogress", specifier = ">=0.4,<1" },
     { name = "ipykernel", specifier = ">=6.29.4,<7" },
     { name = "jinja2", specifier = "==3.1.5" },
     { name = "markdown", specifier = "==3.7" },


### PR DESCRIPTION
## Summary
- Guard bitfinex imports with try/except — `bfxapi` is optional (`qubx[bitfinex]`), shouldn't crash when not installed
- Move `ipywidgets` from jupyter extra to core deps — needed by tqdm `IProgress` in TUI kernel
- Remove `iprogress` (unused package, was confused with `ipywidgets.IProgress`)
- Stop including `[[tool.uv.index]]` in generated release pyproject — private packages are already bundled as wheels in `wheels/`

## Test plan
- [x] 1118 unit tests pass
- [x] Deployed strategy runs without bfxapi installed (bitfinex gracefully skipped)
- [x] TUI IProgress warning resolved with ipywidgets in core