### PR TITLE
feat: warmup/simulation improvements, typed time helpers, logging enhancements

### DIFF
--- a/src/qubx/__init__.py
+++ b/src/qubx/__init__.py
@@ -47,6 +47,16 @@ def format_platform_identity(record) -> str:
     return ""
 
 
+def format_phase(record) -> str:
+    """Return a colored phase tag from record extras."""
+    phase = record["extra"].get("phase")
+    if phase == "warmup":
+        return "<yellow>[WARMUP]</yellow> "
+    elif phase == "live":
+        return "<green>[LIVE]</green> "
+    return ""
+
+
 def formatter(record):
     end = record["extra"].get("end", "\n")
     fmt = "<lvl>{message}</lvl>%s" % end
@@ -54,9 +64,10 @@ def formatter(record):
         fmt = "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - %s" % fmt
 
     identity = format_platform_identity(record)
+    phase = format_phase(record)
     prefix = (
-        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> [ <level>%s</level> ] %s<cyan>({module})</cyan> "
-        % (record["level"].icon, identity)
+        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> [ <level>%s</level> ] %s%s<cyan>({module})</cyan> "
+        % (record["level"].icon, identity, phase)
     )
 
     if record["exception"] is not None:
@@ -158,16 +169,35 @@ class QubxLogConfig:
         )
         logger = logger.opt(colors=colorize)
 
+    _bot_id: str | None = None
+    _instance_id: str | None = None
+    _phase: str | None = None
+
+    @staticmethod
+    def _update_patcher():
+        """Reconfigure loguru with a single patcher that applies all bound fields."""
+        def patcher(record):
+            if QubxLogConfig._bot_id:
+                record["extra"]["bot_id"] = QubxLogConfig._bot_id
+            if QubxLogConfig._instance_id:
+                record["extra"]["instance_id"] = QubxLogConfig._instance_id
+            if QubxLogConfig._phase:
+                record["extra"]["phase"] = QubxLogConfig._phase
+
+        logger.configure(patcher=patcher)
+
     @staticmethod
     def bind_platform_identity(bot_id: str | None = None, instance_id: str | None = None):
         """Bind platform identity fields (bot_id, instance_id) to all log messages globally."""
-        def patcher(record):
-            if bot_id:
-                record["extra"]["bot_id"] = bot_id
-            if instance_id:
-                record["extra"]["instance_id"] = instance_id
+        QubxLogConfig._bot_id = bot_id
+        QubxLogConfig._instance_id = instance_id
+        QubxLogConfig._update_patcher()
 
-        logger.configure(patcher=patcher)
+    @staticmethod
+    def bind_phase(phase: str | None):
+        """Bind phase (warmup/live) to all log messages globally."""
+        QubxLogConfig._phase = phase
+        QubxLogConfig._update_patcher()
 
 
 QubxLogConfig.setup_logger()

--- a/src/qubx/backtester/data.py
+++ b/src/qubx/backtester/data.py
@@ -12,6 +12,7 @@ from qubx.core.basics import (
 )
 from qubx.core.interfaces import IDataProvider
 from qubx.core.series import Bar, Quote
+from qubx.utils.time import to_timestamp
 
 from .account import SimulatedAccountProcessor
 from .utils import SimulatedTimeProvider
@@ -144,7 +145,7 @@ class SimulatedDataProvider(IDataProvider):
             self._data_source.set_warmup_period(si[0], warm_period)
 
     def get_ohlc(self, instrument: Instrument, timeframe: str, nbarsback: int) -> list[Bar]:
-        start = pd.Timestamp(self.time_provider.time())
+        start = to_timestamp(self.time_provider.time())
         end = start - nbarsback * pd.Timedelta(timeframe)
         return self._data_source.get_ohlc(instrument, timeframe, start, end)
 

--- a/src/qubx/backtester/data.py
+++ b/src/qubx/backtester/data.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
 from typing import TypeVar
 
-import pandas as pd
-
 from qubx import logger
 from qubx.backtester.simulated_data import SimulatedDataIterator
 from qubx.core.basics import (
@@ -12,7 +10,7 @@ from qubx.core.basics import (
 )
 from qubx.core.interfaces import IDataProvider
 from qubx.core.series import Bar, Quote
-from qubx.utils.time import to_timestamp
+from qubx.utils.time import to_timedelta, to_timestamp
 
 from .account import SimulatedAccountProcessor
 from .utils import SimulatedTimeProvider
@@ -146,7 +144,7 @@ class SimulatedDataProvider(IDataProvider):
 
     def get_ohlc(self, instrument: Instrument, timeframe: str, nbarsback: int) -> list[Bar]:
         start = to_timestamp(self.time_provider.time())
-        end = start - nbarsback * pd.Timedelta(timeframe)
+        end = start - nbarsback * to_timedelta(timeframe)
         return self._data_source.get_ohlc(instrument, timeframe, start, end)
 
     def get_quote(self, instrument: Instrument) -> Quote | None:

--- a/src/qubx/backtester/runner.py
+++ b/src/qubx/backtester/runner.py
@@ -611,10 +611,8 @@ class SimulationRunner:
 
         _account_processors = {}
         for exchange in self.setup.exchanges:
-            _initial_capital = self.setup.capital
-            if isinstance(_initial_capital, dict):
-                _initial_capital = _initial_capital[exchange]
-            assert isinstance(_initial_capital, (float, int))
+            assert isinstance(self.setup.capital, dict)
+            _initial_capital = self.setup.capital[exchange]
             _account_processors[exchange] = SimulatedAccountProcessor(
                 account_id=self.account_id,
                 exchange=_exchange_to_simulated_exchange[exchange],

--- a/src/qubx/backtester/runner.py
+++ b/src/qubx/backtester/runner.py
@@ -34,7 +34,7 @@ from qubx.health import DummyHealthMonitor
 from qubx.loggers.inmemory import InMemoryLogsWriter
 from qubx.pandaz.utils import _frame_to_str
 from qubx.utils.runner.configs import PrefetchConfig
-from qubx.utils.time import now_ns
+from qubx.utils.time import now_ns, to_timedelta
 
 from .account import SimulatedAccountProcessor
 from .broker import SimulatedBroker
@@ -437,7 +437,7 @@ class SimulationRunner:
         # - TimeGuard is applied by callers that need it (aux/strategy-facing access).
         # - Main simulation data (DataPump) must NOT be time-guarded: DataPump provides
         #   its own explicit [start, end] window and needs to read the full range upfront.
-        _prefetch_period = str(min(self.stop - self.start, pd.Timedelta(prefetch_cfg.prefetch_period)))
+        _prefetch_period = str(min(self.stop - self.start, to_timedelta(prefetch_cfg.prefetch_period)))
         return CachedStorage(
             storage, prefetch_period=_prefetch_period, cache_factory=lambda: MemoryCache(prefetch_cfg.cache_size_mb)
         )

--- a/src/qubx/backtester/simulated_data.py
+++ b/src/qubx/backtester/simulated_data.py
@@ -16,7 +16,7 @@ from qubx.data.containers import IRawContainer, RawData, RawMultiData
 from qubx.data.storage import IDataTransformer, IReader, IStorage, Transformable
 from qubx.data.storages.utils import find_column_index_in_list
 from qubx.data.transformers import TypedRecords
-from qubx.utils.time import convert_times_to_ns, infer_series_frequency, to_timestamp
+from qubx.utils.time import convert_times_to_ns, infer_series_frequency, to_timedelta, to_timestamp
 
 
 class EmulatedUpdatesFromOHLC(IDataTransformer):
@@ -26,7 +26,7 @@ class EmulatedUpdatesFromOHLC(IDataTransformer):
 
     @staticmethod
     def timedelta_to_numpy(x: str) -> int:
-        return pd.Timedelta(x).to_numpy().item()
+        return to_timedelta(x).to_numpy().item()
 
     D1, H1 = timedelta_to_numpy("1D"), timedelta_to_numpy("1h")
     MS1 = 1_000_000
@@ -876,7 +876,7 @@ class SimulatedDataIterator(Iterator):
     def set_warmup_period(self, subscription: str, warmup_period: str | None = None):
         if warmup_period:
             access_key, _, _ = self._parse_subscription_spec(subscription)
-            self._warmups[access_key] = pd.Timedelta(warmup_period)
+            self._warmups[access_key] = to_timedelta(warmup_period)
 
     def _parse_subscription_spec(self, subscription: str) -> tuple[str, str, dict[str, object]]:
         _subtype, _params = DataType.from_str(subscription)
@@ -1160,7 +1160,7 @@ class SimulatedDataIterator(Iterator):
         assert isinstance(t_records, Transformable)
 
         return self._process_bar_records(
-            t_records.transform(TypedRecords()), time_as_nsec(start), pd.Timedelta(timeframe).asm8.item()
+            t_records.transform(TypedRecords()), time_as_nsec(start), to_timedelta(timeframe).asm8.item()
         )
 
     def _process_bar_records(self, records: list[Bar], cut_time_ns: int, timeframe_ns: int) -> list[Bar]:

--- a/src/qubx/backtester/simulated_data.py
+++ b/src/qubx/backtester/simulated_data.py
@@ -16,7 +16,7 @@ from qubx.data.containers import IRawContainer, RawData, RawMultiData
 from qubx.data.storage import IDataTransformer, IReader, IStorage, Transformable
 from qubx.data.storages.utils import find_column_index_in_list
 from qubx.data.transformers import TypedRecords
-from qubx.utils.time import convert_times_to_ns, infer_series_frequency
+from qubx.utils.time import convert_times_to_ns, infer_series_frequency, to_timestamp
 
 
 class EmulatedUpdatesFromOHLC(IDataTransformer):
@@ -329,9 +329,9 @@ class RawSymbolBuffer:
         if isinstance(value, pd.Timestamp):
             return value.value
         if isinstance(value, np.datetime64):
-            return pd.Timestamp(value).value
+            return to_timestamp(value).value
         # - fallback: try to convert via pd.Timestamp
-        return pd.Timestamp(value).value
+        return to_timestamp(value).value
 
     def activate(self):
         self._active = True
@@ -367,10 +367,10 @@ class RawSymbolBuffer:
         # - dedup: filter out rows already in buffer using native pyarrow comparison
         if self._watermark > 0:
             if pa.types.is_timestamp(time_col.type):
-                wm_scalar = pa.scalar(pd.Timestamp(self._watermark, unit="ns"), type=time_col.type)
+                wm_scalar = pa.scalar(to_timestamp(self._watermark, unit="ns"), type=time_col.type)
             elif pa.types.is_date(time_col.type):
                 # - date32 stores days since epoch; watermark is ns, convert to datetime.date
-                wm_scalar = pa.scalar(pd.Timestamp(self._watermark, unit="ns").date(), type=time_col.type)
+                wm_scalar = pa.scalar(to_timestamp(self._watermark, unit="ns").date(), type=time_col.type)
             else:
                 wm_scalar = pa.scalar(self._watermark, type=time_col.type)
             mask = pa.compute.greater(time_col, wm_scalar)
@@ -398,7 +398,7 @@ class RawSymbolBuffer:
         return len(self._batches)
 
     def __repr__(self) -> str:
-        _wm = pd.Timestamp(self._watermark, unit="ns") if self._watermark else "N/A"
+        _wm = to_timestamp(self._watermark, unit="ns") if self._watermark else "N/A"
         return f"RawSymbolBuffer({self._symbol}, chunks={len(self)}, wm={_wm}, active={self._active})"
 
 
@@ -644,13 +644,13 @@ class DataPump:
         Starts backend reader, creates MemReaders for all symbols.
         Returns dict suitable for slicer.put().
         """
-        self._end = pd.Timestamp(end)
+        self._end = to_timestamp(end)
         symbols = self._active_symbols()
         if not symbols:
             return {}
 
         # - all symbols need warmup on first read
-        read_start = pd.Timestamp(start)
+        read_start = to_timestamp(start)
         if self._warmup_period:
             read_start = read_start - self._warmup_period
             self._warmed.update(symbols)
@@ -686,7 +686,7 @@ class DataPump:
             dict of NEW MemReaders only (for slicer.put())
         """
         if end is not None:
-            self._end = pd.Timestamp(end)
+            self._end = to_timestamp(end)
 
         symbols = self._active_symbols()
         if not symbols:
@@ -695,7 +695,7 @@ class DataPump:
 
         # - determine start time: extend into past if new symbols need warmup
         new_symbols = [s for s in symbols if s not in self._warmed]
-        read_start = pd.Timestamp(current_time)
+        read_start = to_timestamp(current_time)
 
         if new_symbols and self._warmup_period:
             read_start = read_start - self._warmup_period
@@ -999,7 +999,7 @@ class SimulatedDataIterator(Iterator):
 
             # - if simulation is running, restart read to include new symbols
             if self.is_running and new_instruments:
-                new_mem_readers = pump.restart_read(pd.Timestamp(self._current_time, unit="ns"), self._stop)  # type: ignore
+                new_mem_readers = pump.restart_read(to_timestamp(self._current_time, unit="ns"), self._stop)  # type: ignore
                 if new_mem_readers and self._slicer is not None:
                     self._slicer.put(new_mem_readers)
 
@@ -1101,8 +1101,8 @@ class SimulatedDataIterator(Iterator):
         return self._current_time is not None
 
     def create_iterable(self, start: str | pd.Timestamp, stop: str | pd.Timestamp) -> Iterator:
-        self._start = pd.Timestamp(start)
-        self._stop = pd.Timestamp(stop)
+        self._start = to_timestamp(start)
+        self._stop = to_timestamp(stop)
         self._current_time = None
         self._slicer = IteratedDataStreamsSlicer()
         return self
@@ -1110,7 +1110,7 @@ class SimulatedDataIterator(Iterator):
     def __iter__(self) -> Iterator:
         assert self._start is not None and self._stop is not None
         assert self._slicer is not None
-        self._current_time = int(pd.Timestamp(self._start).timestamp() * 1e9)
+        self._current_time = int(to_timestamp(self._start).timestamp() * 1e9)
 
         # - initial read for all pumps
         for pump in self._pumps.values():

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -141,10 +141,11 @@ class SimulatedLogFormatter:
         else:
             now = self.time_provider.time().astype("datetime64[us]").item().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
-        from qubx import format_platform_identity
+        from qubx import format_phase, format_platform_identity
 
         identity = format_platform_identity(record)
-        prefix = f"<lc>{now}</lc> [<level>{record['level'].icon}</level>] {identity}<cyan>({{module}})</cyan> "
+        phase = format_phase(record)
+        prefix = f"<lc>{now}</lc> [<level>{record['level'].icon}</level>] {identity}{phase}<cyan>({{module}})</cyan> "
 
         if record["exception"] is not None:
             record["extra"]["stack"] = stackprinter.format(record["exception"], style="darkbg3")

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -25,6 +25,7 @@ from qubx.core.utils import time_delta_to_str
 from qubx.data.storage import IStorage
 from qubx.utils.misc import safe_dtype_timeframe
 from qubx.utils.runner.configs import PrefetchConfig
+from qubx.utils.time import to_timedelta
 
 SymbolOrInstrument_t: TypeAlias = str | Instrument
 ExchangeName_t: TypeAlias = str
@@ -45,7 +46,7 @@ StrategiesDecls_t: TypeAlias = (
 
 
 def _timedelta_to_numpy(x: str | int) -> int:
-    return pd.Timedelta(x).to_numpy().item()
+    return to_timedelta(x).to_numpy().item()
 
 
 DEFAULT_DAILY_SESSION = (_timedelta_to_numpy("00:00:00.100"), _timedelta_to_numpy("23:59:59.900"))
@@ -528,15 +529,15 @@ def _adjust_open_close_time_indent_secs(timeframe: pd.Timedelta | None, original
         return original_indent_secs
 
     # - if it triggers at daily+ bar let's assume this bar is 'closed' 5 min before exact closing time
-    if timeframe >= pd.Timedelta("1d"):
+    if timeframe >= to_timedelta("1d"):
         return max(original_indent_secs, 5 * 60)
 
     # - if it triggers at 1Min+ bar let's assume this bar is 'closed' 5 sec before exact closing time
-    if timeframe >= pd.Timedelta("1min"):
+    if timeframe >= to_timedelta("1min"):
         return max(original_indent_secs, 5)
 
     # - for all sub-minute timeframes just use 1 sec shift
-    if timeframe > pd.Timedelta("1s"):
+    if timeframe > to_timedelta("1s"):
         return max(original_indent_secs, 1)
 
     # - for rest just keep original indent
@@ -545,9 +546,9 @@ def _adjust_open_close_time_indent_secs(timeframe: pd.Timedelta | None, original
 
 def _get_default_warmup_period(base_subscription: str, in_timeframe: pd.Timedelta | None) -> pd.Timedelta:
     if in_timeframe is None or base_subscription in [DataType.QUOTE, DataType.TRADE, DataType.ORDERBOOK]:
-        return pd.Timedelta("1Min")
+        return to_timedelta("1Min")
 
-    if in_timeframe < pd.Timedelta("1h"):
+    if in_timeframe < to_timedelta("1h"):
         return 5 * in_timeframe
 
     return 2 * in_timeframe

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -98,6 +98,13 @@ class SimulationSetup:
     accurate_stop_orders_execution: bool = False
     enable_funding: bool = False
 
+    def __post_init__(self) -> None:
+        # Normalize capital to a per-exchange dict: split evenly when a single float is given
+        if isinstance(self.capital, (int, float)):
+            n = len(self.exchanges)
+            per_exchange = float(self.capital) / n if n > 0 else float(self.capital)
+            self.capital = {exchange: per_exchange for exchange in self.exchanges}
+
     def __str__(self) -> str:
         return f"{self.name} {self.setup_type} capital {self.capital} {self.base_currency} for [{','.join(map(lambda x: x.symbol, self.instruments))}] @ {self.exchanges}[{self.commissions}]"
 

--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -231,15 +231,6 @@ def run(
     "--report", "-r", default=None, type=str, help="Output directory for simulation reports.", show_default=True
 )
 @click.option(
-    "--log",
-    "-L",
-    "log_to_file",
-    is_flag=True,
-    default=False,
-    help="Write simulation logs to a file in the output directory.",
-    show_default=True,
-)
-@click.option(
     "--name",
     "-n",
     default=None,
@@ -261,7 +252,6 @@ def simulate(
     end: str | None,
     output: str | None,
     report: str | None,
-    log_to_file: bool,
     name: str | None,
     log_file: str | None,
 ):
@@ -276,7 +266,7 @@ def simulate(
     logo()
     logger.info(f"Process PID: <g>{os.getpid()}</g>")
     simulate_strategy(
-        config_file, output, start, end, report, log_to_file, name=name, log_file=log_file,
+        config_file, output, start, end, report, name=name, log_file=log_file,
     )
 
 

--- a/src/qubx/connectors/ccxt/account.py
+++ b/src/qubx/connectors/ccxt/account.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Awaitable, Callable
 
 import ccxt.pro as cxp
 import numpy as np
-import pandas as pd
 from ccxt import ExchangeClosedByUser, ExchangeError, ExchangeNotAvailable, NetworkError
 
 from qubx import logger
@@ -29,6 +28,7 @@ from qubx.core.helpers import extract_price
 from qubx.core.interfaces import IHealthMonitor, ISubscriptionManager
 from qubx.utils.marketdata.ccxt import ccxt_symbol_to_instrument
 from qubx.utils.misc import AsyncThreadLoop
+from qubx.utils.time import to_timedelta
 
 from .exceptions import CcxtSymbolNotRecognized
 from .exchange_manager import ExchangeManager
@@ -252,11 +252,11 @@ class CcxtAccountProcessor(BasicAccountProcessor):
         interval: str,
         backoff: str | None = None,
     ):
-        sleep_time = pd.Timedelta(interval).total_seconds()
+        sleep_time = to_timedelta(interval).total_seconds()
         retries = 0
 
         if backoff is not None:
-            sleep_time = pd.Timedelta(backoff).total_seconds()
+            sleep_time = to_timedelta(backoff).total_seconds()
             await asyncio.sleep(sleep_time)
 
         while self.channel.control.is_set():
@@ -308,7 +308,7 @@ class CcxtAccountProcessor(BasicAccountProcessor):
     async def _update_subscriptions(self) -> None:
         """Subscribe to required instruments"""
         assert self._subscription_manager is not None
-        await asyncio.sleep(pd.Timedelta(self.subscription_interval).total_seconds())
+        await asyncio.sleep(to_timedelta(self.subscription_interval).total_seconds())
 
         # if required instruments have changed, subscribe to them
         if not self._latest_instruments.issuperset(self._required_instruments):
@@ -380,7 +380,7 @@ class CcxtAccountProcessor(BasicAccountProcessor):
             current_pos.set_external_maint_margin(new_pos.maint_margin)
 
     def _get_start_time_in_ms(self, days_before: int) -> int:
-        return (self.time_provider.time() - days_before * pd.Timedelta("1d")).asm8.item() // 1000000  # type: ignore
+        return (self.time_provider.time() - days_before * to_timedelta("1d")).asm8.item() // 1000000  # type: ignore
 
     def _is_our_order(self, order: Order) -> bool:
         if order.client_id is None:
@@ -408,7 +408,7 @@ class CcxtAccountProcessor(BasicAccountProcessor):
         _fetch_instruments: list[Instrument] = []
         for instr in instruments:
             _dt, _ = self._instrument_to_last_price.get(instr, (None, None))
-            if _dt is None or pd.Timedelta(_current_time - _dt) > pd.Timedelta(self.balance_interval):  # type: ignore
+            if _dt is None or to_timedelta(_current_time - _dt) > to_timedelta(self.balance_interval):  # type: ignore
                 _fetch_instruments.append(instr)
 
         _symbol_to_instrument = {instr.symbol: instr for instr in instruments}

--- a/src/qubx/connectors/ccxt/broker.py
+++ b/src/qubx/connectors/ccxt/broker.py
@@ -3,7 +3,6 @@ import traceback
 from typing import TYPE_CHECKING, Any
 
 import ccxt
-import pandas as pd
 from ccxt.base.errors import ExchangeError
 
 from qubx import logger
@@ -24,6 +23,7 @@ from qubx.core.interfaces import (
     ITimeProvider,
 )
 from qubx.utils.misc import AsyncThreadLoop
+from qubx.utils.time import to_timedelta
 
 from .exchange_manager import ExchangeManager
 from .utils import ccxt_convert_order_info, instrument_to_ccxt_symbol
@@ -545,7 +545,7 @@ class CcxtBroker(IBroker):
 
             # Common retry logic for all retryable errors
             current_time = self.time_provider.time()
-            elapsed_seconds = pd.Timedelta(current_time - start_time).total_seconds()
+            elapsed_seconds = to_timedelta(current_time - start_time).total_seconds()
             retries += 1
 
             if elapsed_seconds >= timeout_delta or retries >= self.max_cancel_retries:

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -12,6 +12,7 @@ from qubx.core.basics import CtrlChannel, DataType, Instrument, ITimeProvider
 from qubx.core.interfaces import IDataProvider, IHealthMonitor
 from qubx.core.series import Bar, Quote
 from qubx.utils.misc import AsyncThreadLoop
+from qubx.utils.time import to_timestamp
 
 from .connection_manager import ConnectionManager
 from .exchange_manager import ExchangeManager
@@ -319,7 +320,7 @@ class CcxtDataProvider(IDataProvider):
         return _key is None or _key == ""
 
     def _time_msec_nbars_back(self, timeframe: str, nbarsback: int = 1) -> int:
-        now = pd.Timestamp(self.time_provider.time())
+        now = to_timestamp(self.time_provider.time())
         delta = pd.to_timedelta(timeframe) * nbarsback
         return int((now - delta).value // 1_000_000)
 

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -2,8 +2,6 @@ import asyncio
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
-import pandas as pd
-
 # CCXT exceptions are now handled in ConnectionManager
 from qubx import logger
 from qubx.connectors.ccxt.utils import ccxt_convert_timeframe_to_exchange_format
@@ -12,7 +10,7 @@ from qubx.core.basics import CtrlChannel, DataType, Instrument, ITimeProvider
 from qubx.core.interfaces import IDataProvider, IHealthMonitor
 from qubx.core.series import Bar, Quote
 from qubx.utils.misc import AsyncThreadLoop
-from qubx.utils.time import to_timestamp
+from qubx.utils.time import to_timedelta, to_timestamp
 
 from .connection_manager import ConnectionManager
 from .exchange_manager import ExchangeManager
@@ -321,7 +319,7 @@ class CcxtDataProvider(IDataProvider):
 
     def _time_msec_nbars_back(self, timeframe: str, nbarsback: int = 1) -> int:
         now = to_timestamp(self.time_provider.time())
-        delta = pd.to_timedelta(timeframe) * nbarsback
+        delta = to_timedelta(timeframe) * nbarsback
         return int((now - delta).value // 1_000_000)
 
     def _get_exch_timeframe(self, timeframe: str) -> str:

--- a/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
@@ -16,7 +16,7 @@ from ccxt.base.types import (
     Strings,
 )
 
-from qubx.utils.time import now_utc
+from qubx.utils.time import now_utc, to_timedelta
 
 from ..base import CcxtFuturePatchMixin
 
@@ -418,7 +418,7 @@ class BinanceQVUSDM(cxp.binanceusdm, BinanceQV):
         super().__init__(*args, **kwargs)
         self._funding_intervals = {}
         self._funding_intervals_updated_at = None
-        self._funding_interval_cache_ttl = cast(pd.Timedelta, pd.Timedelta(minutes=10))
+        self._funding_interval_cache_ttl = to_timedelta(minutes=10)
 
     def describe(self):
         """

--- a/src/qubx/connectors/ccxt/handlers/ohlc.py
+++ b/src/qubx/connectors/ccxt/handlers/ohlc.py
@@ -7,13 +7,13 @@ Handles subscription and warmup for OHLC (candlestick) data.
 import asyncio
 from typing import Set
 
-import pandas as pd
 from ccxt import BadSymbol
 
 from qubx import logger
 from qubx.core.basics import CtrlChannel, DataType, Instrument
 from qubx.core.exceptions import NotSupported
 from qubx.core.series import Bar, Quote
+from qubx.utils.time import to_timedelta
 
 from ..subscription_config import SubscriptionConfiguration
 from ..utils import ccxt_find_instrument, create_market_type_batched_subscriber, instrument_to_ccxt_symbol
@@ -89,9 +89,9 @@ class OhlcDataHandler(BaseDataTypeHandler):
             warmup_period: Period to warm up (e.g., "30d", "1000h")
             timeframe: Timeframe for OHLC data (e.g., "1m", "5m", "1h")
         """
-        nbarsback = pd.Timedelta(warmup_period) // pd.Timedelta(timeframe)
+        nbarsback = to_timedelta(warmup_period) // to_timedelta(timeframe)
         exch_timeframe = self._data_provider._get_exch_timeframe(timeframe)
-        _tf_msec = pd.to_timedelta(timeframe).value // 1_000_000
+        _tf_msec = to_timedelta(timeframe).value // 1_000_000
 
         for instrument in instruments:
             start_since = self._data_provider._time_msec_nbars_back(timeframe, nbarsback)
@@ -149,7 +149,7 @@ class OhlcDataHandler(BaseDataTypeHandler):
         exch_timeframe = self._data_provider._get_exch_timeframe(timeframe)
 
         loaded_bars = {}
-        _tf_msec = pd.to_timedelta(timeframe).value // 1_000_000  # convert to msec
+        _tf_msec = to_timedelta(timeframe).value // 1_000_000  # convert to msec
 
         # - retrieve OHLC data from exchange by chunks as some providers limit number of bars per request
         # Loop until we have enough bars or exchange stops returning data.

--- a/src/qubx/connectors/ccxt/utils.py
+++ b/src/qubx/connectors/ccxt/utils.py
@@ -26,7 +26,7 @@ from qubx.utils.marketdata.ccxt import (
     ccxt_symbol_to_instrument,
 )
 from qubx.utils.orderbook import accumulate_orderbook_levels
-from qubx.utils.time import now_utc
+from qubx.utils.time import now_utc, to_timestamp
 
 from .exceptions import (
     CcxtLiquidationParsingError,
@@ -103,7 +103,7 @@ def ccxt_convert_deal_info(raw: Dict[str, Any]) -> Deal:
     return Deal(
         id=raw["id"],
         order_id=raw["order"],
-        time=pd.Timestamp(raw["timestamp"], unit="ms"),  # type: ignore
+        time=to_timestamp(raw["timestamp"], unit="ms"),
         amount=float(raw["amount"]) * (-1 if raw["side"] == "sell" else +1),
         price=float(raw["price"]),
         aggressive=raw["takerOrMaker"] == "taker",

--- a/src/qubx/connectors/tardis/data.py
+++ b/src/qubx/connectors/tardis/data.py
@@ -15,6 +15,7 @@ from qubx.core.interfaces import IDataProvider, IHealthMonitor
 from qubx.core.series import Bar, Quote, Trade
 from qubx.health import DummyHealthMonitor
 from qubx.utils.misc import AsyncThreadLoop, synchronized
+from qubx.utils.time import to_timedelta
 
 from .utils import (
     tardis_convert_orderbook,
@@ -244,7 +245,7 @@ class TardisDataProvider(IDataProvider):
 
         # Calculate start time based on timeframe and nbarsback
         end_time = self.time_provider.time()
-        start_time = end_time - pd.Timedelta(timeframe) * nbarsback
+        start_time = end_time - to_timedelta(timeframe) * nbarsback
 
         # Format dates for Tardis API
         start_str = pd.Timestamp(start_time).strftime("%Y-%m-%d")
@@ -521,7 +522,7 @@ class TardisDataProvider(IDataProvider):
         """Fetch historical OHLC data for warmup."""
         # Calculate start and end time
         end_time = self.time_provider.time()
-        start_time = end_time - pd.Timedelta(period)
+        start_time = end_time - to_timedelta(period)
 
         # Format dates for Tardis API
         start_str = pd.Timestamp(start_time).strftime("%Y-%m-%d")
@@ -578,7 +579,7 @@ class TardisDataProvider(IDataProvider):
         """Fetch historical trade data for warmup."""
         # Calculate start and end time
         end_time = self.time_provider.time()
-        start_time = end_time - pd.Timedelta(period)
+        start_time = end_time - to_timedelta(period)
 
         # Format dates for Tardis API
         start_str = pd.Timestamp(start_time).strftime("%Y-%m-%d")
@@ -632,7 +633,7 @@ class TardisDataProvider(IDataProvider):
         """Fetch historical orderbook data for warmup."""
         # Calculate start and end time
         end_time = self.time_provider.time()
-        start_time = end_time - pd.Timedelta(period)
+        start_time = end_time - to_timedelta(period)
 
         # Format dates for Tardis API
         start_str = pd.Timestamp(start_time).strftime("%Y-%m-%d")
@@ -724,7 +725,7 @@ class TardisDataProvider(IDataProvider):
 
         # Otherwise, try to parse the timeframe
         try:
-            pd_timedelta = pd.Timedelta(timeframe)
+            pd_timedelta = to_timedelta(timeframe)
             return f"{int(pd_timedelta.total_seconds() * 1000)}ms"
         except:
             # Fallback to default 1m if parsing fails

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -15,6 +15,7 @@ from qubx.core.series import Bar, OrderBook, Quote, Trade, time_as_nsec
 from qubx.core.utils import prec_ceil, prec_floor, time_delta_to_str, time_to_str
 from qubx.utils.misc import Stopwatch
 from qubx.utils.ntp import start_ntp_thread, time_now
+from qubx.utils.time import to_timedelta
 
 if TYPE_CHECKING:
     from qubx.core.interfaces import IStrategyContext
@@ -1262,30 +1263,30 @@ class DataType(StrEnum):
                 params = [p.strip() for p in params_str.rstrip(")").split(",")]
                 match type_name.lower():
                     case DataType.OHLC.value:
-                        return DataType.OHLC, {"timeframe": time_delta_to_str(pd.Timedelta(params[0]).asm8.item())}
+                        return DataType.OHLC, {"timeframe": time_delta_to_str(to_timedelta(params[0]).asm8.item())}
 
                     case DataType.AGGREGATED_LIQUIDATIONS.value:
                         return DataType.AGGREGATED_LIQUIDATIONS, {
-                            "timeframe": time_delta_to_str(pd.Timedelta(params[0]).asm8.item())
+                            "timeframe": time_delta_to_str(to_timedelta(params[0]).asm8.item())
                         }
 
                     case DataType.OHLC_QUOTES.value:
                         return DataType.OHLC_QUOTES, {
-                            "timeframe": time_delta_to_str(pd.Timedelta(params[0]).asm8.item())
+                            "timeframe": time_delta_to_str(to_timedelta(params[0]).asm8.item())
                         }
 
                     case DataType.OHLC_TRADES.value:
                         return DataType.OHLC_TRADES, {
-                            "timeframe": time_delta_to_str(pd.Timedelta(params[0]).asm8.item())
+                            "timeframe": time_delta_to_str(to_timedelta(params[0]).asm8.item())
                         }
 
                     case DataType.QUOTE.value:
-                        return DataType.QUOTE, {"timeframe": time_delta_to_str(pd.Timedelta(params[0]).asm8.item())}
+                        return DataType.QUOTE, {"timeframe": time_delta_to_str(to_timedelta(params[0]).asm8.item())}
 
                     case DataType.ORDERBOOK.value:
                         if len(params) == 1 and not params[0].replace(".", "").isdigit():
                             return DataType.ORDERBOOK, {
-                                "timeframe": time_delta_to_str(pd.Timedelta(params[0]).asm8.item())
+                                "timeframe": time_delta_to_str(to_timedelta(params[0]).asm8.item())
                             }
                         return DataType.ORDERBOOK, {"tick_size_pct": float(params[0]), "depth": int(params[1])}
 

--- a/src/qubx/core/detectors/delisting.py
+++ b/src/qubx/core/detectors/delisting.py
@@ -3,7 +3,7 @@ import pandas as pd
 from qubx import logger
 from qubx.core.basics import Instrument
 from qubx.core.interfaces import ITimeProvider
-from qubx.utils.time import to_timestamp
+from qubx.utils.time import to_timedelta, to_timestamp
 
 
 class DelistingDetector:
@@ -34,7 +34,7 @@ class DelistingDetector:
             return []
 
         current_time = to_timestamp(self._time_provider.time())
-        check_ahead = current_time + pd.Timedelta(days=self._delisting_check_days)
+        check_ahead = current_time + to_timedelta(days=self._delisting_check_days)
 
         delisting = []
         for instrument in instruments:

--- a/src/qubx/core/detectors/delisting.py
+++ b/src/qubx/core/detectors/delisting.py
@@ -1,10 +1,9 @@
-from typing import cast
-
 import pandas as pd
 
 from qubx import logger
 from qubx.core.basics import Instrument
 from qubx.core.interfaces import ITimeProvider
+from qubx.utils.time import to_timestamp
 
 
 class DelistingDetector:
@@ -34,8 +33,8 @@ class DelistingDetector:
         if self._delisting_check_days <= 0:
             return []
 
-        current_time = pd.Timestamp(self._time_provider.time())
-        check_ahead = cast(pd.Timestamp, current_time + pd.Timedelta(days=self._delisting_check_days))
+        current_time = to_timestamp(self._time_provider.time())
+        check_ahead = current_time + pd.Timedelta(days=self._delisting_check_days)
 
         delisting = []
         for instrument in instruments:
@@ -43,7 +42,7 @@ class DelistingDetector:
                 continue
 
             try:
-                delist_timestamp = pd.Timestamp(instrument.delist_date).replace(tzinfo=None)
+                delist_timestamp = to_timestamp(instrument.delist_date).replace(tzinfo=None)
                 if bool(pd.isna(delist_timestamp)):
                     continue
 

--- a/src/qubx/core/detectors/stale.py
+++ b/src/qubx/core/detectors/stale.py
@@ -5,11 +5,10 @@ This module provides functionality to detect when instrument prices haven't move
 for a specified period of time, indicating stale or inactive market data.
 """
 
-import pandas as pd
-
 from qubx import logger
 from qubx.core.basics import Instrument, dt_64, td_64
 from qubx.core.interfaces import IMarketManager, ITimeProvider
+from qubx.utils.time import to_timedelta
 
 
 class InstrumentStaleState:
@@ -79,7 +78,7 @@ class StaleDataDetector:
 
         # Parse string parameters to td_64 if needed
         if isinstance(detection_period, str):
-            self._detection_period = td_64(pd.Timedelta(detection_period).value, "ns")
+            self._detection_period = td_64(to_timedelta(detection_period).value, "ns")
         else:
             self._detection_period = detection_period
 

--- a/src/qubx/core/helpers.py
+++ b/src/qubx/core/helpers.py
@@ -13,7 +13,7 @@ from croniter import croniter
 from qubx import logger
 from qubx.core.basics import CtrlChannel, Timestamped
 from qubx.core.series import Bar, OrderBook, Quote, Trade
-from qubx.utils.time import convert_seconds_to_str, convert_tf_str_td64, interval_to_cron
+from qubx.utils.time import convert_seconds_to_str, convert_tf_str_td64, interval_to_cron, to_timestamp
 
 SPEC_REGEX = re.compile(
     r"((?P<type>[A-Za-z]+)(\.?(?P<timeframe>[0-9A-Za-z]+))?\s*:)?"
@@ -300,7 +300,7 @@ class BasicScheduler:
         if event_name in self._crons:
             _iter = self._crons[event_name]
             _c = _iter.get_current()
-            _t = pd.Timestamp(_iter.get_prev(), unit="s")
+            _t = to_timestamp(_iter.get_prev(), unit="s")
             _iter.set_current(_c, force=True)
             return _t
         return None
@@ -308,7 +308,7 @@ class BasicScheduler:
     def get_event_next_time(self, event_name: str) -> pd.Timestamp | None:
         if event_name in self._crons:
             _iter = self._crons[event_name]
-            _t = pd.Timestamp(_iter.get_next(start_time=self.time_sec()), unit="s")
+            _t = to_timestamp(_iter.get_next(start_time=self.time_sec()), unit="s")
             return _t
         return None
 

--- a/src/qubx/core/helpers.py
+++ b/src/qubx/core/helpers.py
@@ -13,7 +13,7 @@ from croniter import croniter
 from qubx import logger
 from qubx.core.basics import CtrlChannel, Timestamped
 from qubx.core.series import Bar, OrderBook, Quote, Trade
-from qubx.utils.time import convert_seconds_to_str, convert_tf_str_td64, interval_to_cron, to_timestamp
+from qubx.utils.time import convert_seconds_to_str, convert_tf_str_td64, interval_to_cron, to_timedelta, to_timestamp
 
 SPEC_REGEX = re.compile(
     r"((?P<type>[A-Za-z]+)(\.?(?P<timeframe>[0-9A-Za-z]+))?\s*:)?"
@@ -48,8 +48,8 @@ def _mk_cron(time: str, by: list | None) -> str:
 
 
 def _make_shift(_b, _w, _d, _h, _m, _s):
-    D0 = pd.Timedelta(0)
-    AS_TD = lambda d: pd.Timedelta(d)  # noqa: E731
+    D0 = to_timedelta(0)
+    AS_TD = lambda d: to_timedelta(d)  # noqa: E731
     P, N = D0, D0
 
     # return AS_TD(f'{_b*4}W') + AS_TD(f'{_w}W') + AS_TD(f'{_d}D') + AS_TD(f'{_h}h') + AS_TD(f'{_m}Min') + AS_TD(f'{_s}Sec')

--- a/src/qubx/core/loggers.py
+++ b/src/qubx/core/loggers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np
@@ -12,6 +14,7 @@ from qubx.core.basics import (
     Signal,
     TargetPosition,
 )
+from qubx.core.interfaces import IAccountViewer
 from qubx.core.series import time_as_nsec
 from qubx.core.utils import recognize_timeframe
 from qubx.utils.misc import Stopwatch
@@ -335,6 +338,7 @@ class StrategyLogging:
     heartbeat_freq: np.timedelta64 | None = None
 
     _last_heartbeat_ts: np.datetime64 | None = None
+    _account: IAccountViewer
 
     def __init__(
         self,
@@ -376,7 +380,10 @@ class StrategyLogging:
         timestamp: np.datetime64,
         positions: dict[Instrument, Position],
         balances: list[AssetBalance],
+        account: IAccountViewer,
     ) -> None:
+        self._account = account
+
         # - attach positions to loggers
         if self.positions_dumper:
             self.positions_dumper.attach_positions(*list(positions.values()))
@@ -439,4 +446,14 @@ class StrategyLogging:
         _floored_ts = floor_t64(timestamp, self.heartbeat_freq)
         if not self._last_heartbeat_ts or _floored_ts - self._last_heartbeat_ts >= self.heartbeat_freq:
             self._last_heartbeat_ts = _floored_ts
-            logger.info(f"Heartbeat at {_floored_ts.astype('datetime64[s]')}")
+            ts = str(_floored_ts.astype("datetime64[s]"))
+            capital = self._account.get_total_capital()
+            positions = self._account.positions
+            n_pos = sum(1 for p in positions.values() if p.quantity != 0)
+            gross_lev = self._account.get_gross_leverage()
+            net_lev = self._account.get_net_leverage()
+            logger.info(
+                f"[HEARTBEAT] {ts} | capital={capital:,.0f} | "
+                f"positions={n_pos}/{len(positions)} | "
+                f"gross_lev={gross_lev:.1%} net_lev={net_lev:.1%}"
+            )

--- a/src/qubx/core/lookups.py
+++ b/src/qubx/core/lookups.py
@@ -22,6 +22,7 @@ from qubx.core.basics import (
 )
 from qubx.utils.marketdata.dukas import SAMPLE_INSTRUMENTS
 from qubx.utils.misc import get_local_qubx_folder, load_qubx_resources_as_json, load_qubx_resources_as_text, makedirs
+from qubx.utils.time import to_timedelta
 
 _DEF_INSTRUMENTS_FOLDER = "instruments"
 _DEF_FEES_FOLDER = "fees"
@@ -415,7 +416,7 @@ class InstrumentsLookupMongo(InstrumentsLookup):
 
     def __init__(self, mongo_url: str = "mongodb://localhost:27017/", reload_interval: str | None = None):
         self._mongo_url = mongo_url
-        self._reload_interval = pd.Timedelta(reload_interval) if reload_interval else None
+        self._reload_interval = to_timedelta(reload_interval) if reload_interval else None
         self.load()
 
     def load(self):

--- a/src/qubx/core/metrics.py
+++ b/src/qubx/core/metrics.py
@@ -18,7 +18,7 @@ from qubx.core.basics import Instrument
 from qubx.core.lookups import lookup
 from qubx.core.series import OHLCV
 from qubx.utils.misc import makedirs, version
-from qubx.utils.time import convert_seconds_to_str, handle_start_stop, infer_series_frequency
+from qubx.utils.time import convert_seconds_to_str, handle_start_stop, infer_series_frequency, to_timestamp
 
 if TYPE_CHECKING:
     # - only needed for type annotations; loaded lazily at runtime by the methods that use them
@@ -668,7 +668,7 @@ class TradingSessionResult:
         self.strategy_class = strategy_class
         self.parameters = parameters if parameters else {}
         self.is_simulation = is_simulation
-        self.creation_time = pd.Timestamp(creation_time) if creation_time else pd.Timestamp.now()
+        self.creation_time = to_timestamp(creation_time) if creation_time else pd.Timestamp.now()
         self.author = author
         self.qubx_version = version()
         self.variation_name = variation_name
@@ -697,8 +697,8 @@ class TradingSessionResult:
                     pfl[cols] = pfl[cols] - pfl[cols].iloc[0]
             return pfl
 
-        start = pd.Timestamp(key.start) if key.start is not None else None
-        stop = pd.Timestamp(key.stop) if key.stop is not None else None
+        start = to_timestamp(key.start) if key.start is not None else None
+        stop = to_timestamp(key.stop) if key.stop is not None else None
 
         # Recompute capital as equity value at the cut start point
         if start is not None and not self.portfolio_log.empty:
@@ -1118,8 +1118,8 @@ class TradingSessionResult:
         return {
             "id": self.id,
             "name": self.name,
-            "start": pd.Timestamp(self.start).isoformat(),
-            "stop": pd.Timestamp(self.stop).isoformat(),
+            "start": to_timestamp(self.start).isoformat(),
+            "stop": to_timestamp(self.stop).isoformat(),
             "exchanges": self.exchanges,
             "capital": self.capital,
             "base_currency": self.base_currency,
@@ -1127,7 +1127,7 @@ class TradingSessionResult:
             "strategy_class": self.strategy_class,
             "parameters": self.parameters,
             "is_simulation": self.is_simulation,
-            "creation_time": pd.Timestamp(self.creation_time).isoformat(),
+            "creation_time": to_timestamp(self.creation_time).isoformat(),
             "author": self.author,
             "qubx_version": self.qubx_version,
             "symbols": self.symbols,
@@ -1213,7 +1213,7 @@ class TradingSessionResult:
         return {
             "name": self.name,
             "id": self.id,
-            "period": [pd.Timestamp(self.start).isoformat(), pd.Timestamp(self.stop).isoformat()],
+            "period": [to_timestamp(self.start).isoformat(), to_timestamp(self.stop).isoformat()],
             "strategy": {
                 "class": self.strategy_class,
                 "config": self.config(short=False),
@@ -1241,7 +1241,7 @@ class TradingSessionResult:
                 "is_simulation": self.is_simulation,
             },
             "metadata": {
-                "creation_time": pd.Timestamp(self.creation_time).isoformat() if self.creation_time else None,
+                "creation_time": to_timestamp(self.creation_time).isoformat() if self.creation_time else None,
                 "author": self.author,
                 "qubx_version": self.qubx_version,
                 "variation_name": self.variation_name,
@@ -1378,7 +1378,7 @@ class TradingSessionResult:
         if "qubx" not in tags:
             tags.append("qubx")
 
-        c_time = pd.Timestamp(info["creation_time"]).strftime("%Y-%m-%dT%H:%M")
+        c_time = to_timestamp(info["creation_time"]).strftime("%Y-%m-%dT%H:%M")
         perf = info["performance"]
         params = info["parameters"]
 
@@ -1386,9 +1386,9 @@ class TradingSessionResult:
         _dd_mtrx = ["mdd_pct", "mdd_usd", "mdd_start", "mdd_peak", "mdd_recover"]
         perf_main = {"".join(list(map(str.capitalize, c.split("_")))): v for c, v in perf.items() if c not in _dd_mtrx}
         perf_dd = {"".join(list(map(str.capitalize, c.split("_")))): v for c, v in perf.items() if c in _dd_mtrx}
-        perf_dd["MddStart"] = pd.Timestamp(perf_dd["MddStart"]).strftime("%Y-%m-%d %H:%M:%S")
-        perf_dd["MddPeak"] = pd.Timestamp(perf_dd["MddPeak"]).strftime("%Y-%m-%d %H:%M:%S")
-        perf_dd["MddRecover"] = pd.Timestamp(perf_dd["MddRecover"]).strftime("%Y-%m-%d %H:%M:%S")
+        perf_dd["MddStart"] = to_timestamp(perf_dd["MddStart"]).strftime("%Y-%m-%d %H:%M:%S")
+        perf_dd["MddPeak"] = to_timestamp(perf_dd["MddPeak"]).strftime("%Y-%m-%d %H:%M:%S")
+        perf_dd["MddRecover"] = to_timestamp(perf_dd["MddRecover"]).strftime("%Y-%m-%d %H:%M:%S")
 
         _sr = perf_main["Sharpe"]
         _qr = perf_main["Qr"]
@@ -1403,8 +1403,8 @@ class TradingSessionResult:
 
         _desc_body = "- " + "\n- ".join(_desc0.split("\n"))
 
-        _start = pd.Timestamp(self.portfolio_log.index[0]).strftime("%Y-%m-%d %H:%M:%S")
-        _stop = pd.Timestamp(self.portfolio_log.index[-1]).strftime("%Y-%m-%d %H:%M:%S")
+        _start = to_timestamp(self.portfolio_log.index[0]).strftime("%Y-%m-%d %H:%M:%S")
+        _stop = to_timestamp(self.portfolio_log.index[-1]).strftime("%Y-%m-%d %H:%M:%S")
 
         # - optional simulation_time line in frontmatter (only when timing was recorded)
         _sim_time_line = (
@@ -1428,7 +1428,7 @@ start: {_start}
 stop: {_stop}{_sim_time_line}
 ---
 """
-        _time_id = pd.Timestamp(info["creation_time"]).strftime("%y%m%d%H%M%S")
+        _time_id = to_timestamp(info["creation_time"]).strftime("%y%m%d%H%M%S")
         _name = f"{_strat}_{_time_id}"
 
         # - set color theme
@@ -1996,7 +1996,7 @@ def _estimate_timeframe(
     stop: str | pd.Timestamp | None = None,
 ) -> str:
     session = session[0] if isinstance(session, list) else session
-    start, end = pd.Timestamp(start or session.start), pd.Timestamp(stop or session.stop)
+    start, end = to_timestamp(start or session.start), to_timestamp(stop or session.stop)
     diff = end - start
     if diff > pd.Timedelta("360d"):
         return "1d"

--- a/src/qubx/core/metrics.py
+++ b/src/qubx/core/metrics.py
@@ -794,10 +794,7 @@ class TradingSessionResult:
             pft_total["Total_Commissions"] = pft_total["Total_Commissions"].cumsum()
 
             # Get initial capital for this exchange
-            if isinstance(self.capital, dict):
-                init_capital = self.capital.get(exchange, 0.0)
-            else:
-                init_capital = self.capital
+            init_capital = self.capital[exchange] if isinstance(self.capital, dict) else self.capital
 
             # Calculate base equity
             equity = init_capital + pft_total["Total_PnL"] - pft_total["Total_Commissions"] * commission_factor

--- a/src/qubx/core/metrics.py
+++ b/src/qubx/core/metrics.py
@@ -18,7 +18,13 @@ from qubx.core.basics import Instrument
 from qubx.core.lookups import lookup
 from qubx.core.series import OHLCV
 from qubx.utils.misc import makedirs, version
-from qubx.utils.time import convert_seconds_to_str, handle_start_stop, infer_series_frequency, to_timestamp
+from qubx.utils.time import (
+    convert_seconds_to_str,
+    handle_start_stop,
+    infer_series_frequency,
+    to_timedelta,
+    to_timestamp,
+)
 
 if TYPE_CHECKING:
     # - only needed for type annotations; loaded lazily at runtime by the methods that use them
@@ -37,8 +43,8 @@ MINUTELY = HOURLY * 60
 HOURLY_FX = DAILY * 24
 MINUTELY_FX = HOURLY_FX * 60
 
-_D1 = pd.Timedelta("1D")
-_W1 = pd.Timedelta("1W")
+_D1 = to_timedelta("1D")
+_W1 = to_timedelta("1W")
 
 OptTimestamp: TypeAlias = str | pd.Timestamp | None
 
@@ -1998,13 +2004,13 @@ def _estimate_timeframe(
     session = session[0] if isinstance(session, list) else session
     start, end = to_timestamp(start or session.start), to_timestamp(stop or session.stop)
     diff = end - start
-    if diff > pd.Timedelta("360d"):
+    if diff > to_timedelta("360d"):
         return "1d"
-    elif diff > pd.Timedelta("30d"):
+    elif diff > to_timedelta("30d"):
         return "1h"
-    elif diff > pd.Timedelta("7d"):
+    elif diff > to_timedelta("7d"):
         return "15min"
-    elif diff > pd.Timedelta("1d"):
+    elif diff > to_timedelta("1d"):
         return "5min"
     else:
         return "1min"

--- a/src/qubx/core/mixins/market.py
+++ b/src/qubx/core/mixins/market.py
@@ -17,6 +17,7 @@ from qubx.utils.time import (
     floor_t64,
     infer_series_frequency,
     timedelta_to_str,
+    to_timedelta,
     to_timestamp,
 )
 
@@ -372,7 +373,7 @@ class MarketManager(IMarketManager):
             _last_bar_time = rc[0].time
 
             # - temporary fix:
-            _min_delta_ns = MIN_TIMEFRAMES_GAP_TO_REQUEST_PROVIDER * pd.Timedelta(timeframe).asm8.item()
+            _min_delta_ns = MIN_TIMEFRAMES_GAP_TO_REQUEST_PROVIDER * to_timedelta(timeframe).asm8.item()
             _time_now = _data_provider.time_provider.time().item()
 
             # - if need to do request
@@ -403,7 +404,7 @@ class MarketManager(IMarketManager):
 
         if consolidated and timeframe:
             _time = to_timestamp(self._time_provider.time())
-            _timedelta = pd.Timedelta(timeframe)
+            _timedelta = to_timedelta(timeframe)
             if len(ohlc) > 0:  # Check if DataFrame is not empty
                 _last_bar_time = ohlc.index[-1]
                 if _last_bar_time + _timedelta > _time:

--- a/src/qubx/core/mixins/market.py
+++ b/src/qubx/core/mixins/market.py
@@ -17,6 +17,7 @@ from qubx.utils.time import (
     floor_t64,
     infer_series_frequency,
     timedelta_to_str,
+    to_timestamp,
 )
 
 from .utils import EXCHANGE_MAPPINGS
@@ -401,7 +402,7 @@ class MarketManager(IMarketManager):
             timeframe = infer_series_frequency(ohlc[:20])
 
         if consolidated and timeframe:
-            _time = pd.Timestamp(self._time_provider.time())
+            _time = to_timestamp(self._time_provider.time())
             _timedelta = pd.Timedelta(timeframe)
             if len(ohlc) > 0:  # Check if DataFrame is not empty
                 _last_bar_time = ohlc.index[-1]

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -222,7 +222,7 @@ class UniverseManager(IUniverseManager):
         )
 
         # - reinitialize strategy loggers
-        self._logging.initialize(self._time_provider.time(), self._account.positions, self._account.get_balances())
+        self._logging.initialize(self._time_provider.time(), self._account.positions, self._account.get_balances(), self._account)
 
     def _create_and_update_positions(self, instruments: list[Instrument]):
         for instrument in instruments:

--- a/src/qubx/data/cache.py
+++ b/src/qubx/data/cache.py
@@ -34,7 +34,7 @@ from qubx import logger
 from qubx.core.basics import DataType
 from qubx.data.containers import RawData, RawMultiData
 from qubx.data.storage import IReader, IStorage, Transformable
-from qubx.utils.time import now_utc
+from qubx.utils.time import now_utc, to_timestamp
 
 
 class ICache:
@@ -213,8 +213,8 @@ class MemoryCache(ICache):
     @staticmethod
     def _ranges_cover(ranges: list[tuple[str, str]], start: str | None, stop: str | None) -> bool:
         merged = _merge_time_ranges(ranges)
-        req_start = pd.Timestamp(start) if start else pd.Timestamp.min
-        req_stop = pd.Timestamp(stop) if stop else pd.Timestamp.max
+        req_start = to_timestamp(start) if start else pd.Timestamp.min
+        req_stop = to_timestamp(stop) if stop else pd.Timestamp.max
         for rs, re in merged:
             if rs <= req_start and re >= req_stop:
                 return True
@@ -316,7 +316,7 @@ def _to_arrow_timestamp(time_str: str, target_type: pa.DataType) -> pa.Scalar:
     """
     Convert time string to Arrow scalar matching the target column type.
     """
-    ts = pd.Timestamp(time_str)
+    ts = to_timestamp(time_str)
     if pa.types.is_timestamp(target_type):
         return pa.scalar(ts, type=target_type)
     # - fallback: int64 nanoseconds
@@ -335,7 +335,7 @@ def _merge_time_ranges(ranges: list[tuple[str, str]]) -> list[tuple[pd.Timestamp
     parsed = []
     for s, e in ranges:
         try:
-            parsed.append((pd.Timestamp(s), pd.Timestamp(e)))
+            parsed.append((to_timestamp(s), to_timestamp(e)))
         except Exception:
             continue
 
@@ -403,7 +403,7 @@ class CachedReader(IReader):
         **kwargs,
     ) -> Iterator[Transformable] | Transformable:
         # Normalize start/stop so that start <= stop regardless of caller ordering
-        if start is not None and stop is not None and pd.Timestamp(start) > pd.Timestamp(stop):
+        if start is not None and stop is not None and to_timestamp(start) > to_timestamp(stop):
             start, stop = stop, start
 
         # - detect "all symbols" request (empty collection)
@@ -506,7 +506,7 @@ class CachedReader(IReader):
         Returns stop unchanged when prefetch is disabled.
         """
         if self._prefetch_period is not None and stop is not None:
-            prefetched = pd.Timestamp(stop) + self._prefetch_period
+            prefetched = to_timestamp(stop) + self._prefetch_period
             # - clamp to now_utc() to avoid recording future timestamps in cache ranges;
             #   without this, live mode gets false cache hits for data that doesn't exist yet
             return str(min(prefetched, now_utc()))

--- a/src/qubx/data/cache.py
+++ b/src/qubx/data/cache.py
@@ -34,7 +34,7 @@ from qubx import logger
 from qubx.core.basics import DataType
 from qubx.data.containers import RawData, RawMultiData
 from qubx.data.storage import IReader, IStorage, Transformable
-from qubx.utils.time import now_utc, to_timestamp
+from qubx.utils.time import now_utc, to_timedelta, to_timestamp
 
 
 class ICache:
@@ -381,7 +381,7 @@ class CachedReader(IReader):
     ) -> None:
         self._reader = reader
         self._cache = cache if cache is not None else MemoryCache()
-        self._prefetch_period = pd.Timedelta(prefetch_period) if prefetch_period else None
+        self._prefetch_period = to_timedelta(prefetch_period) if prefetch_period else None
         self._data_id_cache = {}
         self._data_types_cache = {}
         self._time_range_cache = {}

--- a/src/qubx/data/guards.py
+++ b/src/qubx/data/guards.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 from qubx.core.basics import DataType, ITimeProvider
 from qubx.data.storage import IReader, IStorage, Transformable
-from qubx.utils.time import to_timestamp
+from qubx.utils.time import to_timedelta, to_timestamp
 
 
 class TimeGuardedReader(IReader):
@@ -74,7 +74,7 @@ class TimeGuardedReader(IReader):
         tf = kwargs.get("timeframe")
         if tf is not None:
             try:
-                return pd.Timedelta(tf)
+                return to_timedelta(tf)
             except Exception:
                 return None
 
@@ -83,7 +83,7 @@ class TimeGuardedReader(IReader):
                 _, params = DataType.from_str(dtype)
                 tf_str = params.get("timeframe")
                 if tf_str:
-                    return pd.Timedelta(tf_str)
+                    return to_timedelta(tf_str)
             except Exception:
                 pass
 

--- a/src/qubx/data/guards.py
+++ b/src/qubx/data/guards.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from qubx.core.basics import DataType, ITimeProvider
 from qubx.data.storage import IReader, IStorage, Transformable
+from qubx.utils.time import to_timestamp
 
 
 class TimeGuardedReader(IReader):
@@ -49,11 +50,11 @@ class TimeGuardedReader(IReader):
             return stop
 
         # - convert to Timestamp for comparison
-        guard_time = pd.Timestamp(current_time)
+        guard_time = to_timestamp(current_time)
 
         # - if caller provided stop, use the earlier of the two
         if stop is not None:
-            caller_stop = pd.Timestamp(stop)
+            caller_stop = to_timestamp(stop)
             if caller_stop < guard_time:
                 return stop
 
@@ -92,7 +93,7 @@ class TimeGuardedReader(IReader):
         """Floor stop to the nearest timeframe boundary to avoid partial resampled bars."""
         if stop is None or timeframe is None:
             return stop
-        ts = pd.Timestamp(stop)
+        ts = to_timestamp(stop)
         floored = ts.floor(timeframe)
         if floored != ts:
             return str(floored)
@@ -117,7 +118,7 @@ class TimeGuardedReader(IReader):
         # - if start is beyond clamped stop, entire range is in the future — force empty result
         #   (without this, handle_start_stop would swap start/stop and return past data)
         if clamped_stop is not None and start is not None:
-            if pd.Timestamp(start) >= pd.Timestamp(clamped_stop):
+            if to_timestamp(start) >= to_timestamp(clamped_stop):
                 start = clamped_stop
         return self._reader.read(data_id, dtype, start=start, stop=clamped_stop, chunksize=chunksize, **kwargs)
 

--- a/src/qubx/data/storages/ccxt.py
+++ b/src/qubx/data/storages/ccxt.py
@@ -49,7 +49,7 @@ from qubx.data.containers import IteratorsMaster, RawData, RawMultiData
 from qubx.data.registry import storage
 from qubx.data.storage import IReader, IStorage, Transformable
 from qubx.utils.misc import AsyncThreadLoop
-from qubx.utils.time import handle_start_stop, now_utc
+from qubx.utils.time import handle_start_stop, now_utc, to_timedelta
 
 # - default market type per well-known exchange name
 _EXCHANGE_MARKET_DEFAULTS: dict[str, str] = {
@@ -314,7 +314,7 @@ class CcxtStorage(IStorage):
         max_history: str = "3650d",
     ) -> None:
         self._max_bars = max_bars
-        self._max_history = cast(pd.Timedelta, pd.Timedelta(max_history))
+        self._max_history = to_timedelta(max_history)
         # - shared async loop (created from first exchange connection)
         self._loop = None
         self._capabilities = None
@@ -686,7 +686,7 @@ class CcxtStorage(IStorage):
         ccxt_ex = self._exchanges[exchange]
         # - resolve start/stop through the same handle_start_stop path used by OHLC
         # - default timeframe = 8h (typical funding interval) for the fallback window
-        _start, _stop = self._get_start_stop(start, stop, pd.Timedelta("8h"))
+        _start, _stop = self._get_start_stop(start, stop, to_timedelta("8h"))
         since = int(_start.timestamp() * 1000)
         stop_ts_ms = int(_stop.timestamp() * 1000)
 
@@ -740,7 +740,7 @@ class CcxtStorage(IStorage):
                 from qubx.connectors.ccxt.utils import ccxt_convert_timeframe_to_exchange_format
 
                 timeframe = params.get("timeframe", "1h")
-                _tf = cast(pd.Timedelta, pd.Timedelta(timeframe))
+                _tf = to_timedelta(timeframe)
                 _start, _stop = self._get_start_stop(start, stop, _tf)
                 exc_tf = ccxt_convert_timeframe_to_exchange_format(timeframe)
                 if exc_tf is None or exc_tf not in ccxt_ex.timeframes:
@@ -781,7 +781,7 @@ class CcxtStorage(IStorage):
                 from qubx.connectors.ccxt.utils import ccxt_convert_timeframe_to_exchange_format
 
                 timeframe = params.get("timeframe", "1h")
-                _tf = cast(pd.Timedelta, pd.Timedelta(timeframe))
+                _tf = to_timedelta(timeframe)
                 _start, _stop = self._get_start_stop(start, stop, _tf)
                 exc_tf = ccxt_convert_timeframe_to_exchange_format(timeframe)
                 if exc_tf is None or exc_tf not in ccxt_ex.timeframes:

--- a/src/qubx/data/storages/multi.py
+++ b/src/qubx/data/storages/multi.py
@@ -2,7 +2,6 @@ from collections.abc import Iterator
 from typing import Any
 
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 from numba import njit
 
@@ -11,6 +10,7 @@ from qubx.core.basics import DataType
 from qubx.data.containers import RawData, RawMultiData
 from qubx.data.registry import storage
 from qubx.data.storage import IReader, IStorage
+from qubx.utils.time import to_timedelta
 
 
 @njit
@@ -337,7 +337,7 @@ class MultiReader(IReader):
         else:
             times_ns = np.ascontiguousarray(times_np.astype(np.int64))
 
-        tolerance_ns = pd.Timedelta(self._tolerance).value
+        tolerance_ns = to_timedelta(self._tolerance).value
         return _tol_mask_nb(times_ns, tolerance_ns, self._keep == "last")
 
     def _chunk_iter(self, raw: Any, chunksize: int) -> Iterator:

--- a/src/qubx/data/storages/questdb.py
+++ b/src/qubx/data/storages/questdb.py
@@ -16,7 +16,7 @@ from qubx.data.containers import RawData, RawMultiData
 from qubx.data.registry import storage
 from qubx.data.storage import IReader, IStorage, Transformable
 from qubx.data.storages.utils import calculate_time_windows_for_chunking, find_column_index_in_list
-from qubx.utils.time import handle_start_stop, timedelta_to_str, to_timestamp
+from qubx.utils.time import handle_start_stop, timedelta_to_str, to_timedelta, to_timestamp
 
 MANIFEST_TABLE_NAME = "_qubx_symbols_manifest"
 
@@ -497,7 +497,7 @@ class QuestDBReader(IReader):
                     _type_ctor = DataType.OHLC if x.dtype == DataType.OHLC else DataType.AGGREGATED_LIQUIDATIONS
                     if self.synthetic_ohlc_timeframes_types and x.data_timeframe:
                         # - for making life bit easy let's generate all possible frames we can contruct from available base
-                        for f in _ext_frames[_ext_frames.searchsorted(pd.Timedelta(x.data_timeframe)) :]:
+                        for f in _ext_frames[_ext_frames.searchsorted(to_timedelta(x.data_timeframe)) :]:
                             _symbs_lookup[symb][dt := _type_ctor[timedelta_to_str(f)]] = x
                             dtypes.append(dt)
                     else:
@@ -505,7 +505,7 @@ class QuestDBReader(IReader):
                         dtypes.append(dt)
                 elif x.dtype == DataType.QUOTE:
                     if self.synthetic_ohlc_timeframes_types and x.data_timeframe:
-                        for f in _ext_frames[_ext_frames.searchsorted(pd.Timedelta(x.data_timeframe)) :]:
+                        for f in _ext_frames[_ext_frames.searchsorted(to_timedelta(x.data_timeframe)) :]:
                             _symbs_lookup[symb][dt := DataType.QUOTE[timedelta_to_str(f)]] = x
                             dtypes.append(dt)
                     else:

--- a/src/qubx/data/storages/questdb.py
+++ b/src/qubx/data/storages/questdb.py
@@ -16,7 +16,7 @@ from qubx.data.containers import RawData, RawMultiData
 from qubx.data.registry import storage
 from qubx.data.storage import IReader, IStorage, Transformable
 from qubx.data.storages.utils import calculate_time_windows_for_chunking, find_column_index_in_list
-from qubx.utils.time import handle_start_stop, timedelta_to_str
+from qubx.utils.time import handle_start_stop, timedelta_to_str, to_timestamp
 
 MANIFEST_TABLE_NAME = "_qubx_symbols_manifest"
 
@@ -201,7 +201,7 @@ class SymbolsManifestManager:
         # Group by table_name and find max last_updated per table
         data: dict[str, tuple[set[str], pd.Timestamp]] = {}
         for table_name, symbol, last_updated in records:
-            ts = pd.Timestamp(last_updated)
+            ts = to_timestamp(last_updated)
             if table_name in data:
                 symbols, max_ts = data[table_name]
                 symbols.add(symbol)

--- a/src/qubx/data/storages/utils.py
+++ b/src/qubx/data/storages/utils.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from qubx import logger
 from qubx.core.series import OrderBook
-from qubx.utils.time import to_timestamp
+from qubx.utils.time import to_timedelta, to_timestamp
 
 
 def recognize_t(t: int | str, defaultvalue, timeunit: str) -> np.datetime64:
@@ -54,7 +54,7 @@ def calculate_time_windows_for_chunking(
             return [(start_dt, end_dt)]
 
         # - Calculate time period per chunk based on timeframe and chunksize
-        tf_delta = pd.Timedelta(timeframe)
+        tf_delta = to_timedelta(timeframe)
 
         # - newer pandas returns NaT for pd.Timedelta("") instead of raising → guard it
         if pd.isna(tf_delta):

--- a/src/qubx/data/storages/utils.py
+++ b/src/qubx/data/storages/utils.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from qubx import logger
 from qubx.core.series import OrderBook
+from qubx.utils.time import to_timestamp
 
 
 def recognize_t(t: int | str, defaultvalue, timeunit: str) -> np.datetime64:
@@ -45,7 +46,7 @@ def calculate_time_windows_for_chunking(
     if not start or not end:
         return []
 
-    start_dt, end_dt = pd.Timestamp(start), pd.Timestamp(end)
+    start_dt, end_dt = to_timestamp(start), to_timestamp(end)
 
     try:
         # - empty timeframe (e.g. funding_payment has no resample) → single window

--- a/src/qubx/data/transformers.py
+++ b/src/qubx/data/transformers.py
@@ -18,7 +18,7 @@ from qubx.core.series import OHLCV, Bar, ColumnarSeries, GenericSeries, Quote, T
 from qubx.data.storage import IDataTransformer, IRawContainer
 from qubx.data.storages.utils import build_snapshots, find_column_index_in_list
 from qubx.pandaz.utils import scols, srows
-from qubx.utils.time import convert_times_to_ns, infer_series_frequency
+from qubx.utils.time import convert_times_to_ns, infer_series_frequency, to_timedelta
 
 
 def _extract_column(data: pa.RecordBatch, field_idx: int | None, default_dtype: type = np.float64) -> np.ndarray:
@@ -230,7 +230,7 @@ class OHLCVSeries(IDataTransformer):
         times = convert_times_to_ns(_data.column(index).to_numpy(zero_copy_only=False), self.timestamp_units)
 
         # - infer timeframe from first 100 timestamps
-        timeframe = pd.Timedelta(infer_series_frequency(pd.DatetimeIndex(times[:100]))).asm8.item()
+        timeframe = to_timedelta(infer_series_frequency(pd.DatetimeIndex(times[:100]))).asm8.item()
         ohlc = OHLCV(raw_data.data_id, timeframe, max_series_length=self.max_length)
 
         # - use vectorized append_data (Cython)
@@ -498,7 +498,7 @@ class TypedGenericSeries(TypedRecords):
             times = _data.column(index).to_numpy(zero_copy_only=False)
             times = convert_times_to_ns(times, self.timestamp_units)
             ts = list(sorted(set(times[:1000].tolist())))
-            timeframe = pd.Timedelta(infer_series_frequency(ts)).asm8.item()
+            timeframe = to_timedelta(infer_series_frequency(ts)).asm8.item()
 
         gens = GenericSeries(raw_data.data_id, timeframe, max_series_length=self.max_length)
         scheme = self._recognize_type_ctor_scheme(dtype, names, index)
@@ -575,7 +575,7 @@ class ColumnarSeriesTransformer(IDataTransformer):
         timeframe = self.timeframe
         if not timeframe:
             ts_list = list(sorted(set(times[:1000].tolist())))
-            timeframe = pd.Timedelta(infer_series_frequency(ts_list)).asm8.item()
+            timeframe = to_timedelta(infer_series_frequency(ts_list)).asm8.item()
 
         # Create ColumnarSeries with known columns
         series = ColumnarSeries(raw_data.data_id, timeframe, column_names, max_series_length=self.max_length)

--- a/src/qubx/emitters/base.py
+++ b/src/qubx/emitters/base.py
@@ -6,11 +6,10 @@ This module provides a base implementation of IMetricEmitter that can be extende
 
 from typing import Any, Dict, List, Optional, Set
 
-import pandas as pd
-
 from qubx import logger
 from qubx.core.basics import Instrument, Signal, TargetPosition, dt_64
 from qubx.core.interfaces import IAccountViewer, IMetricEmitter, IStrategyContext
+from qubx.utils.time import to_timedelta
 
 
 class BaseMetricEmitter(IMetricEmitter):
@@ -46,7 +45,7 @@ class BaseMetricEmitter(IMetricEmitter):
             tags: Dictionary of default tags/labels to include with all metrics
         """
         self._stats_to_emit: Set[str] = set(stats_to_emit) if stats_to_emit else self.DEFAULT_STATS
-        self._stats_interval = pd.Timedelta(stats_interval)
+        self._stats_interval = to_timedelta(stats_interval)
         self._default_tags = tags or {}
         self._last_emission_time = None
         self._context = None

--- a/src/qubx/emitters/indicator.py
+++ b/src/qubx/emitters/indicator.py
@@ -8,12 +8,12 @@ and automatically emit their values when there are updates.
 from typing import Any
 
 import numpy as np
-import pandas as pd
 
 from qubx import logger
 from qubx.core.basics import Instrument
 from qubx.core.interfaces import IMetricEmitter
 from qubx.core.series import Indicator, TimeSeries
+from qubx.utils.time import to_timestamp
 
 
 class IndicatorEmitter(Indicator):
@@ -115,7 +115,7 @@ class IndicatorEmitter(Indicator):
                 if isinstance(time, int):
                     timestamp = np.datetime64(time, "ns")
                 else:
-                    timestamp = pd.Timestamp(time).to_datetime64()
+                    timestamp = to_timestamp(time).to_datetime64()
 
                 self._metric_emitter.emit(
                     name=self._metric_name,

--- a/src/qubx/emitters/inmemory.py
+++ b/src/qubx/emitters/inmemory.py
@@ -14,6 +14,7 @@ from qubx.core.basics import Instrument, dt_64
 from qubx.core.interfaces import IStrategyContext
 from qubx.emitters.base import BaseMetricEmitter
 from qubx.utils.ntp import time_now
+from qubx.utils.time import to_timestamp
 
 
 class InMemoryMetricEmitter(BaseMetricEmitter):
@@ -59,7 +60,7 @@ class InMemoryMetricEmitter(BaseMetricEmitter):
             context: The strategy context to get statistics from
         """
         # Convert to pandas timestamp for easier time calculations
-        current_time = pd.Timestamp(context.time())
+        current_time = to_timestamp(context.time())
 
         # Floor current time to the stats interval
         floored_current = current_time.floor(self._stats_interval)
@@ -91,7 +92,7 @@ class InMemoryMetricEmitter(BaseMetricEmitter):
 
             # Convert numpy datetime64 to pandas Timestamp
             if isinstance(current_timestamp, dt_64):
-                current_timestamp = pd.Timestamp(current_timestamp)
+                current_timestamp = to_timestamp(current_timestamp)
 
             # Extract symbol and exchange from tags
             symbol = tags.pop("symbol", None)

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -17,6 +17,7 @@ from qubx.core.basics import Deal, Instrument, Signal, TargetPosition, dt_64
 from qubx.core.interfaces import IAccountViewer, IStrategyContext
 from qubx.emitters.base import BaseMetricEmitter
 from qubx.utils.questdb import QuestDBClient
+from qubx.utils.time import to_timedelta
 
 
 class QuestDBMetricEmitter(BaseMetricEmitter):
@@ -65,7 +66,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._signals_table_name = signals_table_name
         self._deals_table_name = deals_table_name
         self._conn_str = f"http::addr={host}:{port};"
-        self._flush_interval = pd.Timedelta(flush_interval)
+        self._flush_interval = to_timedelta(flush_interval)
         self._sender = self._try_get_sender()
         self._last_flush = None
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="questdb_emitter")

--- a/src/qubx/exporters/formatters/base.py
+++ b/src/qubx/exporters/formatters/base.py
@@ -7,12 +7,11 @@ for formatting trading data before it is exported to external systems.
 
 import json
 from abc import ABC, abstractmethod
-from typing import Any, cast
-
-import pandas as pd
+from typing import Any
 
 from qubx.core.basics import Instrument, Signal, TargetPosition, dt_64
 from qubx.core.interfaces import IAccountViewer
+from qubx.utils.time import to_timestamp
 
 
 class IExportFormatter(ABC):
@@ -90,7 +89,7 @@ class DefaultFormatter(IExportFormatter):
             The formatted timestamp as a string
         """
         if timestamp is not None:
-            return cast(pd.Timestamp, pd.Timestamp(timestamp)).isoformat()
+            return to_timestamp(timestamp).isoformat()
         else:
             return ""
 

--- a/src/qubx/pandaz/ta.py
+++ b/src/qubx/pandaz/ta.py
@@ -10,7 +10,7 @@ from statsmodels.regression.linear_model import OLS
 
 from qubx.pandaz.utils import check_frame_columns, continuous_periods, has_columns, ohlc_resample, scols, srows
 from qubx.utils.misc import Struct
-from qubx.utils.time import infer_series_frequency
+from qubx.utils.time import infer_series_frequency, to_timedelta
 
 
 def __apply_to_frame(func: types.FunctionType, x: pd.Series | pd.DataFrame, *args, **kwargs):
@@ -731,8 +731,8 @@ def rolling_atr(x, window, periods, smoother="sma") -> pd.Series:
     """
     check_frame_columns(x, "open", "high", "low", "close")
 
-    window = pd.Timedelta(window) if isinstance(window, str) else window
-    tf_orig = pd.Timedelta(infer_series_frequency(x))
+    window = to_timedelta(window) if isinstance(window, str) else window
+    tf_orig = to_timedelta(infer_series_frequency(x))
 
     if window < tf_orig:
         raise ValueError("window size must be great or equal to OHLC series timeframe !!!")
@@ -1004,7 +1004,7 @@ def rolling_series_slope(x: pd.Series, period: int, method="ols", scaling="trans
 
     _min_p = period
     if isinstance(period, str):
-        _min_p = pd.Timedelta(period).days
+        _min_p = to_timedelta(period).days
 
     roll_slope = x.rolling(period, min_periods=_min_p).apply(slp_meth)
 
@@ -1140,7 +1140,7 @@ def pivot_point(data: pd.DataFrame, method="classic", timeframe="D", timezone=No
     else:
         raise ValueError("Unknown method %s. Available methods are: 'classic', 'woodie', 'camarilla'" % method)
 
-    pp.index = pp.index + pd.Timedelta("1D")
+    pp.index = pp.index + to_timedelta("1D")
     return data.combine_first(pp).ffill(axis=0)[pp.columns]
 
 
@@ -1278,7 +1278,7 @@ def calc_ema_time(t, vv, period, min_time_quant, with_correction=True):
 
 
 def ema_time(
-    x: pd.Series, period: str | pd.Timedelta, min_time_quant=pd.Timedelta("1ms"), with_correction=True
+    x: pd.Series, period: str | pd.Timedelta, min_time_quant=to_timedelta("1ms"), with_correction=True
 ) -> pd.Series:
     """
     EMA on non consistent time series
@@ -1292,7 +1292,7 @@ def ema_time(
     vv = x.values
 
     if isinstance(period, str):
-        period = pd.Timedelta(period)
+        period = to_timedelta(period)
 
     index, values = calc_ema_time(t.astype("int64"), vv, period.value, min_time_quant.value, with_correction)
 

--- a/src/qubx/restarts/time_finders.py
+++ b/src/qubx/restarts/time_finders.py
@@ -1,4 +1,6 @@
-from qubx.core.basics import RestoredState, dt_64
+from qubx.core.basics import RestoredState, dt_64, td_64
+from qubx.core.interfaces import StartTimeFinderProtocol
+from qubx.core.utils import recognize_timeframe
 
 
 class TimeFinder:
@@ -105,3 +107,24 @@ class TimeFinder:
 
         # Return the minimum time among all instruments' last signals
         return min(instrument_to_start_time.values())
+
+    @staticmethod
+    def with_max_lookback(finder: StartTimeFinderProtocol, max_lookback: str) -> StartTimeFinderProtocol:
+        """
+        Wrap any time finder to cap how far back in time it can go.
+
+        Args:
+            finder: The underlying time finder to wrap
+            max_lookback: Maximum lookback period (e.g., "30d", "720h")
+
+        Returns:
+            A new time finder that clamps the result to at most max_lookback before current time
+        """
+        max_td = td_64(recognize_timeframe(max_lookback), "ns")
+
+        def capped(time: dt_64, state: RestoredState) -> dt_64:
+            result = finder(time, state)
+            earliest_allowed = time - max_td
+            return max(result, earliest_allowed)
+
+        return capped

--- a/src/qubx/trackers/advanced.py
+++ b/src/qubx/trackers/advanced.py
@@ -8,6 +8,7 @@ from qubx.core.basics import Deal, Instrument, Signal, TargetPosition
 from qubx.core.interfaces import IPositionSizer, IStrategyContext, PositionsTracker
 from qubx.core.series import OHLCV, Bar, Quote, Trade
 from qubx.trackers.riskctrl import State, StopTakePositionTracker
+from qubx.utils.time import to_timedelta
 
 
 @dataclass
@@ -285,7 +286,7 @@ class TimeExpirationTracker(PositionsTracker):
 
     def __init__(self, expiration_time: str | pd.Timedelta, sizer: IPositionSizer) -> None:
         super().__init__(sizer)
-        self.expiration_time = np.timedelta64(pd.Timedelta(expiration_time))
+        self.expiration_time = np.timedelta64(to_timedelta(expiration_time))
         self._opening_time = {}
         self._waiting = {}
 
@@ -318,7 +319,7 @@ class TimeExpirationTracker(PositionsTracker):
         if _o_time is not None:
             if ctx.time() - _o_time >= self.expiration_time:
                 ctx.emit_signal(
-                    instrument.service_signal(ctx, 0, comment=f"Time expired: {pd.Timedelta(self.expiration_time)}")
+                    instrument.service_signal(ctx, 0, comment=f"Time expired: {to_timedelta(self.expiration_time)}")
                 )
                 _res.append(instrument.target(ctx, 0.0))
 

--- a/src/qubx/trackers/sizers.py
+++ b/src/qubx/trackers/sizers.py
@@ -5,7 +5,7 @@ from qubx import logger
 from qubx.core.basics import Signal, TargetPosition
 from qubx.core.interfaces import IPositionSizer, IStrategyContext
 from qubx.ta.indicators import atr
-from qubx.utils.time import infer_series_frequency
+from qubx.utils.time import infer_series_frequency, to_timedelta
 
 _S_YEAR = 24 * 3600 * 365
 
@@ -14,7 +14,7 @@ def annual_factor(tframe_or_series: str | pd.Series) -> float:
     timeframe = (
         infer_series_frequency(tframe_or_series[:25]) if isinstance(tframe_or_series, pd.Series) else tframe_or_series
     )
-    return _S_YEAR / pd.Timedelta(timeframe).total_seconds()
+    return _S_YEAR / to_timedelta(timeframe).total_seconds()
 
 
 def annual_factor_sqrt(tframe_or_series: str | pd.Series) -> float:

--- a/src/qubx/utils/charting/lookinglass.py
+++ b/src/qubx/utils/charting/lookinglass.py
@@ -10,6 +10,7 @@ from plotly.subplots import make_subplots
 from qubx.core.series import OHLCV, TimeSeries
 from qubx.utils import Struct
 from qubx.utils.charting.mpl_helpers import ohlc_plot, plot_trends, subplot
+from qubx.utils.time import to_timedelta
 
 
 def install_plotly_helpers():
@@ -271,10 +272,10 @@ class AbstractLookingGlass:
                     raise ValueError("Argument must be date time not timedelta !")
 
                 if z1.time() == datetime.time(0, 0):
-                    shift = pd.Timedelta(kwargs.get("shift", "24h"))
+                    shift = to_timedelta(kwargs.get("shift", "24h"))
                     zoom = slice(z1, z1 + shift)
                 else:
-                    shift = pd.Timedelta(kwargs.get("shift", "12h"))
+                    shift = to_timedelta(kwargs.get("shift", "12h"))
                     zoom = slice(z1 - shift, z1 + shift)
                     _vert_bar = z1
             else:
@@ -289,7 +290,7 @@ class AbstractLookingGlass:
         _is_delta = False
         if isinstance(z, str):
             try:
-                z = pd.Timedelta(z)
+                z = to_timedelta(z)
                 _is_delta = True
             except:
                 try:

--- a/src/qubx/utils/charting/mpl_helpers.py
+++ b/src/qubx/utils/charting/mpl_helpers.py
@@ -22,7 +22,7 @@ from matplotlib.patches import Rectangle
 from matplotlib.transforms import Affine2D
 
 from qubx.utils.misc import Struct
-from qubx.utils.time import infer_series_frequency
+from qubx.utils.time import infer_series_frequency, to_timedelta
 
 DARK_MATLPLOT_THEME = [
     ("backend", "module://matplotlib_inline.backend_inline"),
@@ -1104,7 +1104,7 @@ def ohlc_plot(ohlc: pd.DataFrame, width=0, colorup="#209040", colordown="#e02020
     if ohlc_f.shape[1] != 4:
         raise ValueError("DataFrame ohlc must contain 'open', 'high', 'low', 'close' columns !")
 
-    _freq = pd.Timedelta(infer_series_frequency(ohlc_f))
+    _freq = to_timedelta(infer_series_frequency(ohlc_f))
 
     # customization of the axis
     f = plt.gcf()

--- a/src/qubx/utils/misc.py
+++ b/src/qubx/utils/misc.py
@@ -20,6 +20,8 @@ import numpy as np
 import pandas as pd
 from tqdm.auto import tqdm
 
+from qubx.utils.time import to_timedelta
+
 
 def version() -> str:
     """Get Qubx version."""
@@ -483,7 +485,7 @@ class TimeLimitedDeque(deque):
 
     def __init__(self, time_limit: str, time_key=lambda x: x[0], unit="ns", *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.time_limit = pd.Timedelta(time_limit).to_timedelta64()
+        self.time_limit = to_timedelta(time_limit).to_timedelta64()
         self.unit = unit
         self.time_key = lambda x: self._to_datetime64(time_key(x))
 
@@ -629,5 +631,5 @@ def safe_dtype_timeframe(dtype: str) -> pd.Timedelta | None:
 
     _t, _p = DataType.from_str(dtype)
     if _t in [DataType.OHLC, DataType.OHLC_QUOTES, DataType.OHLC_TRADES]:
-        return pd.Timedelta(_p["timeframe"]) if "timeframe" in _p else None
+        return to_timedelta(_p["timeframe"]) if "timeframe" in _p else None
     return None

--- a/src/qubx/utils/results.py
+++ b/src/qubx/utils/results.py
@@ -24,7 +24,7 @@ import pyarrow.parquet as pq
 from qubx import logger
 from qubx.core.metrics import TradingSessionResult
 from qubx.utils.s3 import S3Client, is_cloud_path
-from qubx.utils.time import to_utc
+from qubx.utils.time import to_timestamp, to_utc
 
 
 def get_short_class_name(strategy_class: str | list[str]) -> str:
@@ -633,7 +633,7 @@ class SimulationResultsSaver:
         def _ts_utc(ts: str | pd.Timestamp | None) -> pd.Timestamp | None:
             if ts is None:
                 return None
-            t = pd.Timestamp(ts)
+            t = to_timestamp(ts)
             return t.tz_localize("UTC") if t.tz is None else t.tz_convert("UTC")
 
         return {

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -100,7 +100,6 @@ class PrefetchConfig(StrictBaseModel):
 class WarmupConfig(StrictBaseModel):
     data: StorageConfig
     custom_data: list[TypedStorageConfig] = Field(default_factory=list)
-    aux: list[StorageConfig] | StorageConfig | None = None
     restorer: RestorerConfig | None = None
     enable_funding: bool = False
 

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -186,7 +186,7 @@ class LiveConfig(StrictBaseModel):
 
 
 class SimulationConfig(StrictBaseModel):
-    capital: float
+    capital: float | dict[str, float]
     instruments: list[str]
     start: str
     stop: str

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -943,6 +943,7 @@ def _run_warmup(
     simulated_formatter.time_provider = warmup_runner.ctx
 
     ctx._strategy_state.is_warmup_in_progress = True
+    QubxLogConfig.bind_phase("warmup")
 
     try:
         warmup_runner.run(catch_keyboard_interrupt=False, close_data_readers=True)
@@ -954,6 +955,7 @@ def _run_warmup(
             ctx.emitter.set_context(ctx)
         ctx._strategy_state.is_warmup_in_progress = False
         ctx.initializer.simulation = False
+        QubxLogConfig.bind_phase("live")
 
     logger.info("<yellow>Warmup completed</yellow>")
 

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -63,7 +63,6 @@ from qubx.utils.runner.configs import (
     StrategyConfig,
     WarmupConfig,
     load_strategy_config_from_yaml,
-    normalize_aux_config,
     resolve_aux_config,
 )
 from qubx.utils.runner.factory import (
@@ -309,6 +308,7 @@ def run_strategy(
             simulated_formatter=simulated_formatter,
             account_manager=account_manager,
             enable_funding=config.live.warmup.enable_funding if config.live.warmup else False,
+            aux_configs=aux_configs,
         )
     except KeyboardInterrupt:
         logger.info("Warmup interrupted by user")
@@ -852,6 +852,7 @@ def _run_warmup(
     simulated_formatter: SimulatedLogFormatter,
     account_manager: AccountConfigurationManager | None = None,
     enable_funding: bool = False,
+    aux_configs: list[StorageConfig] | None = None,
     trading_sessions_time: str | None = None,
 ) -> None:
     """
@@ -893,12 +894,8 @@ def _run_warmup(
     _warmup_data_storage = construct_storage(warmup.data)
     assert _warmup_data_storage is not None, f"Failed to construct warmup data storage from: {warmup.data}"
     _warmup_custom_data = create_data_type_storages(warmup.custom_data) if warmup.custom_data else None
-    # - use explicitly configured aux storage, otherwise a stub that raises on access
-    _warmup_aux_storage = (
-        construct_multi_storage(normalize_aux_config(warmup.aux))
-        if warmup.aux
-        else NoConfiguredStorage("No aux storage configured for warmup — specify 'aux:' in warmup config")
-    )
+    # - use resolved live/global aux configs (passed from caller)
+    _warmup_aux_storage = construct_multi_storage(aux_configs) if aux_configs else None
 
     # - create instruments
     instruments = []
@@ -1084,7 +1081,6 @@ def simulate_strategy(
     start: str | None = None,
     stop: str | None = None,
     report: str | None = None,
-    log_to_file: bool = False,
     storage_options: dict | None = None,
     name: str | None = None,
     log_file: str | None = None,
@@ -1096,11 +1092,10 @@ def simulate_strategy(
         config_file: Path to the strategy configuration file
         save_path: Path to save the simulation results. Always uses parquet-based storage.
                    Supports local paths and cloud URIs (s3://, gs://, az://).
+                   When set, simulation logs are automatically written alongside results.
         start: Start time for the simulation
         stop: Stop time for the simulation
         report: Ignored (kept for backward compatibility — parquet storage has no separate report)
-        log_to_file: If True, writes all simulation logs to a .log file alongside results
-                     (local paths only — ignored for cloud URIs)
         storage_options: Cloud storage credentials dict. None = uses default_s3_account from settings.
         name: Override the run name used for output folder construction. When provided, takes
               precedence over the 'name:' field in the config file. Useful for distinguishing
@@ -1198,8 +1193,8 @@ def simulate_strategy(
         # - explicit log file path from CLI --log-file
         _log_file = log_file
         print(f" > Logging to file {green(_log_file)} ...")
-    elif log_to_file:
-        _is_cloud = save_path is not None and is_cloud_path(save_path)
+    elif save_path is not None:
+        _is_cloud = is_cloud_path(save_path)
 
         if _is_cloud:
             import tempfile

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -6,8 +6,6 @@ from functools import reduce
 from pathlib import Path
 from threading import Thread
 
-import pandas as pd
-
 from qubx import QubxLogConfig, logger
 from qubx.backtester.optimization import variate
 from qubx.backtester.runner import SimulationRunner
@@ -74,7 +72,7 @@ from qubx.utils.runner.factory import (
     create_state_persistence,
 )
 from qubx.utils.s3 import is_cloud_path
-from qubx.utils.time import convert_seconds_to_str, to_timestamp
+from qubx.utils.time import convert_seconds_to_str, to_timedelta, to_timestamp
 
 from .accounts import AccountConfigurationManager
 
@@ -874,12 +872,12 @@ def _run_warmup(
     warmup_start_time = current_time
     if restored_state is not None:
         warmup_start_time = start_time_finder(current_time, restored_state)
-        time_delta = pd.Timedelta(current_time - warmup_start_time)
+        time_delta = to_timedelta(current_time - warmup_start_time)
         if time_delta.total_seconds() > 0:
             logger.info(f"<yellow>Start time finder estimated to go back in time by {time_delta}</yellow>")
 
     if warmup_period is not None:
-        logger.info(f"<yellow>Warmup period is set to {pd.Timedelta(warmup_period)}</yellow>")
+        logger.info(f"<yellow>Warmup period is set to {to_timedelta(warmup_period)}</yellow>")
         warmup_start_time -= warmup_period
 
     if warmup_start_time == current_time:

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from functools import reduce
 from pathlib import Path
 from threading import Thread
-from typing import cast
 
 import pandas as pd
 
@@ -75,7 +74,7 @@ from qubx.utils.runner.factory import (
     create_state_persistence,
 )
 from qubx.utils.s3 import is_cloud_path
-from qubx.utils.time import convert_seconds_to_str
+from qubx.utils.time import convert_seconds_to_str, to_timestamp
 
 from .accounts import AccountConfigurationManager
 
@@ -929,8 +928,8 @@ def _run_warmup(
             prefetch_config=prefetch_config,
             trading_sessions_time=trading_sessions_time,
         ),
-        start=cast(pd.Timestamp, pd.Timestamp(warmup_start_time)),
-        stop=cast(pd.Timestamp, pd.Timestamp(current_time)),
+        start=to_timestamp(warmup_start_time),
+        stop=to_timestamp(current_time),
         emitter=ctx.emitter,
         notifier=ctx.notifier,
         strategy_state=ctx._strategy_state,
@@ -1122,7 +1121,7 @@ def simulate_strategy(
     stg_cls, _strategy_full_classes = _import_strategy_class(cfg.strategy)
 
     simulation_name = config_file.stem
-    _v_id = cast(pd.Timestamp, pd.Timestamp("now")).strftime("%Y%m%d_%H%M%S")
+    _v_id = to_timestamp("now").strftime("%Y%m%d_%H%M%S")
 
     # - resolve run name: CLI --name > config 'name:' field > config filename stem
     _yaml_name = name or cfg.name or simulation_name

--- a/src/qubx/utils/runner/textual/init_code.py
+++ b/src/qubx/utils/runner/textual/init_code.py
@@ -82,17 +82,10 @@ if _ipython:
 
     _ipython.events.register('post_execute', _qubx_post_execute_hook)
 
-# Initialize the strategy context
-config_file = Path('{config_path_str}')
-account_file = Path('{account_path_str}') if '{account_path_str}' != 'None' else None
+# Define helper functions before strategy init so they exist even if init fails
+from IPython.display import display
 
-# Add project to system path
-{'add_project_to_system_path()  # dev mode: adds ~/projects' if dev else '# dev mode disabled - ~/projects not added'}
-add_project_to_system_path(config_file.parent)
-
-# Run the strategy
-ctx = run_strategy_yaml(config_file, account_file, paper={paper}, restore={restore}, blocking=False, no_emission={no_emission}, no_notifiers={no_notifiers}, no_exporters={no_exporters})
-S = ctx.strategy
+_CUSTOM_MIME_DASHBOARD = "application/x-qubx-dashboard+json"
 
 def _sanitize_number(value):
     \"\"\"Convert NaN or infinity to 0.0 for safe JSON serialization.\"\"\"
@@ -139,11 +132,6 @@ __exit = exit
 def exit():
     ctx.stop()
     __exit()
-
-# Unified dashboard emit helper for Textual UI
-from IPython.display import display
-
-_CUSTOM_MIME_DASHBOARD = "application/x-qubx-dashboard+json"
 
 def _positions_as_records(all=True):
     \"\"\"Convert positions to records for dashboard.\"\"\"
@@ -236,7 +224,7 @@ def emit_dashboard(all=True, debug=False):
         }}
 
         # Let strategy inject custom data
-        if hasattr(S, 'get_dashboard_data'):
+        if 'S' in globals() and hasattr(S, 'get_dashboard_data'):
             custom = S.get_dashboard_data(ctx)
             if custom:
                 data["custom"] = custom
@@ -248,6 +236,18 @@ def emit_dashboard(all=True, debug=False):
             print(f"emit_dashboard error: {{e}}")
             print(traceback.format_exc())
         # Silently fail if context is not ready
+
+# Initialize the strategy context
+config_file = Path('{config_path_str}')
+account_file = Path('{account_path_str}') if '{account_path_str}' != 'None' else None
+
+# Add project to system path
+{'add_project_to_system_path()  # dev mode: adds ~/projects' if dev else '# dev mode disabled - ~/projects not added'}
+add_project_to_system_path(config_file.parent)
+
+# Run the strategy
+ctx = run_strategy_yaml(config_file, account_file, paper={paper}, restore={restore}, blocking=False, no_emission={no_emission}, no_notifiers={no_notifiers}, no_exporters={no_exporters})
+S = ctx.strategy
 
 print(f"Strategy initialized: {{ctx.strategy.__class__.__name__}}")
 print(f"Instruments: {{[i.symbol for i in ctx.instruments]}}")

--- a/src/qubx/utils/time.py
+++ b/src/qubx/utils/time.py
@@ -443,6 +443,14 @@ def interval_to_cron(inv: str) -> str:
         raise ValueError(f"Invalid schedule format: {inv}") from e
 
 
+def to_timestamp(value, **kwargs) -> pd.Timestamp:
+    """Convert a value to pd.Timestamp, raising if the result is NaT."""
+    result = pd.Timestamp(value, **kwargs)
+    if result is pd.NaT:
+        raise ValueError(f"Cannot convert {value!r} to Timestamp (got NaT)")
+    return result  # type: ignore[return-value]
+
+
 def to_utc(timestamp: pd.Timestamp | datetime | str | None) -> pd.Timestamp | None:
     """
     Convert a timestamp to UTC-aware (timezone-aware with UTC timezone).

--- a/src/qubx/utils/time.py
+++ b/src/qubx/utils/time.py
@@ -451,6 +451,17 @@ def to_timestamp(value, **kwargs) -> pd.Timestamp:
     return result  # type: ignore[return-value]
 
 
+_SENTINEL = object()
+
+
+def to_timedelta(value=_SENTINEL, **kwargs) -> pd.Timedelta:
+    """Convert a value to pd.Timedelta, raising if the result is NaT."""
+    result = pd.Timedelta(value, **kwargs) if value is not _SENTINEL else pd.Timedelta(**kwargs)
+    if result is pd.NaT:
+        raise ValueError(f"Cannot convert {value!r} to Timedelta (got NaT)")
+    return result  # type: ignore[return-value]
+
+
 def to_utc(timestamp: pd.Timestamp | datetime | str | None) -> pd.Timestamp | None:
     """
     Convert a timestamp to UTC-aware (timezone-aware with UTC timezone).

--- a/tests/qubx/restarts/test_time_finders.py
+++ b/tests/qubx/restarts/test_time_finders.py
@@ -267,3 +267,94 @@ class TestTimeFinderLASTSIGNAL:
         # For ETH: 2023-01-01T10:30:00
         # Minimum: 2023-01-01T10:30:00
         assert result == np.datetime64("2023-01-01T10:30:00")
+
+
+# Tests for TimeFinder.with_max_lookback
+class TestTimeFinderWithMaxLookback:
+    """Tests for the TimeFinder.with_max_lookback wrapper."""
+
+    def test_does_not_clamp_when_within_limit(self, sample_time, sample_instrument):
+        """When the finder returns a time within max_lookback, it should pass through unchanged."""
+        # Signal 1 hour ago — well within 30d cap
+        signals = [
+            Signal(time=np.datetime64("2023-01-01T11:00:00"), instrument=sample_instrument, signal=1.0, price=50000.0),
+            Signal(time=np.datetime64("2023-01-01T10:00:00"), instrument=sample_instrument, signal=0.0, price=50000.0),
+        ]
+        state = RestoredState(
+            time=sample_time,
+            balances=[],
+            instrument_to_target_positions={},
+            instrument_to_signal_positions={sample_instrument: signals},
+            positions={},
+        )
+        capped_finder = TimeFinder.with_max_lookback(TimeFinder.LAST_SIGNAL, "30d")
+        result = capped_finder(sample_time, state)
+        # LAST_SIGNAL returns 11:00 (the nonzero signal before zero), which is 1h ago — not clamped
+        assert result == np.datetime64("2023-01-01T11:00:00")
+
+    def test_clamps_when_exceeding_limit(self, sample_time, sample_instrument):
+        """When the finder returns a time beyond max_lookback, it should be clamped."""
+        # Signal 60 days ago — exceeds 30d cap
+        old_time = np.datetime64("2022-12-01T12:00:00")
+        signals = [
+            Signal(time=old_time, instrument=sample_instrument, signal=1.0, price=50000.0),
+        ]
+        state = RestoredState(
+            time=sample_time,
+            balances=[],
+            instrument_to_target_positions={},
+            instrument_to_signal_positions={sample_instrument: signals},
+            positions={},
+        )
+        capped_finder = TimeFinder.with_max_lookback(TimeFinder.LAST_SIGNAL, "30d")
+        result = capped_finder(sample_time, state)
+        expected = sample_time - np.timedelta64(30, "D")
+        assert result == expected
+
+    def test_clamps_exactly_at_boundary(self, sample_time, sample_instrument):
+        """When the finder returns a time exactly at the max_lookback boundary, it should pass through."""
+        exactly_2h_ago = sample_time - np.timedelta64(2, "h")
+        signals = [
+            Signal(time=exactly_2h_ago, instrument=sample_instrument, signal=1.0, price=50000.0),
+        ]
+        state = RestoredState(
+            time=sample_time,
+            balances=[],
+            instrument_to_target_positions={},
+            instrument_to_signal_positions={sample_instrument: signals},
+            positions={},
+        )
+        capped_finder = TimeFinder.with_max_lookback(TimeFinder.LAST_SIGNAL, "2h")
+        result = capped_finder(sample_time, state)
+        assert result == exactly_2h_ago
+
+    def test_works_with_now_finder(self, sample_time, empty_state):
+        """Should compose with any finder, including NOW."""
+        capped_finder = TimeFinder.with_max_lookback(TimeFinder.NOW, "30d")
+        result = capped_finder(sample_time, empty_state)
+        # NOW returns current_time, which is always within the cap
+        assert result == sample_time
+
+    def test_works_with_last_target(self, sample_time, sample_instrument):
+        """Should compose with LAST_TARGET the same way."""
+        old_time = np.datetime64("2022-11-01T12:00:00")
+        targets = [
+            TargetPosition(time=old_time, instrument=sample_instrument, target_position_size=1.0),
+        ]
+        state = RestoredState(
+            time=sample_time,
+            balances=[],
+            instrument_to_target_positions={sample_instrument: targets},
+            instrument_to_signal_positions={},
+            positions={},
+        )
+        capped_finder = TimeFinder.with_max_lookback(TimeFinder.LAST_TARGET, "7d")
+        result = capped_finder(sample_time, state)
+        expected = sample_time - np.timedelta64(7, "D")
+        assert result == expected
+
+    def test_empty_state_returns_current_time(self, sample_time, empty_state):
+        """When LAST_SIGNAL returns current_time (no signals), capped result should be the same."""
+        capped_finder = TimeFinder.with_max_lookback(TimeFinder.LAST_SIGNAL, "30d")
+        result = capped_finder(sample_time, empty_state)
+        assert result == sample_time


### PR DESCRIPTION
## Summary

- **Warmup aux config fallback**: Removed redundant `warmup.aux` field; warmup now inherits aux config from live/global level
- **Always write simulation logs**: Removed `-L` flag from `qubx simulate`; logs are written automatically when output path is set
- **Fix multi-exchange capital split**: Single capital float is now split evenly across exchanges instead of being duplicated to each
- **Typed time helpers**: Added `to_timestamp()` and `to_timedelta()` wrappers that validate against NaT, replacing ~80 `pd.Timestamp()`/`pd.Timedelta()` calls and eliminating all `cast(pd.Timestamp, ...)` workarounds
- **Warmup/live phase logging**: Log lines now show `[WARMUP]`/`[LIVE]` phase tags during live trading
- **Enriched heartbeat**: Heartbeat log includes capital, positions count, and leverage info
- **Start time finder max horizon wrapper**

## Test plan
- [x] `just test` — 1170 passed
- [x] `just style-check` — no new errors