### PR TITLE
feat: get_state_schema action + control protocol docs

### DIFF
--- a/docs/trading/control-protocol.md
+++ b/docs/trading/control-protocol.md
@@ -1,0 +1,314 @@
+# Bot Control Protocol
+
+The control protocol allows external systems (CLI, web UI, LLM agents) to interact with a running Qubx strategy via HTTP. It replaces the old health-only server with a full control API while remaining backward compatible with Kubernetes health probes.
+
+## Enabling the Control Server
+
+Set the `QUBX_CONTROL_PORT` environment variable:
+
+```bash
+QUBX_CONTROL_PORT=8080 qubx run config.yml --paper
+```
+
+The legacy `QUBX_HEALTH_PORT` also works as a fallback.
+
+The server starts immediately (before strategy warmup) so that `/health` is available for K8s liveness probes. Action endpoints become available once the strategy context is attached.
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Liveness probe (always 200) |
+| `GET` | `/ready` | Readiness probe (200 after warmup, 503 during) |
+| `GET` | `/actions` | List all available actions with parameter schemas |
+| `POST` | `/actions/{name}` | Execute an action |
+
+### Request Format
+
+```bash
+curl -X POST http://localhost:8080/actions/get_positions \
+  -H 'Content-Type: application/json' \
+  -d '{"params": {}}'
+```
+
+Actions with parameters:
+
+```bash
+curl -X POST http://localhost:8080/actions/get_quote \
+  -H 'Content-Type: application/json' \
+  -d '{"params": {"symbol": "BTCUSDT"}}'
+```
+
+### Response Format
+
+```json
+{
+  "status": "ok",
+  "data": { ... },
+  "message": null
+}
+```
+
+On error:
+
+```json
+{
+  "detail": "Unknown symbol: XYZUSDT"
+}
+```
+
+## Built-in Actions
+
+Every bot gets these actions automatically, regardless of whether the strategy implements any custom actions.
+
+### Discovery
+
+| Action | Description | Params |
+|--------|-------------|--------|
+| `get_available_instruments` | All tradable instruments on an exchange | `exchange`, `quote?`, `market_type?` |
+| `get_instrument_details` | Tick size, lot size, min notional for instruments | `symbols`, `exchange?` |
+| `get_top_instruments` | Top N by turnover, market cap, or funding rate | `exchange`, `count?`, `sort_by?`, `period?`, `timeframe?`, `quote?`, `market_type?` |
+
+**Market types**: `SPOT`, `SWAP` (perpetual futures), `FUTURE` (dated futures), `OPTION`, `MARGIN`
+
+Example — top 10 by turnover:
+
+```bash
+curl -X POST http://localhost:8080/actions/get_top_instruments \
+  -d '{"params": {"exchange": "BINANCE.UM", "count": 10, "sort_by": "turnover", "period": "3d", "timeframe": "1d"}}'
+```
+
+!!! note
+    `get_top_instruments` requires auxiliary storage configured (e.g., `aux: storage: "qdb::quantlab"`). Turnover and funding use the exchange aux reader; market cap uses `COINGECKO:FUNDAMENTAL`.
+
+### Universe
+
+| Action | Description | Params | Dangerous |
+|--------|-------------|--------|-----------|
+| `get_universe` | Current trading universe | — | — |
+| `add_instruments` | Add instruments | `symbols`, `exchange?` | — |
+| `remove_instruments` | Remove instruments | `symbols`, `exchange?`, `if_has_position?` | Yes |
+| `set_universe` | Replace entire universe | `symbols`, `exchange?`, `if_has_position?` | Yes |
+
+Symbols can include the exchange prefix for multi-exchange setups: `"BINANCE.UM:BTCUSDT"`. Or pass the `exchange` parameter to apply to all symbols in the list.
+
+### Diagnostics
+
+| Action | Description | Params |
+|--------|-------------|--------|
+| `get_positions` | Positions with unrealized PnL | — |
+| `get_balances` | Account balances per exchange | — |
+| `get_orders` | Open orders | `symbol?` |
+| `get_quote` | Latest bid/ask | `symbol` |
+| `get_ohlc` | Recent OHLC bars | `symbol`, `timeframe?`, `length?` |
+| `get_state` | Full state dump (multi-exchange) | — |
+| `get_health` | Connectivity, queue size, latencies | — |
+| `get_total_capital` | Total capital across exchanges | — |
+| `get_leverages` | Per-instrument and portfolio leverage | — |
+| `get_subscriptions` | Active data subscriptions | `symbol?` |
+
+### Trading
+
+| Action | Description | Params | Dangerous |
+|--------|-------------|--------|-----------|
+| `trade` | Place an order | `symbol`, `amount`, `price?`, `time_in_force?` | Yes |
+| `set_target_position` | Set target position size | `symbol`, `target`, `price?` | Yes |
+| `set_target_leverage` | Set target leverage | `symbol`, `leverage`, `price?` | Yes |
+| `close_position` | Close one position | `symbol` | Yes |
+| `close_positions` | Close all positions | — | Yes |
+| `cancel_orders` | Cancel open orders | `symbol?` | — |
+| `emit_signal` | Emit a trading signal | `symbol`, `signal_value`, `price?`, `group?` | Yes |
+
+## Custom Actions with `@action`
+
+Strategies can expose custom actions using the `@action` decorator:
+
+```python
+from qubx.control import IControllable, action
+from qubx.control.types import ActionResult
+from qubx.core.interfaces import IStrategy, IStrategyContext
+
+class MyStrategy(IStrategy, IControllable):
+    threshold: float = 0.7
+    paused: bool = False
+
+    @action(description="Get strategy parameters", category="diagnostics", read_only=True)
+    def get_params(self, ctx: IStrategyContext):
+        return {"threshold": self.threshold, "paused": self.paused}
+
+    @action(description="Update confidence threshold", category="config")
+    def set_threshold(self, ctx: IStrategyContext, value: float):
+        if not 0.0 <= value <= 1.0:
+            return ActionResult(status="error", error="Must be between 0 and 1")
+        old = self.threshold
+        self.threshold = value
+        return ActionResult(status="ok", data={"old": old, "new": value})
+
+    @action(description="Pause signal generation", category="config")
+    def pause(self, ctx: IStrategyContext):
+        self.paused = True
+
+    @action(description="Resume signal generation", category="config")
+    def resume(self, ctx: IStrategyContext):
+        self.paused = False
+```
+
+### Decorator Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `description` | `str` | required | Human-readable description (also used by LLMs) |
+| `category` | `str` | `"custom"` | Grouping: `trading`, `universe`, `diagnostics`, `config`, `custom` |
+| `read_only` | `bool` | `False` | If `True`, executes directly on the server thread (fast). If `False`, executes on the strategy thread via command queue (safe). |
+| `dangerous` | `bool` | `False` | Hint for UIs to show confirmation prompts |
+| `hidden` | `bool` | `False` | If `True`, not listed in `GET /actions` |
+
+### Parameter Inference
+
+Action parameters are automatically inferred from the method signature:
+
+```python
+@action(description="Multi-param example")
+def my_action(self, ctx, name: str, count: int, items: list, flag: bool = True):
+    ...
+```
+
+| Python type | Schema type |
+|-------------|------------|
+| `str` | `"string"` |
+| `int` | `"integer"` |
+| `float` | `"number"` |
+| `bool` | `"boolean"` |
+| `list` | `"array"` |
+| `dict` | `"object"` |
+
+Parameters with defaults are marked as `required: false`.
+
+### Return Values
+
+Actions can return:
+
+- **A dict** — automatically wrapped in `ActionResult(status="ok", data=...)`
+- **An `ActionResult`** — returned as-is (useful for error handling)
+- **`None`** — returns `ActionResult(status="ok", data=None)`
+
+## Custom State with `@state`
+
+The `@state` decorator marks methods whose return values are automatically included in the `get_state` response under the `"custom"` key:
+
+```python
+from qubx.control import state
+
+class MyStrategy(IStrategy):
+
+    @state(description="MACD indicator values")
+    def macd_values(self, ctx: IStrategyContext) -> dict:
+        return {i.symbol: self._indicators[i].value for i in ctx.instruments}
+
+    @state(description="Current market regime")
+    def regime(self, ctx: IStrategyContext) -> str:
+        return "trending" if self.vol > 0.5 else "ranging"
+```
+
+The `get_state` response will include:
+
+```json
+{
+  "total_capital": 100000.0,
+  "exchanges": { ... },
+  "custom": {
+    "macd_values": {"BTCUSDT": -7.98, "ETHUSDT": -1.10},
+    "regime": "trending"
+  }
+}
+```
+
+### Guidelines
+
+- `@state` methods must be **fast and read-only** — they're called on every `get_state` request
+- If a `@state` method throws an exception, the error is captured as `"error: <message>"` without failing the entire state response
+- `@state` and `@action` are independent — use `@action` for callable operations, `@state` for automatic state inclusion
+
+## The `get_state` Response
+
+`get_state` returns a multi-exchange snapshot matching the format used by the platform's state persistence:
+
+```json
+{
+  "timestamp": "2026-04-05T10:30:00",
+  "total_capital": 100000.0,
+  "exchanges": {
+    "BINANCE.UM": {
+      "base_currency": "USDT",
+      "capital": { "total": 100000.0, "available": 96500.0 },
+      "net_leverage": 0.333,
+      "gross_leverage": 1.0,
+      "open_positions": 3,
+      "positions": {
+        "BTCUSDT": {
+          "quantity": 0.5,
+          "avg_price": 67500.0,
+          "market_price": 68000.0,
+          "unrealized_pnl": 250.0,
+          "market_value": 34000.0,
+          "leverage": 0.34
+        }
+      },
+      "orders": {
+        "BTCUSDT": [
+          { "id": "...", "type": "LIMIT", "side": "SELL", "quantity": 0.5, "price": 69000.0, "status": "OPEN" }
+        ]
+      },
+      "balances": {
+        "USDT": { "total": 100000.0, "free": 96500.0, "locked": 3500.0 }
+      }
+    }
+  },
+  "instruments": ["BINANCE.UM:SWAP:BTCUSDT", "BINANCE.UM:SWAP:ETHUSDT"],
+  "is_warmup": false,
+  "is_simulation": false,
+  "custom": { ... }
+}
+```
+
+## Thread Safety
+
+Actions are categorized as **read-only** or **write**:
+
+- **Read-only actions** (`read_only=True`) execute directly on the HTTP server thread. They can read strategy state without blocking the data processing loop. This is safe because Python's GIL prevents data corruption — you may see slightly stale values, but the process won't crash.
+
+- **Write actions** (`read_only=False`) are enqueued on a command queue and executed on the strategy's data processing thread. This ensures they don't race with market data processing. The HTTP request blocks until the command completes (up to 30s timeout).
+
+All built-in diagnostic actions (`get_*`) are read-only. Trading and universe actions are write actions.
+
+## LLM Tool Compatibility
+
+The `/actions` endpoint returns a JSON schema that maps directly to LLM function/tool definitions:
+
+```python
+# Convert actions to Anthropic tool format
+response = requests.get("http://localhost:8080/actions")
+actions = response.json()["actions"]
+
+tools = []
+for action in actions:
+    properties = {}
+    required = []
+    for param in action["params"]:
+        properties[param["name"]] = {
+            "type": param["type"],
+            "description": param["description"],
+        }
+        if param.get("required", True):
+            required.append(param["name"])
+
+    tools.append({
+        "name": action["name"],
+        "description": action["description"],
+        "input_schema": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+        },
+    })
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - Trading:
       - Paper Trading: trading/paper-trading.md
       - Live Trading: trading/live-trading.md
+      - Bot Control Protocol: trading/control-protocol.md
       - Risk Management: trading/risk-management.md
   - Analysis and Reporting:
       - Visualization: analysis/visualization.md

--- a/src/qubx/control/__init__.py
+++ b/src/qubx/control/__init__.py
@@ -1,4 +1,4 @@
-from .decorator import action, collect_actions, collect_state, execute_decorated_action, state
+from .decorator import action, collect_actions, collect_state, collect_state_schema, execute_decorated_action, state
 from .interfaces import IControllable
 from .server import ControlServer
 from .types import ActionDef, ActionParam, ActionResult
@@ -13,5 +13,6 @@ __all__ = [
     "state",
     "collect_actions",
     "collect_state",
+    "collect_state_schema",
     "execute_decorated_action",
 ]

--- a/src/qubx/control/builtin.py
+++ b/src/qubx/control/builtin.py
@@ -11,7 +11,7 @@ from qubx.core.basics import Instrument, MarketType, Signal
 from qubx.core.lookups import lookup
 from qubx.utils.time import to_timedelta, to_timestamp
 
-from .decorator import collect_state
+from .decorator import collect_state, collect_state_schema
 from .types import ActionDef, ActionParam, ActionResult
 
 if TYPE_CHECKING:
@@ -512,6 +512,11 @@ def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
     )
 
 
+def _get_state_schema(ctx: IStrategyContext, **kwargs) -> ActionResult:
+    schema = collect_state_schema(ctx.strategy)
+    return ActionResult(status="ok", data={"fields": schema})
+
+
 # --- Trading actions ---
 
 
@@ -761,6 +766,10 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
     "get_health": (
         ActionDef(name="get_health", description="Get health metrics: connectivity, queue size, data latencies", category="diagnostics", read_only=True),
         _get_health,
+    ),
+    "get_state_schema": (
+        ActionDef(name="get_state_schema", description="Get descriptions of custom state fields returned by get_state", category="diagnostics", read_only=True),
+        _get_state_schema,
     ),
     "get_total_capital": (
         ActionDef(name="get_total_capital", description="Get total capital across all exchanges", category="diagnostics", read_only=True),

--- a/src/qubx/control/decorator.py
+++ b/src/qubx/control/decorator.py
@@ -118,6 +118,19 @@ def collect_state(strategy: Any, ctx: Any) -> dict:
     return result
 
 
+def collect_state_schema(strategy: Any) -> dict[str, str]:
+    """Scan a strategy instance for @state-decorated methods and return their descriptions."""
+    schema = {}
+    for attr_name in dir(strategy):
+        try:
+            attr = getattr(strategy, attr_name, None)
+        except Exception:
+            continue
+        if callable(attr) and hasattr(attr, "__state__"):
+            schema[attr.__name__] = attr.__state__
+    return schema
+
+
 def collect_actions(strategy: Any) -> list[ActionDef]:
     """Scan a strategy instance for @action-decorated methods."""
     actions = []

--- a/tests/qubx/control/test_builtin.py
+++ b/tests/qubx/control/test_builtin.py
@@ -241,9 +241,9 @@ class TestBuiltinRegistry:
     def test_read_only_actions_are_marked(self):
         read_only = {
             "get_universe", "get_positions", "get_balances", "get_orders", "get_quote",
-            "get_ohlc", "get_state", "get_health", "get_total_capital", "get_leverages",
-            "get_subscriptions", "get_available_instruments", "get_instrument_details",
-            "get_top_instruments",
+            "get_ohlc", "get_state", "get_health", "get_state_schema", "get_total_capital",
+            "get_leverages", "get_subscriptions", "get_available_instruments",
+            "get_instrument_details", "get_top_instruments",
         }
         for name in read_only:
             action_def, _ = BUILTIN_ACTIONS[name]
@@ -259,5 +259,4 @@ class TestBuiltinRegistry:
             assert action_def.dangerous is True, f"{name} should be dangerous"
 
     def test_expected_action_count(self):
-        # 4 universe + 3 discovery + 7 diagnostics + 7 trading = 21... now 24
-        assert len(BUILTIN_ACTIONS) == 24
+        assert len(BUILTIN_ACTIONS) == 25

--- a/tests/qubx/control/test_decorator.py
+++ b/tests/qubx/control/test_decorator.py
@@ -1,5 +1,12 @@
 
-from qubx.control.decorator import action, collect_actions, collect_state, execute_decorated_action, state
+from qubx.control.decorator import (
+    action,
+    collect_actions,
+    collect_state,
+    collect_state_schema,
+    execute_decorated_action,
+    state,
+)
 from qubx.control.types import ActionDef, ActionResult
 
 
@@ -209,3 +216,19 @@ class TestStateDecorator:
         actions = collect_actions(s)
         assert any(a.name == "get_params" for a in actions)
         assert not any(a.name == "regime" for a in actions)
+
+    def test_collect_state_schema(self):
+        class S:
+            @state(description="Current regime")
+            def regime(self, ctx):
+                return "trending"
+
+            @state(description="Score metric")
+            def score(self, ctx):
+                return 42
+
+        s = S()
+        schema = collect_state_schema(s)
+        assert schema["regime"] == "Current regime"
+        assert schema["score"] == "Score metric"
+        assert len(schema) == 2


### PR DESCRIPTION
## Summary
- **`get_state_schema` action**: returns descriptions of all `@state`-decorated methods so LLM agents can learn what custom state fields mean
- **Control protocol docs**: new `docs/trading/control-protocol.md` covering all built-in actions, `@action`/`@state` decorators, thread safety, LLM tool compatibility

## Test plan
- [x] 74 unit + e2e tests passing
- [x] New test for `collect_state_schema`