### PR TITLE
feat: control protocol - state decorator, discovery & ranking actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends libgomp1 && rm -rf /var/lib/apt/lists/*
 
+# Install uv for strategy deployment (uv sync --frozen, no pip resolver)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
 COPY --from=builder /wheels/ /tmp/wheels/
 
 # Install qubx wheel with connectors extra (db, tui, k8 are now core deps)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -38,9 +38,9 @@ print('Downloaded from $STRATEGY_ARTIFACT_URL')
         exit 1
     fi
 
-    # 2. Deploy using qubx deploy --system (pip install wheels, no venv/uv)
+    # 2. Deploy using qubx deploy (uv sync --frozen, creates .venv in strategy dir)
     echo "Deploying strategy..."
-    qubx deploy "$ARTIFACT_FILE" -o "$STRATEGY_DIR" --system
+    qubx deploy "$ARTIFACT_FILE" -o "$STRATEGY_DIR"
 fi
 
 # 3. Build run command
@@ -59,7 +59,7 @@ if [ -f /app/overrides.yml ]; then
     ARGS="$ARGS --override /app/overrides.yml"
 fi
 
-# 4. Run directly (wheels installed into system site-packages)
+# 4. Run via the strategy venv (installed by uv sync --frozen from uv.lock)
 echo "Starting: qubx $ARGS"
 cd "$STRATEGY_DIR"
-exec qubx $ARGS
+exec .venv/bin/qubx $ARGS

--- a/src/qubx/control/__init__.py
+++ b/src/qubx/control/__init__.py
@@ -1,4 +1,4 @@
-from .decorator import action, collect_actions, execute_decorated_action
+from .decorator import action, collect_actions, collect_state, execute_decorated_action, state
 from .interfaces import IControllable
 from .server import ControlServer
 from .types import ActionDef, ActionParam, ActionResult
@@ -10,6 +10,8 @@ __all__ = [
     "ActionResult",
     "ControlServer",
     "action",
+    "state",
     "collect_actions",
+    "collect_state",
     "execute_decorated_action",
 ]

--- a/src/qubx/control/builtin.py
+++ b/src/qubx/control/builtin.py
@@ -2,14 +2,31 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Callable
 
-from qubx.core.basics import Signal
+import pandas as pd
 
+from qubx.core.basics import Instrument, MarketType, Signal
+from qubx.core.lookups import lookup
+from qubx.utils.time import to_timedelta, to_timestamp
+
+from .decorator import collect_state
 from .types import ActionDef, ActionParam, ActionResult
 
 if TYPE_CHECKING:
     from qubx.core.interfaces import IStrategyContext
+
+
+# --- Helpers ---
+
+
+def _resolve(ctx: IStrategyContext, symbol: str, exchange: str | None = None) -> Instrument | None:
+    """Resolve a symbol to an Instrument, returning None if not found."""
+    try:
+        return ctx.query_instrument(symbol, exchange=exchange)
+    except Exception:
+        return None
 
 
 # --- Rounding helpers ---
@@ -30,6 +47,9 @@ def _rms(v: float) -> float:
     return round(v, 1)
 
 
+# --- Universe actions ---
+
+
 def _get_universe(ctx: IStrategyContext, **kwargs) -> ActionResult:
     instruments = ctx.instruments
     return ActionResult(
@@ -38,11 +58,11 @@ def _get_universe(ctx: IStrategyContext, **kwargs) -> ActionResult:
     )
 
 
-def _add_instruments(ctx: IStrategyContext, symbols: list[str], **kwargs) -> ActionResult:
+def _add_instruments(ctx: IStrategyContext, symbols: list[str], exchange: str | None = None, **kwargs) -> ActionResult:
     instruments = []
     errors = []
     for s in symbols:
-        instr = ctx.query_instrument(s)
+        instr = _resolve(ctx, s, exchange)
         if instr is not None:
             instruments.append(instr)
         else:
@@ -58,11 +78,11 @@ def _add_instruments(ctx: IStrategyContext, symbols: list[str], **kwargs) -> Act
     )
 
 
-def _remove_instruments(ctx: IStrategyContext, symbols: list[str], if_has_position: str = "close", **kwargs) -> ActionResult:
+def _remove_instruments(ctx: IStrategyContext, symbols: list[str], exchange: str | None = None, if_has_position: str = "close", **kwargs) -> ActionResult:
     instruments = []
     errors = []
     for s in symbols:
-        instr = ctx.query_instrument(s)
+        instr = _resolve(ctx, s, exchange)
         if instr is not None:
             instruments.append(instr)
         else:
@@ -78,6 +98,194 @@ def _remove_instruments(ctx: IStrategyContext, symbols: list[str], if_has_positi
     )
 
 
+def _set_universe(ctx: IStrategyContext, symbols: list[str], exchange: str | None = None, if_has_position: str = "close", **kwargs) -> ActionResult:
+    instruments = []
+    errors = []
+    for s in symbols:
+        instr = _resolve(ctx, s, exchange)
+        if instr is not None:
+            instruments.append(instr)
+        else:
+            errors.append(s)
+
+    if errors:
+        return ActionResult(status="error", error=f"Unknown symbols: {errors}")
+
+    ctx.set_universe(instruments, if_has_position_then=if_has_position)
+    return ActionResult(
+        status="ok",
+        data={"instruments": [str(i) for i in instruments], "count": len(instruments)},
+    )
+
+
+# --- Instrument discovery actions ---
+
+
+def _get_available_instruments(ctx: IStrategyContext, exchange: str, quote: str = "USDT", market_type: str = "SWAP", **kwargs) -> ActionResult:
+    mt = MarketType(market_type) if market_type else None
+    as_of = to_timestamp(ctx.time())
+    instruments = lookup.find_instruments(exchange, quote=quote, market_type=mt, as_of=as_of)
+    if instruments is None:
+        instruments = []
+    symbols = [i.symbol for i in instruments]
+    return ActionResult(
+        status="ok",
+        data={
+            "exchange": exchange,
+            "market_type": market_type,
+            "quote": quote,
+            "count": len(symbols),
+            "instruments": symbols,
+        },
+    )
+
+
+def _get_instrument_details(ctx: IStrategyContext, symbols: list[str], exchange: str | None = None, **kwargs) -> ActionResult:
+    details = {}
+    errors = []
+    for s in symbols:
+        instr = _resolve(ctx, s, exchange)
+        if instr is None:
+            errors.append(s)
+            continue
+        details[str(instr)] = {
+            "symbol": instr.symbol,
+            "exchange": instr.exchange,
+            "market_type": instr.market_type,
+            "base": instr.base,
+            "quote": instr.quote,
+            "tick_size": instr.tick_size,
+            "lot_size": instr.lot_size,
+            "min_size": instr.min_size,
+            "min_notional": instr.min_notional,
+            "contract_size": instr.contract_size,
+        }
+    result: dict = {"instruments": details}
+    if errors:
+        result["not_found"] = errors
+    return ActionResult(status="ok", data=result)
+
+
+def _get_top_instruments(
+    ctx: IStrategyContext,
+    exchange: str,
+    count: int = 20,
+    sort_by: str = "turnover",
+    period: str = "3d",
+    timeframe: str = "1d",
+    quote: str = "USDT",
+    market_type: str = "SWAP",
+    **kwargs,
+) -> ActionResult:
+    stop = to_timestamp(ctx.time())
+    start = stop - to_timedelta(period)
+
+    if sort_by == "market_cap":
+        return _rank_by_market_cap(ctx, exchange, market_type, quote, count, start, stop)
+    elif sort_by == "turnover":
+        return _rank_by_turnover(ctx, exchange, market_type, quote, count, timeframe, start, stop)
+    elif sort_by == "funding":
+        return _rank_by_funding(ctx, exchange, market_type, quote, count, start, stop)
+    else:
+        return ActionResult(status="error", error=f"Unknown sort_by: {sort_by}. Use 'turnover', 'market_cap', or 'funding'.")
+
+
+def _rank_by_turnover(
+    ctx: IStrategyContext, exchange: str, market_type: str, quote: str,
+    count: int, timeframe: str, start: pd.Timestamp, stop: pd.Timestamp,
+) -> ActionResult:
+    try:
+        reader = ctx.get_aux_reader(exchange, market_type)
+    except Exception as e:
+        return ActionResult(status="error", error=f"Aux reader for {exchange}:{market_type} not available: {e}")
+
+    try:
+        mt = MarketType(market_type) if market_type else None
+        instruments = lookup.find_instruments(exchange, quote=quote, market_type=mt) or []
+        if not instruments:
+            return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "turnover"})
+
+        symbols = [i.symbol for i in instruments]
+        candles = reader.read(symbols, f"ohlc({timeframe})", start=str(start), stop=str(stop)).to_pd(True)
+
+        if candles is None or candles.empty:
+            return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "turnover"})
+
+        candles = candles.reset_index("symbol")
+        volumes = candles.groupby("symbol")["quote_volume"].mean()
+        ranked = volumes.sort_values(ascending=False).head(count)
+
+        result = [{"symbol": sym, "avg_turnover": _rm(vol)} for sym, vol in ranked.items()]
+        return ActionResult(status="ok", data={"instruments": result, "count": len(result), "sort_by": "turnover"})
+    except Exception as e:
+        return ActionResult(status="error", error=f"Failed to rank by turnover: {e}")
+
+
+def _rank_by_market_cap(
+    ctx: IStrategyContext, exchange: str, market_type: str, quote: str,
+    count: int, start: pd.Timestamp, stop: pd.Timestamp,
+) -> ActionResult:
+    try:
+        reader = ctx.get_aux_reader("COINGECKO", "FUNDAMENTAL")
+    except Exception as e:
+        return ActionResult(status="error", error=f"CoinGecko aux reader not available: {e}. Configure aux data with COINGECKO:FUNDAMENTAL.")
+
+    try:
+        coins = reader.get_data_id()
+        raw = reader.read(coins, "fundamental", start=str(start), stop=str(stop)).to_pd(True)
+
+        if raw is None or raw.empty:
+            return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "market_cap"})
+
+        df = raw.pivot_table(index=["timestamp", "asset"], columns="metric", values="value")
+        if "market_cap" not in df.columns:
+            return ActionResult(status="error", error="market_cap metric not available in fundamental data")
+
+        latest = df.groupby("asset")["market_cap"].last()
+        ranked = latest.sort_values(ascending=False).head(count)
+
+        result = [{"symbol": f"{asset}{quote}", "market_cap": _rm(cap)} for asset, cap in ranked.items()]
+        return ActionResult(status="ok", data={"instruments": result, "count": len(result), "sort_by": "market_cap"})
+    except Exception as e:
+        return ActionResult(status="error", error=f"Failed to rank by market cap: {e}")
+
+
+def _rank_by_funding(
+    ctx: IStrategyContext, exchange: str, market_type: str, quote: str,
+    count: int, start: pd.Timestamp, stop: pd.Timestamp,
+) -> ActionResult:
+    try:
+        reader = ctx.get_aux_reader(exchange, market_type)
+    except Exception as e:
+        return ActionResult(status="error", error=f"Aux reader for {exchange}:{market_type} not available: {e}")
+
+    try:
+        mt = MarketType(market_type) if market_type else None
+        instruments = lookup.find_instruments(exchange, quote=quote, market_type=mt) or []
+        if not instruments:
+            return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "funding"})
+
+        symbols = [i.symbol for i in instruments]
+        fp = reader.read(symbols, "funding_payment", start=str(start), stop=str(stop)).to_pd(True)
+
+        if fp is None or fp.empty:
+            return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "funding"})
+
+        fp = fp.reset_index("symbol")
+        hours = max((stop - start).total_seconds() / 3600, 1)
+        avg_rate = fp.groupby("symbol")["funding_rate"].sum() / hours
+        apr = avg_rate * 24 * 365 * 100  # annualized percentage
+        ranked = apr.abs().sort_values(ascending=False).head(count)
+
+        result = [{"symbol": sym, "funding_apr": _rm(apr.loc[sym])} for sym in ranked.index]
+        return ActionResult(status="ok", data={"instruments": result, "count": len(result), "sort_by": "funding"})
+    except Exception as e:
+        return ActionResult(status="error", error=f"Failed to rank by funding: {e}")
+
+
+# --- Diagnostics actions ---
+
+
 def _get_positions(ctx: IStrategyContext, **kwargs) -> ActionResult:
     positions = {}
     for instr, pos in ctx.get_positions().items():
@@ -85,7 +293,7 @@ def _get_positions(ctx: IStrategyContext, **kwargs) -> ActionResult:
             "quantity": pos.quantity,
             "avg_price": pos.position_avg_price,
             "market_price": pos.last_update_price,
-            "pnl": _rm(pos.pnl),
+            "unrealized_pnl": _rm(pos.unrealized_pnl()),
             "realized_pnl": _rm(pos.r_pnl),
             "market_value": _rm(pos.market_value_funds),
         }
@@ -103,7 +311,7 @@ def _get_balances(ctx: IStrategyContext, **kwargs) -> ActionResult:
 def _get_orders(ctx: IStrategyContext, symbol: str | None = None, **kwargs) -> ActionResult:
     orders_data = []
     if symbol:
-        instr = ctx.query_instrument(symbol)
+        instr = _resolve(ctx, symbol)
         if instr is None:
             return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
         orders = ctx.get_orders(instrument=instr)
@@ -126,15 +334,13 @@ def _get_orders(ctx: IStrategyContext, symbol: str | None = None, **kwargs) -> A
 
 
 def _get_quote(ctx: IStrategyContext, symbol: str, **kwargs) -> ActionResult:
-    instr = ctx.query_instrument(symbol)
+    instr = _resolve(ctx, symbol)
     if instr is None:
         return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
 
     quote = ctx.quote(instr)
     if quote is None:
         return ActionResult(status="error", error=f"No quote available for {symbol}")
-
-    import pandas as pd
 
     return ActionResult(
         status="ok",
@@ -143,13 +349,13 @@ def _get_quote(ctx: IStrategyContext, symbol: str, **kwargs) -> ActionResult:
             "ask": quote.ask,
             "bid_size": quote.bid_size,
             "ask_size": quote.ask_size,
-            "time": str(pd.Timestamp(quote.time, unit="ns")),
+            "time": str(to_timestamp(quote.time)),
         },
     )
 
 
 def _get_ohlc(ctx: IStrategyContext, symbol: str, timeframe: str = "1h", length: int = 20, **kwargs) -> ActionResult:
-    instr = ctx.query_instrument(symbol)
+    instr = _resolve(ctx, symbol)
     if instr is None:
         return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
 
@@ -175,107 +381,82 @@ def _get_ohlc(ctx: IStrategyContext, symbol: str, timeframe: str = "1h", length:
         return ActionResult(status="error", error=str(e))
 
 
-def _trade(ctx: IStrategyContext, symbol: str, amount: float, price: float | None = None, time_in_force: str = "gtc", **kwargs) -> ActionResult:
-    instr = ctx.query_instrument(symbol)
-    if instr is None:
-        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
-
-    try:
-        order = ctx.trade(instr, amount, price=price, time_in_force=time_in_force)
-        return ActionResult(
-            status="ok",
-            data={"order_id": order.id if order else None, "instrument": str(instr), "amount": amount},
-        )
-    except Exception as e:
-        return ActionResult(status="error", error=str(e))
-
-
-def _set_target_position(ctx: IStrategyContext, symbol: str, target: float, price: float | None = None, **kwargs) -> ActionResult:
-    instr = ctx.query_instrument(symbol)
-    if instr is None:
-        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
-
-    positions = ctx.get_positions()
-    previous = positions[instr].quantity if instr in positions else 0.0
-
-    try:
-        ctx.set_target_position(instr, target, price=price)
-        return ActionResult(status="ok", data={"previous": previous, "new": target, "instrument": str(instr)})
-    except Exception as e:
-        return ActionResult(status="error", error=str(e))
-
-
-def _close_position(ctx: IStrategyContext, symbol: str, **kwargs) -> ActionResult:
-    instr = ctx.query_instrument(symbol)
-    if instr is None:
-        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
-
-    positions = ctx.get_positions()
-    amount = positions[instr].quantity if instr in positions else 0.0
-
-    try:
-        ctx.close_position(instr)
-        return ActionResult(status="ok", data={"closed": True, "amount": amount, "instrument": str(instr)})
-    except Exception as e:
-        return ActionResult(status="error", error=str(e))
-
-
-def _cancel_orders(ctx: IStrategyContext, symbol: str | None = None, **kwargs) -> ActionResult:
-    try:
-        if symbol:
-            instr = ctx.query_instrument(symbol)
-            if instr is None:
-                return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
-            ctx.cancel_orders(instr)
-        else:
-            for instr in ctx.instruments:
-                ctx.cancel_orders(instr)
-        return ActionResult(status="ok", data={"cancelled": True})
-    except Exception as e:
-        return ActionResult(status="error", error=str(e))
-
-
-def _emit_signal(ctx: IStrategyContext, symbol: str, signal_value: float, price: float | None = None, group: str = "", **kwargs) -> ActionResult:
-    instr = ctx.query_instrument(symbol)
-    if instr is None:
-        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
-
-    try:
-        sig = Signal(
-            time=ctx.time(),
-            instrument=instr,
-            signal=signal_value,
-            price=price,
-            group=group,
-        )
-        ctx.emit_signal(sig)
-        return ActionResult(status="ok", data={"emitted": True, "instrument": str(instr), "signal": signal_value})
-    except Exception as e:
-        return ActionResult(status="error", error=str(e))
-
-
 def _get_state(ctx: IStrategyContext, **kwargs) -> ActionResult:
-    positions = {}
-    for instr, pos in ctx.get_positions().items():
-        positions[str(instr)] = {
-            "quantity": pos.quantity,
-            "avg_price": pos.position_avg_price,
-            "market_price": pos.last_update_price,
-            "pnl": _rm(pos.pnl),
+    account = ctx.account
+    exchanges = ctx.exchanges
+
+    exchanges_snapshot: dict[str, dict] = {}
+    for exchange in exchanges:
+        positions = account.get_positions(exchange)
+        orders = account.get_orders(exchange=exchange)
+
+        # Group orders by instrument symbol
+        orders_by_symbol: dict[str, list[dict]] = defaultdict(list)
+        for order in orders.values():
+            orders_by_symbol[order.instrument.symbol].append(
+                {
+                    "id": order.id,
+                    "type": order.type,
+                    "side": order.side,
+                    "quantity": order.quantity,
+                    "price": order.price,
+                    "status": order.status,
+                }
+            )
+
+        # Build positions snapshot
+        positions_snapshot: dict[str, dict] = {}
+        open_positions = 0
+        for instr, pos in positions.items():
+            if pos.is_open():
+                open_positions += 1
+            positions_snapshot[instr.symbol] = {
+                "quantity": pos.quantity,
+                "avg_price": pos.position_avg_price,
+                "market_price": pos.last_update_price,
+                "unrealized_pnl": _rm(pos.unrealized_pnl()),
+                "market_value": _rm(pos.market_value_funds),
+                "leverage": _rl(account.get_leverage(instr)),
+            }
+
+        # Build balances snapshot
+        balances_snapshot: dict[str, dict] = {}
+        for bal in account.get_balances(exchange):
+            balances_snapshot[bal.currency] = {
+                "total": _rm(bal.total),
+                "free": _rm(bal.free),
+                "locked": _rm(bal.locked),
+            }
+
+        exchanges_snapshot[exchange] = {
+            "base_currency": account.get_base_currency(exchange),
+            "capital": {
+                "total": _rm(account.get_total_capital(exchange)),
+                "available": _rm(account.get_capital(exchange)),
+            },
+            "net_leverage": _rl(account.get_net_leverage(exchange)),
+            "gross_leverage": _rl(account.get_gross_leverage(exchange)),
+            "open_positions": open_positions,
+            "positions": positions_snapshot,
+            "orders": dict(orders_by_symbol),
+            "balances": balances_snapshot,
         }
 
-    return ActionResult(
-        status="ok",
-        data={
-            "total_capital": _rm(ctx.get_total_capital()),
-            "net_leverage": _rl(ctx.get_net_leverage()),
-            "gross_leverage": _rl(ctx.get_gross_leverage()),
-            "positions": positions,
-            "instruments": [str(i) for i in ctx.instruments],
-            "is_warmup": ctx.is_warmup_in_progress,
-            "is_simulation": ctx.is_simulation,
-        },
-    )
+    data: dict = {
+        "timestamp": str(ctx.time()),
+        "total_capital": _rm(ctx.get_total_capital()),
+        "exchanges": exchanges_snapshot,
+        "instruments": [str(i) for i in ctx.instruments],
+        "is_warmup": ctx.is_warmup_in_progress,
+        "is_simulation": ctx.is_simulation,
+    }
+
+    # Include custom state from @state-decorated methods
+    custom = collect_state(ctx.strategy, ctx)
+    if custom:
+        data["custom"] = custom
+
+    return ActionResult(status="ok", data=data)
 
 
 def _get_total_capital(ctx: IStrategyContext, **kwargs) -> ActionResult:
@@ -301,7 +482,7 @@ def _get_leverages(ctx: IStrategyContext, **kwargs) -> ActionResult:
 
 def _get_subscriptions(ctx: IStrategyContext, symbol: str | None = None, **kwargs) -> ActionResult:
     if symbol:
-        instr = ctx.query_instrument(symbol)
+        instr = _resolve(ctx, symbol)
         if instr is None:
             return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
         subs = ctx.get_subscriptions(instr)
@@ -311,47 +492,6 @@ def _get_subscriptions(ctx: IStrategyContext, symbol: str | None = None, **kwarg
     for instr in ctx.instruments:
         result[str(instr)] = ctx.get_subscriptions(instr)
     return ActionResult(status="ok", data={"subscriptions": result})
-
-
-def _set_universe(ctx: IStrategyContext, symbols: list[str], if_has_position: str = "close", **kwargs) -> ActionResult:
-    instruments = []
-    errors = []
-    for s in symbols:
-        instr = ctx.query_instrument(s)
-        if instr is not None:
-            instruments.append(instr)
-        else:
-            errors.append(s)
-
-    if errors:
-        return ActionResult(status="error", error=f"Unknown symbols: {errors}")
-
-    ctx.set_universe(instruments, if_has_position_then=if_has_position)
-    return ActionResult(
-        status="ok",
-        data={"instruments": [str(i) for i in instruments], "count": len(instruments)},
-    )
-
-
-def _set_target_leverage(ctx: IStrategyContext, symbol: str, leverage: float, price: float | None = None, **kwargs) -> ActionResult:
-    instr = ctx.query_instrument(symbol)
-    if instr is None:
-        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
-
-    try:
-        ctx.set_target_leverage(instr, leverage, price=price)
-        return ActionResult(status="ok", data={"instrument": str(instr), "leverage": leverage})
-    except Exception as e:
-        return ActionResult(status="error", error=str(e))
-
-
-def _close_positions(ctx: IStrategyContext, **kwargs) -> ActionResult:
-    try:
-        positions = {str(i): p.quantity for i, p in ctx.get_positions().items() if p.quantity != 0}
-        ctx.close_positions()
-        return ActionResult(status="ok", data={"closed": positions})
-    except Exception as e:
-        return ActionResult(status="error", error=str(e))
 
 
 def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
@@ -372,9 +512,115 @@ def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
     )
 
 
+# --- Trading actions ---
+
+
+def _trade(ctx: IStrategyContext, symbol: str, amount: float, price: float | None = None, time_in_force: str = "gtc", **kwargs) -> ActionResult:
+    instr = _resolve(ctx, symbol)
+    if instr is None:
+        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
+
+    try:
+        order = ctx.trade(instr, amount, price=price, time_in_force=time_in_force)
+        return ActionResult(
+            status="ok",
+            data={"order_id": order.id if order else None, "instrument": str(instr), "amount": amount},
+        )
+    except Exception as e:
+        return ActionResult(status="error", error=str(e))
+
+
+def _set_target_position(ctx: IStrategyContext, symbol: str, target: float, price: float | None = None, **kwargs) -> ActionResult:
+    instr = _resolve(ctx, symbol)
+    if instr is None:
+        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
+
+    positions = ctx.get_positions()
+    previous = positions[instr].quantity if instr in positions else 0.0
+
+    try:
+        ctx.set_target_position(instr, target, price=price)
+        return ActionResult(status="ok", data={"previous": previous, "new": target, "instrument": str(instr)})
+    except Exception as e:
+        return ActionResult(status="error", error=str(e))
+
+
+def _set_target_leverage(ctx: IStrategyContext, symbol: str, leverage: float, price: float | None = None, **kwargs) -> ActionResult:
+    instr = _resolve(ctx, symbol)
+    if instr is None:
+        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
+
+    try:
+        ctx.set_target_leverage(instr, leverage, price=price)
+        return ActionResult(status="ok", data={"instrument": str(instr), "leverage": leverage})
+    except Exception as e:
+        return ActionResult(status="error", error=str(e))
+
+
+def _close_position(ctx: IStrategyContext, symbol: str, **kwargs) -> ActionResult:
+    instr = _resolve(ctx, symbol)
+    if instr is None:
+        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
+
+    positions = ctx.get_positions()
+    amount = positions[instr].quantity if instr in positions else 0.0
+
+    try:
+        ctx.close_position(instr)
+        return ActionResult(status="ok", data={"closed": True, "amount": amount, "instrument": str(instr)})
+    except Exception as e:
+        return ActionResult(status="error", error=str(e))
+
+
+def _close_positions(ctx: IStrategyContext, **kwargs) -> ActionResult:
+    try:
+        positions = {str(i): p.quantity for i, p in ctx.get_positions().items() if p.quantity != 0}
+        ctx.close_positions()
+        return ActionResult(status="ok", data={"closed": positions})
+    except Exception as e:
+        return ActionResult(status="error", error=str(e))
+
+
+def _cancel_orders(ctx: IStrategyContext, symbol: str | None = None, **kwargs) -> ActionResult:
+    try:
+        if symbol:
+            instr = _resolve(ctx, symbol)
+            if instr is None:
+                return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
+            ctx.cancel_orders(instr)
+        else:
+            for instr in ctx.instruments:
+                ctx.cancel_orders(instr)
+        return ActionResult(status="ok", data={"cancelled": True})
+    except Exception as e:
+        return ActionResult(status="error", error=str(e))
+
+
+def _emit_signal(ctx: IStrategyContext, symbol: str, signal_value: float, price: float | None = None, group: str = "", **kwargs) -> ActionResult:
+    instr = _resolve(ctx, symbol)
+    if instr is None:
+        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
+
+    try:
+        sig = Signal(
+            time=ctx.time(),
+            instrument=instr,
+            signal=signal_value,
+            price=price,
+            group=group,
+        )
+        ctx.emit_signal(sig)
+        return ActionResult(status="ok", data={"emitted": True, "instrument": str(instr), "signal": signal_value})
+    except Exception as e:
+        return ActionResult(status="error", error=str(e))
+
+
 # --- Action registry ---
 
+_MARKET_TYPE_DOC = "Market type: SPOT, SWAP (perpetual futures), FUTURE (dated futures), OPTION, MARGIN"
+
 BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
+    # Universe
     "get_universe": (
         ActionDef(name="get_universe", description="Get current trading universe", category="universe", read_only=True),
         _get_universe,
@@ -382,9 +628,12 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
     "add_instruments": (
         ActionDef(
             name="add_instruments",
-            description="Add instruments to the trading universe",
+            description="Add instruments to the trading universe. Symbols can include exchange prefix (e.g., BINANCE.UM:BTCUSDT) or use the exchange parameter.",
             category="universe",
-            params=[ActionParam(name="symbols", type="array", description="List of symbol strings to add", items_type="string")],
+            params=[
+                ActionParam(name="symbols", type="array", description="List of symbol strings to add", items_type="string"),
+                ActionParam(name="exchange", type="string", description="Exchange for symbol resolution (optional if symbols include exchange prefix)", required=False, default=None),
+            ],
         ),
         _add_instruments,
     ),
@@ -396,11 +645,73 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
             dangerous=True,
             params=[
                 ActionParam(name="symbols", type="array", description="List of symbol strings to remove", items_type="string"),
+                ActionParam(name="exchange", type="string", description="Exchange for symbol resolution (optional if symbols include exchange prefix)", required=False, default=None),
                 ActionParam(name="if_has_position", type="string", description="Policy if instrument has position: close, wait_for_close, wait_for_change", required=False, default="close"),
             ],
         ),
         _remove_instruments,
     ),
+    "set_universe": (
+        ActionDef(
+            name="set_universe",
+            description="Replace the entire trading universe",
+            category="universe",
+            dangerous=True,
+            params=[
+                ActionParam(name="symbols", type="array", description="List of symbol strings for the new universe", items_type="string"),
+                ActionParam(name="exchange", type="string", description="Exchange for symbol resolution (optional if symbols include exchange prefix)", required=False, default=None),
+                ActionParam(name="if_has_position", type="string", description="Policy for removed instruments with positions: close, wait_for_close, wait_for_change", required=False, default="close"),
+            ],
+        ),
+        _set_universe,
+    ),
+    # Instrument discovery
+    "get_available_instruments": (
+        ActionDef(
+            name="get_available_instruments",
+            description="Get all tradable instruments on an exchange. " + _MARKET_TYPE_DOC,
+            category="discovery",
+            read_only=True,
+            params=[
+                ActionParam(name="exchange", type="string", description="Exchange name (e.g., BINANCE.UM, KRAKEN, BYBIT)"),
+                ActionParam(name="quote", type="string", description="Quote currency filter", required=False, default="USDT"),
+                ActionParam(name="market_type", type="string", description=_MARKET_TYPE_DOC, required=False, default="SWAP"),
+            ],
+        ),
+        _get_available_instruments,
+    ),
+    "get_instrument_details": (
+        ActionDef(
+            name="get_instrument_details",
+            description="Get trading details (tick size, lot size, min notional, etc.) for a list of instruments",
+            category="discovery",
+            read_only=True,
+            params=[
+                ActionParam(name="symbols", type="array", description="List of symbol strings to get details for", items_type="string"),
+                ActionParam(name="exchange", type="string", description="Exchange for symbol resolution (optional if symbols include exchange prefix)", required=False, default=None),
+            ],
+        ),
+        _get_instrument_details,
+    ),
+    "get_top_instruments": (
+        ActionDef(
+            name="get_top_instruments",
+            description="Get top N instruments ranked by turnover, market cap, or funding rate. Requires aux data configured.",
+            category="discovery",
+            read_only=True,
+            params=[
+                ActionParam(name="exchange", type="string", description="Exchange name (e.g., BINANCE.UM)"),
+                ActionParam(name="count", type="integer", description="Number of top instruments to return", required=False, default=20),
+                ActionParam(name="sort_by", type="string", description="Ranking metric: turnover, market_cap, or funding", required=False, default="turnover"),
+                ActionParam(name="period", type="string", description="Lookback period (e.g., 3d, 7d, 1h)", required=False, default="3d"),
+                ActionParam(name="timeframe", type="string", description="Candle timeframe for turnover (e.g., 1d, 1h)", required=False, default="1d"),
+                ActionParam(name="quote", type="string", description="Quote currency filter", required=False, default="USDT"),
+                ActionParam(name="market_type", type="string", description=_MARKET_TYPE_DOC, required=False, default="SWAP"),
+            ],
+        ),
+        _get_top_instruments,
+    ),
+    # Diagnostics
     "get_positions": (
         ActionDef(name="get_positions", description="Get all current positions with PnL", category="diagnostics", read_only=True),
         _get_positions,
@@ -443,6 +754,33 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
         ),
         _get_ohlc,
     ),
+    "get_state": (
+        ActionDef(name="get_state", description="Get full bot state: per-exchange capital, leverage, positions, orders, balances, and custom strategy state", category="diagnostics", read_only=True),
+        _get_state,
+    ),
+    "get_health": (
+        ActionDef(name="get_health", description="Get health metrics: connectivity, queue size, data latencies", category="diagnostics", read_only=True),
+        _get_health,
+    ),
+    "get_total_capital": (
+        ActionDef(name="get_total_capital", description="Get total capital across all exchanges", category="diagnostics", read_only=True),
+        _get_total_capital,
+    ),
+    "get_leverages": (
+        ActionDef(name="get_leverages", description="Get per-instrument and portfolio leverage", category="diagnostics", read_only=True),
+        _get_leverages,
+    ),
+    "get_subscriptions": (
+        ActionDef(
+            name="get_subscriptions",
+            description="Get active data subscriptions",
+            category="diagnostics",
+            read_only=True,
+            params=[ActionParam(name="symbol", type="string", description="Filter by symbol", required=False, default=None)],
+        ),
+        _get_subscriptions,
+    ),
+    # Trading
     "trade": (
         ActionDef(
             name="trade",
@@ -472,6 +810,20 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
         ),
         _set_target_position,
     ),
+    "set_target_leverage": (
+        ActionDef(
+            name="set_target_leverage",
+            description="Set target leverage for an instrument",
+            category="trading",
+            dangerous=True,
+            params=[
+                ActionParam(name="symbol", type="string", description="Trading instrument symbol"),
+                ActionParam(name="leverage", type="number", description="Target leverage"),
+                ActionParam(name="price", type="number", description="Limit price", required=False, default=None),
+            ],
+        ),
+        _set_target_leverage,
+    ),
     "close_position": (
         ActionDef(
             name="close_position",
@@ -481,6 +833,10 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
             params=[ActionParam(name="symbol", type="string", description="Trading instrument symbol")],
         ),
         _close_position,
+    ),
+    "close_positions": (
+        ActionDef(name="close_positions", description="Close all open positions", category="trading", dangerous=True),
+        _close_positions,
     ),
     "cancel_orders": (
         ActionDef(
@@ -505,62 +861,5 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
             ],
         ),
         _emit_signal,
-    ),
-    "get_state": (
-        ActionDef(name="get_state", description="Get full bot state dump", category="diagnostics", read_only=True),
-        _get_state,
-    ),
-    "get_health": (
-        ActionDef(name="get_health", description="Get health metrics", category="diagnostics", read_only=True),
-        _get_health,
-    ),
-    "get_total_capital": (
-        ActionDef(name="get_total_capital", description="Get total capital across all exchanges", category="diagnostics", read_only=True),
-        _get_total_capital,
-    ),
-    "get_leverages": (
-        ActionDef(name="get_leverages", description="Get per-instrument and portfolio leverage", category="diagnostics", read_only=True),
-        _get_leverages,
-    ),
-    "get_subscriptions": (
-        ActionDef(
-            name="get_subscriptions",
-            description="Get active data subscriptions",
-            category="diagnostics",
-            read_only=True,
-            params=[ActionParam(name="symbol", type="string", description="Filter by symbol", required=False, default=None)],
-        ),
-        _get_subscriptions,
-    ),
-    "set_universe": (
-        ActionDef(
-            name="set_universe",
-            description="Replace the entire trading universe",
-            category="universe",
-            dangerous=True,
-            params=[
-                ActionParam(name="symbols", type="array", description="List of symbol strings for the new universe", items_type="string"),
-                ActionParam(name="if_has_position", type="string", description="Policy for removed instruments with positions: close, wait_for_close, wait_for_change", required=False, default="close"),
-            ],
-        ),
-        _set_universe,
-    ),
-    "set_target_leverage": (
-        ActionDef(
-            name="set_target_leverage",
-            description="Set target leverage for an instrument",
-            category="trading",
-            dangerous=True,
-            params=[
-                ActionParam(name="symbol", type="string", description="Trading instrument symbol"),
-                ActionParam(name="leverage", type="number", description="Target leverage"),
-                ActionParam(name="price", type="number", description="Limit price", required=False, default=None),
-            ],
-        ),
-        _set_target_leverage,
-    ),
-    "close_positions": (
-        ActionDef(name="close_positions", description="Close all open positions", category="trading", dangerous=True),
-        _close_positions,
     ),
 }

--- a/src/qubx/control/decorator.py
+++ b/src/qubx/control/decorator.py
@@ -83,6 +83,41 @@ def _infer_params(method: Callable) -> list[ActionParam]:
     return params
 
 
+def state(description: str):
+    """Mark a strategy method as a state provider.
+
+    The method is called automatically when building state snapshots.
+    It receives `ctx` as first arg (injected). Must be fast and read-only.
+    The return value is included under the "custom" key in get_state responses.
+    """
+
+    def decorator(method: Callable) -> Callable:
+        @functools.wraps(method)
+        def wrapper(*args, **kwargs):
+            return method(*args, **kwargs)
+
+        setattr(wrapper, "__state__", description)
+        return wrapper
+
+    return decorator
+
+
+def collect_state(strategy: Any, ctx: Any) -> dict:
+    """Scan a strategy instance for @state-decorated methods and collect their values."""
+    result = {}
+    for attr_name in dir(strategy):
+        try:
+            attr = getattr(strategy, attr_name, None)
+        except Exception:
+            continue
+        if callable(attr) and hasattr(attr, "__state__"):
+            try:
+                result[attr.__name__] = attr(ctx)
+            except Exception as e:
+                result[attr.__name__] = f"error: {e}"
+    return result
+
+
 def collect_actions(strategy: Any) -> list[ActionDef]:
     """Scan a strategy instance for @action-decorated methods."""
     actions = []

--- a/tests/qubx/control/test_builtin.py
+++ b/tests/qubx/control/test_builtin.py
@@ -10,28 +10,54 @@ def _make_mock_ctx():
     # Mock instruments
     instr1 = MagicMock()
     instr1.__str__ = lambda self: "BTCUSDT"
+    instr1.symbol = "BTCUSDT"
+    instr1.exchange = "BINANCE.UM"
+    instr1.market_type = "SWAP"
+    instr1.base = "BTC"
+    instr1.quote = "USDT"
+    instr1.tick_size = 0.1
+    instr1.lot_size = 0.001
+    instr1.min_size = 0.001
+    instr1.min_notional = 5.0
+    instr1.contract_size = 1.0
     instr1.min_size = 0.001
     instr2 = MagicMock()
     instr2.__str__ = lambda self: "ETHUSDT"
-    instr2.min_size = 0.01
+    instr2.symbol = "ETHUSDT"
+    instr2.exchange = "BINANCE.UM"
+    instr2.market_type = "SWAP"
+    instr2.base = "ETH"
+    instr2.quote = "USDT"
     ctx.instruments = [instr1, instr2]
 
-    # Mock positions
+    # Mock account (multi-exchange aware)
+    account = MagicMock()
     pos1 = MagicMock()
     pos1.quantity = 0.5
     pos1.position_avg_price = 67500.0
     pos1.last_update_price = 68000.0
-    pos1.pnl = 250.0
+    pos1.unrealized_pnl.return_value = 250.0
     pos1.r_pnl = 100.0
     pos1.market_value_funds = 34000.0
+    pos1.is_open.return_value = True
     pos2 = MagicMock()
     pos2.quantity = 0.0
     pos2.position_avg_price = 0.0
     pos2.last_update_price = 3800.0
-    pos2.pnl = 0.0
+    pos2.unrealized_pnl.return_value = 0.0
     pos2.r_pnl = 0.0
     pos2.market_value_funds = 0.0
+    pos2.is_open.return_value = False
+
     ctx.get_positions.return_value = {instr1: pos1, instr2: pos2}
+    account.get_positions.return_value = {instr1: pos1, instr2: pos2}
+    account.get_orders.return_value = {}
+    account.get_leverage.return_value = 0.34
+    account.get_total_capital.return_value = 10000.0
+    account.get_capital.return_value = 9500.0
+    account.get_net_leverage.return_value = 0.15
+    account.get_gross_leverage.return_value = 0.15
+    account.get_base_currency.return_value = "USDT"
 
     # Mock balances
     bal = MagicMock()
@@ -41,6 +67,9 @@ def _make_mock_ctx():
     bal.free = 9500.0
     bal.locked = 500.0
     ctx.get_balances.return_value = [bal]
+    account.get_balances.return_value = [bal]
+
+    ctx.account = account
 
     # Mock orders
     ctx.get_orders.return_value = {}
@@ -51,12 +80,20 @@ def _make_mock_ctx():
     ctx.get_gross_leverage.return_value = 0.15
     ctx.is_warmup_in_progress = False
     ctx.is_simulation = False
+    ctx.exchanges = ["BINANCE.UM"]
+    ctx.time.return_value = "2026-04-05T10:00:00"
+
+    # Mock strategy (no @state decorators)
+    ctx.strategy = type("FakeStrategy", (), {})()
 
     # Mock health
     ctx.health = MagicMock()
     ctx.health.is_connected.return_value = True
     ctx.health.get_queue_size.return_value = 0
-    ctx.health.is_stale.return_value = False
+    ctx.health.get_data_latencies.return_value = {}
+
+    # Mock query_instrument
+    ctx.query_instrument.side_effect = lambda s, exchange=None: instr1 if "BTC" in s else (instr2 if "ETH" in s else None)
 
     return ctx
 
@@ -82,7 +119,7 @@ class TestGetPositions:
         pos = result.data["positions"]["BTCUSDT"]
         assert pos["quantity"] == 0.5
         assert pos["avg_price"] == 67500.0
-        assert pos["market_price"] == 68000.0
+        assert pos["unrealized_pnl"] == 250.0
 
 
 class TestGetBalances:
@@ -96,20 +133,52 @@ class TestGetBalances:
 
 
 class TestGetState:
-    def test_returns_full_state(self):
+    def test_returns_multi_exchange_state(self):
         ctx = _make_mock_ctx()
         _, handler = BUILTIN_ACTIONS["get_state"]
         result = handler(ctx)
         assert result.status == "ok"
-        assert result.data["total_capital"] == 10000.0
-        assert result.data["net_leverage"] == 0.15
-        assert len(result.data["instruments"]) == 2
+        data = result.data
+
+        # Top-level fields
+        assert data["total_capital"] == 10000.0
+        assert "timestamp" in data
+        assert "instruments" in data
+
+        # Per-exchange structure
+        assert "BINANCE.UM" in data["exchanges"]
+        exch = data["exchanges"]["BINANCE.UM"]
+        assert exch["base_currency"] == "USDT"
+        assert "capital" in exch
+        assert exch["capital"]["total"] == 10000.0
+        assert exch["capital"]["available"] == 9500.0
+        assert "net_leverage" in exch
+        assert "gross_leverage" in exch
+        assert "open_positions" in exch
+        assert "positions" in exch
+        assert "orders" in exch
+        assert "balances" in exch
+
+    def test_includes_custom_state(self):
+        ctx = _make_mock_ctx()
+
+        # Add a @state-decorated method to the strategy
+        from qubx.control import state
+
+        class StrategyWithState:
+            @state(description="Current regime")
+            def regime(self, ctx):
+                return "trending"
+
+        ctx.strategy = StrategyWithState()
+        _, handler = BUILTIN_ACTIONS["get_state"]
+        result = handler(ctx)
+        assert result.data["custom"]["regime"] == "trending"
 
 
 class TestGetHealth:
     def test_returns_health_info(self):
         ctx = _make_mock_ctx()
-        ctx.exchanges = ["BINANCE.UM"]
         _, handler = BUILTIN_ACTIONS["get_health"]
         result = handler(ctx)
         assert result.status == "ok"
@@ -127,6 +196,41 @@ class TestGetOrders:
         assert result.data["orders"] == []
 
 
+class TestGetAvailableInstruments:
+    def test_returns_instrument_list(self):
+        ctx = _make_mock_ctx()
+        _, handler = BUILTIN_ACTIONS["get_available_instruments"]
+        # This calls lookup.find_instruments which we can't easily mock,
+        # but we can at least verify it doesn't crash
+        result = handler(ctx, exchange="BINANCE.UM", quote="USDT", market_type="SWAP")
+        assert result.status == "ok"
+        assert "count" in result.data
+        assert "instruments" in result.data
+        assert result.data["exchange"] == "BINANCE.UM"
+        assert result.data["market_type"] == "SWAP"
+
+
+class TestGetInstrumentDetails:
+    def test_returns_details(self):
+        ctx = _make_mock_ctx()
+        _, handler = BUILTIN_ACTIONS["get_instrument_details"]
+        result = handler(ctx, symbols=["BTCUSDT"])
+        assert result.status == "ok"
+        assert len(result.data["instruments"]) == 1
+        details = list(result.data["instruments"].values())[0]
+        assert "tick_size" in details
+        assert "lot_size" in details
+        assert "min_notional" in details
+
+    def test_returns_not_found(self):
+        ctx = _make_mock_ctx()
+        _, handler = BUILTIN_ACTIONS["get_instrument_details"]
+        result = handler(ctx, symbols=["XYZUSDT"])
+        assert result.status == "ok"
+        assert "not_found" in result.data
+        assert "XYZUSDT" in result.data["not_found"]
+
+
 class TestBuiltinRegistry:
     def test_all_actions_have_definitions(self):
         for name, (action_def, handler) in BUILTIN_ACTIONS.items():
@@ -138,7 +242,8 @@ class TestBuiltinRegistry:
         read_only = {
             "get_universe", "get_positions", "get_balances", "get_orders", "get_quote",
             "get_ohlc", "get_state", "get_health", "get_total_capital", "get_leverages",
-            "get_subscriptions",
+            "get_subscriptions", "get_available_instruments", "get_instrument_details",
+            "get_top_instruments",
         }
         for name in read_only:
             action_def, _ = BUILTIN_ACTIONS[name]
@@ -152,3 +257,7 @@ class TestBuiltinRegistry:
         for name in dangerous:
             action_def, _ = BUILTIN_ACTIONS[name]
             assert action_def.dangerous is True, f"{name} should be dangerous"
+
+    def test_expected_action_count(self):
+        # 4 universe + 3 discovery + 7 diagnostics + 7 trading = 21... now 24
+        assert len(BUILTIN_ACTIONS) == 24

--- a/tests/qubx/control/test_decorator.py
+++ b/tests/qubx/control/test_decorator.py
@@ -1,5 +1,5 @@
 
-from qubx.control.decorator import action, collect_actions, execute_decorated_action
+from qubx.control.decorator import action, collect_actions, collect_state, execute_decorated_action, state
 from qubx.control.types import ActionDef, ActionResult
 
 
@@ -147,3 +147,65 @@ class TestExecuteDecoratedAction:
         result = execute_decorated_action(s, ctx=None, name="boom", params={})
         assert result.status == "error"
         assert result.error is not None and "kaboom" in result.error
+
+
+class TestStateDecorator:
+    def test_decorator_marks_method(self):
+        class S:
+            @state(description="Current regime")
+            def regime(self, ctx):
+                return "trending"
+
+        s = S()
+        assert hasattr(s.regime, "__state__")
+        assert s.regime.__state__ == "Current regime"
+
+    def test_collect_state(self):
+        class S:
+            @state(description="Regime")
+            def regime(self, ctx):
+                return "trending"
+
+            @state(description="Score")
+            def score(self, ctx):
+                return 42
+
+            def not_state(self):
+                pass
+
+        s = S()
+        result = collect_state(s, ctx=None)
+        assert result["regime"] == "trending"
+        assert result["score"] == 42
+        assert "not_state" not in result
+
+    def test_collect_state_handles_errors(self):
+        class S:
+            @state(description="Broken")
+            def broken(self, ctx):
+                raise ValueError("oops")
+
+        s = S()
+        result = collect_state(s, ctx=None)
+        assert "error:" in result["broken"]
+
+    def test_state_and_action_coexist(self):
+        class S:
+            @state(description="Regime")
+            def regime(self, ctx):
+                return "trending"
+
+            @action(description="Get params", read_only=True)
+            def get_params(self, ctx):
+                return {"x": 1}
+
+        s = S()
+        # State works
+        result = collect_state(s, ctx=None)
+        assert result["regime"] == "trending"
+        assert "get_params" not in result
+
+        # Action works
+        actions = collect_actions(s)
+        assert any(a.name == "get_params" for a in actions)
+        assert not any(a.name == "regime" for a in actions)

--- a/tests/qubx/control/test_e2e.py
+++ b/tests/qubx/control/test_e2e.py
@@ -72,6 +72,7 @@ def _make_mock_data_provider(instruments: list[Instrument], is_simulation: bool 
 
 def _make_mock_broker():
     broker = MagicMock()
+    broker.exchange.return_value = "BINANCE.UM"
     return broker
 
 
@@ -79,17 +80,26 @@ def _make_mock_account(instruments: list[Instrument]):
     account = MagicMock()
     pos = MagicMock()
     pos.quantity = 0.0
-    pos.avg_price = 0.0
-    pos.market_price = 0.0
-    pos.unrealized_pnl = 0.0
-    pos.realized_pnl = 0.0
+    pos.position_avg_price = 0.0
+    pos.last_update_price = 0.0
+    pos.unrealized_pnl.return_value = 0.0
+    pos.r_pnl = 0.0
+    pos.market_value_funds = 0.0
     pos.is_open.return_value = False
     account.get_positions.return_value = {i: pos for i in instruments}
-    account.get_balances.return_value = {}
-    account.get_open_orders.return_value = {}
+    bal = MagicMock()
+    bal.currency = "USDT"
+    bal.total = 10000.0
+    bal.free = 10000.0
+    bal.locked = 0.0
+    account.get_balances.return_value = [bal]
+    account.get_orders.return_value = {}
     account.get_total_capital.return_value = 10000.0
+    account.get_capital.return_value = 10000.0
     account.get_net_leverage.return_value = 0.0
     account.get_gross_leverage.return_value = 0.0
+    account.get_base_currency.return_value = "USDT"
+    account.get_leverage.return_value = 0.0
     return account
 
 


### PR DESCRIPTION
## Summary
Extends the bot control protocol (from #232) with:

- **`@state` decorator** — strategy methods automatically included in `get_state` custom section
- **Rewritten `get_state`** — multi-exchange format: base_currency, per-exchange capital/leverage/positions/orders/balances
- **3 new discovery actions**: `get_available_instruments` (with as_of delisting filter), `get_instrument_details`, `get_top_instruments` (turnover/market_cap/funding ranking via aux storage)
- **`exchange` parameter** on universe actions (`add_instruments`, `remove_instruments`, `set_universe`, `get_instrument_details`) for multi-exchange symbol resolution
- **Fixes**: `unrealized_pnl()` method call, `_resolve()` helper for safe symbol lookup, `to_timestamp`/`to_timedelta` instead of `pd.Timestamp.utcnow`
- **Rounding** for LLM-friendly output (money 2dp, leverage 4dp, latency 1dp)
- Total: 24 built-in + custom actions, 73 tests

## Test plan
- [x] 73 unit + e2e tests passing
- [x] Manually tested all actions against live MACD paper strategy
- [x] Verified turnover numbers against Binance exchange API
- [x] Tested market_cap and funding ranking via QuestDB aux storage
- [ ] Run full CI suite