### PR TITLE
feat: shared exchange rate limiting engine

### DIFF
--- a/src/qubx/connectors/ccxt/connection_manager.py
+++ b/src/qubx/connectors/ccxt/connection_manager.py
@@ -12,7 +12,16 @@ from asyncio.exceptions import CancelledError
 from collections import defaultdict
 from typing import Awaitable, Callable
 
-from ccxt import BadSymbol, ExchangeClosedByUser, ExchangeError, ExchangeNotAvailable, NetworkError, UnsubscribeError
+from ccxt import (
+    BadSymbol,
+    DDoSProtection,
+    ExchangeClosedByUser,
+    ExchangeError,
+    ExchangeNotAvailable,
+    NetworkError,
+    RateLimitExceeded,
+    UnsubscribeError,
+)
 from ccxt.async_support.base.ws.client import Client as _WsClient
 from ccxt.pro import Exchange
 
@@ -144,6 +153,18 @@ class ConnectionManager:
                     f"<yellow>{self._exchange_id}</yellow> UnsubscribeError in {stream_name} (expected during restart): {e}"
                 )
                 await asyncio.sleep(1)
+                continue
+            except (RateLimitExceeded, DDoSProtection) as e:
+                # Rate limit hit — report to rate limiter if available and backoff
+                logger.warning(
+                    f"<yellow>{self._exchange_id}</yellow> Rate limited in {stream_name}: {e}"
+                )
+                if hasattr(self, "_exchange_manager") and self._exchange_manager.rate_limiter:
+                    self._exchange_manager.rate_limiter.report_limit_hit(
+                        pool_name="ccxt_rest", reason=f"{e.__class__.__name__}: {e}"
+                    )
+                await asyncio.sleep(min(2 ** (n_retry + 1), 60))
+                n_retry += 1
                 continue
             except (NetworkError, ExchangeError, ExchangeNotAvailable) as e:
                 # Network/exchange errors - retry after short delay

--- a/src/qubx/connectors/ccxt/exchange_manager.py
+++ b/src/qubx/connectors/ccxt/exchange_manager.py
@@ -254,6 +254,45 @@ class ExchangeManager:
     # === Exchange Property Access ===
     # Explicit property to access underlying CCXT exchange
 
+    # === Rate Limiting ===
+
+    def attach_rate_limiter(self, rate_limiter) -> None:
+        """Attach an ExchangeRateLimiter to this exchange manager.
+
+        Disables CCXT's built-in rate limiting and replaces the throttle
+        method with our rate limiter. Survives exchange recreation.
+
+        Args:
+            rate_limiter: ExchangeRateLimiter instance
+        """
+        self._rate_limiter = rate_limiter
+        self._apply_rate_limiter_to_exchange(self._exchange)
+        self.register_recreation_callback(lambda: self._apply_rate_limiter_to_exchange(self._exchange))
+        logger.info(f"Rate limiter attached to {self._exchange_name}")
+
+    def _apply_rate_limiter_to_exchange(self, exchange: cxp.Exchange) -> None:
+        """Disable CCXT's built-in rate limiter and install our throttle override."""
+        rate_limiter = getattr(self, "_rate_limiter", None)
+        if rate_limiter is None:
+            return
+
+        exchange.enableRateLimit = False
+
+        # Override the throttle method to use our rate limiter
+        # CCXT calls self.throttle(cost) in fetch2() before every REST request
+        # cost comes from calculateRateLimiterCost() which uses per-endpoint weights
+        async def _rate_limit_throttle(cost=None):
+            if cost is None:
+                cost = 1.0
+            await rate_limiter.acquire("ccxt_rest", weight_override=float(cost))
+
+        exchange.throttle = _rate_limit_throttle
+
+    @property
+    def rate_limiter(self):
+        """Access the attached rate limiter (if any)."""
+        return getattr(self, "_rate_limiter", None)
+
     @property
     def exchange(self) -> cxp.Exchange:
         """Access to the underlying CCXT exchange instance.

--- a/src/qubx/connectors/ccxt/factory.py
+++ b/src/qubx/connectors/ccxt/factory.py
@@ -129,6 +129,11 @@ def get_ccxt_exchange_manager(
         check_interval_seconds=check_interval_seconds,
     )
 
+    # Attach rate limiter if provided in kwargs
+    rate_limiter = kwargs.pop("rate_limiter", None)
+    if rate_limiter is not None:
+        manager.attach_rate_limiter(rate_limiter)
+
     _exchange_manager_cache[cache_key] = manager
     return manager
 

--- a/src/qubx/connectors/ccxt/rate_limits.py
+++ b/src/qubx/connectors/ccxt/rate_limits.py
@@ -1,0 +1,277 @@
+"""
+CCXT exchange rate limit configurations.
+
+Provides default rate limit configs per exchange, differentiated by market type
+(spot vs futures). Also includes response header parsers for syncing modeled
+state with exchange-reported usage.
+
+References:
+- Binance: https://binance-docs.github.io/apidocs/spot/en/#limits
+- Binance Futures: https://binance-docs.github.io/apidocs/futures/en/#limits
+- OKX: https://www.okx.com/docs-v5/en/#overview-rate-limit
+- Kraken: https://docs.kraken.com/api/docs/guides/rate-limits
+- Bybit: https://bybit-exchange.github.io/docs/v5/rate-limit
+"""
+
+from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, PoolConfig
+
+
+def create_ccxt_rate_limit_config(exchange_name: str, ccxt_exchange=None) -> ExchangeRateLimitConfig:
+    """Create rate limit config for a CCXT exchange.
+
+    Handles exchange.market_type differentiation (spot vs futures).
+
+    Args:
+        exchange_name: Exchange name (e.g., "binance", "binance.um", "kraken")
+        ccxt_exchange: Optional CCXT exchange instance for auto-detection
+    """
+    name = exchange_name.lower()
+    base = name.split(".")[0]
+
+    if base in ("binance", "binanceusdm", "binancecoinm"):
+        return _binance_config(name)
+    elif base == "okx":
+        return _okx_config()
+    elif base == "bybit":
+        return _bybit_config()
+    elif base in ("kraken", "krakenfutures"):
+        return _kraken_config(name)
+    else:
+        return _default_config(exchange_name, ccxt_exchange)
+
+
+# === Binance ===
+
+
+def _binance_config(exchange_name: str) -> ExchangeRateLimitConfig:
+    """Binance rate limits differentiated by market type.
+
+    Spot:
+    - IP weight: 6000/min (recently increased from 1200)
+    - UID weight: 180,000/min
+    - Orders: 10/sec, 200,000/day per account
+
+    USDM Futures (binance.um):
+    - IP weight: 2400/min
+    - Orders: 300/10sec per account
+
+    COIN-M Futures (binance.cm):
+    - IP weight: 6000/min
+    - Orders: 300/10sec per account
+
+    Headers: X-MBX-USED-WEIGHT-1M, X-MBX-ORDER-COUNT-1S, X-MBX-ORDER-COUNT-1D
+    """
+    if exchange_name in ("binance.um", "binanceusdm"):
+        # USDM Futures
+        return ExchangeRateLimitConfig(
+            pools={
+                "ccxt_rest": PoolConfig("ccxt_rest", "ip", 2400, 40.0, cooldown=30.0),
+                "orders": PoolConfig("orders", "account", 300, 30.0, cooldown=10.0),
+            },
+            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            default_costs=EndpointCosts([("ccxt_rest", 1)]),
+        )
+    elif exchange_name in ("binance.cm", "binancecoinm"):
+        # COIN-M Futures
+        return ExchangeRateLimitConfig(
+            pools={
+                "ccxt_rest": PoolConfig("ccxt_rest", "ip", 6000, 100.0, cooldown=30.0),
+                "orders": PoolConfig("orders", "account", 300, 30.0, cooldown=10.0),
+            },
+            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            default_costs=EndpointCosts([("ccxt_rest", 1)]),
+        )
+    else:
+        # Spot
+        return ExchangeRateLimitConfig(
+            pools={
+                "ccxt_rest": PoolConfig("ccxt_rest", "ip", 6000, 100.0, cooldown=30.0),
+                "orders": PoolConfig("orders", "account", 10, 10.0, cooldown=10.0),
+            },
+            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            default_costs=EndpointCosts([("ccxt_rest", 1)]),
+        )
+
+
+# === OKX ===
+
+
+def _okx_config() -> ExchangeRateLimitConfig:
+    """OKX rate limits (unified across spot/futures).
+
+    - REST: varies heavily by endpoint (2-60 req/2sec per endpoint)
+    - Trade endpoints: 60/2sec per account
+    - Market data: 20/2sec per IP
+
+    Headers: x-ratelimit-remaining, x-ratelimit-limit, x-ratelimit-reset
+    """
+    return ExchangeRateLimitConfig(
+        pools={
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 20, 10.0, cooldown=15.0),
+            "orders": PoolConfig("orders", "account", 60, 30.0, cooldown=10.0),
+        },
+        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        default_costs=EndpointCosts([("ccxt_rest", 1)]),
+    )
+
+
+# === Bybit ===
+
+
+def _bybit_config() -> ExchangeRateLimitConfig:
+    """Bybit rate limits (unified v5 API).
+
+    - REST: 10 req/sec per endpoint per IP (varies by endpoint)
+    - Orders: 10/sec per account
+    - Rate limit info in response body: rate_limit_status, rate_limit_reset_ms
+    """
+    return ExchangeRateLimitConfig(
+        pools={
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 120, 24.0, cooldown=15.0),
+            "orders": PoolConfig("orders", "account", 10, 10.0, cooldown=10.0),
+        },
+        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        default_costs=EndpointCosts([("ccxt_rest", 1)]),
+    )
+
+
+# === Kraken ===
+
+
+def _kraken_config(exchange_name: str) -> ExchangeRateLimitConfig:
+    """Kraken rate limits.
+
+    Kraken Spot uses a unique "call counter" system:
+    - Each API call adds to a counter (1-6 depending on endpoint)
+    - Counter decays at a fixed rate based on verification level
+    - Intermediate verified: max counter 20, decay 0.33/sec
+    - Pro verified: max counter 20, decay 1.0/sec
+
+    Per-endpoint costs from CCXT:
+    - Public: 1.0-1.2 per call
+    - Private: 0-6 per call (orders=0, balance=3, ledgers=6)
+    - Orders: cost 0 (separate matching engine limit)
+
+    Kraken Futures:
+    - Simple: ~1.67 req/sec (600ms rateLimit)
+    - No per-endpoint weights documented
+
+    Matching engine (order) limits (separate from REST):
+    - Spot: based on tier, typically 60/min for intermediate
+    - Futures: separate per-instrument limits
+    """
+    if exchange_name in ("krakenfutures",):
+        return ExchangeRateLimitConfig(
+            pools={
+                "ccxt_rest": PoolConfig("ccxt_rest", "ip", 10, 1.67, cooldown=15.0),
+            },
+            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            default_costs=EndpointCosts([("ccxt_rest", 1)]),
+        )
+
+    # Kraken Spot — counter-decay system maps to token bucket:
+    # capacity=20 (max counter), refill=0.33/sec (intermediate) or 1.0/sec (pro)
+    # Using intermediate as default — can be overridden via config
+    return ExchangeRateLimitConfig(
+        pools={
+            # Main REST counter (per IP, decays at 0.33/sec for intermediate tier)
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 20, 0.33, cooldown=30.0),
+            # Order matching engine (separate limit per account)
+            "orders": PoolConfig("orders", "account", 60, 1.0, cooldown=15.0),
+        },
+        endpoint_map={
+            # CCXT defines per-endpoint costs for Kraken — these are the weights
+            # that get passed through CCXT's calculateRateLimiterCost → our throttle override.
+            # Key costs: Balance=3, ClosedOrders=3, TradesHistory=6, Ledgers=6
+            # Orders have cost=0 in the REST counter (separate matching engine limit)
+            "ccxt_rest": EndpointCosts([("ccxt_rest", 1)]),
+        },
+        default_costs=EndpointCosts([("ccxt_rest", 1)]),
+    )
+
+
+# === Default ===
+
+
+def _default_config(exchange_name: str, ccxt_exchange=None) -> ExchangeRateLimitConfig:
+    """Default conservative config for unknown exchanges.
+
+    Derives from CCXT's rateLimit property if exchange instance provided.
+    """
+    rate_limit_ms = 50  # default: 20 req/sec
+    if ccxt_exchange and hasattr(ccxt_exchange, "rateLimit"):
+        rate_limit_ms = ccxt_exchange.rateLimit or 50
+
+    rps = 1000.0 / rate_limit_ms
+    capacity = rps * 60  # 1 minute capacity
+
+    return ExchangeRateLimitConfig(
+        pools={
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", capacity, rps, cooldown=15.0),
+        },
+        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        default_costs=EndpointCosts([("ccxt_rest", 1)]),
+    )
+
+
+# === Response Header Parsers ===
+
+
+def parse_binance_headers(headers: dict, rate_limiter) -> None:
+    """Parse Binance rate limit headers and sync with rate limiter.
+
+    Binance returns:
+    - X-MBX-USED-WEIGHT-1M: weight used in current 1-minute window
+    - X-MBX-ORDER-COUNT-1S: orders placed in current 1-second window
+    - X-MBX-ORDER-COUNT-1D: orders placed in current day
+    """
+    if rate_limiter is None:
+        return
+
+    # Try both casing conventions (CCXT normalizes to lowercase)
+    used_weight = headers.get("x-mbx-used-weight-1m") or headers.get("X-MBX-USED-WEIGHT-1M")
+    if used_weight:
+        try:
+            rate_limiter.sync_from_exchange("ccxt_rest", used=int(used_weight))
+        except Exception:
+            pass
+
+    order_count = headers.get("x-mbx-order-count-1s") or headers.get("X-MBX-ORDER-COUNT-1S")
+    if order_count and "orders" in rate_limiter.config.pools:
+        try:
+            rate_limiter.sync_from_exchange("orders", used=int(order_count))
+        except Exception:
+            pass
+
+
+def parse_okx_headers(headers: dict, rate_limiter) -> None:
+    """Parse OKX rate limit headers and sync with rate limiter.
+
+    OKX returns:
+    - x-ratelimit-remaining: remaining requests for this endpoint
+    - x-ratelimit-limit: total limit for this endpoint
+    - x-ratelimit-reset: timestamp when limit resets (ms)
+    """
+    if rate_limiter is None:
+        return
+
+    remaining = headers.get("x-ratelimit-remaining") or headers.get("X-RateLimit-Remaining")
+    if remaining:
+        try:
+            rate_limiter.sync_from_exchange("ccxt_rest", remaining=float(remaining))
+        except Exception:
+            pass
+
+
+HEADER_PARSERS = {
+    "binance": parse_binance_headers,
+    "binanceusdm": parse_binance_headers,
+    "binancecoinm": parse_binance_headers,
+    "okx": parse_okx_headers,
+}
+
+
+def get_header_parser(exchange_name: str):
+    """Get the response header parser for an exchange."""
+    name = exchange_name.lower().split(".")[0]
+    return HEADER_PARSERS.get(name)

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -159,6 +159,8 @@ class StrategyContext(IStrategyContext):
         data_throttler: "InstrumentThrottler | None" = None,
         state_persistence: IStatePersistence | None = None,
         state_snapshot_interval: str | None = None,
+        rate_limit_backend: Any | None = None,
+        rate_limiting_config: Any | None = None,
     ) -> None:
         self.account = account
         self.strategy = self.__instantiate_strategy(strategy, config)
@@ -190,6 +192,8 @@ class StrategyContext(IStrategyContext):
         self.health = self._health_monitor
         self._state_persistence = state_persistence or DummyStatePersistence()
         self._state_snapshot_interval = state_snapshot_interval
+        self._rate_limit_backend = rate_limit_backend
+        self._rate_limiting_config = rate_limiting_config
 
         # Initialize shutdown handling
         self._stop_lock = Lock()
@@ -307,6 +311,16 @@ class StrategyContext(IStrategyContext):
 
         # Configure periodic state snapshot persistence
         self._processing_manager.configure_state_snapshot(self._state_snapshot_interval)
+
+        # Collect rate limiters from data providers
+        for dp in self._data_providers:
+            rl = dp.rate_limiter
+            if rl is not None:
+                self.rate_limiters[rl.exchange] = rl
+
+        # Configure periodic rate limit metric emission
+        _rl_metrics_interval = self._rate_limiting_config.metrics_interval if self._rate_limiting_config else None
+        self._processing_manager.configure_rate_limit_metrics(_rl_metrics_interval)
 
         if self.is_simulation and isinstance(self.account, CompositeAccountProcessor):
             # Auto-assign simulation transfer manager
@@ -572,6 +586,22 @@ class StrategyContext(IStrategyContext):
     @property
     def persistence(self) -> IStatePersistence:
         return self._state_persistence
+
+    @property
+    def rate_limiters(self) -> dict:
+        """Registry of ExchangeRateLimiter instances by exchange name.
+
+        Connectors register their rate limiters here at startup.
+        Used by the processing mixin for periodic metric emission.
+        """
+        if not hasattr(self, "_rate_limiters"):
+            self._rate_limiters: dict = {}
+        return self._rate_limiters
+
+    @property
+    def rate_limit_backend(self):
+        """Rate limit storage backend (InMemoryBackend or RedisBackend)."""
+        return self._rate_limit_backend
 
     # IAccountViewer delegation
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -831,6 +831,11 @@ class IDataProvider:
         """
         raise NotImplementedError("exchange() is not implemented")
 
+    @property
+    def rate_limiter(self):
+        """Return the ExchangeRateLimiter for this provider, if any."""
+        return None
+
     def is_connected(self) -> bool:
         """
         Check if the data provider is currently connected to the exchange.

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -293,6 +293,51 @@ class ProcessingManager(IProcessingManager):
                 self._scheduler.schedule_event(cron_schedule, "state_snapshot")
                 logger.info(f"State snapshot enabled with interval: {interval}")
 
+    def configure_rate_limit_metrics(self, interval: str | None) -> None:
+        """
+        Configure periodic rate limit metric emission.
+
+        Emits pool utilization, gate state, hit counts etc. for all registered
+        rate limiters via ctx.emitter.emit(). Only active in live mode.
+
+        Args:
+            interval: Emission interval (e.g., "60s", "1m"). None to disable.
+        """
+        self._scheduler.unschedule_event("rate_limit_metrics")
+
+        if interval is not None and not self._is_simulation:
+            cron_schedule = interval_to_cron(interval)
+            self._scheduler.schedule_event(cron_schedule, "rate_limit_metrics")
+            self._custom_scheduled_methods["rate_limit_metrics"] = self._emit_rate_limit_metrics
+            logger.info(f"Rate limit metrics emission enabled with interval: {interval}")
+
+    def _emit_rate_limit_metrics(self, ctx) -> None:
+        """Emit rate limit metrics for all registered rate limiters."""
+        import asyncio
+
+        if ctx.emitter is None:
+            return
+
+        for exchange_name, rate_limiter in ctx.rate_limiters.items():
+            try:
+                # collect_metrics is async but we're in sync context
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    future = asyncio.ensure_future(rate_limiter.collect_metrics())
+                    future.add_done_callback(
+                        lambda f, _ctx=ctx: self._do_emit_metrics(_ctx, f.result()) if not f.cancelled() else None
+                    )
+                else:
+                    metrics = loop.run_until_complete(rate_limiter.collect_metrics())
+                    self._do_emit_metrics(ctx, metrics)
+            except Exception as e:
+                logger.error(f"Failed to collect rate limit metrics for {exchange_name}: {e}")
+
+    @staticmethod
+    def _do_emit_metrics(ctx, metrics: list[dict]) -> None:
+        for m in metrics:
+            ctx.emitter.emit(m["name"], m["value"], m["tags"])
+
     def process_data(self, instrument: Instrument, d_type: str, data: Any, is_historical: bool) -> bool:
         should_stop = self.__process_data(instrument, d_type, data, is_historical)
         if not is_historical:

--- a/src/qubx/rate_limiting/__init__.py
+++ b/src/qubx/rate_limiting/__init__.py
@@ -1,0 +1,32 @@
+"""
+Exchange-aware rate limiting engine.
+
+Provides a shared, multi-pool rate limiting system that connectors use
+to comply with exchange API limits. Supports per-IP and per-account scoping,
+gate mechanism for cooldowns, and optional Redis backend for cross-bot coordination.
+
+Usage:
+    >>> from qubx.rate_limiting import ExchangeRateLimiter, ExchangeRateLimitConfig, PoolConfig, EndpointCosts
+    >>>
+    >>> config = ExchangeRateLimitConfig(
+    ...     pools={"rest": PoolConfig("rest", "ip", 1200, 20.0)},
+    ...     endpoint_map={"fetch_ohlcv": EndpointCosts([("rest", 5)])},
+    ...     default_costs=EndpointCosts([("rest", 1)]),
+    ... )
+    >>> limiter = ExchangeRateLimiter("binance", config)
+    >>> await limiter.acquire("fetch_ohlcv")
+"""
+
+from qubx.rate_limiting.backend import IRateLimitBackend, InMemoryBackend
+from qubx.rate_limiting.config import EndpointCosts, ExchangeRateLimitConfig, PoolConfig
+from qubx.rate_limiting.engine import ExchangeRateLimiter, RateLimitGateTimeout
+
+__all__ = [
+    "EndpointCosts",
+    "ExchangeRateLimitConfig",
+    "ExchangeRateLimiter",
+    "IRateLimitBackend",
+    "InMemoryBackend",
+    "PoolConfig",
+    "RateLimitGateTimeout",
+]

--- a/src/qubx/rate_limiting/backend.py
+++ b/src/qubx/rate_limiting/backend.py
@@ -1,0 +1,83 @@
+"""
+Rate limit storage backends.
+
+Provides the interface and in-memory implementation for token bucket state.
+Redis backend can be added later for cross-bot coordination.
+"""
+
+import time
+from abc import ABC, abstractmethod
+
+from qubx.utils.rate_limiter import TokenBucketRateLimiter
+
+
+class IRateLimitBackend(ABC):
+    """Interface for rate limit token storage.
+
+    Backends manage token bucket state — either in-process (InMemoryBackend)
+    or distributed (RedisBackend for cross-bot coordination).
+    """
+
+    @abstractmethod
+    async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
+        """Acquire tokens from a bucket. Blocks until available.
+
+        Args:
+            key: Unique bucket identifier (e.g., "ratelimit:binance:rest:ip_1.2.3.4")
+            weight: Tokens to consume
+            capacity: Bucket capacity (used to create bucket on first access)
+            refill_rate: Tokens per second (used to create bucket on first access)
+
+        Returns:
+            Time spent waiting in seconds (0.0 if immediate)
+        """
+
+    @abstractmethod
+    async def get_remaining(self, key: str) -> float | None:
+        """Get remaining tokens for a key (non-blocking).
+
+        Returns:
+            Token count, or None if key doesn't exist
+        """
+
+    @abstractmethod
+    async def set_remaining(self, key: str, remaining: float) -> None:
+        """Force-set remaining tokens (for syncing with exchange-reported state).
+
+        Used when exchange headers/responses tell us the actual remaining budget,
+        correcting any drift in our model.
+        """
+
+
+class InMemoryBackend(IRateLimitBackend):
+    """In-process token bucket backend.
+
+    Each key gets its own TokenBucketRateLimiter instance.
+    Suitable for single-bot usage without cross-bot coordination.
+    """
+
+    def __init__(self):
+        self._limiters: dict[str, TokenBucketRateLimiter] = {}
+
+    def _get_or_create(self, key: str, capacity: float, refill_rate: float) -> TokenBucketRateLimiter:
+        if key not in self._limiters:
+            self._limiters[key] = TokenBucketRateLimiter(capacity, refill_rate, name=key)
+        return self._limiters[key]
+
+    async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
+        limiter = self._get_or_create(key, capacity, refill_rate)
+        start = time.monotonic()
+        await limiter.acquire(weight)
+        return time.monotonic() - start
+
+    async def get_remaining(self, key: str) -> float | None:
+        limiter = self._limiters.get(key)
+        if limiter is None:
+            return None
+        return limiter.get_available_tokens()
+
+    async def set_remaining(self, key: str, remaining: float) -> None:
+        limiter = self._limiters.get(key)
+        if limiter is not None:
+            limiter._tokens = remaining
+            limiter._last_refill = time.monotonic()

--- a/src/qubx/rate_limiting/config.py
+++ b/src/qubx/rate_limiting/config.py
@@ -1,0 +1,69 @@
+"""
+Rate limiting configuration data classes.
+
+Defines the declarative configuration that each exchange connector provides
+to describe its rate limit pools, endpoint weights, and scoping rules.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PoolConfig:
+    """Configuration for a single rate limit pool.
+
+    A pool represents one independent rate limit enforced by the exchange.
+    Exchanges typically have multiple pools (e.g., request weight + order count).
+
+    Args:
+        name: Pool identifier (e.g., "request_weight", "orders", "sendtx")
+        scope: What the limit is scoped to: "ip", "account", "address", or "local"
+        capacity: Maximum tokens in the bucket
+        refill_rate: Tokens replenished per second (0 for quota pools)
+        pool_type: "rate" for time-based refill, "quota" for externally-managed
+        cooldown: Seconds to close gate when rate limit is hit
+    """
+
+    name: str
+    scope: str
+    capacity: float
+    refill_rate: float
+    pool_type: str = "rate"
+    cooldown: float = 15.0
+
+
+@dataclass
+class EndpointCosts:
+    """Cost of an endpoint across multiple pools.
+
+    Each tuple is (pool_name, weight) — the endpoint consumes `weight` tokens
+    from the named pool. A single request can consume from multiple pools.
+
+    Example:
+        >>> # Binance create_order: 1 weight from request pool + 1 from order pool
+        >>> EndpointCosts([("request_weight", 1), ("orders", 1)])
+    """
+
+    costs: list[tuple[str, float]]
+
+
+@dataclass
+class ExchangeRateLimitConfig:
+    """Complete rate limit configuration for an exchange.
+
+    Connectors provide this declaratively. The ExchangeRateLimiter uses it
+    to create pools and map endpoint calls to the correct pools/weights.
+
+    Args:
+        pools: Named pool configurations
+        endpoint_map: Maps endpoint names to their costs across pools
+        default_costs: Fallback costs for unmapped endpoints
+        gate_max_wait: Max seconds to wait for a closed gate before raising timeout
+        metrics_interval: Seconds between metric emissions (0 to disable)
+    """
+
+    pools: dict[str, PoolConfig] = field(default_factory=dict)
+    endpoint_map: dict[str, EndpointCosts] = field(default_factory=dict)
+    default_costs: EndpointCosts = field(default_factory=lambda: EndpointCosts([]))
+    gate_max_wait: float = 15.0
+    metrics_interval: float = 60.0

--- a/src/qubx/rate_limiting/engine.py
+++ b/src/qubx/rate_limiting/engine.py
@@ -1,0 +1,392 @@
+"""
+Exchange rate limiting engine.
+
+The central component that connectors interact with. Handles multi-pool
+token acquisition, gate mechanism for cooldowns, exchange state sync,
+and metric collection.
+"""
+
+import asyncio
+import time
+from typing import Any
+
+from qubx import logger
+
+from .backend import InMemoryBackend, IRateLimitBackend
+from .config import ExchangeRateLimitConfig, PoolConfig
+
+
+class RateLimitGateTimeout(Exception):
+    """Raised when acquire() times out waiting for a gate to reopen."""
+
+
+class ExchangeRateLimiter:
+    """Multi-pool rate limiting engine for exchange API calls.
+
+    Connectors create one instance per exchange, configured with pools and
+    endpoint mappings. The engine handles:
+    - Multi-key acquisition (wait until ALL pools have budget)
+    - Gate mechanism (pause requests on rate limit hits)
+    - Exchange state sync (calibrate model from response headers/WS events)
+    - Quota pools (externally-managed, no time-based refill)
+    - Metric collection for dashboarding
+
+    Usage:
+        >>> config = ExchangeRateLimitConfig(
+        ...     pools={"rest": PoolConfig("rest", "ip", 24000, 400.0)},
+        ...     endpoint_map={"fetch_candles": EndpointCosts([("rest", 50)])},
+        ...     default_costs=EndpointCosts([("rest", 300)]),
+        ... )
+        >>> limiter = ExchangeRateLimiter("lighter", config)
+        >>> await limiter.acquire("fetch_candles")
+    """
+
+    def __init__(
+        self,
+        exchange: str,
+        config: ExchangeRateLimitConfig,
+        backend: IRateLimitBackend | None = None,
+        scope_ids: dict[str, str] | None = None,
+    ):
+        """
+        Args:
+            exchange: Exchange name (e.g., "binance", "lighter")
+            config: Rate limit configuration with pools and endpoint mappings
+            backend: Storage backend (default: InMemoryBackend)
+            scope_ids: Maps scope type to identifier, e.g. {"ip": "1.2.3.4", "account": "abc123"}
+        """
+        self._exchange = exchange
+        self._config = config
+        self._backend = backend or InMemoryBackend()
+        self._scope_ids = scope_ids or {}
+
+        # Per-pool gates (asyncio.Event: set = open, clear = closed)
+        self._gates: dict[str, asyncio.Event] = {}
+        self._gate_tasks: dict[str, asyncio.Task] = {}
+        for pool_name in config.pools:
+            gate = asyncio.Event()
+            gate.set()
+            self._gates[pool_name] = gate
+
+        # Quota pools: externally-managed remaining count
+        self._quota_remaining: dict[str, float] = {}
+        for pool_name, pool in config.pools.items():
+            if pool.pool_type == "quota":
+                self._quota_remaining[pool_name] = pool.capacity
+
+        # Stats tracking
+        self._hits: dict[str, int] = {}
+        self._total_wait: dict[str, float] = {}
+        self._consumed: dict[str, float] = {}
+        self._last_metrics_time = time.monotonic()
+
+    @property
+    def exchange(self) -> str:
+        return self._exchange
+
+    @property
+    def config(self) -> ExchangeRateLimitConfig:
+        return self._config
+
+    def _key_for(self, pool: PoolConfig) -> str:
+        """Construct Redis/backend key for a pool based on its scope."""
+        scope_id = self._scope_ids.get(pool.scope, "local")
+        return f"ratelimit:{self._exchange}:{pool.name}:{scope_id}"
+
+    def update_scope_id(self, scope: str, new_id: str) -> None:
+        """Update scope identifier (e.g., when egress IP changes).
+
+        The old key's tokens will naturally expire. New requests use the new key.
+        """
+        old_id = self._scope_ids.get(scope)
+        if old_id != new_id:
+            logger.info(f"Rate limiter {self._exchange}: {scope} scope changed {old_id} → {new_id}")
+            self._scope_ids[scope] = new_id
+
+    async def acquire(self, endpoint: str, weight_override: float | None = None) -> None:
+        """Wait until all pools for this endpoint have sufficient budget.
+
+        This is the main entry point for connectors. Call before making any
+        exchange API request.
+
+        Args:
+            endpoint: Endpoint name matching endpoint_map keys
+            weight_override: Override the weight for the first (primary) pool.
+                Useful when CCXT computes dynamic costs (e.g., Binance depth limit tiers).
+
+        Raises:
+            RateLimitGateTimeout: If a gate doesn't reopen within gate_max_wait
+        """
+        endpoint_costs = self._config.endpoint_map.get(endpoint, self._config.default_costs)
+        if not endpoint_costs.costs:
+            return
+
+        for i, (pool_name, weight) in enumerate(endpoint_costs.costs):
+            pool = self._config.pools.get(pool_name)
+            if pool is None:
+                continue
+
+            actual_weight = weight_override if (weight_override is not None and i == 0) else weight
+
+            # Wait for gate to be open
+            gate = self._gates.get(pool_name)
+            if gate is not None and not gate.is_set():
+                try:
+                    await asyncio.wait_for(gate.wait(), timeout=self._config.gate_max_wait)
+                except asyncio.TimeoutError:
+                    raise RateLimitGateTimeout(
+                        f"{self._exchange}: gate for pool '{pool_name}' did not reopen "
+                        f"within {self._config.gate_max_wait:.0f}s"
+                    ) from None
+
+            # For quota pools, check remaining (no time-based refill)
+            if pool.pool_type == "quota":
+                remaining = self._quota_remaining.get(pool_name, 0)
+                if remaining <= 0:
+                    # Gate should already be closed, but double-check
+                    self._close_gate(pool_name, pool.cooldown, "quota depleted")
+                    gate = self._gates.get(pool_name)
+                    if gate is not None:
+                        try:
+                            await asyncio.wait_for(gate.wait(), timeout=self._config.gate_max_wait)
+                        except asyncio.TimeoutError:
+                            raise RateLimitGateTimeout(
+                                f"{self._exchange}: quota pool '{pool_name}' depleted, "
+                                f"gate did not reopen within {self._config.gate_max_wait:.0f}s"
+                            ) from None
+                # Decrement quota locally
+                if pool_name in self._quota_remaining:
+                    self._quota_remaining[pool_name] = max(0, self._quota_remaining[pool_name] - actual_weight)
+                continue
+
+            # For rate pools, acquire from backend
+            key = self._key_for(pool)
+            wait_time = await self._backend.acquire(key, actual_weight, pool.capacity, pool.refill_rate)
+
+            # Track stats
+            self._total_wait[pool_name] = self._total_wait.get(pool_name, 0) + wait_time
+            self._consumed[pool_name] = self._consumed.get(pool_name, 0) + actual_weight
+
+    def report_limit_hit(
+        self,
+        pool_name: str | None = None,
+        endpoint: str | None = None,
+        retry_after: float | None = None,
+        reason: str = "",
+    ) -> None:
+        """Report a rate limit hit (429, WS error, etc.).
+
+        Closes the gate for affected pools and applies cooldown.
+        Call this when the exchange tells you you've been rate limited.
+
+        Args:
+            pool_name: Specific pool that was hit (if known)
+            endpoint: Endpoint that was called (to look up affected pools)
+            retry_after: Seconds to wait (from Retry-After header)
+            reason: Human-readable reason for logging
+        """
+        pools_to_close = []
+
+        if pool_name:
+            pools_to_close.append(pool_name)
+        elif endpoint:
+            costs = self._config.endpoint_map.get(endpoint, self._config.default_costs)
+            pools_to_close = [p for p, _ in costs.costs]
+        else:
+            # Close all rate pools
+            pools_to_close = [name for name, pool in self._config.pools.items() if pool.pool_type == "rate"]
+
+        for pname in pools_to_close:
+            pool = self._config.pools.get(pname)
+            if pool is None:
+                continue
+            cooldown = retry_after if retry_after is not None else pool.cooldown
+            self._close_gate(pname, cooldown, reason or f"rate limit hit on {pname}")
+            self._hits[pname] = self._hits.get(pname, 0) + 1
+
+    def sync_from_exchange(
+        self,
+        pool_name: str,
+        remaining: float | None = None,
+        used: float | None = None,
+        capacity: float | None = None,
+    ) -> None:
+        """Sync modeled state with exchange-reported state.
+
+        Called when response headers or WS messages report actual usage.
+        Corrects drift between our model and reality (e.g., other bots
+        on the same account consuming budget).
+
+        Args:
+            pool_name: Pool to sync
+            remaining: Remaining tokens reported by exchange
+            used: Used tokens reported by exchange (remaining = capacity - used)
+            capacity: Total capacity reported by exchange (overrides config if provided)
+        """
+        pool = self._config.pools.get(pool_name)
+        if pool is None:
+            return
+
+        actual_capacity = capacity or pool.capacity
+
+        if remaining is not None:
+            actual_remaining = remaining
+        elif used is not None:
+            actual_remaining = actual_capacity - used
+        else:
+            return
+
+        if pool.pool_type == "quota":
+            self._quota_remaining[pool_name] = actual_remaining
+            if actual_remaining <= 0:
+                self._close_gate(pool_name, pool.cooldown, f"exchange reports {pool_name} depleted")
+            return
+
+        # For rate pools, update backend
+        key = self._key_for(pool)
+        # Fire-and-forget since set_remaining may be async but we're in sync context
+        # Use a helper to run it
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._backend.set_remaining(key, actual_remaining))
+        except RuntimeError:
+            pass  # No running loop — skip sync (e.g., during shutdown)
+
+    def sync_quota(self, pool_name: str, remaining: float) -> None:
+        """Update externally-managed quota pool from exchange response.
+
+        Convenience wrapper for quota pools (e.g., Lighter volume quota
+        reported in sendTx responses).
+
+        Args:
+            pool_name: Quota pool name
+            remaining: Remaining quota reported by exchange
+        """
+        self._quota_remaining[pool_name] = remaining
+        if remaining <= 0:
+            pool = self._config.pools.get(pool_name)
+            cooldown = pool.cooldown if pool else 15.0
+            self._close_gate(pool_name, cooldown, f"quota {pool_name} depleted (remaining={remaining})")
+
+    def _close_gate(self, pool_name: str, cooldown: float, reason: str) -> None:
+        """Close a pool's gate for the given cooldown period."""
+        gate = self._gates.get(pool_name)
+        if gate is None:
+            return
+
+        verb = "extended" if not gate.is_set() else "closed"
+        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{pool_name} ({cooldown:.1f}s): {reason}")
+        gate.clear()
+
+        # Cancel existing reopen task
+        old_task = self._gate_tasks.get(pool_name)
+        if old_task is not None and not old_task.done():
+            old_task.cancel()
+
+        self._gate_tasks[pool_name] = asyncio.ensure_future(self._reopen_gate_after(pool_name, cooldown))
+
+    async def _reopen_gate_after(self, pool_name: str, delay: float) -> None:
+        """Reopen a pool's gate after a cooldown delay."""
+        try:
+            await asyncio.sleep(delay)
+            gate = self._gates.get(pool_name)
+            if gate is not None:
+                gate.set()
+                logger.info(f"Rate limit gate reopened for {self._exchange}:{pool_name} after {delay:.1f}s")
+        except asyncio.CancelledError:
+            pass
+
+    def reset_gates(self) -> None:
+        """Reopen all gates and cancel pending reopen tasks.
+
+        Call on connection reset / reconnection.
+        """
+        for pool_name, gate in self._gates.items():
+            gate.set()
+        for pool_name, task in self._gate_tasks.items():
+            if not task.done():
+                task.cancel()
+        self._gate_tasks.clear()
+
+    def is_gate_closed(self, pool_name: str | None = None) -> bool:
+        """Check if a gate is closed.
+
+        Args:
+            pool_name: Specific pool, or None to check if ANY gate is closed
+        """
+        if pool_name:
+            gate = self._gates.get(pool_name)
+            return gate is not None and not gate.is_set()
+        return any(not gate.is_set() for gate in self._gates.values())
+
+    async def get_pool_state(self, pool_name: str) -> dict[str, Any] | None:
+        """Get current state of a pool for monitoring.
+
+        Returns:
+            Dict with remaining, capacity, gate_closed, hits, etc. or None if pool doesn't exist
+        """
+        pool = self._config.pools.get(pool_name)
+        if pool is None:
+            return None
+
+        if pool.pool_type == "quota":
+            remaining = self._quota_remaining.get(pool_name, 0)
+        else:
+            key = self._key_for(pool)
+            remaining = await self._backend.get_remaining(key)
+            if remaining is None:
+                remaining = pool.capacity
+
+        return {
+            "pool": pool_name,
+            "exchange": self._exchange,
+            "scope": pool.scope,
+            "scope_id": self._scope_ids.get(pool.scope, "local"),
+            "pool_type": pool.pool_type,
+            "remaining": remaining,
+            "capacity": pool.capacity,
+            "utilization": 1.0 - (remaining / pool.capacity) if pool.capacity > 0 else 0,
+            "gate_closed": self.is_gate_closed(pool_name),
+            "hits": self._hits.get(pool_name, 0),
+            "total_wait_s": self._total_wait.get(pool_name, 0),
+            "consumed": self._consumed.get(pool_name, 0),
+        }
+
+    async def collect_metrics(self) -> list[dict[str, Any]]:
+        """Collect current metrics for all pools.
+
+        Returns a list of metric dicts suitable for emitting via ctx.emitter.emit().
+        Each dict has: name, value, tags.
+
+        Call this periodically (e.g., once per minute) and emit via:
+            for m in await rate_limiter.collect_metrics():
+                ctx.emitter.emit(m["name"], m["value"], m["tags"])
+        """
+        metrics = []
+        for pool_name in self._config.pools:
+            state = await self.get_pool_state(pool_name)
+            if state is None:
+                continue
+
+            tags = {
+                "exchange": self._exchange,
+                "pool": pool_name,
+                "scope": state["scope"],
+                "type": "rate_limit",
+            }
+
+            metrics.append({"name": "rate_limit.remaining", "value": state["remaining"], "tags": {**tags}})
+            metrics.append({"name": "rate_limit.capacity", "value": state["capacity"], "tags": {**tags}})
+            metrics.append({"name": "rate_limit.utilization", "value": state["utilization"], "tags": {**tags}})
+            metrics.append(
+                {"name": "rate_limit.gate_closed", "value": 1.0 if state["gate_closed"] else 0.0, "tags": {**tags}}
+            )
+            metrics.append({"name": "rate_limit.hits", "value": float(state["hits"]), "tags": {**tags}})
+            metrics.append({"name": "rate_limit.wait_seconds", "value": state["total_wait_s"], "tags": {**tags}})
+            metrics.append({"name": "rate_limit.consumed", "value": state["consumed"], "tags": {**tags}})
+
+        return metrics
+
+    def __repr__(self) -> str:
+        pools = ", ".join(f"{name}({pool.scope})" for name, pool in self._config.pools.items())
+        return f"ExchangeRateLimiter({self._exchange}, pools=[{pools}])"

--- a/src/qubx/rate_limiting/ip_resolver.py
+++ b/src/qubx/rate_limiting/ip_resolver.py
@@ -1,0 +1,98 @@
+"""
+Egress IP resolver for rate limit scoping.
+
+Discovers the bot's public egress IP address periodically, updating
+rate limiter scope IDs when the IP changes (e.g., after Cilium egress
+policy update on the platform).
+"""
+
+import asyncio
+import socket
+
+import aiohttp
+
+from qubx import logger
+
+# Reliable IP echo services (try in order)
+_IP_ECHO_URLS = [
+    "https://ifconfig.me/ip",
+    "https://api.ipify.org",
+    "https://checkip.amazonaws.com",
+]
+
+
+
+class EgressIPResolver:
+    """Discovers and tracks this bot's egress IP.
+
+    Call start() to begin periodic discovery. When the IP changes,
+    registered callbacks are invoked with (old_ip, new_ip).
+
+    Usage:
+        >>> resolver = EgressIPResolver(check_interval=60)
+        >>> resolver.on_ip_changed(lambda old, new: print(f"{old} → {new}"))
+        >>> await resolver.start()
+        >>> resolver.current_ip  # "1.2.3.4"
+    """
+
+    def __init__(self, check_interval: float = 60.0, initial_ip: str | None = None):
+        self._check_interval = check_interval
+        self._current_ip = initial_ip
+        self._callbacks: list = []
+        self._task: asyncio.Task | None = None
+
+    @property
+    def current_ip(self) -> str | None:
+        return self._current_ip
+
+    def on_ip_changed(self, callback) -> None:
+        """Register callback: callback(old_ip: str | None, new_ip: str)"""
+        self._callbacks.append(callback)
+
+    async def discover(self) -> str | None:
+        """Discover current egress IP (tries multiple services)."""
+        for url in _IP_ECHO_URLS:
+            try:
+                connector = aiohttp.TCPConnector(family=socket.AF_INET)
+                async with aiohttp.ClientSession(connector=connector) as session:
+                    async with session.get(url, timeout=aiohttp.ClientTimeout(total=5)) as resp:
+                        if resp.status == 200:
+                            ip = (await resp.text()).strip()
+                            if ip:
+                                return ip
+            except Exception:
+                continue
+        logger.warning("Failed to discover egress IP from all services")
+        return None
+
+    async def start(self) -> None:
+        """Start periodic IP discovery."""
+        # Do initial discovery
+        ip = await self.discover()
+        if ip:
+            self._current_ip = ip
+            logger.info(f"Egress IP discovered: {ip}")
+
+        # Start monitoring loop
+        self._task = asyncio.ensure_future(self._monitor_loop())
+
+    def stop(self) -> None:
+        if self._task and not self._task.done():
+            self._task.cancel()
+
+    async def _monitor_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._check_interval)
+                new_ip = await self.discover()
+                if new_ip and new_ip != self._current_ip:
+                    old_ip = self._current_ip
+                    self._current_ip = new_ip
+                    logger.warning(f"Egress IP changed: {old_ip} → {new_ip}")
+                    for cb in self._callbacks:
+                        try:
+                            cb(old_ip, new_ip)
+                        except Exception as e:
+                            logger.error(f"IP change callback error: {e}")
+        except asyncio.CancelledError:
+            pass

--- a/src/qubx/rate_limiting/redis_backend.py
+++ b/src/qubx/rate_limiting/redis_backend.py
@@ -1,0 +1,130 @@
+"""
+Redis-based rate limit backend for cross-bot coordination.
+
+Uses Lua scripts for atomic token bucket operations in Redis.
+Multiple bots sharing an exchange account or egress IP coordinate
+through shared Redis keys.
+"""
+
+import time
+
+from qubx import logger
+
+from .backend import IRateLimitBackend
+
+# Lua script: atomic token bucket acquire
+# Returns: wait_time_seconds (0 if immediate, >0 if had to wait conceptually)
+# The script refills tokens, checks availability, and decrements atomically.
+_LUA_ACQUIRE = """
+local key = KEYS[1]
+local weight = tonumber(ARGV[1])
+local capacity = tonumber(ARGV[2])
+local refill_rate = tonumber(ARGV[3])
+local now = tonumber(ARGV[4])
+
+-- Get current state or initialize
+local tokens = tonumber(redis.call('HGET', key, 'tokens') or capacity)
+local last_refill = tonumber(redis.call('HGET', key, 'last_refill') or now)
+
+-- Refill tokens based on elapsed time
+local elapsed = now - last_refill
+local tokens_to_add = elapsed * refill_rate
+tokens = math.min(capacity, tokens + tokens_to_add)
+
+-- Check if we have enough tokens
+if tokens >= weight then
+    tokens = tokens - weight
+    redis.call('HSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 300)  -- 5 min TTL to auto-cleanup stale keys
+    return 0  -- no wait needed
+else
+    -- Calculate wait time
+    local tokens_needed = weight - tokens
+    local wait_time = tokens_needed / refill_rate
+
+    -- Update last_refill to now (tokens were refilled but not enough)
+    redis.call('HSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 300)
+    return wait_time * 1000  -- return milliseconds
+end
+"""
+
+_LUA_GET_REMAINING = """
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_rate = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+
+local tokens = tonumber(redis.call('HGET', key, 'tokens'))
+if tokens == nil then return capacity * 1000 end
+
+local last_refill = tonumber(redis.call('HGET', key, 'last_refill') or now)
+local elapsed = now - last_refill
+local tokens_to_add = elapsed * refill_rate
+tokens = math.min(capacity, tokens + tokens_to_add)
+
+return math.floor(tokens * 1000)  -- return as millitokens for precision
+"""
+
+_LUA_SET_REMAINING = """
+local key = KEYS[1]
+local remaining = tonumber(ARGV[1])
+local now = tonumber(ARGV[2])
+
+redis.call('HSET', key, 'tokens', remaining, 'last_refill', now)
+redis.call('EXPIRE', key, 300)
+return 1
+"""
+
+
+class RedisBackend(IRateLimitBackend):
+    """Redis-based token bucket backend for cross-bot coordination.
+
+    Uses atomic Lua scripts so multiple bots can safely share rate limit
+    pools without races. Keys auto-expire after 5 minutes of inactivity.
+
+    Args:
+        redis_url: Redis connection URL (e.g., "redis://redis.platform.svc:6379/0")
+    """
+
+    def __init__(self, redis_url: str):
+        import redis.asyncio as aioredis
+
+        self._redis = aioredis.from_url(redis_url, decode_responses=True)
+        self._acquire_script = self._redis.register_script(_LUA_ACQUIRE)
+        self._get_remaining_script = self._redis.register_script(_LUA_GET_REMAINING)
+        self._set_remaining_script = self._redis.register_script(_LUA_SET_REMAINING)
+        logger.info(f"Redis rate limit backend connected: {redis_url}")
+
+    async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
+        now = time.time()
+        while True:
+            wait_ms = await self._acquire_script(
+                keys=[key],
+                args=[weight, capacity, refill_rate, now],
+            )
+            wait_ms = float(wait_ms)
+            if wait_ms <= 0:
+                return 0.0
+            # Need to wait — sleep and retry
+            wait_s = wait_ms / 1000.0
+            await __import__("asyncio").sleep(wait_s)
+            now = time.time()
+
+    async def get_remaining(self, key: str) -> float | None:
+        # We need capacity and refill_rate to compute remaining after refill,
+        # but we don't have them here. Return raw stored tokens.
+        raw = await self._redis.hget(key, "tokens")
+        if raw is None:
+            return None
+        return float(raw)
+
+    async def set_remaining(self, key: str, remaining: float) -> None:
+        now = time.time()
+        await self._set_remaining_script(
+            keys=[key],
+            args=[remaining, now],
+        )
+
+    async def close(self) -> None:
+        await self._redis.close()

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -170,6 +170,16 @@ class ThrottlingConfig(StrictBaseModel):
     throttles: list[DataTypeThrottleConfig] = Field(default_factory=list)
 
 
+class RateLimitingConfig(StrictBaseModel):
+    """Configuration for exchange rate limiting."""
+
+    backend: str = "local"  # "local" (in-memory) or "redis"
+    redis_url: str | None = None  # Required when backend is "redis"
+    egress_ip: str = "auto"  # "auto" for periodic discovery, or explicit IP
+    ip_check_interval: int = 60  # Seconds between egress IP checks (when "auto")
+    metrics_interval: str = "60s"  # Interval for emitting rate limit metrics (None to disable)
+
+
 class LiveConfig(StrictBaseModel):
     read_only: bool = False
     base_currency: str | None = None
@@ -184,6 +194,7 @@ class LiveConfig(StrictBaseModel):
     aux: list[StorageConfig] | StorageConfig | None = None
     prefetch: PrefetchConfig = Field(default_factory=PrefetchConfig)
     state: StatePersistenceConfig | None = None
+    rate_limiting: RateLimitingConfig | None = None
 
 
 class SimulationConfig(StrictBaseModel):

--- a/src/qubx/utils/runner/factory.py
+++ b/src/qubx/utils/runner/factory.py
@@ -16,6 +16,7 @@ from qubx.utils.runner.configs import (
     EmissionConfig,
     ExporterConfig,
     NotifierConfig,
+    RateLimitingConfig,
     StatePersistenceConfig,
     StorageConfig,
     TypedStorageConfig,
@@ -474,3 +475,30 @@ def create_state_persistence(
         logger.error(f"Failed to create state persistence {persistence_class_name}: {e}")
         logger.opt(colors=False).error(f"State persistence parameters: {config.parameters}")
         raise
+
+
+def create_rate_limit_backend(config: RateLimitingConfig | None):
+    """
+    Create rate limit backend from configuration.
+
+    Returns:
+        IRateLimitBackend instance, or None if rate limiting is not configured.
+    """
+    if config is None:
+        return None
+
+    from qubx.rate_limiting.backend import InMemoryBackend
+
+    if config.backend == "redis":
+        if not config.redis_url:
+            logger.warning("Rate limiting backend set to 'redis' but no redis_url provided, falling back to local")
+            return InMemoryBackend()
+        try:
+            from qubx.rate_limiting.redis_backend import RedisBackend
+
+            return RedisBackend(config.redis_url)
+        except Exception as e:
+            logger.error(f"Failed to create Redis rate limit backend: {e}, falling back to local")
+            return InMemoryBackend()
+
+    return InMemoryBackend()

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -70,6 +70,7 @@ from qubx.utils.runner.factory import (
     create_exporters,
     create_metric_emitters,
     create_notifiers,
+    create_rate_limit_backend,
     create_state_persistence,
 )
 from qubx.utils.s3 import S3Client, is_account_uri, is_cloud_path
@@ -498,6 +499,36 @@ def create_strategy_context(
 
     exchanges = list(config.live.exchanges.keys())
 
+    # Create rate limit backend early so connectors can use it
+    _rate_limit_backend = create_rate_limit_backend(config.live.rate_limiting)
+    _ip_resolver = None
+
+    # Resolve egress IP for rate limit scoping (before connectors start)
+    if _rate_limit_backend is not None and config.live.rate_limiting:
+        rl_cfg = config.live.rate_limiting
+        if rl_cfg.egress_ip == "auto":
+            from qubx.rate_limiting.ip_resolver import EgressIPResolver
+
+            _ip_resolver = EgressIPResolver(check_interval=rl_cfg.ip_check_interval)
+            # Do initial discovery synchronously on the shared loop
+            import concurrent.futures
+
+            future = asyncio.run_coroutine_threadsafe(_ip_resolver.discover(), loop)
+            try:
+                ip = future.result(timeout=10)
+                if ip:
+                    _ip_resolver._current_ip = ip
+                    logger.info(f"Egress IP discovered: {ip}")
+            except (concurrent.futures.TimeoutError, Exception) as e:
+                logger.warning(f"Failed to discover egress IP: {e}")
+
+            # Start periodic monitoring on the shared loop
+            asyncio.run_coroutine_threadsafe(_ip_resolver.start(), loop)
+
+    _egress_ip = (_ip_resolver.current_ip if _ip_resolver else None) or (
+        config.live.rate_limiting.egress_ip if config.live.rate_limiting and config.live.rate_limiting.egress_ip != "auto" else None
+    )
+
     _exchange_to_tcc = {}
     _exchange_to_broker = {}
     _exchange_to_data_provider = {}
@@ -505,6 +536,11 @@ def create_strategy_context(
     _instruments = []
 
     for exchange_name, exchange_config in config.live.exchanges.items():
+        # Inject rate limit backend and egress IP into connector params
+        if _rate_limit_backend is not None:
+            exchange_config.params["rate_limit_backend"] = _rate_limit_backend
+        if _egress_ip is not None:
+            exchange_config.params["rate_limit_egress_ip"] = _egress_ip
         _exchange_to_tcc[exchange_name] = (tcc := _create_tcc(exchange_name, account_manager))
         _exchange_to_data_provider[exchange_name] = (
             data_provider := _create_data_provider(
@@ -594,6 +630,8 @@ def create_strategy_context(
     _state_persistence = create_state_persistence(config.live.state, stg_name)
     _state_snapshot_interval = config.live.state.snapshot_interval if config.live.state else None
 
+    _rate_limiting_config = config.live.rate_limiting
+
     logger.info(f"- Strategy: <blue>{stg_name}</blue>\n- Mode: {_run_mode}\n- Parameters: {config.parameters}")
 
     ctx = StrategyContext(
@@ -617,6 +655,8 @@ def create_strategy_context(
         data_throttler=_data_throttler,
         state_persistence=_state_persistence,
         state_snapshot_interval=_state_snapshot_interval,
+        rate_limit_backend=_rate_limit_backend,
+        rate_limiting_config=_rate_limiting_config,
     )
 
     # Store the shared event loop reference for cleanup
@@ -626,6 +666,16 @@ def create_strategy_context(
     # Set context for metric emitters to enable is_live tag and time access
     if _metric_emitter is not None:
         _metric_emitter.set_context(ctx)
+
+    # Register IP change callback to update rate limiter scope IDs
+    if _ip_resolver is not None and ctx.rate_limiters:
+
+        def _on_ip_changed(old_ip, new_ip):
+            for rl in ctx.rate_limiters.values():
+                rl.update_scope_id("ip", f"ip_{new_ip}")
+
+        _ip_resolver.on_ip_changed(_on_ip_changed)
+        ctx._ip_resolver = _ip_resolver  # type: ignore  # prevent GC
 
     return ctx
 


### PR DESCRIPTION
## Summary

- Multi-pool rate limiting engine (`src/qubx/rate_limiting/`) shared across all connectors
- Token bucket per pool with multi-key acquire, gate mechanism, quota pools
- Redis backend for cross-bot coordination (bots sharing exchange accounts/egress IPs)
- Egress IP auto-discovery with periodic monitoring (IPv4)
- Per-exchange CCXT configs: Binance (spot/USDM/COIN-M), OKX, Bybit, Kraken
- CCXT throttle override + RateLimitExceeded/DDoSProtection handling
- Binance/OKX response header parsing for real-time usage sync
- Periodic metric emission via `ctx.emitter.emit()` (rate_limit.remaining, utilization, hits, etc.)
- `IDataProvider.rate_limiter` property for clean rate limiter collection
- `RateLimitingConfig` in YAML config with backend/redis_url/egress_ip/metrics_interval

## Test plan

- [x] 1257 Qubx unit tests pass
- [x] Tested with Lighter connector locally — Redis keys created with actual IPv4 egress IP
- [x] Rate limit pools tracked: rest_weight, ws_sub consumed during warmup
- [x] Metric emission scheduling confirmed in logs
- [ ] Platform deployment test with redis-ratelimit preset