### PR TITLE
feat: add qubx s3 CLI, browse TUI improvements, and contract-size fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: Qubx CI
 
 on:
-  push:
-    branches:
-      - main
-      - dev
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,8 @@
 name: Release
 
 on:
-  # Triggers after CI passes (not on push directly)
-  workflow_run:
-    workflows: ["Qubx CI"]
+  push:
     branches: [main, dev]
-    types: [completed]
   workflow_dispatch:
     inputs:
       force_channel:
@@ -19,15 +16,57 @@ permissions:
   id-token: write
 
 jobs:
+  # ---- Phase 0: Run tests before anything else ----
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run style checks with ruff
+        run: |
+          pip install ruff
+          ruff check . --output-format=github --exclude=experiments --exit-zero
+
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install dependencies and compile Cython
+        run: just install
+
+      - name: Run unit tests
+        run: just test
+
   # ---- Phase 1: Determine version & build (all in parallel) ----
 
   version:
     name: Determine version
+    needs: [lint, test]
     runs-on: ubuntu-latest
-    # Skip if triggered by workflow_run and CI failed
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -36,8 +75,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # For workflow_run, check out the branch that triggered CI
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Determine next version
@@ -76,7 +113,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Set up uv
@@ -126,7 +162,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Set up uv
@@ -158,7 +193,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
@@ -225,7 +259,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Create and push tag
@@ -302,7 +335,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Download sdist
@@ -348,7 +380,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           fetch-depth: 0
 
       - name: Set up Python

--- a/src/qubx/backtester/data.py
+++ b/src/qubx/backtester/data.py
@@ -102,19 +102,14 @@ class SimulatedDataProvider(IDataProvider):
             # - try to peek most recent market data
             h_data = self._data_source.peek_historical_data(i, subscription_type)
             if h_data:
-                # _s_type = DataType.from_str(subscription_type)[0]
+                self.channel.send((i, subscription_type, h_data, True))
+
                 last_update = h_data[-1]
                 if last_quote := self._account._exchange.emulate_quote_from_data(i, last_update.time, last_update):  # type: ignore
-                    # - send historical data to the channel
-                    self.channel.send((i, subscription_type, h_data, True))
-
-                    # - set last quote
                     self._last_quotes[i] = last_quote
-
-                    # - also need to pass this quote to OME !
                     self._account.process_market_data(last_quote.time, i, last_quote)  # type: ignore
 
-                    logger.debug(f" | subscribed {subscription_type} {i} -> {last_quote}")
+                logger.debug(f" | subscribed {subscription_type} {i} -> {len(h_data)} records")
 
     def unsubscribe(self, subscription_type: str, instruments: set[Instrument] | Instrument | None = None) -> None:
         # logger.debug(f" | unsubscribe: {subscription_type} -> {instruments}")

--- a/src/qubx/backtester/management.py
+++ b/src/qubx/backtester/management.py
@@ -49,7 +49,8 @@ import pandas as pd
 
 from qubx.core.metrics import TradingSessionResult
 from qubx.utils.misc import blue, cyan, green, magenta, red, yellow
-from qubx.utils.results import SimulationResultsSaver, is_cloud_path, resolve_s3_storage_options
+from qubx.utils.results import SimulationResultsSaver
+from qubx.utils.s3 import S3Client, is_cloud_path
 
 
 class BacktestStorage:
@@ -119,8 +120,10 @@ class BacktestStorage:
         self.base_path = base_path.rstrip("/") + "/"
         self._is_cloud = is_cloud_path(base_path)
 
-        # - for cloud paths: resolve credentials once (env vars → explicit dict)
-        self._storage_options: dict | None = resolve_s3_storage_options(storage_options) if self._is_cloud else None
+        # - for cloud paths: resolve credentials once
+        self._storage_options: dict | None = (
+            S3Client(storage_options=storage_options).storage_options if self._is_cloud else None
+        )
         self._conn = self._duckdb.connect()
 
         if self._is_cloud:
@@ -130,14 +133,12 @@ class BacktestStorage:
         """Configure DuckDB httpfs extension for cloud storage access."""
         self._conn.execute("INSTALL httpfs; LOAD httpfs;")
 
-        # - _storage_options is already resolved at __init__ for cloud paths
         opts = self._storage_options or {}
         if "key" in opts:
             self._conn.execute(f"SET s3_access_key_id='{opts['key']}';")
         if "secret" in opts:
             self._conn.execute(f"SET s3_secret_access_key='{opts['secret']}';")
         if "endpoint_url" in opts:
-            # - strip protocol prefix — DuckDB expects hostname only
             endpoint = opts["endpoint_url"].removeprefix("https://").removeprefix("http://")
             self._conn.execute(f"SET s3_endpoint='{endpoint}';")
         if "client_kwargs" in opts:

--- a/src/qubx/backtester/runner.py
+++ b/src/qubx/backtester/runner.py
@@ -437,7 +437,7 @@ class SimulationRunner:
         # - TimeGuard is applied by callers that need it (aux/strategy-facing access).
         # - Main simulation data (DataPump) must NOT be time-guarded: DataPump provides
         #   its own explicit [start, end] window and needs to read the full range upfront.
-        _prefetch_period = str(max(self.stop - self.start, pd.Timedelta(prefetch_cfg.prefetch_period)))
+        _prefetch_period = str(min(self.stop - self.start, pd.Timedelta(prefetch_cfg.prefetch_period)))
         return CachedStorage(
             storage, prefetch_period=_prefetch_period, cache_factory=lambda: MemoryCache(prefetch_cfg.cache_size_mb)
         )

--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -248,6 +248,13 @@ def run(
     "Overrides the 'name:' field from the config file.",
     show_default=True,
 )
+@click.option(
+    "--log-file",
+    default=None,
+    type=click.Path(dir_okay=False),
+    help="Write simulation logs to a specific file path.",
+    show_default=True,
+)
 def simulate(
     config_file: Path,
     start: str | None,
@@ -256,6 +263,7 @@ def simulate(
     report: str | None,
     log_to_file: bool,
     name: str | None,
+    log_file: str | None,
 ):
     """
     Simulates the strategy with the given configuration file.
@@ -267,7 +275,9 @@ def simulate(
     add_project_to_system_path(str(config_file.parent))
     logo()
     logger.info(f"Process PID: <g>{os.getpid()}</g>")
-    simulate_strategy(config_file, output, start, end, report, log_to_file, name=name)
+    simulate_strategy(
+        config_file, output, start, end, report, log_to_file, name=name, log_file=log_file,
+    )
 
 
 @main.command()
@@ -489,7 +499,7 @@ def browse(results_path: str | None):
         qubx browse s3://my-bucket/backtests/
     """
     from qubx.config import get_settings
-    from qubx.utils.results import is_cloud_path
+    from qubx.utils.s3 import is_cloud_path
 
     from .tui import run_backtest_browser
 

--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -467,9 +467,10 @@ def deploy(zip_file: str, output_dir: str | None, force: bool, system: bool):
 @click.argument(
     "results-path",
     type=str,
-    default="results",
+    default=None,
+    required=False,
 )
-def browse(results_path: str):
+def browse(results_path: str | None):
     """
     Browse backtest results using an interactive TUI.
 
@@ -487,9 +488,13 @@ def browse(results_path: str):
 
         qubx browse s3://my-bucket/backtests/
     """
+    from qubx.config import get_settings
     from qubx.utils.results import is_cloud_path
 
     from .tui import run_backtest_browser
+
+    if results_path is None:
+        results_path = get_settings().default_browse_path or "results"
 
     # - only resolve local paths; cloud URIs (s3://, gs://, az://) are passed as-is
     if not is_cloud_path(results_path):

--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -755,5 +755,87 @@ def backtests(storage_path: str, where: str | None, order_by: str, limit: int | 
     bs.print(where=where, order_by=order_by, limit=limit, params=params)
 
 
+@main.group()
+def s3():
+    """
+    Operate on S3-compatible storage using named accounts.
+
+    Paths use the format: account:bucket/path
+
+    Examples:\n
+      qubx s3 ls hetzner:frab/spreads/\n
+      qubx s3 rm hetzner:frab/spreads/ --recursive\n
+      qubx s3 cp hetzner:frab/spreads/data.parquet ./local_copy.parquet
+    """
+    pass
+
+
+@s3.command("accounts")
+def s3_accounts_cmd():
+    """List configured S3 accounts."""
+    from .s3 import s3_accounts
+
+    s3_accounts()
+
+
+@s3.command("ls")
+@click.argument("path", type=str)
+@click.option("--recursive", "-r", is_flag=True, help="List files recursively.")
+@click.option("--long", "-l", is_flag=True, help="Show detailed info (size, type).")
+def s3_ls_cmd(path: str, recursive: bool, long: bool):
+    """
+    List files in an S3 path.
+
+    Examples:\n
+      qubx s3 ls hetzner:frab/\n
+      qubx s3 ls hetzner:frab/spreads/ -r -l
+    """
+    from .s3 import s3_ls
+
+    s3_ls(path, recursive=recursive, long=long)
+
+
+@s3.command("rm")
+@click.argument("path", type=str)
+@click.option("--recursive", "-r", is_flag=True, help="Delete recursively.")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+def s3_rm_cmd(path: str, recursive: bool, yes: bool):
+    """
+    Delete files from S3.
+
+    Examples:\n
+      qubx s3 rm hetzner:frab/spreads/long_exchange=BINANCE.UM/asset=BTC/data.parquet\n
+      qubx s3 rm hetzner:frab/spreads/ -r
+    """
+    if not yes:
+        label = f"{path} (recursive)" if recursive else path
+        click.confirm(f"Delete {label}?", abort=True)
+
+    from .s3 import s3_rm
+
+    s3_rm(path, recursive=recursive)
+
+
+@s3.command("cp")
+@click.argument("src", type=str)
+@click.argument("dst", type=str)
+@click.option("--recursive", "-r", is_flag=True, help="Copy recursively.")
+def s3_cp_cmd(src: str, dst: str, recursive: bool):
+    """
+    Copy files to/from S3.
+
+    At least one of SRC or DST must be an S3 path (account:bucket/path).
+    The other can be a local path for upload/download.
+
+    Examples:\n
+      qubx s3 cp hetzner:frab/data.parquet ./local.parquet\n
+      qubx s3 cp ./local.parquet hetzner:frab/data.parquet\n
+      qubx s3 cp hetzner:frab/spreads/ ./spreads/ -r
+    """
+    from .s3 import s3_cp
+
+    s3_cp(src, dst, recursive=recursive)
+
+
 if __name__ == "__main__":
     main()

--- a/src/qubx/cli/s3.py
+++ b/src/qubx/cli/s3.py
@@ -1,0 +1,159 @@
+"""S3 storage operations using named accounts from Qubx settings.
+
+Uses pyarrow.fs.S3FileSystem — no dependency on s3fs/aiobotocore.
+"""
+
+from __future__ import annotations
+
+import click
+from pyarrow.fs import FileSelector, FileType, LocalFileSystem, copy_files
+
+from qubx.config import get_s3_account, get_settings
+from qubx.utils.results import _make_pa_s3_filesystem, _s3_account_to_opts
+
+
+def _parse_path(path: str) -> tuple[str, str, str]:
+    """Parse ``account:bucket/key`` into (account, bucket, key).
+
+    Supports formats:
+        account:bucket/path/to/key
+        account:bucket
+
+    Returns:
+        (account_name, bucket, key)  — *key* may be empty string.
+    """
+    if ":" not in path:
+        raise click.BadParameter(
+            f"Invalid path '{path}'. Expected format: account:bucket/path"
+        )
+    account, rest = path.split(":", 1)
+    if not account:
+        raise click.BadParameter("Account name cannot be empty")
+    if not rest:
+        raise click.BadParameter("Bucket/path cannot be empty")
+
+    parts = rest.split("/", 1)
+    bucket = parts[0]
+    key = parts[1] if len(parts) > 1 else ""
+    return account, bucket, key
+
+
+def _get_fs(account: str):
+    """Build a pyarrow.fs.S3FileSystem from a named Qubx account."""
+    acct = get_s3_account(account)
+    opts = _s3_account_to_opts(acct)
+    return _make_pa_s3_filesystem(opts)
+
+
+def _human_size(nbytes: int) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(nbytes) < 1024:
+            return f"{nbytes:6.1f} {unit}"
+        nbytes /= 1024  # type: ignore[assignment]
+    return f"{nbytes:.1f} PB"
+
+
+def _full_path(bucket: str, key: str) -> str:
+    return f"{bucket}/{key}".rstrip("/") if key else bucket
+
+
+def s3_ls(path: str, recursive: bool = False, long: bool = False) -> None:
+    account, bucket, key = _parse_path(path)
+    fs = _get_fs(account)
+    full = _full_path(bucket, key)
+
+    try:
+        entries = fs.get_file_info(FileSelector(full, recursive=recursive))
+    except Exception as e:
+        click.echo(click.style(f"Error listing {full}: {e}", fg="red"), err=True)
+        raise click.Abort()
+
+    if not entries:
+        click.echo(click.style(f"No files found under: {full}", fg="yellow"))
+        return
+
+    for info in sorted(entries, key=lambda e: e.path):
+        if long:
+            size = _human_size(info.size) if info.type == FileType.File else "     -"
+            kind = "DIR " if info.type == FileType.Directory else "FILE"
+            click.echo(f"  {kind}  {size}  {info.path}")
+        else:
+            click.echo(f"  {info.path}")
+
+
+def s3_rm(path: str, recursive: bool = False) -> None:
+    account, bucket, key = _parse_path(path)
+    fs = _get_fs(account)
+    full = _full_path(bucket, key)
+
+    try:
+        if recursive:
+            entries = fs.get_file_info(FileSelector(full, recursive=True))
+            files = [e for e in entries if e.type == FileType.File]
+            if not files:
+                click.echo(click.style(f"No files found under: {full}", fg="yellow"))
+                return
+            click.echo(f"Deleting {len(files)} file(s) under {full} ...")
+            fs.delete_dir(full)
+        else:
+            fs.delete_file(full)
+        click.echo(click.style(f"✓ Deleted {full}", fg="green"))
+    except Exception as e:
+        click.echo(click.style(f"Error deleting {full}: {e}", fg="red"), err=True)
+        raise click.Abort()
+
+
+def s3_cp(src: str, dst: str, recursive: bool = False) -> None:
+    src_is_s3 = ":" in src
+    dst_is_s3 = ":" in dst
+
+    if src_is_s3 and dst_is_s3:
+        src_account, src_bucket, src_key = _parse_path(src)
+        dst_account, dst_bucket, dst_key = _parse_path(dst)
+        if src_account != dst_account:
+            click.echo(
+                click.style("Cross-account copy is not supported yet.", fg="red"),
+                err=True,
+            )
+            raise click.Abort()
+        fs = _get_fs(src_account)
+        src_path = _full_path(src_bucket, src_key)
+        dst_path = _full_path(dst_bucket, dst_key)
+        copy_files(src_path, dst_path, source_filesystem=fs, destination_filesystem=fs)
+        click.echo(click.style(f"✓ Copied {src_path} → {dst_path}", fg="green"))
+
+    elif src_is_s3 and not dst_is_s3:
+        account, bucket, key = _parse_path(src)
+        s3_fs = _get_fs(account)
+        src_path = _full_path(bucket, key)
+        copy_files(src_path, dst, source_filesystem=s3_fs, destination_filesystem=LocalFileSystem())
+        click.echo(click.style(f"✓ Downloaded {src_path} → {dst}", fg="green"))
+
+    elif not src_is_s3 and dst_is_s3:
+        account, bucket, key = _parse_path(dst)
+        s3_fs = _get_fs(account)
+        dst_path = _full_path(bucket, key)
+        copy_files(src, dst_path, source_filesystem=LocalFileSystem(), destination_filesystem=s3_fs)
+        click.echo(click.style(f"✓ Uploaded {src} → {dst_path}", fg="green"))
+
+    else:
+        click.echo(
+            click.style("At least one path must be an S3 path (account:bucket/path).", fg="red"),
+            err=True,
+        )
+        raise click.Abort()
+
+
+def s3_accounts() -> None:
+    s = get_settings()
+    if not s.s3:
+        click.echo("No S3 accounts configured.")
+        return
+
+    click.echo(click.style("Configured S3 accounts:", fg="cyan", bold=True))
+    for name, acct in s.s3.items():
+        default_marker = " (default)" if name == s.default_s3_account else ""
+        click.echo(f"  {click.style(name, fg='yellow')}{default_marker}")
+        click.echo(f"    endpoint: {acct.endpoint_url}")
+        if acct.region:
+            click.echo(f"    region:   {acct.region}")

--- a/src/qubx/cli/s3.py
+++ b/src/qubx/cli/s3.py
@@ -1,48 +1,13 @@
 """S3 storage operations using named accounts from Qubx settings.
 
-Uses pyarrow.fs.S3FileSystem — no dependency on s3fs/aiobotocore.
+Uses :class:`qubx.utils.s3.S3Client` for all operations.
 """
 
-from __future__ import annotations
-
 import click
-from pyarrow.fs import FileSelector, FileType, LocalFileSystem, copy_files
+from pyarrow.fs import FileType, LocalFileSystem, copy_files
 
-from qubx.config import get_s3_account, get_settings
-from qubx.utils.results import _make_pa_s3_filesystem, _s3_account_to_opts
-
-
-def _parse_path(path: str) -> tuple[str, str, str]:
-    """Parse ``account:bucket/key`` into (account, bucket, key).
-
-    Supports formats:
-        account:bucket/path/to/key
-        account:bucket
-
-    Returns:
-        (account_name, bucket, key)  — *key* may be empty string.
-    """
-    if ":" not in path:
-        raise click.BadParameter(
-            f"Invalid path '{path}'. Expected format: account:bucket/path"
-        )
-    account, rest = path.split(":", 1)
-    if not account:
-        raise click.BadParameter("Account name cannot be empty")
-    if not rest:
-        raise click.BadParameter("Bucket/path cannot be empty")
-
-    parts = rest.split("/", 1)
-    bucket = parts[0]
-    key = parts[1] if len(parts) > 1 else ""
-    return account, bucket, key
-
-
-def _get_fs(account: str):
-    """Build a pyarrow.fs.S3FileSystem from a named Qubx account."""
-    acct = get_s3_account(account)
-    opts = _s3_account_to_opts(acct)
-    return _make_pa_s3_filesystem(opts)
+from qubx.config import get_settings
+from qubx.utils.s3 import S3Client, parse_uri
 
 
 def _human_size(nbytes: int) -> str:
@@ -53,23 +18,20 @@ def _human_size(nbytes: int) -> str:
     return f"{nbytes:.1f} PB"
 
 
-def _full_path(bucket: str, key: str) -> str:
-    return f"{bucket}/{key}".rstrip("/") if key else bucket
-
-
 def s3_ls(path: str, recursive: bool = False, long: bool = False) -> None:
-    account, bucket, key = _parse_path(path)
-    fs = _get_fs(account)
-    full = _full_path(bucket, key)
+    try:
+        client, s3_path = S3Client.from_uri(path)
+    except ValueError as e:
+        raise click.BadParameter(str(e))
 
     try:
-        entries = fs.get_file_info(FileSelector(full, recursive=recursive))
+        entries = client.ls(s3_path, recursive=recursive)
     except Exception as e:
-        click.echo(click.style(f"Error listing {full}: {e}", fg="red"), err=True)
+        click.echo(click.style(f"Error listing {s3_path}: {e}", fg="red"), err=True)
         raise click.Abort()
 
     if not entries:
-        click.echo(click.style(f"No files found under: {full}", fg="yellow"))
+        click.echo(click.style(f"No files found under: {s3_path}", fg="yellow"))
         return
 
     for info in sorted(entries, key=lambda e: e.path):
@@ -82,24 +44,23 @@ def s3_ls(path: str, recursive: bool = False, long: bool = False) -> None:
 
 
 def s3_rm(path: str, recursive: bool = False) -> None:
-    account, bucket, key = _parse_path(path)
-    fs = _get_fs(account)
-    full = _full_path(bucket, key)
+    try:
+        client, s3_path = S3Client.from_uri(path)
+    except ValueError as e:
+        raise click.BadParameter(str(e))
 
     try:
         if recursive:
-            entries = fs.get_file_info(FileSelector(full, recursive=True))
+            entries = client.ls(s3_path, recursive=True)
             files = [e for e in entries if e.type == FileType.File]
             if not files:
-                click.echo(click.style(f"No files found under: {full}", fg="yellow"))
+                click.echo(click.style(f"No files found under: {s3_path}", fg="yellow"))
                 return
-            click.echo(f"Deleting {len(files)} file(s) under {full} ...")
-            fs.delete_dir(full)
-        else:
-            fs.delete_file(full)
-        click.echo(click.style(f"✓ Deleted {full}", fg="green"))
+            click.echo(f"Deleting {len(files)} file(s) under {s3_path} ...")
+        client.rm(s3_path, recursive=recursive)
+        click.echo(click.style(f"✓ Deleted {s3_path}", fg="green"))
     except Exception as e:
-        click.echo(click.style(f"Error deleting {full}: {e}", fg="red"), err=True)
+        click.echo(click.style(f"Error deleting {s3_path}: {e}", fg="red"), err=True)
         raise click.Abort()
 
 
@@ -108,32 +69,36 @@ def s3_cp(src: str, dst: str, recursive: bool = False) -> None:
     dst_is_s3 = ":" in dst
 
     if src_is_s3 and dst_is_s3:
-        src_account, src_bucket, src_key = _parse_path(src)
-        dst_account, dst_bucket, dst_key = _parse_path(dst)
+        try:
+            src_account, src_path = parse_uri(src)
+            dst_account, dst_path = parse_uri(dst)
+        except ValueError as e:
+            raise click.BadParameter(str(e))
+
         if src_account != dst_account:
             click.echo(
                 click.style("Cross-account copy is not supported yet.", fg="red"),
                 err=True,
             )
             raise click.Abort()
-        fs = _get_fs(src_account)
-        src_path = _full_path(src_bucket, src_key)
-        dst_path = _full_path(dst_bucket, dst_key)
-        copy_files(src_path, dst_path, source_filesystem=fs, destination_filesystem=fs)
+        client = S3Client(account=src_account)
+        client.copy_s3(src_path, dst_path, recursive=recursive)
         click.echo(click.style(f"✓ Copied {src_path} → {dst_path}", fg="green"))
 
     elif src_is_s3 and not dst_is_s3:
-        account, bucket, key = _parse_path(src)
-        s3_fs = _get_fs(account)
-        src_path = _full_path(bucket, key)
-        copy_files(src_path, dst, source_filesystem=s3_fs, destination_filesystem=LocalFileSystem())
+        try:
+            client, src_path = S3Client.from_uri(src)
+        except ValueError as e:
+            raise click.BadParameter(str(e))
+        copy_files(src_path, dst, source_filesystem=client.fs, destination_filesystem=LocalFileSystem())
         click.echo(click.style(f"✓ Downloaded {src_path} → {dst}", fg="green"))
 
     elif not src_is_s3 and dst_is_s3:
-        account, bucket, key = _parse_path(dst)
-        s3_fs = _get_fs(account)
-        dst_path = _full_path(bucket, key)
-        copy_files(src, dst_path, source_filesystem=LocalFileSystem(), destination_filesystem=s3_fs)
+        try:
+            client, dst_path = S3Client.from_uri(dst)
+        except ValueError as e:
+            raise click.BadParameter(str(e))
+        copy_files(src, dst_path, source_filesystem=LocalFileSystem(), destination_filesystem=client.fs)
         click.echo(click.style(f"✓ Uploaded {src} → {dst_path}", fg="green"))
 
     else:

--- a/src/qubx/cli/tui.py
+++ b/src/qubx/cli/tui.py
@@ -10,6 +10,8 @@ from textual import on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.coordinate import Coordinate
+from textual.timer import Timer
 from textual.widgets import (
     Button,
     DataTable,
@@ -699,6 +701,7 @@ class BacktestBrowserApp(App):
     DARK = True
 
     BINDINGS = [
+        Binding("q", "quit", "Quit", show=True),
         Binding("j", "vim_down", "Down", show=False),
         Binding("k", "vim_up", "Up", show=False),
         Binding("g", "vim_home", "Top", show=False),
@@ -707,6 +710,7 @@ class BacktestBrowserApp(App):
         Binding("S", "sort_by_key_sharpe", "Sort Sharpe", show=True),
         Binding("C", "sort_by_key_cagr", "Sort CAGR", show=True),
         Binding("G", "vim_end", "Sort Gain", show=True),  # - Tree: scroll end; Table: sort gain
+        Binding("T", "sort_by_key_created", "Sort Created", show=True),
     ]
 
     CSS = """
@@ -865,6 +869,9 @@ class BacktestBrowserApp(App):
         self._selected_result: dict[str, Any] | None = None
         # - tracks which node is currently being loaded to discard stale callbacks
         self._loading_node: BacktestTreeNode | None = None
+        # - cc (copy path) state machine
+        self._pending_copy: bool = False
+        self._pending_copy_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the TUI layout"""
@@ -880,6 +887,7 @@ class BacktestBrowserApp(App):
                     yield Button("Sort by Sharpe", id="sort-sharpe")
                     yield Button("Sort by CAGR", id="sort-cagr")
                     yield Button("Sort by Gain", id="sort-gain")
+                    yield Button("Sort by Created", id="sort-created")
                     yield Button("Open HTML", id="open-html")
                     yield Button("Refresh", id="refresh")
 
@@ -910,7 +918,7 @@ class BacktestBrowserApp(App):
         if node_data.backtest_results:
             # - already loaded: show immediately (cached after first click)
             self.current_results = node_data.backtest_results
-            self._update_table()
+            self._sort_table("creation_time")
             self.query_one("#metrics-table", MetricsTable).focus()
 
         elif node_data.pending_ids:
@@ -1011,7 +1019,7 @@ class BacktestBrowserApp(App):
 
         self.current_results = node_data.backtest_results
         if self.current_results:
-            self._update_table()
+            self._sort_table("creation_time")
             table.focus()
         else:
             self.call_later(
@@ -1033,6 +1041,11 @@ class BacktestBrowserApp(App):
     def sort_by_gain(self) -> None:
         """Sort results by total gain"""
         self._sort_table("gain")
+
+    @on(Button.Pressed, "#sort-created")
+    def sort_by_created(self) -> None:
+        """Sort results by creation time"""
+        self._sort_table("creation_time")
 
     @on(Button.Pressed, "#open-html")
     def open_html_tearsheet(self) -> None:
@@ -1071,7 +1084,14 @@ class BacktestBrowserApp(App):
         ``_fv`` substitutes 0.0 for NaN / None so those rows sink to the bottom.
         """
         if self.current_results:
-            self.current_results.sort(key=lambda x: _fv(x.get(metric)), reverse=True)
+            if metric == "creation_time":
+                # - timestamps cannot go through _fv (float coercion); use pd.Timestamp
+                self.current_results.sort(
+                    key=lambda x: pd.Timestamp(x.get("creation_time") or "1970-01-01"),
+                    reverse=True,
+                )
+            else:
+                self.current_results.sort(key=lambda x: _fv(x.get(metric)), reverse=True)
             self._update_table()
 
     def _update_table(self) -> None:
@@ -1162,6 +1182,68 @@ class BacktestBrowserApp(App):
         """Sort table by CAGR (C — right pane only)."""
         if not isinstance(self.focused, Tree):
             self._sort_table("cagr")
+
+    def action_sort_by_key_created(self) -> None:
+        """Sort table by creation time (T — right pane only)."""
+        if not isinstance(self.focused, Tree):
+            self._sort_table("creation_time")
+
+    # ── cc copy path ─────────────────────────────────────────────────────────
+
+    def on_key(self, event) -> None:
+        """Handle key events for multi-key bindings (cc = copy path to clipboard)."""
+        if event.key == "c":
+            if not isinstance(self.focused, DataTable):
+                # - only intercept c when DataTable is focused
+                return
+            if self._pending_copy:
+                # - second 'c' within timeout: complete the copy
+                self._pending_copy = False
+                if self._pending_copy_timer:
+                    self._pending_copy_timer.stop()
+                    self._pending_copy_timer = None
+                self._copy_current_path()
+                event.prevent_default()
+                event.stop()
+            else:
+                # - first 'c': enter pending state, start timeout
+                self._pending_copy = True
+                self._pending_copy_timer = self.set_timer(
+                    0.5, self._cancel_pending_copy, name="cc_timeout"
+                )
+                event.prevent_default()
+                event.stop()
+        elif self._pending_copy:
+            # - any other key cancels the pending copy
+            self._cancel_pending_copy()
+
+    def _cancel_pending_copy(self) -> None:
+        """Cancel the pending cc copy operation (timeout or different key)."""
+        self._pending_copy = False
+        if self._pending_copy_timer:
+            self._pending_copy_timer.stop()
+            self._pending_copy_timer = None
+
+    def _copy_current_path(self) -> None:
+        """Copy the path of the currently highlighted table row to clipboard via OSC 52."""
+        table = self.query_one("#metrics-table", MetricsTable)
+        if table.row_count == 0:
+            return
+
+        try:
+            cursor_row = table.cursor_row
+            cell_key = table.coordinate_to_cell_key(Coordinate(cursor_row, 0))
+            load_id = cell_key.row_key.value
+        except Exception:
+            self.notify("No row selected", severity="warning", timeout=2)
+            return
+
+        if not load_id:
+            return
+
+        # - load_id is the backtest_id = relative path from storage root
+        self.copy_to_clipboard(str(load_id))
+        self.notify(f"Copied: {load_id}", timeout=3)
 
     # ── tearsheet ────────────────────────────────────────────────────────────
 

--- a/src/qubx/config.py
+++ b/src/qubx/config.py
@@ -93,6 +93,7 @@ class QubxSettings(BaseSettings):
     metrics_port: int | None = None
     health_port: int | None = None
     log_format: str = "text"  # "text" or "json"
+    default_browse_path: str | None = None
 
     model_config = {"env_prefix": "QUBX_", "env_nested_delimiter": "__"}
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -148,7 +148,11 @@ class ITradeDataExport:
         pass
 
     def export_position_changes(
-        self, time: dt_64, instrument: Instrument, price: float, account: "IAccountViewer",
+        self,
+        time: dt_64,
+        instrument: Instrument,
+        price: float,
+        account: "IAccountViewer",
         metadata: dict[str, Any] | None = None,
     ) -> None:
         """

--- a/src/qubx/core/loggers.py
+++ b/src/qubx/core/loggers.py
@@ -137,7 +137,7 @@ class PortfolioLogger(PositionsDumper):
                 "exchange": i.exchange,
                 "market_type": i.market_type,
                 "pnl_quoted": p.pnl,
-                "quantity": p.quantity,
+                "quantity": p.quantity * i.quantity_multiplier,
                 "realized_pnl_quoted": p.r_pnl,
                 "avg_position_price": p.position_avg_price if p.quantity != 0.0 else 0.0,
                 "current_price": p.last_update_price,

--- a/src/qubx/core/metrics.py
+++ b/src/qubx/core/metrics.py
@@ -2391,8 +2391,7 @@ def monthly_returns_table(result: "TradingSessionResult", name: str | None = Non
     monthly.index = monthly.index.to_period("M")
 
     pivot: pd.DataFrame = monthly.groupby([monthly.index.year, monthly.index.month]).first().unstack()
-    pivot.columns = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    pivot.columns = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
     pivot.index.name = "Year"
 
     annual: pd.Series = daily_returns.resample("YE").apply(lambda x: (1 + x).prod() - 1)
@@ -2415,23 +2414,33 @@ def monthly_returns_table(result: "TradingSessionResult", name: str | None = Non
     label = name or getattr(result, "name", "Strategy")
 
     styled = (
-        pivot.style
-        .map(_color)
+        pivot.style.map(_color)
         .format(_fmt)
-        .set_table_styles([
-            {"selector": "th", "props": [
-                ("background-color", "#111"), ("color", "#aaa"),
-                ("font-size", "12px"), ("padding", "6px 10px"),
-                ("border", "1px solid #333"),
-            ]},
-            {"selector": "td", "props": [
-                ("font-size", "12px"), ("padding", "6px 10px"),
-                ("border", "1px solid #222"), ("text-align", "right"),
-                ("font-family", "monospace"),
-            ]},
-            {"selector": "th.col_heading.level0.col12",
-             "props": [("border-left", "2px solid #555")]},
-        ])
+        .set_table_styles(
+            [
+                {
+                    "selector": "th",
+                    "props": [
+                        ("background-color", "#111"),
+                        ("color", "#aaa"),
+                        ("font-size", "12px"),
+                        ("padding", "6px 10px"),
+                        ("border", "1px solid #333"),
+                    ],
+                },
+                {
+                    "selector": "td",
+                    "props": [
+                        ("font-size", "12px"),
+                        ("padding", "6px 10px"),
+                        ("border", "1px solid #222"),
+                        ("text-align", "right"),
+                        ("font-family", "monospace"),
+                    ],
+                },
+                {"selector": "th.col_heading.level0.col12", "props": [("border-left", "2px solid #555")]},
+            ]
+        )
         .set_caption(f"Monthly Returns — {label}")
     )
     return HTML(styled.to_html())

--- a/src/qubx/core/metrics.py
+++ b/src/qubx/core/metrics.py
@@ -7,7 +7,7 @@ from copy import copy
 from io import BytesIO
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, cast
 
 import numpy as np
 import pandas as pd
@@ -15,6 +15,7 @@ import yaml
 
 from qubx import logger
 from qubx.core.basics import Instrument
+from qubx.core.lookups import lookup
 from qubx.core.series import OHLCV
 from qubx.utils.misc import makedirs, version
 from qubx.utils.time import convert_seconds_to_str, handle_start_stop, infer_series_frequency
@@ -38,6 +39,8 @@ MINUTELY_FX = HOURLY_FX * 60
 
 _D1 = pd.Timedelta("1D")
 _W1 = pd.Timedelta("1W")
+
+OptTimestamp: TypeAlias = str | pd.Timestamp | None
 
 
 def absmaxdd(data: list | tuple | pd.Series | np.ndarray) -> tuple[float, int, int, int, pd.Series]:
@@ -895,6 +898,16 @@ class TradingSessionResult:
         if self.portfolio_log.empty:
             return pd.Series(dtype=float)
         return calculate_leverage(self.portfolio_log, self.get_total_capital(), self.start)
+
+    def get_funding_per_symbol(self, start: OptTimestamp = None, stop: OptTimestamp = None) -> pd.DataFrame:
+        if self.portfolio_log.empty:
+            return pd.DataFrame(dtype=float)
+        return calculate_funding_per_symbol(self.portfolio_log, start, stop)
+
+    def get_funding_per_asset(self, start: OptTimestamp = None, stop: OptTimestamp = None) -> pd.DataFrame:
+        if self.portfolio_log.empty:
+            return pd.DataFrame(dtype=float)
+        return calculate_funding_per_asset(self.portfolio_log, start, stop)
 
     def performance(self) -> dict[str, float]:
         """
@@ -2069,6 +2082,45 @@ def calculate_pnl_per_symbol(
     if drop_zero_pnl:
         df = df.loc[:, df.gt(0).any(axis=0)]
     return df
+
+
+def _slice_df(df: pd.DataFrame, start: OptTimestamp = None, stop: OptTimestamp = None) -> pd.DataFrame:
+    if start and stop:
+        return df.loc[start:stop]
+    elif start:
+        return df.loc[start:]
+    elif stop:
+        return df.loc[:stop]
+    return df
+
+
+def calculate_funding_per_symbol(
+    portfolio_log: pd.DataFrame, start: OptTimestamp = None, stop: OptTimestamp = None
+) -> pd.DataFrame:
+    """Calculate funding for each symbol in the trading session."""
+    return _slice_df(portfolio_log.filter(like="_Funding"), start, stop)
+
+
+def calculate_funding_per_asset(
+    portfolio_log: pd.DataFrame,
+    start: OptTimestamp = None,
+    stop: OptTimestamp = None,
+) -> pd.DataFrame:
+    """
+    Calculate funding for each asset in the trading session.
+    """
+    df = calculate_funding_per_symbol(portfolio_log, start, stop)
+    df = df.rename(columns=lambda x: x.replace("_Funding", ""))
+
+    # Map each column (EXCHANGE:SYMBOL) to its asset name
+    col_to_asset: dict[str, str] = {}
+    for col in df.columns:
+        exchange, symbol = col.split(":")
+        instr = lookup.find_symbol(exchange, symbol)
+        col_to_asset[col] = instr.asset if instr else col
+
+    # Group by asset and sum
+    return df.rename(columns=col_to_asset).T.groupby(level=0).sum().T
 
 
 def calculate_turnover(

--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -256,17 +256,34 @@ class SubscriptionManager(ISubscriptionManager):
                 set.union(*self._pending_stream_subscriptions.values()) if self._pending_stream_subscriptions else set()
             )
 
-            for sub in self._pending_global_subscriptions:
+            _subs_to_warm = set(self._pending_global_subscriptions)
+            if _new_instruments:
+                _subs_to_warm.update(self._sub_to_warmup.keys())
+
+            logger.info(
+                f"[WARMUP] exchange={_data_provider.exchange()} | "
+                f"pending_global={list(self._pending_global_subscriptions)} | "
+                f"new_instruments={len(_new_instruments)} | "
+                f"subs_to_warm={list(_subs_to_warm)} | "
+                f"sub_to_warmup_keys={list(self._sub_to_warmup.keys())}"
+            )
+
+            for sub in _subs_to_warm:
                 _warmup_period = self._sub_to_warmup.get(sub)
                 if _warmup_period is None:
                     continue
                 _sub_instruments = _data_provider.get_subscribed_instruments(sub)
                 _add_instruments = _subscribed_instruments.union(_new_instruments).difference(_sub_instruments)
+                logger.info(
+                    f"[WARMUP] sub={sub} | warmup={_warmup_period} | "
+                    f"subscribed={len(_sub_instruments)} | add={len(_add_instruments)}"
+                )
                 for instr in _add_instruments:
                     self._pending_warmups[(sub, instr)] = _warmup_period
 
             # TODO: think about appropriate handling of timeouts
             _warmup_configs = self._get_pending_warmups_for_exchange(_data_provider.exchange())
+            logger.info(f"[WARMUP] warmup_configs={len(_warmup_configs)} entries")
             _data_provider.warmup(_warmup_configs)
 
         self._pending_warmups.clear()

--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -260,30 +260,17 @@ class SubscriptionManager(ISubscriptionManager):
             if _new_instruments:
                 _subs_to_warm.update(self._sub_to_warmup.keys())
 
-            logger.info(
-                f"[WARMUP] exchange={_data_provider.exchange()} | "
-                f"pending_global={list(self._pending_global_subscriptions)} | "
-                f"new_instruments={len(_new_instruments)} | "
-                f"subs_to_warm={list(_subs_to_warm)} | "
-                f"sub_to_warmup_keys={list(self._sub_to_warmup.keys())}"
-            )
-
             for sub in _subs_to_warm:
                 _warmup_period = self._sub_to_warmup.get(sub)
                 if _warmup_period is None:
                     continue
                 _sub_instruments = _data_provider.get_subscribed_instruments(sub)
                 _add_instruments = _subscribed_instruments.union(_new_instruments).difference(_sub_instruments)
-                logger.info(
-                    f"[WARMUP] sub={sub} | warmup={_warmup_period} | "
-                    f"subscribed={len(_sub_instruments)} | add={len(_add_instruments)}"
-                )
                 for instr in _add_instruments:
                     self._pending_warmups[(sub, instr)] = _warmup_period
 
             # TODO: think about appropriate handling of timeouts
             _warmup_configs = self._get_pending_warmups_for_exchange(_data_provider.exchange())
-            logger.info(f"[WARMUP] warmup_configs={len(_warmup_configs)} entries")
             _data_provider.warmup(_warmup_configs)
 
         self._pending_warmups.clear()

--- a/src/qubx/data/cache.py
+++ b/src/qubx/data/cache.py
@@ -106,16 +106,23 @@ class MemoryCache(ICache):
     In-memory cache storing RawData per (cache_key, data_id).
     Handles Arrow-level concat when extending ranges, deduplication by time,
     and LRU eviction when max_size_mb is exceeded.
+
+    Tracks time ranges at two levels:
+    - Global ranges per cache_key: used for all-symbols requests
+    - Per-symbol ranges per (cache_key, data_id): used to detect symbols with
+      incomplete coverage (e.g. added via partial hit with a narrower window)
     """
 
     _data: dict[str, dict[str, RawData]]
     _ranges: dict[str, list[tuple[str, str]]]
+    _symbol_ranges: dict[str, dict[str, list[tuple[str, str]]]]
     _access_order: OrderedDict[str, None]
     _max_size_bytes: int
 
     def __init__(self, max_size_mb: int = 1000) -> None:
         self._data = {}
         self._ranges = {}
+        self._symbol_ranges = {}
         self._access_order = OrderedDict()
         self._max_size_bytes = max_size_mb * 1024 * 1024
 
@@ -133,6 +140,7 @@ class MemoryCache(ICache):
         if len(data) == 0:
             # - still record the range even for empty data
             self._record_range(cache_key, start, stop)
+            self._record_symbol_range(cache_key, data.data_id, start, stop)
             return
 
         bucket = self._data.setdefault(cache_key, {})
@@ -146,6 +154,7 @@ class MemoryCache(ICache):
             bucket[data.data_id] = data
 
         self._record_range(cache_key, start, stop)
+        self._record_symbol_range(cache_key, data.data_id, start, stop)
         self._access_order[cache_key] = None
         self._access_order.move_to_end(cache_key, last=True)
         # - skip_key protects the key being actively populated from self-eviction;
@@ -161,16 +170,30 @@ class MemoryCache(ICache):
         if not ranges:
             return False
 
-        merged = _merge_time_ranges(ranges)
-        req_start = pd.Timestamp(start) if start else pd.Timestamp.min
-        req_stop = pd.Timestamp(stop) if stop else pd.Timestamp.max
+        return self._ranges_cover(ranges, start, stop)
 
-        for rs, re in merged:
-            if rs <= req_start and re >= req_stop:
-                logger.info(f"[CACHE-COVERS] {cache_key} | [{start}, {stop}) covered by [{rs}, {re})")
-                return True
-        logger.info(f"[CACHE-NOTCOV] {cache_key} | [{start}, {stop}) NOT covered by {[(str(s), str(e)) for s, e in merged]}")
-        return False
+    def covers_ids(
+        self, cache_key: str, ids: list[str], start: str | None, stop: str | None
+    ) -> tuple[bool, list[str]]:
+        """
+        Check if all requested symbols have per-symbol range coverage for [start, stop).
+        Returns (all_covered, missing_ids) where missing_ids are symbols that either
+        don't exist in cache or don't have sufficient time coverage.
+        """
+        sym_ranges = self._symbol_ranges.get(cache_key, {})
+        missing = []
+        for did in ids:
+            r = sym_ranges.get(did)
+            if not r or not self._ranges_cover(r, start, stop):
+                missing.append(did)
+        result = (len(missing) == 0, missing)
+        if "1d" in cache_key:
+            logger.info(
+                f"[COVERS-IDS] {cache_key} | [{start}, {stop}) | "
+                f"ids={len(ids)} missing={len(missing)} covered={result[0]} | "
+                f"sample_range={sym_ranges.get(ids[0]) if ids else 'N/A'}"
+            )
+        return result
 
     def get_ranges(self, cache_key: str) -> list[tuple[str, str]]:
         return list(self._ranges.get(cache_key, []))
@@ -183,10 +206,12 @@ class MemoryCache(ICache):
         if cache_key is None:
             self._data.clear()
             self._ranges.clear()
+            self._symbol_ranges.clear()
             self._access_order.clear()
         else:
             self._data.pop(cache_key, None)
             self._ranges.pop(cache_key, None)
+            self._symbol_ranges.pop(cache_key, None)
             self._access_order.pop(cache_key, None)
 
     def size_bytes(self) -> int:
@@ -200,12 +225,29 @@ class MemoryCache(ICache):
         # - for in-memory cache, just clear everything
         self.clear()
 
+    @staticmethod
+    def _ranges_cover(ranges: list[tuple[str, str]], start: str | None, stop: str | None) -> bool:
+        merged = _merge_time_ranges(ranges)
+        req_start = pd.Timestamp(start) if start else pd.Timestamp.min
+        req_stop = pd.Timestamp(stop) if stop else pd.Timestamp.max
+        for rs, re in merged:
+            if rs <= req_start and re >= req_stop:
+                return True
+        return False
+
     def _record_range(self, cache_key: str, start: str, stop: str) -> None:
         if cache_key not in self._ranges:
             self._ranges[cache_key] = []
         self._ranges[cache_key].append((start, stop))
         # - keep merged to avoid unbounded growth
         self._ranges[cache_key] = [(str(s), str(e)) for s, e in _merge_time_ranges(self._ranges[cache_key])]
+
+    def _record_symbol_range(self, cache_key: str, data_id: str, start: str, stop: str) -> None:
+        sym_ranges = self._symbol_ranges.setdefault(cache_key, {})
+        if data_id not in sym_ranges:
+            sym_ranges[data_id] = []
+        sym_ranges[data_id].append((start, stop))
+        sym_ranges[data_id] = [(str(s), str(e)) for s, e in _merge_time_ranges(sym_ranges[data_id])]
 
     def _maybe_evict(self, skip_key: str | None = None) -> None:
         while self.size_bytes() > self._max_size_bytes:
@@ -231,13 +273,13 @@ class MemoryCache(ICache):
 
 def _merge_batches(existing: pa.RecordBatch, incoming: pa.RecordBatch, time_col_idx: int) -> pa.RecordBatch:
     """
-    Concatenate two Arrow RecordBatches, deduplicate exact duplicate rows, sort by time.
+    Concatenate two Arrow RecordBatches, deduplicate, sort by time.
 
-    Deduplication is done on ALL columns (exact row match), not just the time column.
-    This correctly handles data where multiple rows share a timestamp but differ in other
-    columns (e.g. fundamental data with one row per metric per timestamp).
-    For OHLC, overlapping rows between existing and incoming are always identical so
-    exact dedup still removes them correctly.
+    Deduplicates on timestamp + string columns (e.g. symbol, metric, asset),
+    keeping the last (incoming) row. This handles:
+    - OHLC per-symbol data: dedup by timestamp only (no string cols in per-symbol batch)
+    - Fundamental data: dedup by timestamp + metric, preserving distinct metric rows
+    - Floating-point drift from QuestDB SUM across different query windows
     """
     tbl = pa.concat_tables(
         [
@@ -245,14 +287,13 @@ def _merge_batches(existing: pa.RecordBatch, incoming: pa.RecordBatch, time_col_
             pa.Table.from_batches([incoming]),
         ]
     )
-    # - sort by time column
     time_col_name = tbl.schema.field(time_col_idx).name
     tbl = tbl.sort_by(time_col_name)
 
-    # - deduplicate exact duplicate rows across all columns, then convert back to Arrow
-    # (Arrow lacks native dedup; pandas roundtrip is fast for cache-sized data)
     pdf = tbl.to_pandas()
-    pdf = pdf.drop_duplicates(keep="last")
+    dedup_cols = [time_col_name] + [f.name for f in existing.schema if pa.types.is_string(f.type) or pa.types.is_large_string(f.type)]
+    pdf = pdf.drop_duplicates(subset=dedup_cols, keep="last")
+
     batch = pa.RecordBatch.from_pandas(pdf, schema=existing.schema, preserve_index=False)
     return batch
 
@@ -404,27 +445,24 @@ class CachedReader(IReader):
             ids = data_id if isinstance(data_id, (list, tuple)) else [data_id]
             is_single = isinstance(data_id, str)
 
-            if self._cache.covers(cache_key, start, stop):
-                missing = self._missing_ids(cache_key, ids)
+            # - per-symbol range check: ensures every requested symbol has data for [start, stop)
+            covered, missing = self._cache.covers_ids(cache_key, ids, start, stop)
 
-                if not missing:
-                    # - full hit: all ids cached and range covered
-                    result = self._build_result(cache_key, ids, is_single, start, stop)
-                    logger.debug(f"[CACHE-HIT] {dtype} | {start} -> {stop} | {len(ids)} ids | {len(result)} rows")
-                    return iter([result]) if chunksize > 0 else result
+            if covered:
+                # - full hit: all ids cached with sufficient time coverage
+                result = self._build_result(cache_key, ids, is_single, start, stop)
+                logger.debug(f"[CACHE-HIT] {dtype} | {start} -> {stop} | {len(ids)} ids | {len(result)} rows")
+                return iter([result]) if chunksize > 0 else result
 
-                if len(missing) < len(ids):
-                    # - partial hit: range covered but some ids are new
-                    # - fetch ONLY the missing symbols — no need to re-read already-cached ones
-                    fetch_stop = self._compute_fetch_stop(stop)
-                    miss_result = self._reader.read(missing, dtype, start, fetch_stop, **kwargs)
-                    # - record stop (not fetch_stop) to avoid inflating range beyond what existing symbols cover
-                    self._store_result(cache_key, miss_result, start or "", stop or "")
-                    result = self._build_result(cache_key, ids, is_single, start, stop)
-                    return iter([result]) if chunksize > 0 else result
+            if missing and len(missing) < len(ids):
+                # - partial hit: some symbols missing or lack time coverage
+                fetch_stop = self._compute_fetch_stop(stop)
+                miss_result = self._reader.read(missing, dtype, start, fetch_stop, **kwargs)
+                self._store_result(cache_key, miss_result, start or "", fetch_stop or "")
+                result = self._build_result(cache_key, ids, is_single, start, stop)
+                return iter([result]) if chunksize > 0 else result
 
-                # - all ids missing but range was recorded by a prior fetch of different symbols
-                # - fall through to all-symbols fallback / full miss below
+            # - all ids missing — fall through to all-symbols fallback / full miss below
 
             # - fallback: check all-symbols cache (data stored via read([], ...) uses a different key)
             all_key = _make_cache_key(dtype, __all__=True, **kwargs)

--- a/src/qubx/data/cache.py
+++ b/src/qubx/data/cache.py
@@ -58,8 +58,14 @@ class ICache:
         ...
 
     def covers(self, cache_key: str, start: str | None, stop: str | None) -> bool:
+        """Check if global cached range fully covers [start, stop)."""
+        ...
+
+    def check(self, cache_key: str, ids: list[str], start: str | None, stop: str | None) -> list[str]:
         """
-        Check if cached ranges fully cover [start, stop).
+        Return ids that are NOT covered for [start, stop).
+        A symbol is uncovered if it doesn't exist in cache or its per-symbol
+        range doesn't span the requested window. Empty list = all covered.
         """
         ...
 
@@ -165,35 +171,14 @@ class MemoryCache(ICache):
     def covers(self, cache_key: str, start: str | None, stop: str | None) -> bool:
         if start is None and stop is None:
             return cache_key in self._data
-
         ranges = self._ranges.get(cache_key)
         if not ranges:
             return False
-
         return self._ranges_cover(ranges, start, stop)
 
-    def covers_ids(
-        self, cache_key: str, ids: list[str], start: str | None, stop: str | None
-    ) -> tuple[bool, list[str]]:
-        """
-        Check if all requested symbols have per-symbol range coverage for [start, stop).
-        Returns (all_covered, missing_ids) where missing_ids are symbols that either
-        don't exist in cache or don't have sufficient time coverage.
-        """
+    def check(self, cache_key: str, ids: list[str], start: str | None, stop: str | None) -> list[str]:
         sym_ranges = self._symbol_ranges.get(cache_key, {})
-        missing = []
-        for did in ids:
-            r = sym_ranges.get(did)
-            if not r or not self._ranges_cover(r, start, stop):
-                missing.append(did)
-        result = (len(missing) == 0, missing)
-        if "1d" in cache_key:
-            logger.info(
-                f"[COVERS-IDS] {cache_key} | [{start}, {stop}) | "
-                f"ids={len(ids)} missing={len(missing)} covered={result[0]} | "
-                f"sample_range={sym_ranges.get(ids[0]) if ids else 'N/A'}"
-            )
-        return result
+        return [did for did in ids if not self._ranges_cover(sym_ranges.get(did, []), start, stop)]
 
     def get_ranges(self, cache_key: str) -> list[tuple[str, str]]:
         return list(self._ranges.get(cache_key, []))
@@ -433,28 +418,21 @@ class CachedReader(IReader):
         cache_key = _make_cache_key(dtype, **cache_kwargs)
 
         if is_all_request:
-            # - for "all" requests: range coverage is sufficient — return whatever was stored
             if self._cache.covers(cache_key, start, stop):
                 stored_ids = self._cache.get_stored_ids(cache_key)
                 result = self._build_result(cache_key, stored_ids, False, start, stop)
-                logger.debug(f"[CACHE-HIT] {dtype} | {start} -> {stop} | all-request | {len(result)} rows")
-                # - when caller requests chunked iteration, wrap the in-memory result in a
-                #   single-element iterator; real chunking offers no benefit once data is cached
                 return iter([result]) if chunksize > 0 else result
         else:
             ids = data_id if isinstance(data_id, (list, tuple)) else [data_id]
             is_single = isinstance(data_id, str)
 
-            # - per-symbol range check: ensures every requested symbol has data for [start, stop)
-            covered, missing = self._cache.covers_ids(cache_key, ids, start, stop)
+            missing = self._cache.check(cache_key, ids, start, stop)
 
-            if covered:
-                # - full hit: all ids cached with sufficient time coverage
+            if not missing:
                 result = self._build_result(cache_key, ids, is_single, start, stop)
-                logger.debug(f"[CACHE-HIT] {dtype} | {start} -> {stop} | {len(ids)} ids | {len(result)} rows")
                 return iter([result]) if chunksize > 0 else result
 
-            if missing and len(missing) < len(ids):
+            if len(missing) < len(ids):
                 # - partial hit: some symbols missing or lack time coverage
                 fetch_stop = self._compute_fetch_stop(stop)
                 miss_result = self._reader.read(missing, dtype, start, fetch_stop, **kwargs)
@@ -467,8 +445,7 @@ class CachedReader(IReader):
             # - fallback: check all-symbols cache (data stored via read([], ...) uses a different key)
             all_key = _make_cache_key(dtype, __all__=True, **kwargs)
             if all_key != cache_key and self._cache.covers(all_key, start, stop):
-                missing = self._missing_ids(all_key, ids)
-                if not missing:
+                if not self._cache.check(all_key, ids, start, stop):
                     result = self._build_result(all_key, ids, is_single, start, stop)
                     return iter([result]) if chunksize > 0 else result
 
@@ -479,7 +456,6 @@ class CachedReader(IReader):
         fetch_stop = self._compute_fetch_stop(stop)
 
         result = self._reader.read(data_id, dtype, start, fetch_stop, **kwargs)
-        _raw_len = len(result) if result is not None else 0
         self._store_result(cache_key, result, start or "", fetch_stop or "")
 
         # - return sliced to originally requested [start, stop)
@@ -490,11 +466,6 @@ class CachedReader(IReader):
             ids = data_id if isinstance(data_id, (list, tuple)) else [data_id]
             result = self._build_result(cache_key, ids, isinstance(data_id, str), start, stop)
 
-        _sliced_len = len(result) if result is not None else 0
-        logger.info(
-            f"[CACHE-MISS] {dtype} | {start} -> {stop} (fetch_stop={fetch_stop}) | "
-            f"raw={_raw_len} -> sliced={_sliced_len}"
-        )
 
         return iter([result]) if chunksize > 0 else result
 
@@ -526,12 +497,6 @@ class CachedReader(IReader):
 
     # -- internal helpers --
 
-    def _missing_ids(self, cache_key: str, ids: list[str]) -> list[str]:
-        """
-        Return the subset of ids not yet stored in cache for this cache_key.
-        """
-        stored = set(self._cache.get_stored_ids(cache_key))
-        return [did for did in ids if did not in stored]
 
     def _compute_fetch_stop(self, stop: str | None) -> str | None:
         """

--- a/src/qubx/data/cache.py
+++ b/src/qubx/data/cache.py
@@ -167,7 +167,9 @@ class MemoryCache(ICache):
 
         for rs, re in merged:
             if rs <= req_start and re >= req_stop:
+                logger.info(f"[CACHE-COVERS] {cache_key} | [{start}, {stop}) covered by [{rs}, {re})")
                 return True
+        logger.info(f"[CACHE-NOTCOV] {cache_key} | [{start}, {stop}) NOT covered by {[(str(s), str(e)) for s, e in merged]}")
         return False
 
     def get_ranges(self, cache_key: str) -> list[tuple[str, str]]:
@@ -394,6 +396,7 @@ class CachedReader(IReader):
             if self._cache.covers(cache_key, start, stop):
                 stored_ids = self._cache.get_stored_ids(cache_key)
                 result = self._build_result(cache_key, stored_ids, False, start, stop)
+                logger.debug(f"[CACHE-HIT] {dtype} | {start} -> {stop} | all-request | {len(result)} rows")
                 # - when caller requests chunked iteration, wrap the in-memory result in a
                 #   single-element iterator; real chunking offers no benefit once data is cached
                 return iter([result]) if chunksize > 0 else result
@@ -407,6 +410,7 @@ class CachedReader(IReader):
                 if not missing:
                     # - full hit: all ids cached and range covered
                     result = self._build_result(cache_key, ids, is_single, start, stop)
+                    logger.debug(f"[CACHE-HIT] {dtype} | {start} -> {stop} | {len(ids)} ids | {len(result)} rows")
                     return iter([result]) if chunksize > 0 else result
 
                 if len(missing) < len(ids):
@@ -414,7 +418,8 @@ class CachedReader(IReader):
                     # - fetch ONLY the missing symbols — no need to re-read already-cached ones
                     fetch_stop = self._compute_fetch_stop(stop)
                     miss_result = self._reader.read(missing, dtype, start, fetch_stop, **kwargs)
-                    self._store_result(cache_key, miss_result, start or "", fetch_stop or "")
+                    # - record stop (not fetch_stop) to avoid inflating range beyond what existing symbols cover
+                    self._store_result(cache_key, miss_result, start or "", stop or "")
                     result = self._build_result(cache_key, ids, is_single, start, stop)
                     return iter([result]) if chunksize > 0 else result
 
@@ -436,6 +441,7 @@ class CachedReader(IReader):
         fetch_stop = self._compute_fetch_stop(stop)
 
         result = self._reader.read(data_id, dtype, start, fetch_stop, **kwargs)
+        _raw_len = len(result) if result is not None else 0
         self._store_result(cache_key, result, start or "", fetch_stop or "")
 
         # - return sliced to originally requested [start, stop)
@@ -445,6 +451,12 @@ class CachedReader(IReader):
         else:
             ids = data_id if isinstance(data_id, (list, tuple)) else [data_id]
             result = self._build_result(cache_key, ids, isinstance(data_id, str), start, stop)
+
+        _sliced_len = len(result) if result is not None else 0
+        logger.info(
+            f"[CACHE-MISS] {dtype} | {start} -> {stop} (fetch_stop={fetch_stop}) | "
+            f"raw={_raw_len} -> sliced={_sliced_len}"
+        )
 
         return iter([result]) if chunksize > 0 else result
 

--- a/src/qubx/data/cache.py
+++ b/src/qubx/data/cache.py
@@ -376,14 +376,18 @@ class CachedReader(IReader):
         if start is not None and stop is not None and pd.Timestamp(start) > pd.Timestamp(stop):
             start, stop = stop, start
 
-        cache_key = _make_cache_key(dtype, **kwargs)
-
         # - detect "all symbols" request (empty collection)
         # - NOTE: do NOT expand to get_data_id() — that returns ALL symbols ever in the
         #   reader (e.g. SELECT DISTINCT asset over full history), but the actual data
         #   returned for a date range is only the subset with data in that range.
         #   Expanding would make _missing_ids() always fail for ranged reads.
         is_all_request = isinstance(data_id, (list, tuple, set)) and not data_id
+
+        cache_kwargs = kwargs.copy()
+        if is_all_request:
+            cache_kwargs["__all__"] = True
+
+        cache_key = _make_cache_key(dtype, **cache_kwargs)
 
         if is_all_request:
             # - for "all" requests: range coverage is sufficient — return whatever was stored
@@ -415,7 +419,15 @@ class CachedReader(IReader):
                     return iter([result]) if chunksize > 0 else result
 
                 # - all ids missing but range was recorded by a prior fetch of different symbols
-                # - fall through to full miss below
+                # - fall through to all-symbols fallback / full miss below
+
+            # - fallback: check all-symbols cache (data stored via read([], ...) uses a different key)
+            all_key = _make_cache_key(dtype, __all__=True, **kwargs)
+            if all_key != cache_key and self._cache.covers(all_key, start, stop):
+                missing = self._missing_ids(all_key, ids)
+                if not missing:
+                    result = self._build_result(all_key, ids, is_single, start, stop)
+                    return iter([result]) if chunksize > 0 else result
 
         # - full miss: fetch from inner reader WITHOUT chunksize to get a full Transformable
         # - this allows the complete result to be stored in cache for subsequent hits;

--- a/src/qubx/data/guards.py
+++ b/src/qubx/data/guards.py
@@ -15,7 +15,6 @@ from collections.abc import Iterator
 import numpy as np
 import pandas as pd
 
-from qubx import logger
 from qubx.core.basics import DataType, ITimeProvider
 from qubx.data.storage import IReader, IStorage, Transformable
 
@@ -120,10 +119,7 @@ class TimeGuardedReader(IReader):
         if clamped_stop is not None and start is not None:
             if pd.Timestamp(start) >= pd.Timestamp(clamped_stop):
                 start = clamped_stop
-        result = self._reader.read(data_id, dtype, start=start, stop=clamped_stop, chunksize=chunksize, **kwargs)
-        if stop != clamped_stop:
-            logger.debug(f"[TIMEGUARD] {dtype} | stop={stop} -> clamped={clamped_stop}")
-        return result
+        return self._reader.read(data_id, dtype, start=start, stop=clamped_stop, chunksize=chunksize, **kwargs)
 
     def get_data_id(self, dtype: DataType | str = DataType.ALL) -> list[str]:
         return self._reader.get_data_id(dtype)

--- a/src/qubx/data/guards.py
+++ b/src/qubx/data/guards.py
@@ -15,6 +15,7 @@ from collections.abc import Iterator
 import numpy as np
 import pandas as pd
 
+from qubx import logger
 from qubx.core.basics import DataType, ITimeProvider
 from qubx.data.storage import IReader, IStorage, Transformable
 
@@ -59,6 +60,45 @@ class TimeGuardedReader(IReader):
 
         return str(guard_time)
 
+    @staticmethod
+    def _resolve_timeframe(dtype: DataType | str, **kwargs) -> pd.Timedelta | None:
+        """
+        Extract the data timeframe from explicit kwarg or by parsing dtype.
+
+        Priority:
+          1. Explicit ``timeframe`` keyword argument
+          2. Timeframe parsed from dtype via ``DataType.from_str`` (e.g. "ohlc(1d)" → "1d")
+
+        Returns None when no timeframe can be determined.
+        """
+        tf = kwargs.get("timeframe")
+        if tf is not None:
+            try:
+                return pd.Timedelta(tf)
+            except Exception:
+                return None
+
+        if isinstance(dtype, str):
+            try:
+                _, params = DataType.from_str(dtype)
+                tf_str = params.get("timeframe")
+                if tf_str:
+                    return pd.Timedelta(tf_str)
+            except Exception:
+                pass
+
+        return None
+
+    def _floor_to_timeframe(self, stop: str | None, timeframe: pd.Timedelta | None) -> str | None:
+        """Floor stop to the nearest timeframe boundary to avoid partial resampled bars."""
+        if stop is None or timeframe is None:
+            return stop
+        ts = pd.Timestamp(stop)
+        floored = ts.floor(timeframe)
+        if floored != ts:
+            return str(floored)
+        return stop
+
     def read(
         self,
         data_id: str | list[str],
@@ -69,12 +109,21 @@ class TimeGuardedReader(IReader):
         **kwargs,
     ) -> Iterator[Transformable] | Transformable:
         clamped_stop = self._clamp_stop(stop)
+
+        # - floor start/stop to timeframe boundary to prevent partial resampled bars
+        timeframe = self._resolve_timeframe(dtype, **kwargs)
+        start = self._floor_to_timeframe(start, timeframe)
+        clamped_stop = self._floor_to_timeframe(clamped_stop, timeframe)
+
         # - if start is beyond clamped stop, entire range is in the future — force empty result
         #   (without this, handle_start_stop would swap start/stop and return past data)
         if clamped_stop is not None and start is not None:
             if pd.Timestamp(start) >= pd.Timestamp(clamped_stop):
                 start = clamped_stop
-        return self._reader.read(data_id, dtype, start=start, stop=clamped_stop, chunksize=chunksize, **kwargs)
+        result = self._reader.read(data_id, dtype, start=start, stop=clamped_stop, chunksize=chunksize, **kwargs)
+        if stop != clamped_stop:
+            logger.debug(f"[TIMEGUARD] {dtype} | stop={stop} -> clamped={clamped_stop}")
+        return result
 
     def get_data_id(self, dtype: DataType | str = DataType.ALL) -> list[str]:
         return self._reader.get_data_id(dtype)

--- a/src/qubx/trackers/sizers.py
+++ b/src/qubx/trackers/sizers.py
@@ -33,12 +33,16 @@ class FixedSizer(IPositionSizer):
 
     def calculate_target_positions(self, ctx: IStrategyContext, signals: list[Signal]) -> list[TargetPosition]:
         if not self.amount_in_quote:
-            return [s.target_for_amount(s.signal * self.fixed_size) for s in signals]
+            return [s.target_for_amount(s.signal * self.fixed_size / s.instrument.quantity_multiplier) for s in signals]
         positions = []
         for signal in signals:
             if (_entry := self.get_signal_entry_price(ctx, signal)) is None:
                 continue
-            positions.append(signal.target_for_amount(signal.signal * self.fixed_size / (_entry * signal.instrument.quantity_multiplier)))
+            positions.append(
+                signal.target_for_amount(
+                    signal.signal * self.fixed_size / (_entry * signal.instrument.quantity_multiplier)
+                )
+            )
         return positions
 
 

--- a/src/qubx/utils/results.py
+++ b/src/qubx/utils/results.py
@@ -16,15 +16,14 @@ All I/O uses ``pyarrow.fs.S3FileSystem`` for cloud paths — no dependency on
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from qubx import logger
-from qubx.config import S3Account
 from qubx.core.metrics import TradingSessionResult
+from qubx.utils.s3 import S3Client, is_cloud_path
 from qubx.utils.time import to_utc
 
 
@@ -52,19 +51,6 @@ def normalize_tags(tags: str | list[str] | None) -> list[str]:
     return list(tags)
 
 
-def is_cloud_path(path: str) -> bool:
-    """Check if path is a cloud storage URI (S3, GCS, Azure)."""
-    return path.startswith(("s3://", "gs://", "az://", "abfs://"))
-
-
-def _strip_cloud_scheme(path: str) -> str:
-    """Strip cloud URI scheme for use with pyarrow.fs (which wants bucket/key, not s3://bucket/key)."""
-    for prefix in ("s3://", "gs://", "az://", "abfs://"):
-        if path.startswith(prefix):
-            return path[len(prefix) :]
-    return path
-
-
 def copy_file_to_storage(
     src: str, dst_dir: str, storage_options: dict | None = None, dst_name: str | None = None
 ) -> None:
@@ -90,55 +76,7 @@ def copy_file_to_storage(
         Path(dst).parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)
     else:
-        fs = _make_pa_s3_filesystem(storage_options or {})
-        with open(src, "rb") as fin:
-            data = fin.read()
-        with fs.open_output_stream(_strip_cloud_scheme(dst)) as fout:
-            fout.write(data)
-
-
-# - module-level cache: one S3FileSystem per unique credential set.
-# - pyarrow.fs.S3FileSystem is thread-safe and pools TCP+SSL connections internally.
-# - without caching, every write() call re-establishes a new connection to the endpoint
-# - which adds ~200-500ms per write — catastrophic for simulations with 10+ status writes.
-_PA_S3_FS_CACHE: dict[tuple, Any] = {}
-
-
-def _make_pa_s3_filesystem(opts: dict):
-    """
-    Return a cached pyarrow.fs.S3FileSystem for the given storage options.
-
-    The instance is keyed on (key, secret, endpoint_url, region) and reused across
-    all calls with identical credentials.  This avoids re-establishing a TCP+SSL
-    connection to the S3 endpoint on every parquet write.
-
-    Uses Arrow's native S3 client — no dependency on s3fs, aiobotocore, or aiohttp.
-    """
-    _region = opts.get("client_kwargs", {}).get("region_name") if opts.get("client_kwargs") else None
-    _cache_key = (opts.get("key"), opts.get("secret"), opts.get("endpoint_url"), _region)
-
-    if _cache_key not in _PA_S3_FS_CACHE:
-        try:
-            import pyarrow.fs as pafs
-        except ImportError:
-            raise ImportError(
-                "pyarrow with S3 support is required for cloud storage. Install with: pip install pyarrow"
-            )
-
-        kwargs: dict = {}
-        if opts.get("key"):
-            kwargs["access_key"] = opts["key"]
-        if opts.get("secret"):
-            kwargs["secret_key"] = opts["secret"]
-        if opts.get("endpoint_url"):
-            # - pyarrow.fs.S3FileSystem expects hostname only (no https://)
-            kwargs["endpoint_override"] = opts["endpoint_url"].removeprefix("https://").removeprefix("http://")
-        if _region:
-            kwargs["region"] = _region
-
-        _PA_S3_FS_CACHE[_cache_key] = pafs.S3FileSystem(**kwargs)
-
-    return _PA_S3_FS_CACHE[_cache_key]
+        S3Client(storage_options=storage_options or {}).copy_local_to_s3(src, dst_dir, dst_name=dst_name)
 
 
 def _sanitize_df_for_parquet(df: pd.DataFrame) -> pd.DataFrame:
@@ -167,11 +105,7 @@ def _sanitize_df_for_parquet(df: pd.DataFrame) -> pd.DataFrame:
 
 def read_parquet(path: str, storage_options: dict | None = None) -> pd.DataFrame:
     """
-    Read parquet file supporting local and cloud paths.
-
-    For cloud paths uses ``pyarrow.fs.S3FileSystem`` (Arrow's own S3 client) instead
-    of going through ``fsspec → s3fs → aiobotocore → aiohttp``, which avoids
-    ``aiohttp.SocketFactoryType`` import errors when package versions are mismatched.
+    Read parquet file supporting local and cloud paths (with retry for cloud).
 
     Args:
         path:            Local path or cloud URI (``s3://bucket/key``).
@@ -183,16 +117,13 @@ def read_parquet(path: str, storage_options: dict | None = None) -> pd.DataFrame
     if not is_cloud_path(path):
         return pd.read_parquet(path)
 
-    fs = _make_pa_s3_filesystem(storage_options or {})
-    table = pq.read_table(_strip_cloud_scheme(path), filesystem=fs)
-    return table.to_pandas()
+    return S3Client(storage_options=storage_options or {}).read_parquet(path)
 
 
 def write_parquet(df: pd.DataFrame | None, path: str, storage_options: dict | None = None) -> None:
     """
-    Write DataFrame to parquet, supporting local and cloud paths.
+    Write DataFrame to parquet, supporting local and cloud paths (with retry for cloud).
     Local: creates parent directories automatically.
-    Cloud: uses pyarrow.fs.S3FileSystem (no s3fs/aiobotocore dependency).
     Skips write silently when df is None or empty.
     """
     if df is None or df.empty:
@@ -202,61 +133,24 @@ def write_parquet(df: pd.DataFrame | None, path: str, storage_options: dict | No
         Path(path).parent.mkdir(parents=True, exist_ok=True)
         df.to_parquet(path, index=True, engine="pyarrow")
     else:
-        fs = _make_pa_s3_filesystem(storage_options or {})
-        table = pa.Table.from_pandas(df, preserve_index=True)
-        pq.write_table(table, _strip_cloud_scheme(path), filesystem=fs)
+        S3Client(storage_options=storage_options or {}).write_parquet(df, path)
 
 
 def write_parquet_table(table: pa.Table, path: str, storage_options: dict | None = None) -> None:
     """
-    Write pyarrow Table to parquet, supporting local and cloud paths.
+    Write pyarrow Table to parquet, supporting local and cloud paths (with retry for cloud).
     Used for schema-enforced writes (status, metadata).
-    Cloud: uses pyarrow.fs.S3FileSystem (no s3fs/aiobotocore dependency).
     """
     if not is_cloud_path(path):
         Path(path).parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(table, path)
     else:
-        fs = _make_pa_s3_filesystem(storage_options or {})
-        pq.write_table(table, _strip_cloud_scheme(path), filesystem=fs)
-
-
-def _s3_account_to_opts(acct: "S3Account") -> dict:
-    """Convert an S3Account to the storage options dict format."""
-    opts: dict = {
-        "key": acct.access_key_id,
-        "secret": acct.secret_access_key,
-    }
-    if acct.endpoint_url:
-        endpoint = acct.endpoint_url
-        if not endpoint.startswith(("http://", "https://")):
-            endpoint = f"https://{endpoint}"
-        opts["endpoint_url"] = endpoint
-    if acct.region:
-        opts["client_kwargs"] = {"region_name": acct.region}
-    return opts
+        S3Client(storage_options=storage_options or {}).write_parquet_table(table, path)
 
 
 def resolve_s3_storage_options(explicit: dict | None = None, account: str | None = None) -> dict:
-    """
-    Resolve S3 storage options from explicit params or named account in settings.
-
-    Priority:
-        1. explicit dict (returned as-is)
-        2. Named account from settings.s3[account]
-        3. settings.default_s3_account (if configured)
-        4. Empty dict (default credential chain)
-    """
-    if explicit is not None:
-        return explicit
-
-    from qubx.config import settings
-
-    name = account or settings.default_s3_account
-    if name and name in settings.s3:
-        return _s3_account_to_opts(settings.s3[name])
-
-    return {}
+    """Resolve S3 storage options. Delegates to :class:`~qubx.utils.s3.S3Client`."""
+    return S3Client._resolve_options(explicit, account)
 
 
 def write_metadata_parquet(

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -1017,6 +1017,167 @@ def _apply_base_live_subscription(ctx: IStrategyContext) -> None:
         ctx.subscribe(base_live_subscription)
 
 
+_SIMULATION_OVERRIDE_KEYS = {
+    "capital", "instruments", "commissions", "base_currency", "n_jobs",
+    "debug", "run_separate_instruments", "enable_funding", "enable_inmemory_emitter",
+    "portfolio_log_freq", "trading_session",
+}
+
+
+def simulate_config(
+    config: str | Path | StrategyConfig,
+    start: str | None = None,
+    stop: str | None = None,
+    **overrides,
+) -> list:
+    """
+    Run a simulation directly from a YAML config file or StrategyConfig object.
+
+    Convenience function for notebooks and scripts — loads the config, constructs
+    storages, instantiates the strategy with parameters, and calls simulate().
+
+    Args:
+        config: Path to YAML config file, or an already-loaded StrategyConfig.
+        start: Override simulation start date.
+        stop: Override simulation stop date.
+        **overrides: Override any strategy parameter or simulation setting.
+            Simulation settings (capital, instruments, commissions, base_currency,
+            n_jobs, debug, run_separate_instruments, enable_funding,
+            enable_inmemory_emitter, portfolio_log_freq, trading_session) are
+            applied to the simulation config. All other keys are treated as
+            strategy parameter overrides.
+
+    Returns:
+        list[TradingSessionResult]: Simulation results.
+
+    Example::
+
+        from qubx.utils.runner.runner import simulate_config
+
+        results = simulate_config(
+            "configs/my_strategy.yml",
+            start="2026-01-01",
+            max_pairs=3,
+            enable_inmemory_emitter=True,
+            debug="INFO",
+        )
+        r = results[0]
+    """
+    if isinstance(config, (str, Path)):
+        cfg = load_strategy_config_from_yaml(config)
+    else:
+        cfg = config
+
+    # Split overrides into simulation settings vs strategy parameters
+    sim_overrides = {k: v for k, v in overrides.items() if k in _SIMULATION_OVERRIDE_KEYS}
+    param_overrides = {k: v for k, v in overrides.items() if k not in _SIMULATION_OVERRIDE_KEYS}
+
+    # Apply simulation overrides to the config
+    if sim_overrides and cfg.simulation is not None:
+        cfg.simulation = cfg.simulation.model_copy(update=sim_overrides)
+
+    return _run_simulation_from_config(cfg, start=start, stop=stop, param_overrides=param_overrides)
+
+
+def _import_strategy_class(stg: str | list[str]):
+    """Import and return the strategy class from a dotted path string (or list of strings)."""
+    match stg:
+        case list():
+            stg_cls = reduce(lambda x, y: x + y, [class_import(x) for x in stg])
+            return stg_cls, stg
+        case str():
+            return class_import(stg), [stg]
+        case _:
+            raise SimulationConfigError(f"Invalid strategy type: {stg}")
+
+
+def _build_sim_params(
+    cfg: StrategyConfig,
+    start: str | None = None,
+    stop: str | None = None,
+) -> tuple[dict, dict[str, object]]:
+    """
+    Build the simulate() kwargs from a StrategyConfig.
+
+    Returns:
+        (data_kwargs, sim_params) where data_kwargs contains 'data' and 'custom_data'
+        keys, and sim_params contains all other simulate() keyword arguments.
+    """
+    sim = cfg.simulation
+    assert sim is not None
+
+    # - resolve storages
+    data = construct_storage(sim.data)
+    data_i = create_data_type_storages(sim.custom_data) if sim.custom_data else {}
+
+    sim_params: dict[str, object] = {
+        "instruments": sim.instruments,
+        "capital": sim.capital,
+        "commissions": sim.commissions,
+        "start": start or sim.start,
+        "stop": stop or sim.stop,
+        "enable_funding": sim.enable_funding,
+        "enable_inmemory_emitter": sim.enable_inmemory_emitter,
+    }
+
+    if sim.base_currency is not None:
+        sim_params["base_currency"] = sim.base_currency
+    if sim.debug is not None:
+        sim_params["debug"] = sim.debug
+    if sim.portfolio_log_freq is not None:
+        sim_params["portfolio_log_freq"] = sim.portfolio_log_freq
+    if sim.n_jobs is not None:
+        sim_params["n_jobs"] = sim.n_jobs
+    if sim.run_separate_instruments:
+        sim_params["run_separate_instruments"] = True
+    if sim.prefetch is not None:
+        sim_params["prefetch_config"] = sim.prefetch
+    if sim.trading_session is not None:
+        sim_params["trading_sessions_time"] = sim.trading_session
+
+    # - resolve aux_data
+    aux_configs = resolve_aux_config(cfg.aux, getattr(sim, "aux", None))
+    if aux_configs:
+        sim_params["aux_data"] = construct_multi_storage(aux_configs)
+
+    return {"data": data, "custom_data": data_i}, sim_params
+
+
+def _run_simulation_from_config(
+    cfg: StrategyConfig,
+    start: str | None = None,
+    stop: str | None = None,
+    param_overrides: dict | None = None,
+) -> list:
+    """
+    Core simulation logic shared by simulate_config() and simulate_strategy().
+
+    Loads plugins, imports strategy, builds sim params, and calls simulate().
+    Does NOT handle result saving, logging, or variation — those are CLI concerns
+    handled by simulate_strategy().
+    """
+    from qubx.plugins import load_plugins
+
+    load_plugins(cfg.plugins)
+
+    if cfg.simulation is None:
+        raise ValueError("Simulation configuration is required")
+
+    stg_cls, _ = _import_strategy_class(cfg.strategy)
+
+    # - merge config parameters with overrides
+    params = cfg.parameters | (param_overrides or {})
+    strategy = stg_cls(**params)
+
+    run_name = cfg.name or "simulation"
+    experiments = {run_name: strategy}
+
+    data_kwargs, sim_params = _build_sim_params(cfg, start=start, stop=stop)
+    sim_params.setdefault("n_jobs", 1)
+
+    return simulate(experiments, **data_kwargs, **sim_params)  # type: ignore
+
+
 def simulate_strategy(
     config_file: Path,
     save_path: str | None = None,
@@ -1028,7 +1189,7 @@ def simulate_strategy(
     name: str | None = None,
 ):
     """
-    Simulate a strategy.
+    Simulate a strategy from the CLI with result saving, logging, and variation support.
 
     Args:
         config_file: Path to the strategy configuration file
@@ -1060,25 +1221,15 @@ def simulate_strategy(
     if cfg.simulation.run_separate_instruments and cfg.simulation.variate:
         raise ValueError("Run separate instruments is not supported with variate")
 
-    stg = cfg.strategy
-    simulation_name = config_file.stem  # - used for config_name metadata field and log paths
+    stg_cls, _strategy_full_classes = _import_strategy_class(cfg.strategy)
+
+    simulation_name = config_file.stem
     _v_id = cast(pd.Timestamp, pd.Timestamp("now")).strftime("%Y%m%d_%H%M%S")
 
     # - resolve run name: CLI --name > config 'name:' field > config filename stem
-    # - {base_path}/{_yaml_name}/{ShortClass}/{timestamp}/
     _yaml_name = name or cfg.name or simulation_name
     if name:
         logger.info(f"Run name overridden via CLI: <g>{name}</g>")
-
-    match stg:
-        case list():
-            stg_cls = reduce(lambda x, y: x + y, [class_import(x) for x in stg])
-            _strategy_full_classes = stg
-        case str():
-            stg_cls = class_import(stg)
-            _strategy_full_classes = [stg]
-        case _:
-            raise SimulationConfigError(f"Invalid strategy type: {stg}")
 
     # - create simulation setup
     if cfg.simulation.variate:
@@ -1096,68 +1247,15 @@ def simulate_strategy(
                 cfg.parameters[k] = [v]
 
         experiments = variate(stg_cls, **(cfg.parameters | cfg.simulation.variate), conditions=conditions)
-        # - use _yaml_name so TradingSessionResult.name matches storage path
         experiments = {f"{_yaml_name}.{_v_id}.[{k}]": v for k, v in experiments.items()}
         print(f"Parameters variation is configured. There are {len(experiments)} simulations to run.")
         _n_jobs = -1
     else:
         strategy = stg_cls(**cfg.parameters)
-        # - use _yaml_name so TradingSessionResult.name matches storage path
         experiments = {_yaml_name: strategy}
         _n_jobs = 1
 
-    # - resolve main data storage (data used for simulation)
-    data = construct_storage(cfg.simulation.data)
-
-    # - resolve custom data storage if configured
-    data_i = create_data_type_storages(cfg.simulation.custom_data) if cfg.simulation.custom_data else {}
-
-    sim_params = {
-        "instruments": cfg.simulation.instruments,
-        "capital": cfg.simulation.capital,
-        "commissions": cfg.simulation.commissions,
-        "start": cfg.simulation.start,
-        "stop": cfg.simulation.stop,
-        "enable_funding": cfg.simulation.enable_funding,
-        "enable_inmemory_emitter": cfg.simulation.enable_inmemory_emitter,
-    }
-
-    if cfg.simulation.base_currency is not None:
-        sim_params["base_currency"] = cfg.simulation.base_currency
-
-    if cfg.simulation.debug is not None:
-        sim_params["debug"] = cfg.simulation.debug
-
-    if cfg.simulation.portfolio_log_freq is not None:
-        sim_params["portfolio_log_freq"] = cfg.simulation.portfolio_log_freq
-
-    if start is not None:
-        sim_params["start"] = start
-        logger.info(f"Start date set to {start}")
-
-    if stop is not None:
-        sim_params["stop"] = stop
-        logger.info(f"Stop date set to {stop}")
-
-    if cfg.simulation.n_jobs is not None:
-        sim_params["n_jobs"] = cfg.simulation.n_jobs
-
-    # - check for aux_data parameter
-    aux_configs = resolve_aux_config(cfg.aux, getattr(cfg.simulation, "aux", None))
-    if aux_configs:
-        sim_params["aux_data"] = construct_multi_storage(aux_configs)
-
-    # - add run_separate_instruments parameter
-    if cfg.simulation.run_separate_instruments:
-        sim_params["run_separate_instruments"] = True
-
-    # - add prefetch_config parameter
-    if cfg.simulation.prefetch is not None:
-        sim_params["prefetch_config"] = cfg.simulation.prefetch
-
-    # - trading sessions config
-    if cfg.simulation.trading_session is not None:
-        sim_params["trading_sessions_time"] = cfg.simulation.trading_session
+    data_kwargs, sim_params = _build_sim_params(cfg, start=start, stop=stop)
 
     # - normalize description and tags from config
     _descr: str = ""
@@ -1219,7 +1317,7 @@ def simulate_strategy(
 
     _t_sim_start = time.monotonic()
     try:
-        test_res = simulate(experiments, data=data, custom_data=data_i, log_file=_log_file, **sim_params)  # type: ignore
+        test_res = simulate(experiments, **data_kwargs, log_file=_log_file, **sim_params)  # type: ignore
     except Exception as e:
         if _results_saver is not None:
             _results_saver.write_failed(e, log_file=_cloud_log_file)

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -52,11 +52,7 @@ from qubx.restarts.state_resolvers import StateResolver
 from qubx.restarts.time_finders import TimeFinder
 from qubx.restorers import create_state_restorer
 from qubx.utils.misc import class_import, green, install_uvloop, makedirs, red
-from qubx.utils.results import (
-    SimulationResultsSaver,
-    is_cloud_path,
-    normalize_tags,
-)
+from qubx.utils.results import SimulationResultsSaver, normalize_tags
 from qubx.utils.runner.configs import (
     ExchangeConfig,
     LiveConfig,
@@ -79,6 +75,7 @@ from qubx.utils.runner.factory import (
     create_notifiers,
     create_state_persistence,
 )
+from qubx.utils.s3 import is_cloud_path
 from qubx.utils.time import convert_seconds_to_str
 
 from .accounts import AccountConfigurationManager
@@ -1017,68 +1014,6 @@ def _apply_base_live_subscription(ctx: IStrategyContext) -> None:
         ctx.subscribe(base_live_subscription)
 
 
-_SIMULATION_OVERRIDE_KEYS = {
-    "capital", "instruments", "commissions", "base_currency", "n_jobs",
-    "debug", "run_separate_instruments", "enable_funding", "enable_inmemory_emitter",
-    "portfolio_log_freq", "trading_session",
-}
-
-
-def simulate_config(
-    config: str | Path | StrategyConfig,
-    start: str | None = None,
-    stop: str | None = None,
-    **overrides,
-) -> list:
-    """
-    Run a simulation directly from a YAML config file or StrategyConfig object.
-
-    Convenience function for notebooks and scripts — loads the config, constructs
-    storages, instantiates the strategy with parameters, and calls simulate().
-
-    Args:
-        config: Path to YAML config file, or an already-loaded StrategyConfig.
-        start: Override simulation start date.
-        stop: Override simulation stop date.
-        **overrides: Override any strategy parameter or simulation setting.
-            Simulation settings (capital, instruments, commissions, base_currency,
-            n_jobs, debug, run_separate_instruments, enable_funding,
-            enable_inmemory_emitter, portfolio_log_freq, trading_session) are
-            applied to the simulation config. All other keys are treated as
-            strategy parameter overrides.
-
-    Returns:
-        list[TradingSessionResult]: Simulation results.
-
-    Example::
-
-        from qubx.utils.runner.runner import simulate_config
-
-        results = simulate_config(
-            "configs/my_strategy.yml",
-            start="2026-01-01",
-            max_pairs=3,
-            enable_inmemory_emitter=True,
-            debug="INFO",
-        )
-        r = results[0]
-    """
-    if isinstance(config, (str, Path)):
-        cfg = load_strategy_config_from_yaml(config)
-    else:
-        cfg = config
-
-    # Split overrides into simulation settings vs strategy parameters
-    sim_overrides = {k: v for k, v in overrides.items() if k in _SIMULATION_OVERRIDE_KEYS}
-    param_overrides = {k: v for k, v in overrides.items() if k not in _SIMULATION_OVERRIDE_KEYS}
-
-    # Apply simulation overrides to the config
-    if sim_overrides and cfg.simulation is not None:
-        cfg.simulation = cfg.simulation.model_copy(update=sim_overrides)
-
-    return _run_simulation_from_config(cfg, start=start, stop=stop, param_overrides=param_overrides)
-
-
 def _import_strategy_class(stg: str | list[str]):
     """Import and return the strategy class from a dotted path string (or list of strings)."""
     match stg:
@@ -1143,41 +1078,6 @@ def _build_sim_params(
     return {"data": data, "custom_data": data_i}, sim_params
 
 
-def _run_simulation_from_config(
-    cfg: StrategyConfig,
-    start: str | None = None,
-    stop: str | None = None,
-    param_overrides: dict | None = None,
-) -> list:
-    """
-    Core simulation logic shared by simulate_config() and simulate_strategy().
-
-    Loads plugins, imports strategy, builds sim params, and calls simulate().
-    Does NOT handle result saving, logging, or variation — those are CLI concerns
-    handled by simulate_strategy().
-    """
-    from qubx.plugins import load_plugins
-
-    load_plugins(cfg.plugins)
-
-    if cfg.simulation is None:
-        raise ValueError("Simulation configuration is required")
-
-    stg_cls, _ = _import_strategy_class(cfg.strategy)
-
-    # - merge config parameters with overrides
-    params = cfg.parameters | (param_overrides or {})
-    strategy = stg_cls(**params)
-
-    run_name = cfg.name or "simulation"
-    experiments = {run_name: strategy}
-
-    data_kwargs, sim_params = _build_sim_params(cfg, start=start, stop=stop)
-    sim_params.setdefault("n_jobs", 1)
-
-    return simulate(experiments, **data_kwargs, **sim_params)  # type: ignore
-
-
 def simulate_strategy(
     config_file: Path,
     save_path: str | None = None,
@@ -1187,6 +1087,7 @@ def simulate_strategy(
     log_to_file: bool = False,
     storage_options: dict | None = None,
     name: str | None = None,
+    log_file: str | None = None,
 ):
     """
     Simulate a strategy from the CLI with result saving, logging, and variation support.
@@ -1293,7 +1194,11 @@ def simulate_strategy(
     # - resolve log file path (after saver so we can use run_dir for the local case)
     _log_file: str | None = None
     _cloud_log_file: str | None = None  # - set only for cloud; uploaded by saver, deleted on failure
-    if log_to_file:
+    if log_file:
+        # - explicit log file path from CLI --log-file
+        _log_file = log_file
+        print(f" > Logging to file {green(_log_file)} ...")
+    elif log_to_file:
         _is_cloud = save_path is not None and is_cloud_path(save_path)
 
         if _is_cloud:

--- a/src/qubx/utils/s3.py
+++ b/src/qubx/utils/s3.py
@@ -1,0 +1,310 @@
+"""Centralized S3 client with named accounts, retry logic, and unified path handling.
+
+Supports two path formats:
+- Cloud URI: ``s3://bucket/key`` (credentials from default account or explicit)
+- Account URI: ``account:bucket/key`` (credentials from named account in settings)
+
+Usage::
+
+    from qubx.utils.s3 import S3Client
+
+    client = S3Client("hetzner")
+    df = client.read_parquet("frab/spreads/asset=BTC/data.parquet")
+
+    # Or parse account:bucket/key
+    client, path = S3Client.from_uri("hetzner:frab/spreads/asset=BTC/data.parquet")
+    df = client.read_parquet(path)
+"""
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from qubx import logger
+
+# ---------------------------------------------------------------------------
+# Module-level filesystem cache (same pattern as before, now owned here)
+# ---------------------------------------------------------------------------
+_PA_S3_FS_CACHE: dict[tuple, Any] = {}
+
+
+def _make_filesystem(opts: dict):
+    """Return a cached ``pyarrow.fs.S3FileSystem`` for the given storage options."""
+    _region = opts.get("client_kwargs", {}).get("region_name") if opts.get("client_kwargs") else None
+    _cache_key = (opts.get("key"), opts.get("secret"), opts.get("endpoint_url"), _region)
+
+    if _cache_key not in _PA_S3_FS_CACHE:
+        import pyarrow.fs as pafs
+
+        kwargs: dict = {}
+        if opts.get("key"):
+            kwargs["access_key"] = opts["key"]
+        if opts.get("secret"):
+            kwargs["secret_key"] = opts["secret"]
+        if opts.get("endpoint_url"):
+            kwargs["endpoint_override"] = opts["endpoint_url"].removeprefix("https://").removeprefix("http://")
+        if _region:
+            kwargs["region"] = _region
+
+        _PA_S3_FS_CACHE[_cache_key] = pafs.S3FileSystem(**kwargs)
+
+    return _PA_S3_FS_CACHE[_cache_key]
+
+
+# ---------------------------------------------------------------------------
+# Path utilities
+# ---------------------------------------------------------------------------
+
+def is_cloud_path(path: str) -> bool:
+    """Check if path is a cloud storage URI (S3, GCS, Azure)."""
+    return path.startswith(("s3://", "gs://", "az://", "abfs://"))
+
+
+def strip_scheme(path: str) -> str:
+    """Strip cloud URI scheme — pyarrow expects ``bucket/key``, not ``s3://bucket/key``."""
+    for prefix in ("s3://", "gs://", "az://", "abfs://"):
+        if path.startswith(prefix):
+            return path[len(prefix):]
+    return path
+
+
+def parse_uri(uri: str) -> tuple[str, str]:
+    """Parse ``account:bucket/key`` into ``(account, bucket_and_key)``.
+
+    Returns:
+        (account_name, "bucket/key") tuple.
+
+    Raises:
+        ValueError: If format is invalid.
+    """
+    if ":" not in uri:
+        raise ValueError(f"Invalid S3 URI '{uri}'. Expected format: account:bucket/path")
+    account, rest = uri.split(":", 1)
+    if not account:
+        raise ValueError("Account name cannot be empty")
+    if not rest:
+        raise ValueError("Bucket/path cannot be empty")
+    return account, rest
+
+
+# ---------------------------------------------------------------------------
+# Retry helper
+# ---------------------------------------------------------------------------
+
+_TRANSIENT_ERROR_SUBSTRINGS = (
+    "NETWORK_CONNECTION",
+    "ConnectionReset",
+    "ConnectionAborted",
+    "BrokenPipe",
+    "Timeout",
+    "throttl",
+    "SlowDown",
+    "ServiceUnavailable",
+    "InternalError",
+    "RequestTimeout",
+)
+
+
+def _is_transient(exc: Exception) -> bool:
+    """Check if an exception looks like a transient S3/network error."""
+    msg = str(exc)
+    return any(s.lower() in msg.lower() for s in _TRANSIENT_ERROR_SUBSTRINGS)
+
+
+def _retry(func, *, max_attempts: int = 3, base_delay: float = 1.0):
+    """Execute func with retries on transient errors using exponential backoff."""
+    last_exc = None
+    for attempt in range(max_attempts):
+        try:
+            return func()
+        except Exception as e:
+            last_exc = e
+            if not _is_transient(e) or attempt == max_attempts - 1:
+                raise
+            delay = base_delay * (2 ** attempt)
+            logger.warning(f"S3 transient error (attempt {attempt + 1}/{max_attempts}), retrying in {delay:.1f}s: {e}")
+            time.sleep(delay)
+    raise last_exc  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# S3Client
+# ---------------------------------------------------------------------------
+
+class S3Client:
+    """S3 client with named account support, connection caching, and retry logic.
+
+    Args:
+        account: Named account from ``~/.qubx/config.json`` (e.g. ``"hetzner"``).
+                 If None, uses the default account from settings.
+        storage_options: Explicit credentials dict. Overrides account lookup.
+        max_retries: Max retry attempts for transient errors.
+        retry_delay: Base delay in seconds for exponential backoff.
+    """
+
+    def __init__(
+        self,
+        account: str | None = None,
+        storage_options: dict | None = None,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ):
+        self._opts = self._resolve_options(storage_options, account)
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
+
+    @staticmethod
+    def from_uri(uri: str, **kwargs) -> tuple["S3Client", str]:
+        """Create client from ``account:bucket/key`` URI.
+
+        Returns:
+            (S3Client, "bucket/key") tuple.
+        """
+        account, path = parse_uri(uri)
+        return S3Client(account=account, **kwargs), path
+
+    @property
+    def fs(self):
+        """Cached ``pyarrow.fs.S3FileSystem`` instance."""
+        return _make_filesystem(self._opts)
+
+    # -- Parquet I/O --------------------------------------------------------
+
+    def read_parquet(self, path: str) -> pd.DataFrame:
+        """Read a parquet file from S3 with retry on transient errors.
+
+        Args:
+            path: ``bucket/key`` path (no ``s3://`` prefix).
+        """
+        path = strip_scheme(path)
+
+        def _read():
+            table = pq.read_table(path, filesystem=self.fs)
+            return table.to_pandas()
+
+        return _retry(_read, max_attempts=self._max_retries, base_delay=self._retry_delay)
+
+    def write_parquet(self, df: pd.DataFrame, path: str) -> None:
+        """Write a DataFrame to parquet on S3 with retry on transient errors.
+
+        Args:
+            df: DataFrame to write.
+            path: ``bucket/key`` path (no ``s3://`` prefix).
+        """
+        if df is None or df.empty:
+            return
+        path = strip_scheme(path)
+        table = pa.Table.from_pandas(df, preserve_index=True)
+
+        def _write():
+            pq.write_table(table, path, filesystem=self.fs)
+
+        _retry(_write, max_attempts=self._max_retries, base_delay=self._retry_delay)
+
+    def write_parquet_table(self, table: pa.Table, path: str) -> None:
+        """Write a pyarrow Table to parquet on S3 with retry."""
+        path = strip_scheme(path)
+
+        def _write():
+            pq.write_table(table, path, filesystem=self.fs)
+
+        _retry(_write, max_attempts=self._max_retries, base_delay=self._retry_delay)
+
+    # -- File operations ----------------------------------------------------
+
+    def ls(self, path: str, recursive: bool = False) -> list:
+        """List files under a path. Returns list of ``pyarrow.fs.FileInfo``."""
+        from pyarrow.fs import FileSelector
+
+        path = strip_scheme(path).rstrip("/")
+
+        def _ls():
+            return self.fs.get_file_info(FileSelector(path, recursive=recursive))
+
+        return _retry(_ls, max_attempts=self._max_retries, base_delay=self._retry_delay)
+
+    def rm(self, path: str, recursive: bool = False) -> None:
+        """Delete a file or directory on S3."""
+        path = strip_scheme(path)
+
+        def _rm():
+            if recursive:
+                self.fs.delete_dir(path)
+            else:
+                self.fs.delete_file(path)
+
+        _retry(_rm, max_attempts=self._max_retries, base_delay=self._retry_delay)
+
+    def copy_local_to_s3(self, src: str, dst: str, dst_name: str | None = None) -> None:
+        """Copy a local file to S3.
+
+        Args:
+            src: Local file path.
+            dst: S3 directory path (``bucket/key/``).
+            dst_name: Override filename. Defaults to source filename.
+        """
+        src_path = Path(src)
+        if not src_path.is_file():
+            logger.warning(f"File not found, skipping: {src}")
+            return
+
+        filename = dst_name or src_path.name
+        full_dst = f"{strip_scheme(dst).rstrip('/')}/{filename}"
+
+        def _copy():
+            with open(src, "rb") as fin:
+                data = fin.read()
+            with self.fs.open_output_stream(full_dst) as fout:
+                fout.write(data)
+
+        _retry(_copy, max_attempts=self._max_retries, base_delay=self._retry_delay)
+
+    def copy_s3(self, src: str, dst: str, recursive: bool = False) -> None:
+        """Copy files within the same S3 account."""
+        from pyarrow.fs import copy_files
+
+        src = strip_scheme(src)
+        dst = strip_scheme(dst)
+
+        def _copy():
+            copy_files(src, dst, source_filesystem=self.fs, destination_filesystem=self.fs)
+
+        _retry(_copy, max_attempts=self._max_retries, base_delay=self._retry_delay)
+
+    # -- Internals ----------------------------------------------------------
+
+    @property
+    def storage_options(self) -> dict:
+        """Resolved storage options dict (for callers that need raw credentials)."""
+        return self._opts
+
+    @staticmethod
+    def _resolve_options(explicit: dict | None, account: str | None) -> dict:
+        """Resolve S3 storage options: explicit → named account → default → empty."""
+        if explicit is not None:
+            return explicit
+
+        from qubx.config import get_settings
+
+        settings = get_settings()
+        name = account or settings.default_s3_account
+        if name and name in settings.s3:
+            acct = settings.s3[name]
+            opts: dict = {
+                "key": acct.access_key_id,
+                "secret": acct.secret_access_key,
+            }
+            if acct.endpoint_url:
+                endpoint = acct.endpoint_url
+                if not endpoint.startswith(("http://", "https://")):
+                    endpoint = f"https://{endpoint}"
+                opts["endpoint_url"] = endpoint
+            if acct.region:
+                opts["client_kwargs"] = {"region_name": acct.region}
+            return opts
+
+        return {}

--- a/tests/qubx/data/test_cache.py
+++ b/tests/qubx/data/test_cache.py
@@ -668,6 +668,96 @@ class TestCachedReader:
         # - should not raise
         reader.close()
 
+    def test_partial_hit_does_not_inflate_range_for_existing_symbols(self):
+        """
+        Regression: when a partial hit fetches data for NEW symbols with an extended
+        fetch_stop, the recorded range must NOT grow beyond what ALL symbols have data for.
+
+        Scenario:
+          1. Read [BTC, ETH] for [Jan 1, Jan 3) with prefetch=3d → fetches [Jan 1, Jan 6),
+             records range [Jan 1, Jan 6). Both BTC and ETH have data through Jan 5.
+          2. Read [BTC, ETH, SOL] for [Jan 1, Jan 3) → partial hit (SOL is new).
+             Fetches SOL with fetch_stop=Jan 6, records range [Jan 1, Jan 6).
+             This is fine — SOL now has data through Jan 5 too.
+          3. Read [BTC, ETH] for [Jan 4, Jan 6) → cache hit, returns data. Correct.
+
+        Bug scenario (partial hit with DIFFERENT time window):
+          1. Read [BTC, ETH] for [Jan 1, Jan 3) with prefetch=3d → fetches [Jan 1, Jan 6),
+             records range [Jan 1, Jan 6). Both have data through Jan 5.
+          2. Read [BTC, ETH, SOL] for [Jan 2, Jan 4) → partial hit (SOL is new).
+             Fetches SOL with fetch_stop = Jan 4 + 3d = Jan 7.
+             BUG: records range [Jan 2, Jan 7) → merged to [Jan 1, Jan 7).
+             But BTC and ETH only have data through Jan 5 (from step 1 fetch).
+          3. Read [BTC, ETH] for [Jan 5, Jan 7) → cache says "covered by [Jan 1, Jan 7)"
+             → cache hit. But BTC/ETH data only goes to Jan 5. Returns incomplete data!
+        """
+        storage = _build_storage()
+        inner = storage.get_reader("BINANCE.UM", "SWAP")
+        reader = CachedReader(inner, prefetch_period="3d")
+
+        # Step 1: cache [BTC, ETH] for [Jan 1, Jan 3) → prefetches to Jan 6
+        r1 = reader.read(["BTCUSDT", "ETHUSDT"], "ohlc(1h)", "2024-01-01", "2024-01-03")
+        df1_btc = r1["BTCUSDT"].transform(PandasFrame())
+        assert df1_btc.index[-1] < pd.Timestamp("2024-01-03")
+
+        # Step 2: partial hit — SOL is new, BTC/ETH are cached
+        r2 = reader.read(["BTCUSDT", "ETHUSDT", "SOLUSDT"], "ohlc(1h)", "2024-01-02", "2024-01-04")
+        df2_sol = r2["SOLUSDT"].transform(PandasFrame())
+        assert len(df2_sol) > 0
+
+        # Step 3: read BTC/ETH for a range beyond the original fetch
+        # Direct read from inner reader (ground truth)
+        r_direct = inner.read(["BTCUSDT", "ETHUSDT"], "ohlc(1h)", "2024-01-05", "2024-01-07")
+        df_direct_btc = r_direct["BTCUSDT"].transform(PandasFrame())
+
+        # Cached read — should match direct read
+        r3 = reader.read(["BTCUSDT", "ETHUSDT"], "ohlc(1h)", "2024-01-05", "2024-01-07")
+        df3_btc = r3["BTCUSDT"].transform(PandasFrame())
+
+        assert len(df3_btc) == len(df_direct_btc), (
+            f"Cached read returned {len(df3_btc)} rows but direct read returned {len(df_direct_btc)} rows. "
+            f"Partial hit inflated the cache range beyond what existing symbols have data for."
+        )
+
+    def test_partial_hit_new_symbol_has_less_coverage_than_range(self):
+        """
+        Known limitation: a symbol added via partial hit with a narrower request window
+        may have less data than the overall cached range claims.
+
+        Scenario:
+          1. Read [BTC, ETH] for [Jan 1, Jan 3) with prefetch=2d
+             → fetches [Jan 1, Jan 5), records [Jan 1, Jan 5).
+          2. Read [BTC, ETH, SOL] for [Jan 1, Jan 2) → partial hit (SOL new).
+             Fetches SOL with fetch_stop = Jan 2 + 2d = Jan 4.
+             Records [Jan 1, Jan 2) (our fix). Range stays [Jan 1, Jan 5).
+             But SOL only has data [Jan 1, Jan 4) — less than BTC/ETH's [Jan 1, Jan 5).
+          3. Read [BTC, ETH, SOL] for [Jan 4, Jan 5) → range [Jan 1, Jan 5) covers → hit.
+             BTC/ETH: have data through Jan 4 23:00 → returns 24 bars ✓
+             SOL: only has data through Jan 3 23:00 → returns 0 bars ✗
+        """
+        storage = _build_storage()
+        inner = storage.get_reader("BINANCE.UM", "SWAP")
+        reader = CachedReader(inner, prefetch_period="2d")
+
+        # Step 1: cache [BTC, ETH] for [Jan 1, Jan 3) → prefetches to Jan 5, records [Jan 1, Jan 5)
+        reader.read(["BTCUSDT", "ETHUSDT"], "ohlc(1h)", "2024-01-01", "2024-01-03")
+
+        # Step 2: partial hit with NARROWER window — SOL is new.
+        # Fetches SOL with fetch_stop = Jan 2 + 2d = Jan 4.
+        # SOL has data [Jan 1, Jan 4). Range stays [Jan 1, Jan 5).
+        reader.read(["BTCUSDT", "ETHUSDT", "SOLUSDT"], "ohlc(1h)", "2024-01-01", "2024-01-02")
+
+        # Step 3: read all 3 for [Jan 4, Jan 5) — within range [Jan 1, Jan 5) → cache hit
+        r_cached = reader.read(["BTCUSDT", "ETHUSDT", "SOLUSDT"], "ohlc(1h)", "2024-01-04", "2024-01-05")
+        r_direct = inner.read(["BTCUSDT", "ETHUSDT", "SOLUSDT"], "ohlc(1h)", "2024-01-04", "2024-01-05")
+
+        cached_ids = set(r_cached.get_data_ids()) if isinstance(r_cached, RawMultiData) else set()
+        direct_ids = set(r_direct.get_data_ids()) if isinstance(r_direct, RawMultiData) else set()
+        assert cached_ids == direct_ids, (
+            f"Cached result has {cached_ids} but direct has {direct_ids}. "
+            f"Per-symbol coverage gap: symbol added via partial hit is missing from cache hit."
+        )
+
     def test_repr(self):
         storage = _build_storage()
         inner = storage.get_reader("BINANCE.UM", "SWAP")

--- a/tests/qubx/data/test_cache.py
+++ b/tests/qubx/data/test_cache.py
@@ -151,6 +151,28 @@ class TestArrowHelpers:
         # - values should be deduplicated: b1 for 00-02, b2 for 03-07
         assert merged.column("v").to_pylist() == [10, 20, 30, 40, 50, 60, 70, 80]
 
+    def test_merge_batches_dedup_with_float_drift(self):
+        """
+        Overlapping batches where the same timestamp has slightly different float values
+        (e.g. QuestDB SUM precision drift across different query windows).
+        Dedup by timestamp should keep only the last (incoming) row.
+        """
+        ts1 = pd.date_range("2024-01-01", periods=5, freq="1h")
+        ts2 = pd.date_range("2024-01-01 03:00", periods=5, freq="1h")
+        b1 = pa.RecordBatch.from_pydict({"timestamp": ts1.values, "v": [10.0, 20.0, 30.0, 40.0, 50.0]})
+        # - overlapping rows (03, 04) have SLIGHTLY different values (float drift)
+        b2 = pa.RecordBatch.from_pydict({"timestamp": ts2.values, "v": [40.001, 50.002, 60.0, 70.0, 80.0]})
+        merged = _merge_batches(b1, b2, 0)
+        # - must still produce 8 unique timestamps, not 10
+        assert merged.num_rows == 8
+        times = merged.column("timestamp").to_pylist()
+        assert times == sorted(times)
+        assert len(set(times)) == 8
+        # - incoming wins for overlapping timestamps
+        vals = merged.column("v").to_pylist()
+        assert vals[3] == 40.001  # incoming value for 03:00
+        assert vals[4] == 50.002  # incoming value for 04:00
+
     def test_merge_batches_multi_row_per_timestamp(self):
         """
         Fundamental-style data: multiple rows per timestamp (one per metric) must all

--- a/tests/qubx/data/test_cache.py
+++ b/tests/qubx/data/test_cache.py
@@ -573,6 +573,55 @@ class TestCachedReader:
         assert "close" in df_ohlc.columns
         assert "funding_rate" in df_fund.columns
 
+    def test_different_symbols_separate_cache(self):
+        """
+        BTCUSDT and ETHUSDT data use different cache keys.
+        """
+        storage = _build_storage()
+        inner = storage.get_reader("BINANCE.UM", "SWAP")
+        reader = CachedReader(inner)
+
+        r_btc = reader.read("BTCUSDT", "ohlc(1h)", "2024-01-01", "2024-01-03")
+        r_eth = reader.read("ETHUSDT", "ohlc(1h)", "2024-01-01", "2024-01-03")
+
+        df_btc = r_btc.transform(PandasFrame())
+        df_eth = r_eth.transform(PandasFrame())
+
+        assert df_btc.index[0] == df_eth.index[0]
+        assert df_btc.index[-1] == df_eth.index[-1]
+
+    def test_per_symbol_works_after_all_symbols_request(self):
+        storage = _build_storage()
+        inner = storage.get_reader("BINANCE.UM", "SWAP")
+        reader = CachedReader(inner)
+
+        _ = reader.read("BTCUSDT", "ohlc(1h)", "2024-01-02", "2024-01-10")
+        _ = reader.read([], "ohlc(1h)", "2024-01-01", "2024-01-03")
+
+        r_eth = reader.read("ETHUSDT", "ohlc(1h)", "2024-01-01", "2024-01-10")
+
+        df_eth = r_eth.transform(PandasFrame())
+
+        assert df_eth.index[0] == pd.Timestamp("2024-01-01")
+        assert df_eth.index[-1] == pd.Timestamp("2024-01-09 23:00:00")
+
+    def test_symbol_reuses_cache_from_all_symbols_request(self):
+        from unittest.mock import patch
+
+        storage = _build_storage()
+        inner = storage.get_reader("BINANCE.UM", "SWAP")
+        reader = CachedReader(inner)
+
+        with patch.object(inner, "read", wraps=inner.read) as mock_read:
+            _ = reader.read([], "ohlc(1h)", "2024-01-01", "2024-01-04")
+            assert mock_read.call_count == 1  # miss → fetched from inner
+
+            r_eth = reader.read("ETHUSDT", "ohlc(1h)", "2024-01-02", "2024-01-03")
+            assert mock_read.call_count == 1  # still 1 → cache hit
+
+            df_eth = r_eth.transform(PandasFrame())
+            assert len(df_eth) > 0
+
     def test_chunked_read_bypasses_cache(self):
         """
         Chunked reads go directly to inner reader.


### PR DESCRIPTION
## Summary
- Adds `qubx s3` command group with `ls`, `rm`, `cp`, and `accounts` subcommands
- Uses named S3 accounts from Qubx settings with `account:bucket/path` syntax
- Built on pyarrow.fs — no new dependencies
- Improves `qubx browse` TUI: default path from settings, quit with `q`, sort by created, `cc` to copy path
- **Fix**: Portfolio logger now logs quantity in tokens (not contracts), fixing wrong leverage, turnover, and Value for instruments with `contract_size != 1`
- **Fix**: `FixedSizer` divides amounts by `quantity_multiplier` so fixed-size targets are in contracts
- **Feat**: `simulate_config()` helper for running simulations from YAML configs in notebooks/scripts

## `qubx s3` Usage
```bash
qubx s3 accounts                          # list configured accounts
qubx s3 ls hetzner:frab/spreads/ -r -l    # recursive listing with sizes
qubx s3 rm hetzner:frab/spreads/ -r       # delete with confirmation
qubx s3 cp hetzner:frab/data.parquet ./   # download
```

## `qubx browse` Improvements
- **Default path**: Add `default_browse_path` to `~/.qubx/config.json` so `qubx browse` without args uses it
- **Quit with `q`**: Previously only `ctrl+c`/`ctrl+q` worked
- **Sort by Created**: New button + `T` keybinding; default sort is now creation time DESC (newest first)
- **Copy path with `cc`**: Press `cc` on a table row to copy the experiment path to clipboard via OSC 52 (works over SSH)

## Contract-size fixes
- `PortfolioLogger` logged raw `p.quantity` (contracts), but `inmemory.py` Value reconstruction, leverage calculation, and turnover all assumed token amounts → crazy leverage values for instruments with `contract_size != 1`
- Fix: multiply by `quantity_multiplier` at the log level so all downstream metrics are correct

## Test plan
- [x] `qubx s3 accounts` lists configured accounts
- [x] `qubx s3 ls` lists bucket contents (flat and recursive, short and long)
- [x] `qubx s3 rm` deletes files with confirmation prompt
- [x] `qubx s3 cp` handles s3→local, local→s3, and s3→s3 copy
- [x] `qubx browse` uses `default_browse_path` from settings when no arg given
- [x] `q` exits the TUI
- [x] Results default to newest-first; `T` / "Sort by Created" button works
- [x] `cc` on a table row copies path to clipboard (toast confirmation shown)
- [x] Verify leverage/turnover metrics are correct for instruments with contract_size > 1
- [x] Verify FixedSizer targets are in contracts after division by quantity_multiplier