### PR TITLE
feat: auto-infer restorer from logger config

### DIFF
--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -274,7 +274,15 @@ def run_strategy(
         _health_server.start()
 
     # Restore state if configured
-    restored_state = _restore_state(config.live.warmup.restorer if config.live.warmup else None) if restore else None
+    restored_state = (
+        _restore_state(
+            restorer_config=config.live.warmup.restorer if config.live.warmup else None,
+            logging_config=config.live.logging if config.live.logging else None,
+            strategy_name=_get_strategy_name(config),
+        )
+        if restore
+        else None
+    )
 
     # Resolve aux config with live section override (needed for both warmup and live context)
     aux_configs = resolve_aux_config(config.aux, getattr(config.live, "aux", None))
@@ -335,7 +343,50 @@ def run_strategy(
     return ctx
 
 
-def _restore_state(restorer_config: RestorerConfig | None) -> RestoredState | None:
+def _infer_restorer_from_logger(logging_config: LoggingConfig, strategy_name: str) -> RestorerConfig | None:
+    """Infer a matching state restorer config from the logger config."""
+    logger_type = logging_config.logger
+    args = logging_config.args
+
+    if logger_type == "PostgresLogsWriter":
+        return RestorerConfig(
+            type="PostgresStateRestorer",
+            parameters={
+                "strategy_name": strategy_name,
+                "postgres_uri": args.get("postgres_uri", "postgresql://localhost:5432/qubx_logs"),
+                "table_prefix": args.get("table_prefix", "qubx_logs"),
+            },
+        )
+    elif logger_type == "MongoDBLogsWriter":
+        return RestorerConfig(
+            type="MongoDBStateRestorer",
+            parameters={
+                "strategy_name": strategy_name,
+                "mongo_uri": args.get("mongo_uri", "mongodb://localhost:27017/"),
+                "db_name": args.get("db_name", "default_logs_db"),
+                "collection_name_prefix": args.get("collection_name_prefix", "qubx_logs"),
+            },
+        )
+    elif logger_type == "CsvFileLogsWriter":
+        return RestorerConfig(
+            type="CsvStateRestorer",
+            parameters={
+                "strategy_name": strategy_name,
+                "base_dir": args.get("log_folder", "logs"),
+            },
+        )
+
+    return None
+
+
+def _restore_state(
+    restorer_config: RestorerConfig | None,
+    logging_config: LoggingConfig | None = None,
+    strategy_name: str = "",
+) -> RestoredState | None:
+    if restorer_config is None and logging_config is not None:
+        restorer_config = _infer_restorer_from_logger(logging_config, strategy_name)
+
     if restorer_config is None:
         restorer_config = RestorerConfig(type="CsvStateRestorer", parameters={"base_dir": "logs"})
 

--- a/tests/qubx/test_infer_restorer.py
+++ b/tests/qubx/test_infer_restorer.py
@@ -1,0 +1,100 @@
+"""Tests for automatic restorer inference from logger config."""
+
+from qubx.utils.runner.configs import LoggingConfig
+from qubx.utils.runner.runner import _infer_restorer_from_logger
+
+
+class TestInferRestorerFromLogger:
+
+    def test_postgres_logger(self):
+        logging_config = LoggingConfig(
+            logger="PostgresLogsWriter",
+            position_interval="10Sec",
+            portfolio_interval="5Min",
+            args={
+                "postgres_uri": "postgresql://user:pass@db:5432/mydb",
+                "table_prefix": "my_prefix",
+            },
+        )
+        result = _infer_restorer_from_logger(logging_config, "my_strategy")
+
+        assert result is not None
+        assert result.type == "PostgresStateRestorer"
+        assert result.parameters["strategy_name"] == "my_strategy"
+        assert result.parameters["postgres_uri"] == "postgresql://user:pass@db:5432/mydb"
+        assert result.parameters["table_prefix"] == "my_prefix"
+
+    def test_postgres_logger_defaults(self):
+        logging_config = LoggingConfig(
+            logger="PostgresLogsWriter",
+            position_interval="10Sec",
+            portfolio_interval="5Min",
+        )
+        result = _infer_restorer_from_logger(logging_config, "strat")
+
+        assert result.parameters["postgres_uri"] == "postgresql://localhost:5432/qubx_logs"
+        assert result.parameters["table_prefix"] == "qubx_logs"
+
+    def test_mongo_logger(self):
+        logging_config = LoggingConfig(
+            logger="MongoDBLogsWriter",
+            position_interval="10Sec",
+            portfolio_interval="5Min",
+            args={
+                "mongo_uri": "mongodb://mongo:27017/",
+                "db_name": "mydb",
+                "collection_name_prefix": "logs",
+            },
+        )
+        result = _infer_restorer_from_logger(logging_config, "my_strategy")
+
+        assert result is not None
+        assert result.type == "MongoDBStateRestorer"
+        assert result.parameters["strategy_name"] == "my_strategy"
+        assert result.parameters["mongo_uri"] == "mongodb://mongo:27017/"
+        assert result.parameters["db_name"] == "mydb"
+        assert result.parameters["collection_name_prefix"] == "logs"
+
+    def test_csv_logger(self):
+        logging_config = LoggingConfig(
+            logger="CsvFileLogsWriter",
+            position_interval="10Sec",
+            portfolio_interval="5Min",
+            args={"log_folder": "/data/logs"},
+        )
+        result = _infer_restorer_from_logger(logging_config, "my_strategy")
+
+        assert result is not None
+        assert result.type == "CsvStateRestorer"
+        assert result.parameters["base_dir"] == "/data/logs"
+        assert result.parameters["strategy_name"] == "my_strategy"
+
+    def test_csv_logger_defaults(self):
+        logging_config = LoggingConfig(
+            logger="CsvFileLogsWriter",
+            position_interval="10Sec",
+            portfolio_interval="5Min",
+        )
+        result = _infer_restorer_from_logger(logging_config, "strat")
+
+        assert result.parameters["base_dir"] == "logs"
+
+    def test_inmemory_logger_returns_none(self):
+        logging_config = LoggingConfig(
+            logger="InMemoryLogsWriter",
+            position_interval="10Sec",
+            portfolio_interval="5Min",
+        )
+        result = _infer_restorer_from_logger(logging_config, "strat")
+
+        assert result is None
+
+    def test_unknown_logger_returns_none(self):
+        logging_config = LoggingConfig(
+            logger="SomeCustomLogger",
+            position_interval="10Sec",
+            portfolio_interval="5Min",
+        )
+        result = _infer_restorer_from_logger(logging_config, "strat")
+
+        assert result is None


### PR DESCRIPTION
## Summary
- When `--restore` is used without an explicit `warmup.restorer` config, automatically infer the matching state restorer from the logger type
- Forwards connection parameters (URIs, prefixes, strategy name) from logger args to the restorer
- Eliminates need to duplicate config between `logging` and `warmup.restorer` sections

### Mapping
| Logger | Inferred Restorer |
|--------|-------------------|
| `PostgresLogsWriter` | `PostgresStateRestorer` |
| `MongoDBLogsWriter` | `MongoDBStateRestorer` |
| `CsvFileLogsWriter` | `CsvStateRestorer` |
| `InMemoryLogsWriter` / unknown | Falls back to `CsvStateRestorer` with `base_dir="logs"` |

### Before (required explicit restorer config)
```yaml
live:
  logging:
    logger: PostgresLogsWriter
    args:
      postgres_uri: "postgresql://user:pass@host:5432/db"
      table_prefix: "qubx_logs"
  warmup:
    restorer:
      type: PostgresStateRestorer
      parameters:
        strategy_name: my_strategy
        postgres_uri: "postgresql://user:pass@host:5432/db"  # duplicated!
        table_prefix: "qubx_logs"                            # duplicated!
```

### After (just use --restore)
```yaml
live:
  logging:
    logger: PostgresLogsWriter
    args:
      postgres_uri: "postgresql://user:pass@host:5432/db"
      table_prefix: "qubx_logs"
```
```bash
qubx run config.yml --restore  # automatically uses PostgresStateRestorer
```

## Test plan
- [x] 7 unit tests for `_infer_restorer_from_logger` covering all logger types, defaults, and unknown loggers
- [x] Existing test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)