### PR TITLE
feat: PostgreSQL support for logs writer and restorers

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -51,6 +51,10 @@ if [ "$QUBX_PAPER" = "true" ]; then
     ARGS="$ARGS --paper"
 fi
 
+if [ "$QUBX_RESTORE" = "true" ]; then
+    ARGS="$ARGS --restore"
+fi
+
 if [ -f /app/overrides.yml ]; then
     ARGS="$ARGS --override /app/overrides.yml"
 fi

--- a/src/qubx/loggers/__init__.py
+++ b/src/qubx/loggers/__init__.py
@@ -8,10 +8,12 @@ from qubx.loggers.csv import CsvFileLogsWriter
 from qubx.loggers.factory import create_logs_writer
 from qubx.loggers.inmemory import InMemoryLogsWriter
 from qubx.loggers.mongo import MongoDBLogsWriter
+from qubx.loggers.postgres import PostgresLogsWriter
 
 __all__ = [
     "CsvFileLogsWriter",
     "InMemoryLogsWriter",
     "MongoDBLogsWriter",
+    "PostgresLogsWriter",
     "create_logs_writer",
 ]

--- a/src/qubx/loggers/factory.py
+++ b/src/qubx/loggers/factory.py
@@ -5,12 +5,14 @@ from qubx.core.loggers import LogsWriter
 from qubx.loggers.csv import CsvFileLogsWriter
 from qubx.loggers.inmemory import InMemoryLogsWriter
 from qubx.loggers.mongo import MongoDBLogsWriter
+from qubx.loggers.postgres import PostgresLogsWriter
 
 # Registry of logs writer types
 LOGS_WRITER_REGISTRY: dict[str, Type[LogsWriter]] = {
     "CsvFileLogsWriter": CsvFileLogsWriter,
     "MongoDBLogsWriter": MongoDBLogsWriter,
     "InMemoryLogsWriter": InMemoryLogsWriter,
+    "PostgresLogsWriter": PostgresLogsWriter,
 }
 
 

--- a/src/qubx/loggers/postgres.py
+++ b/src/qubx/loggers/postgres.py
@@ -1,0 +1,216 @@
+from multiprocessing.pool import ThreadPool
+from typing import Any
+
+from psycopg import sql
+from psycopg.types.json import Jsonb
+from psycopg_pool import ConnectionPool
+
+from qubx import logger
+from qubx.core.loggers import LogsWriter
+
+# Column definitions for each log type: (column_name, sql_type)
+_TABLE_SCHEMAS: dict[str, list[tuple[str, str]]] = {
+    "positions": [
+        ("timestamp", "TIMESTAMPTZ NOT NULL"),
+        ("symbol", "TEXT NOT NULL"),
+        ("exchange", "TEXT NOT NULL"),
+        ("market_type", "TEXT NOT NULL"),
+        ("pnl_quoted", "DOUBLE PRECISION"),
+        ("funding_pnl_quoted", "DOUBLE PRECISION"),
+        ("realized_pnl_quoted", "DOUBLE PRECISION"),
+        ("quantity", "DOUBLE PRECISION"),
+        ("notional", "DOUBLE PRECISION"),
+        ("avg_position_price", "DOUBLE PRECISION"),
+        ("current_price", "DOUBLE PRECISION"),
+        ("market_value_quoted", "DOUBLE PRECISION"),
+        ("commissions_quoted", "DOUBLE PRECISION"),
+    ],
+    "portfolio": [
+        ("timestamp", "TIMESTAMPTZ NOT NULL"),
+        ("symbol", "TEXT NOT NULL"),
+        ("exchange", "TEXT NOT NULL"),
+        ("market_type", "TEXT NOT NULL"),
+        ("pnl_quoted", "DOUBLE PRECISION"),
+        ("quantity", "DOUBLE PRECISION"),
+        ("realized_pnl_quoted", "DOUBLE PRECISION"),
+        ("avg_position_price", "DOUBLE PRECISION"),
+        ("current_price", "DOUBLE PRECISION"),
+        ("market_value_quoted", "DOUBLE PRECISION"),
+        ("exchange_time", "TIMESTAMPTZ"),
+        ("commissions_quoted", "DOUBLE PRECISION"),
+        ("cumulative_funding", "DOUBLE PRECISION"),
+    ],
+    "executions": [
+        ("timestamp", "TIMESTAMPTZ NOT NULL"),
+        ("symbol", "TEXT NOT NULL"),
+        ("exchange", "TEXT NOT NULL"),
+        ("market_type", "TEXT NOT NULL"),
+        ("side", "TEXT NOT NULL"),
+        ("filled_qty", "DOUBLE PRECISION"),
+        ("price", "DOUBLE PRECISION"),
+        ("commissions", "DOUBLE PRECISION"),
+        ("commissions_quoted", "TEXT"),
+        ("order_id", "TEXT"),
+        ("order_type", "TEXT"),
+    ],
+    "signals": [
+        ("timestamp", "TIMESTAMPTZ NOT NULL"),
+        ("symbol", "TEXT NOT NULL"),
+        ("exchange", "TEXT NOT NULL"),
+        ("market_type", "TEXT NOT NULL"),
+        ("signal", "TEXT"),
+        ("reference_price", "DOUBLE PRECISION"),
+        ("price", "DOUBLE PRECISION"),
+        ("take", "DOUBLE PRECISION"),
+        ("stop", "DOUBLE PRECISION"),
+        ("group_name", "TEXT"),
+        ("comment", "TEXT"),
+        ("service", "BOOLEAN"),
+        ("options", "JSONB"),
+    ],
+    "targets": [
+        ("timestamp", "TIMESTAMPTZ NOT NULL"),
+        ("symbol", "TEXT NOT NULL"),
+        ("exchange", "TEXT NOT NULL"),
+        ("market_type", "TEXT NOT NULL"),
+        ("target_position", "DOUBLE PRECISION"),
+        ("entry_price", "DOUBLE PRECISION"),
+        ("take_price", "DOUBLE PRECISION"),
+        ("stop_price", "DOUBLE PRECISION"),
+        ("options", "JSONB"),
+    ],
+    "balance": [
+        ("timestamp", "TIMESTAMPTZ NOT NULL"),
+        ("exchange", "TEXT NOT NULL"),
+        ("currency", "TEXT NOT NULL"),
+        ("total", "DOUBLE PRECISION"),
+        ("locked", "DOUBLE PRECISION"),
+    ],
+}
+
+# Mapping from log data dict keys to column names (only where they differ)
+_COLUMN_RENAMES: dict[str, dict[str, str]] = {
+    "signals": {"group": "group_name"},
+}
+
+# Columns that use JSONB type and need Jsonb() wrapper
+_JSONB_COLUMNS: set[str] = {
+    name for schema in _TABLE_SCHEMAS.values() for name, col_type in schema if col_type == "JSONB"
+}
+
+
+def _table_name(prefix: str, log_type: str) -> str:
+    return f"{prefix}_{log_type}"
+
+
+class PostgresLogsWriter(LogsWriter):
+    """
+    PostgreSQL implementation of LogsWriter interface.
+    Writes log data to typed PostgreSQL tables asynchronously using psycopg v3 and a connection pool.
+    """
+
+    def __init__(
+        self,
+        account_id: str,
+        strategy_id: str,
+        run_id: str,
+        postgres_uri: str = "postgresql://localhost:5432/qubx_logs",
+        table_prefix: str = "qubx_logs",
+        pool_size: int = 4,
+    ) -> None:
+        super().__init__(account_id, strategy_id, run_id)
+        self.table_prefix = table_prefix
+        self._pool = ConnectionPool(postgres_uri, min_size=1, max_size=pool_size)
+        self._thread_pool = ThreadPool(pool_size)
+        self._ensure_tables()
+
+    def _ensure_tables(self) -> None:
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                for log_type, columns in _TABLE_SCHEMAS.items():
+                    tname = _table_name(self.table_prefix, log_type)
+                    col_defs = ",\n    ".join(f"{name} {col_type}" for name, col_type in columns)
+                    cur.execute(
+                        sql.SQL(
+                            """
+                            CREATE TABLE IF NOT EXISTS {table} (
+                                id BIGSERIAL PRIMARY KEY,
+                                run_id TEXT NOT NULL,
+                                account_id TEXT NOT NULL,
+                                strategy_name TEXT NOT NULL,
+                                created_at TIMESTAMPTZ DEFAULT NOW(),
+                                {columns}
+                            )
+                            """
+                        ).format(
+                            table=sql.Identifier(tname),
+                            columns=sql.SQL(col_defs),
+                        )
+                    )
+                    # Index on strategy_name + timestamp for common queries
+                    idx_name = f"idx_{tname}_strategy_ts"
+                    cur.execute(
+                        sql.SQL("CREATE INDEX IF NOT EXISTS {idx} ON {table} (strategy_name, timestamp)").format(
+                            idx=sql.Identifier(idx_name),
+                            table=sql.Identifier(tname),
+                        )
+                    )
+            conn.commit()
+
+    def _remap_keys(self, log_type: str, row: dict[str, Any]) -> dict[str, Any]:
+        renames = _COLUMN_RENAMES.get(log_type)
+        if not renames:
+            return row
+        return {renames.get(k, k): v for k, v in row.items()}
+
+    def _do_write(self, log_type: str, data: list[dict[str, Any]]) -> None:
+        tname = _table_name(self.table_prefix, log_type)
+        schema_cols = [name for name, _ in _TABLE_SCHEMAS[log_type]]
+        meta_cols = ["run_id", "account_id", "strategy_name"]
+        all_cols = meta_cols + schema_cols
+
+        rows = []
+        for raw_row in data:
+            row = self._remap_keys(log_type, raw_row)
+            values = [self.run_id, self.account_id, self.strategy_id]
+            for col in schema_cols:
+                val = row.get(col)
+                # Convert numpy datetime / stringified timestamps
+                if col in ("timestamp", "exchange_time") and val is not None:
+                    val = str(val)
+                # Convert signal value to string
+                if col == "signal" and val is not None:
+                    val = str(val)
+                # Wrap dicts in Jsonb for JSONB columns
+                if col in _JSONB_COLUMNS and isinstance(val, dict):
+                    val = Jsonb(val)
+                values.append(val)
+            rows.append(tuple(values))
+
+        col_ids = sql.SQL(", ").join(sql.Identifier(c) for c in all_cols)
+        placeholders = sql.SQL(", ").join(sql.Placeholder() * len(all_cols))
+        query = sql.SQL("INSERT INTO {table} ({cols}) VALUES ({vals})").format(
+            table=sql.Identifier(tname),
+            cols=col_ids,
+            vals=placeholders,
+        )
+
+        try:
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.executemany(query, rows)
+                conn.commit()
+        except Exception:
+            logger.exception(f"PostgresLogsWriter: failed to write {len(rows)} rows to {tname}")
+
+    def write_data(self, log_type: str, data: list[dict[str, Any]]) -> None:
+        if data:
+            self._thread_pool.apply_async(self._do_write, (log_type, data))
+
+    def flush_data(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self._thread_pool.close()
+        self._thread_pool.join()
+        self._pool.close()

--- a/src/qubx/restorers/balance.py
+++ b/src/qubx/restorers/balance.py
@@ -6,10 +6,11 @@ from various sources.
 """
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pandas as pd
+from psycopg import Connection, sql
 from pymongo import MongoClient
 
 from qubx import logger
@@ -206,4 +207,76 @@ class MongoDBBalanceRestorer(IBalanceRestorer):
             return balances
         except Exception as e:
             logger.error(f"Error restoring balances from MongoDB: {e}")
+            return []
+
+
+class PostgresBalanceRestorer(IBalanceRestorer):
+    """
+    Balance restorer that reads account balances from PostgreSQL tables
+    written by PostgresLogsWriter.
+    """
+
+    def __init__(
+        self,
+        strategy_name: str,
+        connection: Connection,
+        table_name: str = "qubx_logs_balance",
+    ):
+        self.strategy_name = strategy_name
+        self.connection = connection
+        self.table_name = table_name
+
+    def restore_balances(self) -> list[AssetBalance]:
+        try:
+            now = datetime.now(timezone.utc)
+            lookup_range = now - timedelta(days=7)
+
+            with self.connection.cursor() as cur:
+                # Find latest run_id
+                cur.execute(
+                    sql.SQL(
+                        "SELECT run_id FROM {table} WHERE strategy_name = %s AND timestamp >= %s "
+                        "ORDER BY timestamp DESC LIMIT 1"
+                    ).format(table=sql.Identifier(self.table_name)),
+                    (self.strategy_name, lookup_range),
+                )
+                row = cur.fetchone()
+                if not row:
+                    logger.warning("No balance logs found in PostgreSQL for given filters.")
+                    return []
+
+                latest_run_id = row[0]
+                logger.info(f"Restoring balances from PostgreSQL for run_id: {latest_run_id}")
+
+                # Get latest balance per (exchange, currency)
+                cur.execute(
+                    sql.SQL(
+                        "SELECT DISTINCT ON (exchange, currency) "
+                        "exchange, currency, total, locked "
+                        "FROM {table} "
+                        "WHERE strategy_name = %s AND run_id = %s AND timestamp >= %s "
+                        "ORDER BY exchange, currency, timestamp DESC"
+                    ).format(table=sql.Identifier(self.table_name)),
+                    (self.strategy_name, latest_run_id, lookup_range),
+                )
+
+                balances: list[AssetBalance] = []
+                for exchange, currency, total, locked in cur.fetchall():
+                    if not currency:
+                        continue
+                    total = total or 0.0
+                    locked = locked or 0.0
+                    balances.append(
+                        AssetBalance(
+                            exchange=exchange,
+                            currency=currency,
+                            total=total,
+                            locked=locked,
+                            free=total - locked,
+                        )
+                    )
+
+                return balances
+        except Exception as e:
+            logger.error(f"Error restoring balances from PostgreSQL: {e}")
             return []

--- a/src/qubx/restorers/factory.py
+++ b/src/qubx/restorers/factory.py
@@ -8,16 +8,17 @@ based on configuration.
 from typing import Type
 
 from qubx.core.lookups import LookupsManager
-from qubx.restorers.balance import CsvBalanceRestorer, MongoDBBalanceRestorer
+from qubx.restorers.balance import CsvBalanceRestorer, MongoDBBalanceRestorer, PostgresBalanceRestorer
 from qubx.restorers.interfaces import IBalanceRestorer, IPositionRestorer, ISignalRestorer, IStateRestorer
-from qubx.restorers.position import CsvPositionRestorer, MongoDBPositionRestorer
-from qubx.restorers.signal import CsvSignalRestorer, MongoDBSignalRestorer
-from qubx.restorers.state import CsvStateRestorer, MongoDBStateRestorer
+from qubx.restorers.position import CsvPositionRestorer, MongoDBPositionRestorer, PostgresPositionRestorer
+from qubx.restorers.signal import CsvSignalRestorer, MongoDBSignalRestorer, PostgresSignalRestorer
+from qubx.restorers.state import CsvStateRestorer, MongoDBStateRestorer, PostgresStateRestorer
 
 # Registry of position restorer types
 POSITION_RESTORER_REGISTRY: dict[str, Type[IPositionRestorer]] = {
     "CsvPositionRestorer": CsvPositionRestorer,
     "MongoDBPositionRestorer": MongoDBPositionRestorer,
+    "PostgresPositionRestorer": PostgresPositionRestorer,
 }
 
 
@@ -25,6 +26,7 @@ POSITION_RESTORER_REGISTRY: dict[str, Type[IPositionRestorer]] = {
 SIGNAL_RESTORER_REGISTRY: dict[str, Type[ISignalRestorer]] = {
     "CsvSignalRestorer": CsvSignalRestorer,
     "MongoDBSignalRestorer": MongoDBSignalRestorer,
+    "PostgresSignalRestorer": PostgresSignalRestorer,
 }
 
 
@@ -32,6 +34,7 @@ SIGNAL_RESTORER_REGISTRY: dict[str, Type[ISignalRestorer]] = {
 BALANCE_RESTORER_REGISTRY: dict[str, Type[IBalanceRestorer]] = {
     "CsvBalanceRestorer": CsvBalanceRestorer,
     "MongoDBBalanceRestorer": MongoDBBalanceRestorer,
+    "PostgresBalanceRestorer": PostgresBalanceRestorer,
 }
 
 
@@ -39,6 +42,7 @@ BALANCE_RESTORER_REGISTRY: dict[str, Type[IBalanceRestorer]] = {
 STATE_RESTORER_REGISTRY: dict[str, Type[IStateRestorer]] = {
     "CsvStateRestorer": CsvStateRestorer,
     "MongoDBStateRestorer": MongoDBStateRestorer,
+    "PostgresStateRestorer": PostgresStateRestorer,
 }
 
 

--- a/src/qubx/restorers/position.py
+++ b/src/qubx/restorers/position.py
@@ -6,11 +6,12 @@ for restoring positions from various sources.
 """
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast
 
 import pandas as pd
+from psycopg import Connection, sql
 from pymongo import MongoClient
 
 from qubx import logger
@@ -249,4 +250,88 @@ class MongoDBPositionRestorer(IPositionRestorer):
             return positions
         except Exception as e:
             logger.error(f"Error restoring positions from MongoDB: {e}")
+            return {}
+
+
+class PostgresPositionRestorer(IPositionRestorer):
+    """
+    Position restorer that reads positions from PostgreSQL tables
+    written by PostgresLogsWriter.
+    """
+
+    def __init__(
+        self,
+        strategy_name: str,
+        connection: Connection,
+        table_name: str = "qubx_logs_positions",
+    ):
+        self.strategy_name = strategy_name
+        self.connection = connection
+        self.table_name = table_name
+
+    def restore_positions(self) -> dict[Instrument, Position]:
+        try:
+            now = datetime.now(timezone.utc)
+            lookup_range = now - timedelta(days=7)
+
+            with self.connection.cursor() as cur:
+                # Find latest run_id
+                cur.execute(
+                    sql.SQL(
+                        "SELECT run_id FROM {table} WHERE strategy_name = %s AND timestamp >= %s "
+                        "ORDER BY timestamp DESC LIMIT 1"
+                    ).format(table=sql.Identifier(self.table_name)),
+                    (self.strategy_name, lookup_range),
+                )
+                row = cur.fetchone()
+                if not row:
+                    logger.warning("No position logs found in PostgreSQL for given filters.")
+                    return {}
+
+                latest_run_id = row[0]
+                logger.info(f"Restoring positions from PostgreSQL for run_id: {latest_run_id}")
+
+                # Get latest position per instrument
+                cur.execute(
+                    sql.SQL(
+                        "SELECT DISTINCT ON (symbol, exchange, market_type) "
+                        "symbol, exchange, market_type, quantity, avg_position_price, "
+                        "realized_pnl_quoted, current_price, funding_pnl_quoted, commissions_quoted, timestamp "
+                        "FROM {table} "
+                        "WHERE strategy_name = %s AND run_id = %s AND timestamp >= %s "
+                        "ORDER BY symbol, exchange, market_type, timestamp DESC"
+                    ).format(table=sql.Identifier(self.table_name)),
+                    (self.strategy_name, latest_run_id, lookup_range),
+                )
+
+                positions: dict[Instrument, Position] = {}
+                for log in cur.fetchall():
+                    symbol, exchange, market_type, quantity, avg_price, r_pnl, current_price, funding, commissions, ts = log
+
+                    if not (symbol and exchange and market_type):
+                        continue
+
+                    instrument = lookup.find_symbol(exchange, symbol)
+                    if instrument is None:
+                        logger.warning(f"Instrument not found for {symbol} on {exchange}")
+                        continue
+
+                    position = Position(
+                        instrument=instrument,
+                        quantity=cast(float, quantity or 0.0),
+                        pos_average_price=cast(float, avg_price or 0.0),
+                        r_pnl=cast(float, r_pnl or 0.0),
+                        cumulative_funding=cast(float, funding or 0.0),
+                        commissions=cast(float, commissions or 0.0),
+                    )
+
+                    if current_price is not None:
+                        timestamp = recognize_time(ts)
+                        position.update_market_price(timestamp, current_price, 1.0)
+
+                    positions[instrument] = position
+
+                return positions
+        except Exception as e:
+            logger.error(f"Error restoring positions from PostgreSQL: {e}")
             return {}

--- a/src/qubx/restorers/signal.py
+++ b/src/qubx/restorers/signal.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import pandas as pd
+from psycopg import Connection, sql
 from pymongo import MongoClient
 from pymongo.command_cursor import CommandCursor
 
@@ -373,4 +374,120 @@ class MongoDBSignalRestorer(ISignalRestorer):
             logger.error(
                 f"Error restoring {log_type} data from MongoDB::{self.collection_name} for {self.strategy_name} : {e}"
             )
+            return None
+
+
+class PostgresSignalRestorer(ISignalRestorer):
+    """
+    Signal restorer that reads signals and targets from PostgreSQL tables
+    written by PostgresLogsWriter.
+    """
+
+    def __init__(
+        self,
+        strategy_name: str,
+        connection: Connection,
+        signals_table_name: str = "qubx_logs_signals",
+        targets_table_name: str = "qubx_logs_targets",
+        max_restored_records: int = 20,
+    ):
+        self.strategy_name = strategy_name
+        self.connection = connection
+        self.signals_table_name = signals_table_name
+        self.targets_table_name = targets_table_name
+        self.max_restored_records = max_restored_records
+
+    def restore_signals(self) -> dict[Instrument, list[Signal]]:
+        logger.info(f"Restoring latest {self.max_restored_records} signals per symbol from PostgreSQL")
+        result: dict[Instrument, list[Signal]] = {}
+
+        rows = self._load_data(self.signals_table_name)
+        if rows is None:
+            return result
+
+        for log in rows:
+            try:
+                instrument = lookup.find_symbol(log["exchange"], log["symbol"])
+                if instrument is None:
+                    logger.warning(f"Instrument not found for {log['symbol']} on {log['exchange']}")
+                    continue
+
+                signal_value = log.get("signal")
+                if signal_value is not None:
+                    signal_value = float(signal_value)
+
+                if signal_value is None:
+                    logger.warning(f"Missing signal for log: {log}")
+                    continue
+
+                price = log.get("price") or log.get("reference_price")
+                options = log.get("options") or {}
+
+                signal = Signal(
+                    time=recognize_time(log["timestamp"]),
+                    instrument=instrument,
+                    signal=signal_value,
+                    price=price,
+                    stop=None,
+                    take=None,
+                    reference_price=log.get("reference_price"),
+                    group=log.get("group_name", ""),
+                    comment=log.get("comment", ""),
+                    options=options,
+                    is_service=log.get("service", False),
+                )
+
+                result.setdefault(instrument, []).append(signal)
+            except Exception as e:
+                logger.exception(f"Failed to process signal row: {e}")
+
+        return result
+
+    def restore_targets(self) -> dict[Instrument, list[TargetPosition]]:
+        logger.info(f"Restoring latest {self.max_restored_records} targets per symbol from PostgreSQL")
+        result: dict[Instrument, list[TargetPosition]] = {}
+
+        rows = self._load_data(self.targets_table_name)
+        if rows is None:
+            return result
+
+        for log in rows:
+            try:
+                instrument = lookup.find_symbol(log["exchange"], log["symbol"])
+                if instrument is None:
+                    logger.warning(f"Instrument not found for {log['symbol']} on {log['exchange']}")
+                    continue
+
+                target = TargetPosition(
+                    time=recognize_time(log["timestamp"]),
+                    instrument=instrument,
+                    target_position_size=float(log["target_position"]),
+                    entry_price=log.get("entry_price"),
+                    stop_price=log.get("stop_price"),
+                    take_price=log.get("take_price"),
+                    options=log.get("options") or {},
+                )
+
+                result.setdefault(instrument, []).append(target)
+            except Exception as e:
+                logger.exception(f"Failed to process target row: {e}")
+
+        return result
+
+    def _load_data(self, table_name: str) -> list[dict] | None:
+        try:
+            query = sql.SQL(
+                "SELECT * FROM ("
+                "  SELECT *, ROW_NUMBER() OVER ("
+                "    PARTITION BY symbol, exchange, market_type ORDER BY timestamp DESC"
+                "  ) AS rn FROM {table} WHERE strategy_name = %s"
+                ") sub WHERE rn <= %s ORDER BY symbol, exchange, market_type, timestamp DESC"
+            ).format(table=sql.Identifier(table_name))
+
+            with self.connection.cursor() as cur:
+                cur.execute(query, (self.strategy_name, self.max_restored_records))
+                columns = [desc.name for desc in cur.description]
+                return [dict(zip(columns, row)) for row in cur.fetchall()]
+        except Exception as e:
+            logger.error(f"Error restoring data from PostgreSQL::{table_name} for {self.strategy_name}: {e}")
             return None

--- a/src/qubx/restorers/state.py
+++ b/src/qubx/restorers/state.py
@@ -9,15 +9,16 @@ import os
 from pathlib import Path
 
 import numpy as np
+import psycopg
 from pymongo import MongoClient
 
 from qubx import logger
 from qubx.core.basics import RestoredState
 from qubx.core.utils import recognize_time
-from qubx.restorers.balance import CsvBalanceRestorer, MongoDBBalanceRestorer
+from qubx.restorers.balance import CsvBalanceRestorer, MongoDBBalanceRestorer, PostgresBalanceRestorer
 from qubx.restorers.interfaces import IStateRestorer
-from qubx.restorers.position import CsvPositionRestorer, MongoDBPositionRestorer
-from qubx.restorers.signal import CsvSignalRestorer, MongoDBSignalRestorer
+from qubx.restorers.position import CsvPositionRestorer, MongoDBPositionRestorer, PostgresPositionRestorer
+from qubx.restorers.signal import CsvSignalRestorer, MongoDBSignalRestorer, PostgresSignalRestorer
 from qubx.restorers.utils import find_latest_run_folder
 
 
@@ -214,3 +215,86 @@ class MongoDBStateRestorer(IStateRestorer):
             instrument_to_target_positions=targets,
             balances=balances,
         )
+
+
+class PostgresStateRestorer(IStateRestorer):
+    """
+    State restorer that reads strategy state from PostgreSQL.
+
+    Combines PostgresPositionRestorer, PostgresSignalRestorer, and
+    PostgresBalanceRestorer to create a complete RestoredState.
+    """
+
+    def __init__(
+        self,
+        strategy_name: str,
+        postgres_uri: str = "postgresql://localhost:5432/qubx_logs",
+        table_prefix: str = "qubx_logs",
+    ):
+        self.postgres_uri = postgres_uri
+        self.table_prefix = table_prefix
+        self.strategy_name = strategy_name
+
+    def restore_state(self) -> RestoredState:
+        conn = psycopg.connect(self.postgres_uri, autocommit=True)
+        try:
+            # Check that at least some tables exist
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE %s",
+                    (f"{self.table_prefix}_%",),
+                )
+                existing_tables = {row[0] for row in cur.fetchall()}
+
+            required_suffixes = ["positions", "signals", "balance"]
+            if not any(f"{self.table_prefix}_{suffix}" in existing_tables for suffix in required_suffixes):
+                logger.warning(f"No logs tables found in PostgreSQL matching prefix '{self.table_prefix}'.")
+                return RestoredState(
+                    time=np.datetime64("now"),
+                    positions={},
+                    instrument_to_signal_positions={},
+                    instrument_to_target_positions={},
+                    balances={},
+                )
+
+            logger.info(f"Restoring state from PostgreSQL (prefix: {self.table_prefix})")
+
+            position_restorer = PostgresPositionRestorer(
+                strategy_name=self.strategy_name,
+                connection=conn,
+                table_name=f"{self.table_prefix}_positions",
+            )
+            signal_restorer = PostgresSignalRestorer(
+                strategy_name=self.strategy_name,
+                connection=conn,
+                signals_table_name=f"{self.table_prefix}_signals",
+                targets_table_name=f"{self.table_prefix}_targets",
+            )
+            balance_restorer = PostgresBalanceRestorer(
+                strategy_name=self.strategy_name,
+                connection=conn,
+                table_name=f"{self.table_prefix}_balance",
+            )
+
+            positions = position_restorer.restore_positions()
+            signals = signal_restorer.restore_signals()
+            targets = signal_restorer.restore_targets()
+            balances = balance_restorer.restore_balances()
+
+            latest_position_timestamp = (
+                max(position.last_update_time for position in positions.values())
+                if positions
+                else np.datetime64("now")
+            )
+            if np.isnan(latest_position_timestamp):
+                latest_position_timestamp = np.datetime64("now")
+
+            return RestoredState(
+                time=recognize_time(latest_position_timestamp),
+                positions=positions,
+                instrument_to_signal_positions=signals,
+                instrument_to_target_positions=targets,
+                balances=balances,
+            )
+        finally:
+            conn.close()

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -1,0 +1,446 @@
+"""
+Tests for PostgreSQL logger and restorers.
+
+Uses unittest.mock to simulate psycopg connections since there is no
+psycopg equivalent of mongomock.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qubx.core.basics import (
+    Instrument,
+    MarketType,
+    RestoredState,
+)
+from qubx.restorers.balance import PostgresBalanceRestorer
+from qubx.restorers.interfaces import (
+    IBalanceRestorer,
+    IPositionRestorer,
+    ISignalRestorer,
+    IStateRestorer,
+)
+from qubx.restorers.position import PostgresPositionRestorer
+from qubx.restorers.signal import PostgresSignalRestorer
+from qubx.restorers.state import PostgresStateRestorer
+
+# --- Helpers ---
+
+def create_mock_instruments():
+    return {
+        "BINANCE.UM:SWAP:BTCUSDT": Instrument(
+            symbol="BTCUSDT",
+            market_type=MarketType.SWAP,
+            exchange="BINANCE.UM",
+            base="BTC",
+            quote="USDT",
+            settle="USDT",
+            exchange_symbol="BTC/USDT:USDT",
+            tick_size=0.1,
+            lot_size=0.001,
+            min_size=0.001,
+        ),
+        "BINANCE.UM:SWAP:ETHUSDT": Instrument(
+            symbol="ETHUSDT",
+            market_type=MarketType.SWAP,
+            exchange="BINANCE.UM",
+            base="ETH",
+            quote="USDT",
+            settle="USDT",
+            exchange_symbol="ETH/USDT:USDT",
+            tick_size=0.01,
+            lot_size=0.001,
+            min_size=0.001,
+        ),
+    }
+
+
+def mock_find_symbol(exchange, symbol, market_type=None):
+    instruments = create_mock_instruments()
+    for instrument in instruments.values():
+        if instrument.exchange == exchange and instrument.symbol == symbol:
+            if market_type is None or instrument.market_type == market_type:
+                return instrument
+    return None
+
+
+@pytest.fixture
+def mock_lookup():
+    with (
+        patch("qubx.restorers.position.lookup") as mock_pos,
+        patch("qubx.restorers.signal.lookup") as mock_sig,
+    ):
+        mock_pos.find_symbol = mock_find_symbol
+        mock_sig.find_symbol = mock_find_symbol
+        yield
+
+
+def _make_mock_connection():
+    """Create a mock psycopg Connection with cursor context manager support."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return conn, cursor
+
+
+# --- Protocol tests ---
+
+class TestPostgresProtocolImplementations:
+
+    def test_position_restorer_protocol(self):
+        conn, _ = _make_mock_connection()
+        restorer = PostgresPositionRestorer(strategy_name="test", connection=conn)
+        assert isinstance(restorer, IPositionRestorer)
+
+    def test_signal_restorer_protocol(self):
+        conn, _ = _make_mock_connection()
+        restorer = PostgresSignalRestorer(strategy_name="test", connection=conn)
+        assert isinstance(restorer, ISignalRestorer)
+
+    def test_balance_restorer_protocol(self):
+        conn, _ = _make_mock_connection()
+        restorer = PostgresBalanceRestorer(strategy_name="test", connection=conn)
+        assert isinstance(restorer, IBalanceRestorer)
+
+    def test_state_restorer_protocol(self):
+        restorer = PostgresStateRestorer(strategy_name="test")
+        assert isinstance(restorer, IStateRestorer)
+
+
+# --- Position restorer tests ---
+
+class TestPostgresPositionRestorer:
+    _strategy_name = "test_strategy"
+
+    def test_with_no_data(self):
+        conn, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = None
+
+        restorer = PostgresPositionRestorer(strategy_name=self._strategy_name, connection=conn)
+        result = restorer.restore_positions()
+
+        assert isinstance(result, dict)
+        assert len(result) == 0
+
+    def test_with_sample_data(self, mock_lookup):
+        conn, cursor = _make_mock_connection()
+        ts = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        # First call: find latest run_id
+        # Second call: get positions
+        cursor.fetchone.return_value = ("run-123",)
+        cursor.fetchall.return_value = [
+            # symbol, exchange, market_type, quantity, avg_price, r_pnl, current_price, funding, commissions, ts
+            ("BTCUSDT", "BINANCE.UM", "SWAP", 1.5, 90000.0, 100.0, 91000.0, 5.0, 10.0, ts),
+        ]
+
+        restorer = PostgresPositionRestorer(strategy_name=self._strategy_name, connection=conn)
+        result = restorer.restore_positions()
+
+        assert len(result) == 1
+        btc_pos = next(p for i, p in result.items() if i.symbol == "BTCUSDT")
+        assert btc_pos.quantity == 1.5
+        assert btc_pos.position_avg_price == 90000.0
+
+
+# --- Signal restorer tests ---
+
+class TestPostgresSignalRestorer:
+    _strategy_name = "test_strategy"
+
+    def test_with_no_data(self):
+        conn, cursor = _make_mock_connection()
+        cursor.fetchall.return_value = []
+        cursor.description = []
+
+        restorer = PostgresSignalRestorer(strategy_name=self._strategy_name, connection=conn)
+        result = restorer.restore_signals()
+
+        assert isinstance(result, dict)
+        assert len(result) == 0
+
+    def test_with_sample_signals(self, mock_lookup):
+        conn, cursor = _make_mock_connection()
+        ts = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        # Mock cursor.description to return column names
+        col_names = [
+            "id", "run_id", "account_id", "strategy_name", "created_at",
+            "timestamp", "symbol", "exchange", "market_type",
+            "signal", "reference_price", "price", "take", "stop",
+            "group_name", "comment", "service", "options", "rn",
+        ]
+        cursor.description = [MagicMock(name=c) for c in col_names]
+        for desc, name in zip(cursor.description, col_names):
+            desc.name = name
+
+        cursor.fetchall.return_value = [
+            (1, "run-123", "acc", "test_strategy", ts,
+             ts, "BTCUSDT", "BINANCE.UM", "SWAP",
+             "1.0", 90000.0, 90000.0, None, None,
+             "", "", False, {}, 1),
+        ]
+
+        restorer = PostgresSignalRestorer(strategy_name=self._strategy_name, connection=conn)
+        result = restorer.restore_signals()
+
+        assert len(result) == 1
+        btc_signals = next(s for i, s in result.items() if i.symbol == "BTCUSDT")
+        assert len(btc_signals) == 1
+        assert btc_signals[0].signal == 1.0
+
+    def test_with_sample_targets(self, mock_lookup):
+        conn, cursor = _make_mock_connection()
+        ts = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        col_names = [
+            "id", "run_id", "account_id", "strategy_name", "created_at",
+            "timestamp", "symbol", "exchange", "market_type",
+            "target_position", "entry_price", "take_price", "stop_price",
+            "options", "rn",
+        ]
+        cursor.description = [MagicMock(name=c) for c in col_names]
+        for desc, name in zip(cursor.description, col_names):
+            desc.name = name
+
+        cursor.fetchall.return_value = [
+            (1, "run-123", "acc", "test_strategy", ts,
+             ts, "BTCUSDT", "BINANCE.UM", "SWAP",
+             0.5, 90000.0, None, None,
+             {}, 1),
+        ]
+
+        restorer = PostgresSignalRestorer(strategy_name=self._strategy_name, connection=conn)
+        result = restorer.restore_targets()
+
+        assert len(result) == 1
+        btc_targets = next(t for i, t in result.items() if i.symbol == "BTCUSDT")
+        assert len(btc_targets) == 1
+        assert btc_targets[0].target_position_size == 0.5
+
+
+# --- Balance restorer tests ---
+
+class TestPostgresBalanceRestorer:
+    _strategy_name = "test_strategy"
+
+    def test_with_no_data(self):
+        conn, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = None
+
+        restorer = PostgresBalanceRestorer(strategy_name=self._strategy_name, connection=conn)
+        result = restorer.restore_balances()
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    def test_with_sample_data(self):
+        conn, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = ("run-123",)
+        cursor.fetchall.return_value = [
+            ("BINANCE.UM", "USDT", 10000.0, 1000.0),
+        ]
+
+        restorer = PostgresBalanceRestorer(strategy_name=self._strategy_name, connection=conn)
+        result = restorer.restore_balances()
+
+        assert len(result) == 1
+        assert result[0].currency == "USDT"
+        assert result[0].total == 10000.0
+        assert result[0].locked == 1000.0
+        assert result[0].free == 9000.0
+        assert result[0].exchange == "BINANCE.UM"
+
+
+# --- State restorer tests ---
+
+class TestPostgresStateRestorer:
+    _strategy_name = "test_strategy"
+    _postgres_uri = "postgresql://localhost:5432/qubx_logs"
+
+    @patch("qubx.restorers.state.psycopg")
+    def test_with_no_tables(self, mock_psycopg):
+        conn = MagicMock()
+        mock_psycopg.connect.return_value = conn
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # No tables exist
+        cursor.fetchall.return_value = []
+
+        restorer = PostgresStateRestorer(
+            strategy_name=self._strategy_name,
+            postgres_uri=self._postgres_uri,
+        )
+        result = restorer.restore_state()
+
+        assert isinstance(result, RestoredState)
+        assert len(result.positions) == 0
+        assert len(result.balances) == 0
+        conn.close.assert_called_once()
+
+    @patch("qubx.restorers.state.psycopg")
+    def test_with_sample_data(self, mock_psycopg, mock_lookup):
+        conn = MagicMock()
+        mock_psycopg.connect.return_value = conn
+        ts = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # We need to handle multiple sequential cursor calls.
+        # The state restorer: 1) checks tables, then delegates to individual restorers.
+        # Each restorer creates its own cursor via conn.cursor().
+        # We track call count to return appropriate data.
+
+        call_count = {"n": 0}
+
+        def side_effect_fetchall():
+            call_count["n"] += 1
+            n = call_count["n"]
+            if n == 1:
+                # Table existence check
+                return [("qubx_logs_positions",), ("qubx_logs_signals",), ("qubx_logs_balance",)]
+            elif n == 2:
+                # Position restorer: fetch positions
+                return [("BTCUSDT", "BINANCE.UM", "SWAP", 1.0, 90000.0, 50.0, 91000.0, 5.0, 10.0, ts)]
+            elif n == 3:
+                # Signal restorer: fetch signals (returns dicts via _load_data)
+                return []
+            elif n == 4:
+                # Target restorer: fetch targets
+                return []
+            elif n == 5:
+                # Balance restorer: fetch balances
+                return [("BINANCE.UM", "USDT", 10000.0, 500.0)]
+            return []
+
+        fetchone_count = {"n": 0}
+
+        def side_effect_fetchone():
+            fetchone_count["n"] += 1
+            return ("run-123",)
+
+        cursor.fetchall.side_effect = side_effect_fetchall
+        cursor.fetchone.side_effect = side_effect_fetchone
+        cursor.description = []
+
+        restorer = PostgresStateRestorer(
+            strategy_name=self._strategy_name,
+            postgres_uri=self._postgres_uri,
+        )
+        result = restorer.restore_state()
+
+        assert isinstance(result, RestoredState)
+        assert len(result.positions) == 1
+        assert len(result.balances) == 1
+
+        # Check position
+        btc_pos = None
+        for instrument, position in result.positions.items():
+            if instrument.symbol == "BTCUSDT":
+                btc_pos = position
+        assert btc_pos is not None
+        assert btc_pos.quantity == 1.0
+        assert btc_pos.position_avg_price == 90000.0
+
+        # Check balance
+        assert result.balances[0].currency == "USDT"
+        assert result.balances[0].total == 10000.0
+        assert result.balances[0].free == 9500.0
+
+        conn.close.assert_called_once()
+
+
+# --- Logger tests ---
+
+class TestPostgresLogsWriter:
+    """Test that PostgresLogsWriter can be instantiated and registered in the factory."""
+
+    def test_factory_registration(self):
+        from qubx.loggers.factory import LOGS_WRITER_REGISTRY
+        assert "PostgresLogsWriter" in LOGS_WRITER_REGISTRY
+
+    def test_import(self):
+        from qubx.loggers import PostgresLogsWriter
+        assert PostgresLogsWriter is not None
+
+    @patch("qubx.loggers.postgres.ThreadPool")
+    @patch("qubx.loggers.postgres.ConnectionPool")
+    def test_write_data_calls_thread_pool(self, mock_pool_cls, mock_tp_cls):
+        from qubx.loggers.postgres import PostgresLogsWriter
+
+        mock_pool = MagicMock()
+        mock_pool_cls.return_value = mock_pool
+        mock_tp = MagicMock()
+        mock_tp_cls.return_value = mock_tp
+
+        # Mock the connection for _ensure_tables
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_pool.connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        writer = PostgresLogsWriter(
+            account_id="test_acc",
+            strategy_id="test_strat",
+            run_id="run-1",
+            postgres_uri="postgresql://localhost/test",
+        )
+
+        data = [
+            {
+                "timestamp": "2025-01-01T00:00:00",
+                "symbol": "BTCUSDT",
+                "exchange": "BINANCE.UM",
+                "market_type": "SWAP",
+                "pnl_quoted": 100.0,
+                "funding_pnl_quoted": 5.0,
+                "realized_pnl_quoted": 50.0,
+                "quantity": 1.0,
+                "notional": 90000.0,
+                "avg_position_price": 90000.0,
+                "current_price": 91000.0,
+                "market_value_quoted": 91000.0,
+                "commissions_quoted": 10.0,
+            }
+        ]
+
+        writer.write_data("positions", data)
+
+        mock_tp.apply_async.assert_called_once()
+
+    @patch("qubx.loggers.postgres.ThreadPool")
+    @patch("qubx.loggers.postgres.ConnectionPool")
+    def test_write_data_ignores_empty(self, mock_pool_cls, mock_tp_cls):
+        from qubx.loggers.postgres import PostgresLogsWriter
+
+        mock_pool = MagicMock()
+        mock_pool_cls.return_value = mock_pool
+        mock_tp = MagicMock()
+        mock_tp_cls.return_value = mock_tp
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_pool.connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        writer = PostgresLogsWriter(
+            account_id="test_acc",
+            strategy_id="test_strat",
+            run_id="run-1",
+            postgres_uri="postgresql://localhost/test",
+        )
+
+        writer.write_data("positions", [])
+
+        mock_tp.apply_async.assert_not_called()

--- a/tests/qubx/test_postgres_e2e.py
+++ b/tests/qubx/test_postgres_e2e.py
@@ -1,0 +1,442 @@
+"""
+End-to-end tests for PostgreSQL logger and restorers.
+
+Requires a running PostgreSQL instance at localhost:5432 with
+user=xlydian, password=xlydian, database=qubx_test_e2e.
+
+Tests write data via PostgresLogsWriter, then read it back via
+Postgres restorers, verifying the full round-trip.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import numpy as np
+import psycopg
+import pytest
+
+from qubx.core.basics import Instrument, MarketType, RestoredState
+from qubx.loggers.postgres import PostgresLogsWriter
+from qubx.restorers.balance import PostgresBalanceRestorer
+from qubx.restorers.position import PostgresPositionRestorer
+from qubx.restorers.signal import PostgresSignalRestorer
+from qubx.restorers.state import PostgresStateRestorer
+
+POSTGRES_URI = "postgresql://xlydian:xlydian@localhost:5432/qubx_test_e2e"
+TABLE_PREFIX = "e2e_test"
+STRATEGY_NAME = "e2e_test_strategy"
+ACCOUNT_ID = "e2e_account"
+RUN_ID = "e2e_run_001"
+
+
+def _create_mock_instruments():
+    return {
+        "BTCUSDT": Instrument(
+            symbol="BTCUSDT",
+            market_type=MarketType.SWAP,
+            exchange="BINANCE.UM",
+            base="BTC",
+            quote="USDT",
+            settle="USDT",
+            exchange_symbol="BTC/USDT:USDT",
+            tick_size=0.1,
+            lot_size=0.001,
+            min_size=0.001,
+        ),
+        "ETHUSDT": Instrument(
+            symbol="ETHUSDT",
+            market_type=MarketType.SWAP,
+            exchange="BINANCE.UM",
+            base="ETH",
+            quote="USDT",
+            settle="USDT",
+            exchange_symbol="ETH/USDT:USDT",
+            tick_size=0.01,
+            lot_size=0.001,
+            min_size=0.001,
+        ),
+    }
+
+
+def _mock_find_symbol(exchange, symbol, market_type=None):
+    instruments = _create_mock_instruments()
+    inst = instruments.get(symbol)
+    if inst and inst.exchange == exchange:
+        return inst
+    return None
+
+
+@pytest.fixture(scope="module")
+def mock_lookup():
+    with (
+        patch("qubx.restorers.position.lookup") as mock_pos,
+        patch("qubx.restorers.signal.lookup") as mock_sig,
+    ):
+        mock_pos.find_symbol = _mock_find_symbol
+        mock_sig.find_symbol = _mock_find_symbol
+        yield
+
+
+@pytest.fixture(scope="module")
+def pg_writer():
+    """Create a PostgresLogsWriter, write test data, then clean up."""
+    writer = PostgresLogsWriter(
+        account_id=ACCOUNT_ID,
+        strategy_id=STRATEGY_NAME,
+        run_id=RUN_ID,
+        postgres_uri=POSTGRES_URI,
+        table_prefix=TABLE_PREFIX,
+        pool_size=2,
+    )
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+    # --- Write positions ---
+    writer.write_data(
+        "positions",
+        [
+            {
+                "timestamp": now,
+                "symbol": "BTCUSDT",
+                "exchange": "BINANCE.UM",
+                "market_type": "SWAP",
+                "pnl_quoted": 150.0,
+                "funding_pnl_quoted": 3.5,
+                "realized_pnl_quoted": 75.0,
+                "quantity": 0.5,
+                "notional": 45000.0,
+                "avg_position_price": 89000.0,
+                "current_price": 90000.0,
+                "market_value_quoted": 45000.0,
+                "commissions_quoted": 12.0,
+            },
+            {
+                "timestamp": now,
+                "symbol": "ETHUSDT",
+                "exchange": "BINANCE.UM",
+                "market_type": "SWAP",
+                "pnl_quoted": 20.0,
+                "funding_pnl_quoted": 1.0,
+                "realized_pnl_quoted": 10.0,
+                "quantity": 2.0,
+                "notional": 6000.0,
+                "avg_position_price": 2900.0,
+                "current_price": 3000.0,
+                "market_value_quoted": 6000.0,
+                "commissions_quoted": 3.0,
+            },
+        ],
+    )
+
+    # --- Write portfolio ---
+    writer.write_data(
+        "portfolio",
+        [
+            {
+                "timestamp": now,
+                "symbol": "BTCUSDT",
+                "exchange": "BINANCE.UM",
+                "market_type": "SWAP",
+                "pnl_quoted": 150.0,
+                "quantity": 0.5,
+                "realized_pnl_quoted": 75.0,
+                "avg_position_price": 89000.0,
+                "current_price": 90000.0,
+                "market_value_quoted": 45000.0,
+                "exchange_time": now,
+                "commissions_quoted": 12.0,
+                "cumulative_funding": 3.5,
+            },
+        ],
+    )
+
+    # --- Write executions ---
+    writer.write_data(
+        "executions",
+        [
+            {
+                "timestamp": now,
+                "symbol": "BTCUSDT",
+                "exchange": "BINANCE.UM",
+                "market_type": "SWAP",
+                "side": "buy",
+                "filled_qty": 0.5,
+                "price": 89000.0,
+                "commissions": 12.0,
+                "commissions_quoted": "USDT",
+                "order_id": "order-001",
+                "order_type": "TAKER",
+            },
+        ],
+    )
+
+    # --- Write signals ---
+    writer.write_data(
+        "signals",
+        [
+            {
+                "timestamp": now,
+                "symbol": "BTCUSDT",
+                "exchange": "BINANCE.UM",
+                "market_type": "SWAP",
+                "signal": 1.0,
+                "reference_price": 89000.0,
+                "price": 89000.0,
+                "take": None,
+                "stop": None,
+                "group": "main",
+                "comment": "e2e test signal",
+                "service": False,
+                "options": {"reason": "test"},
+            },
+        ],
+    )
+
+    # --- Write targets ---
+    writer.write_data(
+        "targets",
+        [
+            {
+                "timestamp": now,
+                "symbol": "BTCUSDT",
+                "exchange": "BINANCE.UM",
+                "market_type": "SWAP",
+                "target_position": 0.5,
+                "entry_price": 89000.0,
+                "take_price": 95000.0,
+                "stop_price": 85000.0,
+                "options": {"mode": "test"},
+            },
+        ],
+    )
+
+    # --- Write balance ---
+    writer.write_data(
+        "balance",
+        [
+            {
+                "timestamp": now,
+                "exchange": "BINANCE.UM",
+                "currency": "USDT",
+                "total": 50000.0,
+                "locked": 5000.0,
+            },
+            {
+                "timestamp": now,
+                "exchange": "BINANCE.UM",
+                "currency": "BTC",
+                "total": 0.5,
+                "locked": 0.0,
+            },
+        ],
+    )
+
+    # Wait for async thread pool writes to complete
+    writer._thread_pool.close()
+    writer._thread_pool.join()
+
+    yield writer
+
+    # Cleanup: drop all e2e tables
+    conn = psycopg.connect(POSTGRES_URI, autocommit=True)
+    with conn.cursor() as cur:
+        for log_type in ["positions", "portfolio", "executions", "signals", "targets", "balance"]:
+            cur.execute(psycopg.sql.SQL("DROP TABLE IF EXISTS {table}").format(
+                table=psycopg.sql.Identifier(f"{TABLE_PREFIX}_{log_type}")
+            ))
+    conn.close()
+    writer._pool.close()
+
+
+@pytest.fixture(scope="module")
+def pg_conn(pg_writer):
+    """Get a connection to the test database (after data is written)."""
+    conn = psycopg.connect(POSTGRES_URI, autocommit=True)
+    yield conn
+    conn.close()
+
+
+# --- Verify data was written ---
+
+@pytest.mark.e2e
+class TestPostgresE2EDataWritten:
+
+    def test_positions_table_has_rows(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {TABLE_PREFIX}_positions")
+            assert cur.fetchone()[0] == 2
+
+    def test_portfolio_table_has_rows(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {TABLE_PREFIX}_portfolio")
+            assert cur.fetchone()[0] == 1
+
+    def test_executions_table_has_rows(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {TABLE_PREFIX}_executions")
+            assert cur.fetchone()[0] == 1
+
+    def test_signals_table_has_rows(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {TABLE_PREFIX}_signals")
+            assert cur.fetchone()[0] == 1
+
+    def test_targets_table_has_rows(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {TABLE_PREFIX}_targets")
+            assert cur.fetchone()[0] == 1
+
+    def test_balance_table_has_rows(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {TABLE_PREFIX}_balance")
+            assert cur.fetchone()[0] == 2
+
+    def test_metadata_columns(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(
+                f"SELECT run_id, account_id, strategy_name FROM {TABLE_PREFIX}_positions LIMIT 1"
+            )
+            row = cur.fetchone()
+            assert row[0] == RUN_ID
+            assert row[1] == ACCOUNT_ID
+            assert row[2] == STRATEGY_NAME
+
+    def test_index_exists(self, pg_conn):
+        with pg_conn.cursor() as cur:
+            cur.execute(
+                "SELECT indexname FROM pg_indexes WHERE tablename = %s AND indexname LIKE %s",
+                (f"{TABLE_PREFIX}_positions", "idx_%_strategy_ts"),
+            )
+            assert cur.fetchone() is not None
+
+
+# --- Verify restorers can read back the data ---
+
+@pytest.mark.e2e
+class TestPostgresE2EPositionRestorer:
+
+    def test_restore_positions(self, pg_conn, mock_lookup):
+        restorer = PostgresPositionRestorer(
+            strategy_name=STRATEGY_NAME,
+            connection=pg_conn,
+            table_name=f"{TABLE_PREFIX}_positions",
+        )
+        positions = restorer.restore_positions()
+
+        assert len(positions) == 2
+
+        btc_pos = None
+        eth_pos = None
+        for inst, pos in positions.items():
+            if inst.symbol == "BTCUSDT":
+                btc_pos = pos
+            elif inst.symbol == "ETHUSDT":
+                eth_pos = pos
+
+        assert btc_pos is not None
+        assert btc_pos.quantity == 0.5
+        assert btc_pos.position_avg_price == 89000.0
+        assert btc_pos.r_pnl == 75.0
+        assert btc_pos.commissions == 12.0
+
+        assert eth_pos is not None
+        assert eth_pos.quantity == 2.0
+        assert eth_pos.position_avg_price == 2900.0
+
+
+@pytest.mark.e2e
+class TestPostgresE2ESignalRestorer:
+
+    def test_restore_signals(self, pg_conn, mock_lookup):
+        restorer = PostgresSignalRestorer(
+            strategy_name=STRATEGY_NAME,
+            connection=pg_conn,
+            signals_table_name=f"{TABLE_PREFIX}_signals",
+            targets_table_name=f"{TABLE_PREFIX}_targets",
+        )
+        signals = restorer.restore_signals()
+
+        assert len(signals) == 1
+        btc_signals = list(signals.values())[0]
+        assert len(btc_signals) == 1
+        assert btc_signals[0].signal == 1.0
+        assert btc_signals[0].price == 89000.0
+        assert btc_signals[0].group == "main"
+        assert btc_signals[0].comment == "e2e test signal"
+
+    def test_restore_targets(self, pg_conn, mock_lookup):
+        restorer = PostgresSignalRestorer(
+            strategy_name=STRATEGY_NAME,
+            connection=pg_conn,
+            signals_table_name=f"{TABLE_PREFIX}_signals",
+            targets_table_name=f"{TABLE_PREFIX}_targets",
+        )
+        targets = restorer.restore_targets()
+
+        assert len(targets) == 1
+        btc_targets = list(targets.values())[0]
+        assert len(btc_targets) == 1
+        assert btc_targets[0].target_position_size == 0.5
+        assert btc_targets[0].entry_price == 89000.0
+        assert btc_targets[0].take_price == 95000.0
+        assert btc_targets[0].stop_price == 85000.0
+
+
+@pytest.mark.e2e
+class TestPostgresE2EBalanceRestorer:
+
+    def test_restore_balances(self, pg_conn):
+        restorer = PostgresBalanceRestorer(
+            strategy_name=STRATEGY_NAME,
+            connection=pg_conn,
+            table_name=f"{TABLE_PREFIX}_balance",
+        )
+        balances = restorer.restore_balances()
+
+        assert len(balances) == 2
+        by_currency = {b.currency: b for b in balances}
+
+        assert "USDT" in by_currency
+        assert by_currency["USDT"].total == 50000.0
+        assert by_currency["USDT"].locked == 5000.0
+        assert by_currency["USDT"].free == 45000.0
+
+        assert "BTC" in by_currency
+        assert by_currency["BTC"].total == 0.5
+        assert by_currency["BTC"].locked == 0.0
+        assert by_currency["BTC"].free == 0.5
+
+
+@pytest.mark.e2e
+class TestPostgresE2EStateRestorer:
+
+    def test_restore_full_state(self, pg_writer, mock_lookup):
+        restorer = PostgresStateRestorer(
+            strategy_name=STRATEGY_NAME,
+            postgres_uri=POSTGRES_URI,
+            table_prefix=TABLE_PREFIX,
+        )
+        state = restorer.restore_state()
+
+        assert isinstance(state, RestoredState)
+        assert isinstance(state.time, np.datetime64)
+
+        # Positions
+        assert len(state.positions) == 2
+        btc_pos = None
+        for inst, pos in state.positions.items():
+            if inst.symbol == "BTCUSDT":
+                btc_pos = pos
+        assert btc_pos is not None
+        assert btc_pos.quantity == 0.5
+
+        # Signals
+        assert len(state.instrument_to_signal_positions) == 1
+
+        # Targets
+        assert len(state.instrument_to_target_positions) == 1
+
+        # Balances
+        assert len(state.balances) == 2
+        by_currency = {b.currency: b for b in state.balances}
+        assert by_currency["USDT"].total == 50000.0


### PR DESCRIPTION
## Summary
- Add `PostgresLogsWriter` — writes all 6 log types (positions, portfolio, executions, signals, targets, balance) to typed PostgreSQL tables using psycopg v3, connection pooling, and async ThreadPool writes
- Add `PostgresPositionRestorer`, `PostgresSignalRestorer`, `PostgresBalanceRestorer`, `PostgresStateRestorer` for reading logged data back from Postgres
- Register all new classes in their respective factory registries
- Add `QUBX_RESTORE` env var to docker entrypoint for `--restore` flag support

## YAML config example
```yaml
logging:
  logger: PostgresLogsWriter
  position_interval: 10Sec
  portfolio_interval: 5Min
  args:
    postgres_uri: "postgresql://user:pass@localhost:5432/qubx_logs"
    table_prefix: "qubx_logs"
    pool_size: 4
```

## Test plan
- [x] 17 unit tests (mocked psycopg) — `tests/qubx/test_postgres.py`
- [x] 13 E2E tests (real Postgres round-trip: write via logger → read via restorers) — `tests/qubx/test_postgres_e2e.py`
- [x] 20 existing restorer tests pass (no regressions)
- [x] Full test suite passes (`just test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)