### PR TITLE
feat: is_rate_limited flag, get_state_schema, control docs

### DIFF
--- a/src/qubx/control/builtin.py
+++ b/src/qubx/control/builtin.py
@@ -206,7 +206,7 @@ def _rank_by_turnover(
             return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "turnover"})
 
         symbols = [i.symbol for i in instruments]
-        candles = reader.read(symbols, f"ohlc({timeframe})", start=str(start), stop=str(stop)).to_pd(True)
+        candles = reader.read(symbols, f"ohlc({timeframe})", start=str(start), stop=str(stop), skip_rate_limited=True).to_pd(True)
 
         if candles is None or candles.empty:
             return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "turnover"})
@@ -232,7 +232,7 @@ def _rank_by_market_cap(
 
     try:
         coins = reader.get_data_id()
-        raw = reader.read(coins, "fundamental", start=str(start), stop=str(stop)).to_pd(True)
+        raw = reader.read(coins, "fundamental", start=str(start), stop=str(stop), skip_rate_limited=True).to_pd(True)
 
         if raw is None or raw.empty:
             return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "market_cap"})
@@ -266,7 +266,7 @@ def _rank_by_funding(
             return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "funding"})
 
         symbols = [i.symbol for i in instruments]
-        fp = reader.read(symbols, "funding_payment", start=str(start), stop=str(stop)).to_pd(True)
+        fp = reader.read(symbols, "funding_payment", start=str(start), stop=str(stop), skip_rate_limited=True).to_pd(True)
 
         if fp is None or fp.empty:
             return ActionResult(status="ok", data={"instruments": [], "count": 0, "sort_by": "funding"})

--- a/src/qubx/data/storage.py
+++ b/src/qubx/data/storage.py
@@ -48,6 +48,8 @@ class IDataTransformer:
 
 
 class IReader:
+    is_rate_limited: bool = False
+
     def read(
         self,
         data_id: str | list[str],

--- a/src/qubx/data/storages/ccxt.py
+++ b/src/qubx/data/storages/ccxt.py
@@ -191,6 +191,8 @@ class CcxtReader(IReader):
     ``close()`` on a reader; call ``CcxtStorage.close()`` instead.
     """
 
+    is_rate_limited: bool = True
+
     def __init__(self, exchange: str, market: str, storage_ref: "CcxtStorage") -> None:
         self._exchange = exchange.upper()
         self._market = market.upper()
@@ -246,12 +248,6 @@ class CcxtReader(IReader):
 
         if isinstance(data_id, (list, tuple, set)):
             symbols: list[str] = self.get_data_id(dt) if not data_id else list(data_id)
-            if len(symbols) > 20:
-                logger.warning(
-                    f"[CCXT] Skipping bulk read of {len(symbols)} symbols for {dtype_str} on {self._exchange} — "
-                    f"ccxt is too slow for bulk queries. Use a database storage (e.g., qdb) instead."
-                )
-                return RawMultiData([])
             raw_list: list[RawData] = self._storage._fetch_multi(
                 self._exchange, self._market, symbols, dt, params, dtype_str, start, stop
             )

--- a/src/qubx/data/storages/multi.py
+++ b/src/qubx/data/storages/multi.py
@@ -74,6 +74,13 @@ class MultiReader(IReader):
         self._tolerance = tolerance
         self._keep = keep
 
+    def _get_readers(self, **kwargs) -> list[IReader]:
+        """Return readers to use, optionally filtering out rate-limited ones."""
+        skip_rate_limited = kwargs.pop("skip_rate_limited", False)
+        if skip_rate_limited:
+            return [r for r in self._readers if not r.is_rate_limited]
+        return self._readers
+
     def read(
         self,
         data_id: str | list[str],
@@ -83,9 +90,10 @@ class MultiReader(IReader):
         chunksize: int = 0,
         **kwargs,
     ) -> Iterator | Any:
+        readers = self._get_readers(**kwargs)
         if isinstance(data_id, list):
-            return self._read_multi(data_id, dtype, start, stop, chunksize, **kwargs)
-        return self._read_single(data_id, dtype, start, stop, chunksize, **kwargs)
+            return self._read_multi(data_id, dtype, start, stop, chunksize, readers=readers, **kwargs)
+        return self._read_single(data_id, dtype, start, stop, chunksize, readers=readers, **kwargs)
 
     def _read_single(
         self,
@@ -94,9 +102,10 @@ class MultiReader(IReader):
         start: str | None,
         stop: str | None,
         chunksize: int,
+        readers: list[IReader] | None = None,
         **kwargs,
     ) -> Any:
-        batches, time_idx, schema, dtype_ref = self._collect_single(data_id, dtype, start, stop, **kwargs)
+        batches, time_idx, schema, dtype_ref = self._collect_single(data_id, dtype, start, stop, readers=readers, **kwargs)
 
         if not batches:
             raise ValueError(f"No data for '{data_id}' ({dtype}) in any of the {len(self._readers)} readers")
@@ -115,6 +124,7 @@ class MultiReader(IReader):
         dtype: DataType | str,
         start: str | None,
         stop: str | None,
+        readers: list[IReader] | None = None,
         **kwargs,
     ) -> tuple[list[pa.RecordBatch], int, pa.Schema | None, DataType | str]:
         batches: list[pa.RecordBatch] = []
@@ -122,7 +132,7 @@ class MultiReader(IReader):
         schema: pa.Schema | None = None
         dtype_ref: DataType | str = dtype
 
-        for reader in self._readers:
+        for reader in (readers if readers is not None else self._readers):
             try:
                 result = reader.read(data_id, dtype, start, stop, chunksize=0, **kwargs)
                 if result is None:
@@ -156,6 +166,7 @@ class MultiReader(IReader):
         start: str | None,
         stop: str | None,
         chunksize: int,
+        readers: list[IReader] | None = None,
         **kwargs,
     ) -> Any:
         batches_per_id: dict[str, list[pa.RecordBatch]] = {}
@@ -163,7 +174,7 @@ class MultiReader(IReader):
         schema: pa.Schema | None = None
         dtype_ref: DataType | str = dtype
 
-        for reader in self._readers:
+        for reader in (readers if readers is not None else self._readers):
             try:
                 result = reader.read(data_ids, dtype, start, stop, chunksize=0, **kwargs)
                 if result is None:


### PR DESCRIPTION
## Summary
- **`IReader.is_rate_limited`** flag: storages self-declare whether they're rate-limited (ccxt, lighter = True). `MultiReader` supports `skip_rate_limited=True` kwarg to filter these out for bulk queries. Ranking actions use this instead of the blunt >20 symbol guard.
- **`get_state_schema` action**: returns descriptions of `@state`-decorated methods for LLM agent context
- **Control protocol docs**: `docs/trading/control-protocol.md` with full action reference, decorator guide, thread safety, LLM tool compatibility

## Test plan
- [x] 1257 passed, 0 failures (`just test`)
- [x] Merged latest dev