### PR TITLE
fix: normalize start/stop in CachedReader and OHLC warmup pagination

### DIFF
--- a/src/qubx/connectors/ccxt/handlers/ohlc.py
+++ b/src/qubx/connectors/ccxt/handlers/ohlc.py
@@ -91,14 +91,29 @@ class OhlcDataHandler(BaseDataTypeHandler):
         """
         nbarsback = pd.Timedelta(warmup_period) // pd.Timedelta(timeframe)
         exch_timeframe = self._data_provider._get_exch_timeframe(timeframe)
+        _tf_msec = pd.to_timedelta(timeframe).value // 1_000_000
 
         for instrument in instruments:
-            start = self._data_provider._time_msec_nbars_back(timeframe, nbarsback)
+            start_since = self._data_provider._time_msec_nbars_back(timeframe, nbarsback)
             ccxt_symbol = instrument_to_ccxt_symbol(instrument)
-            ohlcv = await self._exchange_manager.exchange.fetch_ohlcv(
-                ccxt_symbol, exch_timeframe, since=start, limit=nbarsback + 1
-            )
 
+            # Paginate: exchanges may return fewer bars than requested per call
+            ohlcv_map: dict[int, list] = {}
+            while len(ohlcv_map) < nbarsback:
+                batch = await self._exchange_manager.exchange.fetch_ohlcv(
+                    ccxt_symbol, exch_timeframe, since=start_since,
+                    limit=min(nbarsback - len(ohlcv_map), self.MAX_BARS_PER_REQUEST_FOR_PROVIDER) + 1,
+                )
+                if not batch:
+                    break
+                prev_count = len(ohlcv_map)
+                for bar in batch:
+                    ohlcv_map[bar[0]] = bar
+                if len(ohlcv_map) == prev_count:
+                    break
+                start_since = batch[-1][0] + _tf_msec
+
+            ohlcv = list(ohlcv_map.values())
             logger.debug(f"<yellow>{self._exchange_id}</yellow> {instrument}: loaded {len(ohlcv)} {timeframe} bars")
 
             channel.send(

--- a/src/qubx/data/cache.py
+++ b/src/qubx/data/cache.py
@@ -372,6 +372,10 @@ class CachedReader(IReader):
         chunksize: int = 0,
         **kwargs,
     ) -> Iterator[Transformable] | Transformable:
+        # Normalize start/stop so that start <= stop regardless of caller ordering
+        if start is not None and stop is not None and pd.Timestamp(start) > pd.Timestamp(stop):
+            start, stop = stop, start
+
         cache_key = _make_cache_key(dtype, **kwargs)
 
         # - detect "all symbols" request (empty collection)


### PR DESCRIPTION
## Summary
- **CachedReader start/stop normalization**: `CachedReader.read()` now swaps `start`/`stop` when `start > stop`. `SimulatedDataProvider.get_ohlc` passes them in reverse order, which caused `CachedStorage` to prefetch from the wrong end — instruments added mid-simulation by TopNUniverse got data capped ~13 days ahead instead of the full range, leaving the rest forward-filled with stale prices and zero volume.
- **OHLC warmup pagination**: `OhlcDataHandler.warmup()` now paginates like `get_historical_ohlc` for exchanges with small page sizes.

## Test plan
- [x] All 1151 unit tests pass
- [x] Verified with live paper run: BNBUSDT now fetches 280 bars (full range) vs 80 bars before fix
- [x] All TopN instruments get data through current time