### PR TITLE
fix: base_currency resolution, ccxt bulk guard, flaky test

### DIFF
--- a/src/qubx/data/storages/ccxt.py
+++ b/src/qubx/data/storages/ccxt.py
@@ -246,6 +246,12 @@ class CcxtReader(IReader):
 
         if isinstance(data_id, (list, tuple, set)):
             symbols: list[str] = self.get_data_id(dt) if not data_id else list(data_id)
+            if len(symbols) > 20:
+                logger.warning(
+                    f"[CCXT] Skipping bulk read of {len(symbols)} symbols for {dtype_str} on {self._exchange} — "
+                    f"ccxt is too slow for bulk queries. Use a database storage (e.g., qdb) instead."
+                )
+                return RawMultiData([])
             raw_list: list[RawData] = self._storage._fetch_multi(
                 self._exchange, self._market, symbols, dt, params, dtype_str, start, stop
             )

--- a/src/qubx/utils/runner/accounts.py
+++ b/src/qubx/utils/runner/accounts.py
@@ -84,11 +84,24 @@ class AccountConfigurationManager:
     def get_exchange_settings(self, exchange: str) -> ExchangeSettings:
         """
         Get the basic settings for an exchange such as the base currency and commission tier.
+
+        Priority: [[accounts]] credentials > [[defaults]] > hardcoded defaults.
+        Credentials are more specific (the actual trading account) so they take precedence.
         """
         exchange = exchange.upper()
-        if exchange not in self._exchange_settings:
-            return ExchangeSettings(exchange=exchange)
-        return self._exchange_settings[exchange.upper()].model_copy()
+        # Credentials take priority — they represent the actual account being used
+        if exchange in self._exchange_credentials:
+            creds = self._exchange_credentials[exchange]
+            return ExchangeSettings(
+                exchange=creds.exchange,
+                testnet=creds.testnet,
+                base_currency=creds.base_currency,
+                commissions=creds.commissions,
+                initial_capital=creds.initial_capital,
+            )
+        if exchange in self._exchange_settings:
+            return self._exchange_settings[exchange].model_copy()
+        return ExchangeSettings(exchange=exchange)
 
     def get_exchange_credentials(self, exchange: str) -> ExchangeCredentials:
         """

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -750,7 +750,7 @@ def _create_account_processor(
             exchange=simulated_exchange,
             channel=channel,
             health_monitor=health_monitor,
-            base_currency=settings.base_currency,
+            base_currency=base_currency,
             exchange_name=exchange_name,
             initial_capital=settings.initial_capital,
             restored_state=restored_state,

--- a/tests/qubx/utils/runner/textual_app/test_autocompletion.py
+++ b/tests/qubx/utils/runner/textual_app/test_autocompletion.py
@@ -6,6 +6,7 @@ from qubx.utils.runner.textual.kernel import IPyKernel
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("kernel")
 async def test_kernel_completion():
     """Test that kernel completion works."""
     kernel = IPyKernel()
@@ -36,6 +37,7 @@ async def test_kernel_completion():
 
 
 @pytest.mark.asyncio
+@pytest.mark.xdist_group("kernel")
 async def test_kernel_completion_empty():
     """Test that kernel returns empty list for invalid completion."""
     kernel = IPyKernel()


### PR DESCRIPTION
## Summary
- **Fix paper mode base_currency**: was ignoring YAML config and using accounts.toml fallback
- **Fix get_exchange_settings priority**: `[[accounts]]` credentials now take precedence over `[[defaults]]` — credentials represent the actual trading account
- **Guard ccxt bulk queries**: log warning and return empty result when >20 symbols requested (prevents slow one-by-one fetching for ranking queries)
- **Fix flaky test_kernel_completion**: add `xdist_group` to prevent ZMQ port collisions in parallel runs

## Test plan
- [x] 1256 passed, 0 failures (`just test`)