### PR TITLE
feat: periodic state snapshot persistence

### DIFF
--- a/examples/macd_crossover/config.yml
+++ b/examples/macd_crossover/config.yml
@@ -13,7 +13,7 @@ parameters:
   slow_period: 26
   signal_period: 9
   leverage: 1.0
-  timeframe: 1h
+  timeframe: 1min
 
 simulation:
   capital: 10000.0

--- a/examples/macd_crossover/config.yml
+++ b/examples/macd_crossover/config.yml
@@ -13,7 +13,7 @@ parameters:
   slow_period: 26
   signal_period: 9
   leverage: 1.0
-  timeframe: 1min
+  timeframe: 1h
 
 simulation:
   capital: 10000.0
@@ -23,7 +23,7 @@ simulation:
   start: "2023-06-01"
   stop: "2023-08-01"
   commissions: "vip0_usdt"
-  debug: "WARNING"
+  debug: "DEBUG"
 
   data:
     storage: "csv::tests/data/storages/csv/"

--- a/examples/macd_crossover/config.yml
+++ b/examples/macd_crossover/config.yml
@@ -23,7 +23,7 @@ simulation:
   start: "2023-06-01"
   stop: "2023-08-01"
   commissions: "vip0_usdt"
-  debug: "DEBUG"
+  debug: "INFO"
 
   data:
     storage: "csv::tests/data/storages/csv/"

--- a/examples/macd_crossover/pyproject.toml
+++ b/examples/macd_crossover/pyproject.toml
@@ -1,12 +1,17 @@
-[tool.poetry]
-name = "macd_crossover"
+[project]
+name = "macd-crossover"
 version = "0.0.1"
 description = "MACD Crossover Strategy"
-authors = ["Yuriy Arabskyy <yuriy.arabskyy@xlydian.com>"]
+authors = [{ name = "Yuriy Arabskyy", email = "yuriy.arabskyy@xlydian.com" }]
 readme = "README.md"
-package-mode = true
-packages = [{ include = "macd_crossover", from = "." }]
+requires-python = ">=3.12"
+dependencies = [
+    "qubx[connectors]>=1.1.0",
+]
 
-[tool.poetry.dependencies]
-python = "^3.11"
-qubx = "^0.5.8"
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/src/qubx/__init__.py
+++ b/src/qubx/__init__.py
@@ -115,11 +115,11 @@ def formatter(record):
     phase = record["extra"].get("phase")
     phase_tag = ""
     if phase == "warmup":
-        phase_tag = "<yellow>[WARMUP]</yellow> "
+        phase_tag = " <yellow>[WARMUP]</yellow>"
     elif phase == "live":
-        phase_tag = "<green>[LIVE]</green> "
+        phase_tag = " <green>[LIVE]</green>"
 
-    prefix = f"{ts} [ <level>{record['level'].icon}</level> ] {phase_tag}<cyan>({{module}})</cyan> "
+    prefix = f"{ts} [ <level>{record['level'].name}</level> ] <cyan>{{module}}</cyan> |{phase_tag} "
 
     if record["exception"] is not None:
         record["extra"]["stack"] = stackprinter.format(record["exception"], style="darkbg3")
@@ -143,8 +143,8 @@ def file_formatter(record):
 
     ts = _resolve_timestamp()
     phase = _format_phase_plain(record)
-    level_name = record["level"].name
-    prefix = ts + " [ " + f"{level_name:<8}" + " ] " + phase + "({module}) "
+    phase_suffix = " " + phase.rstrip() if phase else ""
+    prefix = ts + " [ " + record["level"].name + " ] " + "{module} |" + phase_suffix + " "
 
     if record["exception"] is not None:
         record["extra"]["stack"] = stackprinter.format(record["exception"], style="plaintext")
@@ -275,6 +275,7 @@ class QubxLogConfig:
 
 
 QubxLogConfig.setup_logger()
+logger = logger.opt(colors=True)  # Enable color tag parsing in message text
 
 
 # registering magic for jupyter notebook

--- a/src/qubx/__init__.py
+++ b/src/qubx/__init__.py
@@ -1,7 +1,7 @@
 import json as _json
 import os
 import sys
-from typing import Callable
+from typing import Any, Callable
 
 import stackprinter
 from loguru import logger
@@ -109,11 +109,27 @@ class QubxLogConfig:
         return QubxLogConfig._COLOR_TAG_RE.sub("", text)
 
     @staticmethod
+    def _get_timestamp_for_json(record) -> str:
+        """Get timestamp string, preferring simulation time when available."""
+        tp = QubxLogConfig._time_provider
+        if tp is not None:
+            try:
+                import pandas as pd
+
+                dt = tp.time()
+                if isinstance(dt, int):
+                    return pd.Timestamp(dt).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                return dt.astype("datetime64[us]").item().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            except Exception:
+                pass
+        return record["time"].strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    @staticmethod
     def _json_sink(message):
         """Emit one JSON line per log record for Loki/Promtail ingestion."""
         record = message.record
         entry = {
-            "timestamp": record["time"].strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "timestamp": QubxLogConfig._get_timestamp_for_json(record),
             "level": record["level"].name,
             "module": record["module"],
             "function": record["function"],
@@ -172,6 +188,7 @@ class QubxLogConfig:
     _bot_id: str | None = None
     _instance_id: str | None = None
     _phase: str | None = None
+    _time_provider: Any = None
 
     @staticmethod
     def _update_patcher():
@@ -198,6 +215,11 @@ class QubxLogConfig:
         """Bind phase (warmup/live) to all log messages globally."""
         QubxLogConfig._phase = phase
         QubxLogConfig._update_patcher()
+
+    @staticmethod
+    def bind_time_provider(time_provider=None):
+        """Bind a time provider for simulation timestamps in JSON logs."""
+        QubxLogConfig._time_provider = time_provider
 
 
 QubxLogConfig.setup_logger()

--- a/src/qubx/__init__.py
+++ b/src/qubx/__init__.py
@@ -1,12 +1,17 @@
 import json as _json
 import os
+import re
 import sys
-from typing import Any, Callable
+from dataclasses import dataclass
+from typing import Any
 
 import stackprinter
 from loguru import logger
 
 # - TODO: import some main methods from packages
+
+_COLOR_TAG_RE = re.compile(r"</?[a-z_]+>")
+_SKIP_EXTRA_KEYS = frozenset(("user", "end", "stack"))
 
 
 def runtime_env():
@@ -33,45 +38,90 @@ def runtime_env():
         return "python"  # Probably standard Python interpreter
 
 
-def format_platform_identity(record) -> str:
-    """Return a colored identity prefix from record extras (bot_id / instance_id)."""
-    bot_id = record["extra"].get("bot_id")
-    instance_id = record["extra"].get("instance_id")
-    if bot_id or instance_id:
-        parts = []
-        if bot_id:
-            parts.append(f"bot={bot_id}")
-        if instance_id:
-            parts.append(f"inst={instance_id}")
-        return "<magenta>[%s]</magenta> " % " ".join(parts)
-    return ""
+# ---------------------------------------------------------------------------
+#  LogContext — single source of truth for all mutable logging state
+# ---------------------------------------------------------------------------
 
 
-def format_phase(record) -> str:
-    """Return a colored phase tag from record extras."""
+@dataclass
+class LogContext:
+    """All mutable logging state in one place — explicit, greppable, mockable."""
+
+    bot_id: str | None = None
+    instance_id: str | None = None
+    phase: str | None = None
+    time_provider: Any = None
+
+
+_log_context = LogContext()
+
+
+def get_log_context() -> LogContext:
+    """Return the global log context (useful for testing / direct access)."""
+    return _log_context
+
+
+# ---------------------------------------------------------------------------
+#  Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_provider_time(time_provider) -> str | None:
+    """Convert time_provider.time() to a display string, or None on failure."""
+    try:
+        import pandas as pd
+
+        dt = time_provider.time()
+        if isinstance(dt, int):
+            return pd.Timestamp(dt).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        return dt.astype("datetime64[us]").item().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    except Exception:
+        return None
+
+
+def _resolve_timestamp(fallback="{time:YYYY-MM-DD HH:mm:ss.SSS}") -> str:
+    """Return resolved time-provider string, or *fallback* (a loguru placeholder) on failure."""
+    tp = _log_context.time_provider
+    if tp is not None:
+        now = _resolve_provider_time(tp)
+        if now is not None:
+            return now
+    return fallback
+
+
+def _format_phase_plain(record) -> str:
+    """Return plain phase tag from record extras."""
     phase = record["extra"].get("phase")
     if phase == "warmup":
-        return "<yellow>[WARMUP]</yellow> "
+        return "[WARMUP] "
     elif phase == "live":
-        return "<green>[LIVE]</green> "
+        return "[LIVE] "
     return ""
 
 
 def formatter(record):
+    """Console formatter — colored, with emoji level icons, no identity."""
     end = record["extra"].get("end", "\n")
     fmt = "<lvl>{message}</lvl>%s" % end
     if record["level"].name in {"WARNING", "SNAKY"}:
         fmt = "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - %s" % fmt
 
-    identity = format_platform_identity(record)
-    phase = format_phase(record)
-    prefix = (
-        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> [ <level>%s</level> ] %s%s<cyan>({module})</cyan> "
-        % (record["level"].icon, identity, phase)
-    )
+    ts = _resolve_timestamp()
+    if ts.startswith("{"):
+        ts = f"<green>{ts}</green>"
+    else:
+        ts = f"<lc>{ts}</lc>"
+
+    phase = record["extra"].get("phase")
+    phase_tag = ""
+    if phase == "warmup":
+        phase_tag = "<yellow>[WARMUP]</yellow> "
+    elif phase == "live":
+        phase_tag = "<green>[LIVE]</green> "
+
+    prefix = f"{ts} [ <level>{record['level'].icon}</level> ] {phase_tag}<cyan>({{module}})</cyan> "
 
     if record["exception"] is not None:
-        # stackprinter.set_excepthook(style='darkbg2')
         record["extra"]["stack"] = stackprinter.format(record["exception"], style="darkbg3")
         fmt += "\n{extra[stack]}\n"
 
@@ -81,37 +131,62 @@ def formatter(record):
     return prefix + fmt
 
 
-class QubxLogConfig:
-    @staticmethod
-    def get_log_level():
-        # Env var takes priority (for CLI --log-level override), then settings
-        env_level = os.getenv("QUBX_LOG_LEVEL")
-        if env_level:
-            return env_level
-        from qubx.config import settings
+def file_formatter(record):
+    """Plain-text formatter for file sinks — no colors, no emojis, no identity."""
+    # Embed the stripped message as a literal (escape braces so loguru won't parse them)
+    clean_msg = _COLOR_TAG_RE.sub("", record["message"]).replace("{", "{{").replace("}", "}}")
+    end = record["extra"].get("end", "\n")
+    msg = clean_msg + end
 
-        return settings.log_level
+    if record["level"].name in {"WARNING", "SNAKY"}:
+        msg = "{name}:{function}:{line} - " + msg
 
-    @staticmethod
-    def set_log_level(level: str):
-        os.environ["QUBX_LOG_LEVEL"] = level
-        QubxLogConfig.setup_logger(level)
+    ts = _resolve_timestamp()
+    phase = _format_phase_plain(record)
+    level_name = record["level"].name
+    prefix = ts + " [ " + f"{level_name:<8}" + " ] " + phase + "({module}) "
 
-    _COLOR_TAG_RE = None
+    if record["exception"] is not None:
+        record["extra"]["stack"] = stackprinter.format(record["exception"], style="plaintext")
+        msg += "\n{extra[stack]}\n"
 
-    @staticmethod
-    def _strip_color_tags(text: str) -> str:
-        """Remove loguru color markup tags like <yellow>...</yellow> from text."""
-        import re
+    if record["level"].name == "TEXT":
+        prefix = ""
 
-        if QubxLogConfig._COLOR_TAG_RE is None:
-            QubxLogConfig._COLOR_TAG_RE = re.compile(r"</?[a-z_]+>")
-        return QubxLogConfig._COLOR_TAG_RE.sub("", text)
+    return prefix + msg
 
-    @staticmethod
-    def _get_timestamp_for_json(record) -> str:
-        """Get timestamp string, preferring simulation time when available."""
-        tp = QubxLogConfig._time_provider
+
+# ---------------------------------------------------------------------------
+#  JSON sink
+# ---------------------------------------------------------------------------
+
+
+class JsonSink:
+    """Emits one JSON line per log record for Loki / Promtail ingestion."""
+
+    def __init__(self, context: LogContext):
+        self._ctx = context
+
+    def write(self, message):
+        record = message.record
+        entry = {
+            "timestamp": self._get_timestamp(record),
+            "level": record["level"].name,
+            "module": record["module"],
+            "function": record["function"],
+            "line": record["line"],
+            "message": _COLOR_TAG_RE.sub("", record["message"]),
+        }
+        for key, val in record["extra"].items():
+            if key not in _SKIP_EXTRA_KEYS:
+                entry[key] = val
+        if record["exception"] is not None:
+            entry["exception"] = stackprinter.format(record["exception"], style="plaintext")
+        sys.stdout.write(_json.dumps(entry, default=str) + "\n")
+        sys.stdout.flush()
+
+    def _get_timestamp(self, record) -> str:
+        tp = self._ctx.time_provider
         if tp is not None:
             try:
                 import pandas as pd
@@ -124,102 +199,79 @@ class QubxLogConfig:
                 pass
         return record["time"].strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
+
+# ---------------------------------------------------------------------------
+#  Patcher — injects bound fields into every log record
+# ---------------------------------------------------------------------------
+
+
+def _patcher(record):
+    ctx = _log_context
+    if ctx.bot_id:
+        record["extra"]["bot_id"] = ctx.bot_id
+    if ctx.instance_id:
+        record["extra"]["instance_id"] = ctx.instance_id
+    if ctx.phase:
+        record["extra"]["phase"] = ctx.phase
+
+
+# ---------------------------------------------------------------------------
+#  QubxLogConfig — thin façade for setup / bind operations
+# ---------------------------------------------------------------------------
+
+
+class QubxLogConfig:
     @staticmethod
-    def _json_sink(message):
-        """Emit one JSON line per log record for Loki/Promtail ingestion."""
-        record = message.record
-        entry = {
-            "timestamp": QubxLogConfig._get_timestamp_for_json(record),
-            "level": record["level"].name,
-            "module": record["module"],
-            "function": record["function"],
-            "line": record["line"],
-            "message": QubxLogConfig._strip_color_tags(record["message"]),
-        }
-        # Merge platform identity and any other extras (skip internal loguru keys)
-        for key, val in record["extra"].items():
-            if key not in ("user", "end", "stack"):
-                entry[key] = val
-        if record["exception"] is not None:
-            entry["exception"] = stackprinter.format(record["exception"], style="plaintext")
-        sys.stdout.write(_json.dumps(entry, default=str) + "\n")
-        sys.stdout.flush()
+    def get_log_level():
+        env_level = os.getenv("QUBX_LOG_LEVEL")
+        if env_level:
+            return env_level
+        from qubx.config import settings
+
+        return settings.log_level
 
     @staticmethod
-    def setup_logger(level: str | None = None, custom_formatter: Callable | None = None, colorize: bool = True):
-        global logger
+    def set_log_level(level: str):
+        os.environ["QUBX_LOG_LEVEL"] = level
+        QubxLogConfig.setup_logger(level)
 
-        config = {
-            "handlers": [
-                {"sink": sys.stdout, "format": "{time} - {message}"},
-            ],
-            "extra": {"user": "someone"},
-        }
-        logger.configure(**config)
-        logger.remove(None)
-
+    @staticmethod
+    def setup_logger(level: str | None = None, colorize: bool = True):
+        logger.remove()
         level = level or QubxLogConfig.get_log_level()
 
-        # Check if JSON format is requested (for Loki/container deployments)
         log_format = os.getenv("QUBX_LOG_FORMAT", "text").lower()
         if log_format == "json":
+            sink = JsonSink(_log_context)
+            logger.add(sink.write, level=level, enqueue=True, backtrace=True, diagnose=True)
+        else:
             logger.add(
-                QubxLogConfig._json_sink,
+                sys.stdout,
+                format=formatter,
+                colorize=colorize,
                 level=level,
                 enqueue=True,
                 backtrace=True,
                 diagnose=True,
             )
-            # No colorize opt needed for JSON
-            return
 
-        # Default: human-readable text format
-        logger.add(
-            sys.stdout,
-            format=custom_formatter or formatter,
-            colorize=colorize,
-            level=level,
-            enqueue=True,
-            backtrace=True,
-            diagnose=True,
-        )
-        logger = logger.opt(colors=colorize)
-
-    _bot_id: str | None = None
-    _instance_id: str | None = None
-    _phase: str | None = None
-    _time_provider: Any = None
-
-    @staticmethod
-    def _update_patcher():
-        """Reconfigure loguru with a single patcher that applies all bound fields."""
-        def patcher(record):
-            if QubxLogConfig._bot_id:
-                record["extra"]["bot_id"] = QubxLogConfig._bot_id
-            if QubxLogConfig._instance_id:
-                record["extra"]["instance_id"] = QubxLogConfig._instance_id
-            if QubxLogConfig._phase:
-                record["extra"]["phase"] = QubxLogConfig._phase
-
-        logger.configure(patcher=patcher)
+        logger.configure(patcher=_patcher)
 
     @staticmethod
     def bind_platform_identity(bot_id: str | None = None, instance_id: str | None = None):
-        """Bind platform identity fields (bot_id, instance_id) to all log messages globally."""
-        QubxLogConfig._bot_id = bot_id
-        QubxLogConfig._instance_id = instance_id
-        QubxLogConfig._update_patcher()
+        """Bind platform identity fields to all log messages globally."""
+        _log_context.bot_id = bot_id
+        _log_context.instance_id = instance_id
 
     @staticmethod
     def bind_phase(phase: str | None):
         """Bind phase (warmup/live) to all log messages globally."""
-        QubxLogConfig._phase = phase
-        QubxLogConfig._update_patcher()
+        _log_context.phase = phase
 
     @staticmethod
     def bind_time_provider(time_provider=None):
-        """Bind a time provider for simulation timestamps in JSON logs."""
-        QubxLogConfig._time_provider = time_provider
+        """Bind a time provider for timestamps in both text and JSON logs."""
+        _log_context.time_provider = time_provider
 
 
 QubxLogConfig.setup_logger()

--- a/src/qubx/backtester/simulated_data.py
+++ b/src/qubx/backtester/simulated_data.py
@@ -910,16 +910,17 @@ class SimulatedDataIterator(Iterator):
     # Reader resolution (lazy, cached)
     # -----------------------------------------------------------------------
 
-    def _get_or_create_reader(self, data_type: str, exchange: str, market_type: str) -> IReader:
+    def _get_or_create_reader(self, data_type: str, exchange: str, market_type: str, subscription: str | None = None) -> IReader:
         """
         Get or create cached IReader for given (data_type, exchange, market_type).
 
-        Checks custom storage first (keyed by data_type), falls back to main storage.
+        Checks custom storage first (keyed by full subscription like "ohlc(1min)",
+        then by base data_type like "ohlc"), falls back to main storage.
         Custom storage readers are cached with data_type prefix to avoid collisions.
         Main storage readers are shared across data types for same (exchange, market_type).
         """
-        # - check custom storage first
-        custom_storage = self._custom_storages.get(data_type)
+        # - check custom storage first: try full subscription key, then base data_type
+        custom_storage = (self._custom_storages.get(subscription) if subscription else None) or self._custom_storages.get(data_type)
         if custom_storage is not None:
             cache_key = f"{data_type}:{exchange}:{market_type}"
             if cache_key not in self._readers:
@@ -957,7 +958,7 @@ class SimulatedDataIterator(Iterator):
         if pump_key in self._pumps:
             return self._pumps[pump_key]
 
-        reader = self._get_or_create_reader(data_type, exchange, market_type)
+        reader = self._get_or_create_reader(data_type, exchange, market_type, subscription)
 
         pump = DataPump(
             reader=reader,

--- a/src/qubx/backtester/simulator.py
+++ b/src/qubx/backtester/simulator.py
@@ -3,7 +3,7 @@ from typing import Literal, cast
 import pandas as pd
 from joblib import delayed
 
-from qubx import QubxLogConfig, logger
+from qubx import QubxLogConfig, file_formatter, logger
 from qubx.backtester.utils import SetupTypes
 from qubx.core.basics import Instrument
 from qubx.core.exceptions import SimulationError
@@ -12,13 +12,12 @@ from qubx.data.storage import IStorage
 from qubx.emitters.inmemory import InMemoryMetricEmitter
 from qubx.utils.misc import ProgressParallel, Stopwatch, get_current_user
 from qubx.utils.runner.configs import PrefetchConfig
-from qubx.utils.time import handle_start_stop, to_utc_naive
+from qubx.utils.time import handle_start_stop, to_timestamp, to_utc_naive
 
 from .runner import SimulationRunner
 from .transfers import SimulationTransferManager
 from .utils import (
     ExchangeName_t,
-    SimulatedLogFormatter,
     SimulationDataConfig,
     SimulationSetup,
     StrategiesDecls_t,
@@ -261,7 +260,7 @@ def _run_setup(
         # TODO: this can be removed once we add some artificial data stream to move the simulation
         if setup.setup_type in [SetupTypes.SIGNAL, SetupTypes.SIGNAL_AND_TRACKER]:
             onboard_dates = [
-                to_utc_naive(pd.Timestamp(instrument.onboard_date))
+                to_utc_naive(to_timestamp(instrument.onboard_date))
                 for instrument in setup.instruments
                 if instrument.onboard_date is not None
             ]
@@ -280,16 +279,14 @@ def _run_setup(
 
         # - we want to see simulate time in log messages
         QubxLogConfig.bind_time_provider(runner.ctx)
-        QubxLogConfig.setup_logger(
-            level=QubxLogConfig.get_log_level(), custom_formatter=SimulatedLogFormatter(runner.ctx).formatter
-        )
+        QubxLogConfig.setup_logger(level=QubxLogConfig.get_log_level())
 
         # - add file sink after setup_logger (which removes all existing sinks and re-adds stdout)
         _log_sink_id = None
         if log_file:
             _log_sink_id = logger.add(
                 log_file,
-                format=SimulatedLogFormatter(runner.ctx).formatter,
+                format=file_formatter,
                 colorize=False,
                 level=QubxLogConfig.get_log_level(),
                 enqueue=True,

--- a/src/qubx/backtester/simulator.py
+++ b/src/qubx/backtester/simulator.py
@@ -279,6 +279,7 @@ def _run_setup(
         )
 
         # - we want to see simulate time in log messages
+        QubxLogConfig.bind_time_provider(runner.ctx)
         QubxLogConfig.setup_logger(
             level=QubxLogConfig.get_log_level(), custom_formatter=SimulatedLogFormatter(runner.ctx).formatter
         )
@@ -300,6 +301,9 @@ def _run_setup(
         # - remove file sink if it was added (stdout sink remains untouched)
         if _log_sink_id is not None:
             logger.remove(_log_sink_id)
+
+        # - unbind simulation time provider
+        QubxLogConfig.bind_time_provider(None)
 
         # - service latency report
         if show_latency_report:

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, TypeAlias
 
 import numpy as np
 import pandas as pd
-import stackprinter
 
 from qubx import logger
 from qubx.core.basics import (
@@ -123,38 +122,6 @@ class SimulationDataConfig:
     trading_sessions_time: dict[str, tuple[int, int]] | None = None  # per-exchange session overrides
     default_trading_sessions_time: tuple[int, int] = DEFAULT_DAILY_SESSION  # fallback for exchanges not in the dict
 # fmt: on
-
-
-class SimulatedLogFormatter:
-    def __init__(self, time_provider: ITimeProvider):
-        self.time_provider = time_provider
-
-    def formatter(self, record):
-        end = record["extra"].get("end", "\n")
-        fmt = "<lvl>{message}</lvl>%s" % end
-        if record["level"].name in {"WARNING", "SNAKY"}:
-            fmt = "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - %s" % fmt
-
-        dt = self.time_provider.time()
-        if isinstance(dt, int):
-            now = pd.Timestamp(dt).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-        else:
-            now = self.time_provider.time().astype("datetime64[us]").item().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-
-        from qubx import format_phase, format_platform_identity
-
-        identity = format_platform_identity(record)
-        phase = format_phase(record)
-        prefix = f"<lc>{now}</lc> [<level>{record['level'].icon}</level>] {identity}{phase}<cyan>({{module}})</cyan> "
-
-        if record["exception"] is not None:
-            record["extra"]["stack"] = stackprinter.format(record["exception"], style="darkbg3")
-            fmt += "\n{extra[stack]}\n"
-
-        if record["level"].name in {"TEXT"}:
-            prefix = ""
-
-        return prefix + fmt
 
 
 class SimulatedScheduler(BasicScheduler):

--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -257,7 +257,8 @@ def extract_external_dependencies(strategy_config: StrategyConfig, current_packa
         if isinstance(strat, str):
             package = strat.split(".")[0]
             # Only include if it's NOT the current project's package
-            if package != current_package:
+            # Normalize hyphens/underscores for comparison (PEP 503)
+            if package.replace("-", "_") != (current_package or "").replace("-", "_"):
                 external_packages.add(package)
 
     return sorted(external_packages)

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -150,6 +150,7 @@ class StrategyContext(IStrategyContext):
         restored_state: RestoredState | None = None,
         data_throttler: "InstrumentThrottler | None" = None,
         state_persistence: IStatePersistence | None = None,
+        state_snapshot_interval: str | None = None,
     ) -> None:
         self.account = account
         self.strategy = self.__instantiate_strategy(strategy, config)
@@ -180,6 +181,7 @@ class StrategyContext(IStrategyContext):
         self._health_monitor = health_monitor or DummyHealthMonitor()
         self.health = self._health_monitor
         self._state_persistence = state_persistence or DummyStatePersistence()
+        self._state_snapshot_interval = state_snapshot_interval
 
         # Initialize shutdown handling
         self._stop_lock = Lock()
@@ -294,6 +296,9 @@ class StrategyContext(IStrategyContext):
         # Configure stale data detection based on strategy settings
         stale_data_config = self.initializer.get_stale_data_detection_config()
         self._processing_manager.configure_stale_data_detection(*stale_data_config)
+
+        # Configure periodic state snapshot persistence
+        self._processing_manager.configure_state_snapshot(self._state_snapshot_interval)
 
         if self.is_simulation and isinstance(self.account, CompositeAccountProcessor):
             # Auto-assign simulation transfer manager

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -272,8 +272,37 @@ class ProcessingManager(IProcessingManager):
                 cron_schedule = interval_to_cron("10m")  # default check interval
             self._scheduler.schedule_event(cron_schedule, "stale_data_check")
 
+    def configure_state_snapshot(self, interval: str | None) -> None:
+        """
+        Configure periodic state snapshot persistence.
+
+        When enabled, periodically saves strategy state (capital, positions, leverage, orders)
+        to the configured state persistence backend (e.g., Redis) under the key "state".
+        Only active in live mode when a real state persistence backend is configured.
+
+        Args:
+            interval: Snapshot interval (e.g., "5s", "30s", "1m"). None to disable.
+        """
+        self._scheduler.unschedule_event("state_snapshot")
+
+        if interval is not None and not self._is_simulation:
+            from qubx.state.dummy import DummyStatePersistence
+
+            if not isinstance(self._context.persistence, DummyStatePersistence):
+                cron_schedule = interval_to_cron(interval)
+                self._scheduler.schedule_event(cron_schedule, "state_snapshot")
+                logger.info(f"State snapshot enabled with interval: {interval}")
+
     def process_data(self, instrument: Instrument, d_type: str, data: Any, is_historical: bool) -> bool:
-        should_stop = self.__process_data(instrument, d_type, data, is_historical)
+        # TODO: remove after debugging
+        try:
+            should_stop = self.__process_data(instrument, d_type, data, is_historical)
+        except Exception as e:
+            logger.error(
+                f"Error processing data: dtype {d_type}, instrument {instrument}, data {data}, is_historical {is_historical}, error {e}"
+            )
+            logger.opt(colors=False).error(traceback.format_exc())
+            raise e
         if not is_historical:
             self._logging.notify(self._time_provider.time())
             if self._context.emitter is not None:
@@ -962,6 +991,92 @@ class ProcessingManager(IProcessingManager):
                 f"Removing {len(stale_instruments)} stale instruments from universe: {[i.symbol for i in stale_instruments]}"
             )
             self._universe_manager.remove_instruments(stale_instruments, if_has_position_then="close")
+
+    def _handle_state_snapshot(
+        self, instrument: Instrument | None, event_type: str, data: tuple[dt_64 | None, dt_64]
+    ) -> None:
+        """
+        Periodic state snapshot — persists current strategy state (capital, positions,
+        leverage, orders, balances) per exchange to the configured state persistence
+        backend for dashboard monitoring.
+        """
+        if not self._context._strategy_state.is_on_start_called:
+            return
+
+        account = self._context.account
+
+        exchanges = self._context.exchanges
+
+        exchanges_snapshot: dict[str, dict] = {}
+        for exchange in exchanges:
+            positions = account.get_positions(exchange)
+            orders = account.get_orders(exchange=exchange)
+
+            # Group orders by instrument symbol
+            orders_by_symbol: dict[str, list[dict]] = defaultdict(list)
+            for order in orders.values():
+                orders_by_symbol[order.instrument.symbol].append(
+                    {
+                        "id": order.id,
+                        "type": order.type,
+                        "side": order.side,
+                        "quantity": order.quantity,
+                        "price": order.price,
+                        "status": order.status,
+                    }
+                )
+
+            # Build positions snapshot
+            positions_snapshot: dict[str, dict] = {}
+            open_positions = 0
+            for instr, pos in positions.items():
+                if pos.is_open():
+                    open_positions += 1
+                positions_snapshot[instr.symbol] = {
+                    "quantity": pos.quantity,
+                    "avg_price": pos.position_avg_price,
+                    "market_value": pos.market_value_funds,
+                    "unrealized_pnl": pos.unrealized_pnl(),
+                    "current_price": pos.last_update_price,
+                    "leverage": account.get_leverage(instr),
+                }
+
+            # Add order-only instruments (no position yet) to orders snapshot
+            for symbol in orders_by_symbol:
+                if symbol not in positions_snapshot:
+                    orders_by_symbol[symbol]  # ensure key exists in defaultdict
+
+            # Build balances snapshot
+            balances_snapshot: dict[str, dict] = {}
+            for bal in account.get_balances(exchange):
+                balances_snapshot[bal.currency] = {
+                    "total": bal.total,
+                    "free": bal.free,
+                    "locked": bal.locked,
+                }
+
+            exchanges_snapshot[exchange] = {
+                "capital": {
+                    "total": account.get_total_capital(exchange),
+                    "available": account.get_capital(exchange),
+                },
+                "balances": balances_snapshot,
+                "net_leverage": account.get_net_leverage(exchange),
+                "gross_leverage": account.get_gross_leverage(exchange),
+                "open_positions": open_positions,
+                "positions": positions_snapshot,
+                "orders": dict(orders_by_symbol),
+            }
+
+        snapshot = {
+            "timestamp": str(self._time_provider.time()),
+            "exchanges": exchanges_snapshot,
+        }
+
+        try:
+            self._context.persistence.save("state", snapshot)
+        except Exception as e:
+            logger.warning(f"Failed to save state snapshot: {e}")
 
     def _handle_ohlc(self, instrument: Instrument, event_type: str, bar: Bar) -> MarketEvent:
         base_update = self.__update_base_data(instrument, event_type, bar)

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -291,7 +291,14 @@ class ProcessingManager(IProcessingManager):
         ):
             return False
 
-        handler = self._handlers.get(d_type)
+        if not d_type:
+            handler = None
+        else:
+            handler = self._handlers.get(d_type)
+            if handler is None:
+                _dtype, _ = DataType.from_str(d_type)
+                handler = self._handlers.get(_dtype.value)
+
         if not d_type:
             event = None
         elif is_historical:

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -294,15 +294,7 @@ class ProcessingManager(IProcessingManager):
                 logger.info(f"State snapshot enabled with interval: {interval}")
 
     def process_data(self, instrument: Instrument, d_type: str, data: Any, is_historical: bool) -> bool:
-        # TODO: remove after debugging
-        try:
-            should_stop = self.__process_data(instrument, d_type, data, is_historical)
-        except Exception as e:
-            logger.error(
-                f"Error processing data: dtype {d_type}, instrument {instrument}, data {data}, is_historical {is_historical}, error {e}"
-            )
-            logger.opt(colors=False).error(traceback.format_exc())
-            raise e
+        should_stop = self.__process_data(instrument, d_type, data, is_historical)
         if not is_historical:
             self._logging.notify(self._time_provider.time())
             if self._context.emitter is not None:

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -145,6 +145,7 @@ class StatePersistenceConfig(StrictBaseModel):
 
     type: str  # e.g., "RedisStatePersistence"
     parameters: dict = Field(default_factory=dict)
+    snapshot_interval: str | None = "5s"  # Interval for periodic state snapshots (None to disable)
 
 
 class HealthConfig(StrictBaseModel):

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -980,12 +980,14 @@ def _run_warmup(
 
     ctx._strategy_state.is_warmup_in_progress = True
     QubxLogConfig.bind_phase("warmup")
+    QubxLogConfig.bind_time_provider(warmup_runner.ctx)
 
     try:
         warmup_runner.run(catch_keyboard_interrupt=False, close_data_readers=True)
     finally:
         # Restore the live time provider
         simulated_formatter.time_provider = _live_time_provider
+        QubxLogConfig.bind_time_provider(None)
         # Set back the context for metric emitters to use live context
         if ctx.emitter is not None:
             ctx.emitter.set_context(ctx)

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -577,6 +577,7 @@ def create_strategy_context(
 
     # Create state persistence if configured
     _state_persistence = create_state_persistence(config.live.state, stg_name)
+    _state_snapshot_interval = config.live.state.snapshot_interval if config.live.state else None
 
     logger.info(f"- Strategy: <blue>{stg_name}</blue>\n- Mode: {_run_mode}\n- Parameters: {config.parameters}")
 
@@ -600,6 +601,7 @@ def create_strategy_context(
         restored_state=restored_state,
         data_throttler=_data_throttler,
         state_persistence=_state_persistence,
+        state_snapshot_interval=_state_snapshot_interval,
     )
 
     # Store the shared event loop reference for cleanup

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -6,13 +6,12 @@ from functools import reduce
 from pathlib import Path
 from threading import Thread
 
-from qubx import QubxLogConfig, logger
+from qubx import QubxLogConfig, file_formatter, logger
 from qubx.backtester.optimization import variate
 from qubx.backtester.runner import SimulationRunner
 from qubx.backtester.simulator import simulate
 from qubx.backtester.utils import (
     SetupTypes,
-    SimulatedLogFormatter,
     SimulationConfigError,
     SimulationSetup,
     recognize_simulation_data_config,
@@ -251,11 +250,9 @@ def run_strategy(
 
     register_accounts(account_manager)
 
-    QubxLogConfig.setup_logger(
-        level=QubxLogConfig.get_log_level(),
-        custom_formatter=(simulated_formatter := SimulatedLogFormatter(LiveTimeProvider())).formatter,
-        colorize=not no_color,
-    )
+    _live_time_provider = LiveTimeProvider()
+    QubxLogConfig.bind_time_provider(_live_time_provider)
+    QubxLogConfig.setup_logger(level=QubxLogConfig.get_log_level(), colorize=not no_color)
 
     # Start health server early so liveness probe works during init/warmup
     from qubx.config import settings as _qubx_settings
@@ -293,7 +290,6 @@ def run_strategy(
         account_manager=account_manager,
         paper=paper,
         restored_state=restored_state,
-        simulated_formatter=simulated_formatter,
         no_color=no_color,
         aux_configs=aux_configs,
         loop=loop,
@@ -310,7 +306,7 @@ def run_strategy(
             exchanges=config.live.exchanges,
             warmup=config.live.warmup,
             prefetch_config=config.live.prefetch,
-            simulated_formatter=simulated_formatter,
+            live_time_provider=_live_time_provider,
             account_manager=account_manager,
             enable_funding=config.live.warmup.enable_funding if config.live.warmup else False,
             aux_configs=aux_configs,
@@ -411,7 +407,6 @@ def create_strategy_context(
     account_manager: AccountConfigurationManager,
     paper: bool,
     restored_state: RestoredState | None,
-    simulated_formatter: SimulatedLogFormatter,
     no_color: bool = False,
     aux_configs: list[StorageConfig] | None = None,
     loop: asyncio.AbstractEventLoop | None = None,
@@ -426,7 +421,13 @@ def create_strategy_context(
     if not config.live:
         raise ValueError("Live configuration is required for strategy execution")
 
-    stg_name = _get_strategy_name(config)
+    # --- Platform identity from unified settings ---
+    from qubx.config import settings as qubx_settings
+
+    _bot_id = qubx_settings.bot_id
+
+    # Use BOT_ID as the primary identifier when provided, otherwise fall back to strategy name
+    stg_name = _bot_id or _get_strategy_name(config)
     _run_mode = "paper" if paper else "live"
 
     # Generate run_id once to be shared between logging and metric emissions
@@ -439,12 +440,7 @@ def create_strategy_context(
     else:
         _strategy_class = config.strategy
 
-    _logging = _setup_strategy_logging(stg_name, config.live.logging, simulated_formatter, run_id)
-
-    # --- Platform identity from unified settings ---
-    from qubx.config import settings as qubx_settings
-
-    _bot_id = qubx_settings.bot_id
+    _logging = _setup_strategy_logging(stg_name, config.live.logging, run_id)
     _instance_id = qubx_settings.instance_id or socket.gethostname()
     _platform_tags: dict[str, str] = {}
     if _bot_id:
@@ -631,7 +627,6 @@ def _get_strategy_name(cfg: StrategyConfig) -> str:
 def _setup_strategy_logging(
     stg_name: str,
     log_config: LoggingConfig,
-    simulated_formatter: SimulatedLogFormatter,
     run_id: str,
 ) -> StrategyLogging:
     if not hasattr(log_config, "args") or not isinstance(log_config.args, dict):
@@ -641,9 +636,9 @@ def _setup_strategy_logging(
     run_folder = f"{log_folder}/run_{log_id}"
     logger.add(
         f"{run_folder}/strategy/{stg_name}_{{time}}.log",
-        format=simulated_formatter.formatter,
+        format=file_formatter,
         rotation="100 MB",
-        colorize=False,  # File logs should never have colors
+        colorize=False,
         level=QubxLogConfig.get_log_level(),
     )
 
@@ -885,7 +880,7 @@ def _run_warmup(
     exchanges: dict[str, ExchangeConfig],
     warmup: WarmupConfig | None,
     prefetch_config: PrefetchConfig,
-    simulated_formatter: SimulatedLogFormatter,
+    live_time_provider,
     account_manager: AccountConfigurationManager | None = None,
     enable_funding: bool = False,
     aux_configs: list[StorageConfig] | None = None,
@@ -974,10 +969,6 @@ def _run_warmup(
         warmup_mode=True,
     )
 
-    # - set the time provider to the simulated runner
-    _live_time_provider = simulated_formatter.time_provider
-    simulated_formatter.time_provider = warmup_runner.ctx
-
     ctx._strategy_state.is_warmup_in_progress = True
     QubxLogConfig.bind_phase("warmup")
     QubxLogConfig.bind_time_provider(warmup_runner.ctx)
@@ -986,8 +977,7 @@ def _run_warmup(
         warmup_runner.run(catch_keyboard_interrupt=False, close_data_readers=True)
     finally:
         # Restore the live time provider
-        simulated_formatter.time_provider = _live_time_provider
-        QubxLogConfig.bind_time_provider(None)
+        QubxLogConfig.bind_time_provider(live_time_provider)
         # Set back the context for metric emitters to use live context
         if ctx.emitter is not None:
             ctx.emitter.set_context(ctx)


### PR DESCRIPTION
## Summary
- Adds periodic state snapshot persistence to Redis (or any configured `IStatePersistence` backend) for dashboard monitoring
- Snapshots include per-exchange: capital, balances, positions, orders, net/gross leverage
- Configurable interval via `snapshot_interval` on `StatePersistenceConfig` (defaults to 5s, `null` to disable)
- Live-mode only — no-op in simulation and when `DummyStatePersistence` is active

## Snapshot schema
```json
{
  "timestamp": "...",
  "exchanges": {
    "BINANCE.UM": {
      "capital": { "total": ..., "available": ... },
      "balances": { "USDT": { "total": ..., "free": ..., "locked": ... } },
      "net_leverage": ...,
      "gross_leverage": ...,
      "open_positions": 2,
      "positions": { "BTCUSDT": { "quantity": ..., "avg_price": ..., ... } },
      "orders": { "BTCUSDT": [{ "id": ..., "type": ..., "side": ..., ... }] }
    }
  }
}
```

## Test plan
- [x] All core tests pass (282 passed)
- [x] All runner tests pass (23 passed)
- [x] State resolver tests pass (30 passed)
- [ ] Manual verification with live strategy + Redis persistence