### PR TITLE
fix: quota pool gate storm + rate limiting refactor

### DIFF
--- a/docs/connectors/rate-limiting.md
+++ b/docs/connectors/rate-limiting.md
@@ -1,0 +1,284 @@
+# Exchange Rate Limiting
+
+Qubx provides a multi-pool rate limiting engine that connectors use to comply with exchange API limits. The engine handles token bucket acquisition, gate-based cooldowns, exchange state synchronization, and metric collection.
+
+## Concepts
+
+### Pools
+
+A **pool** represents one independent rate limit enforced by an exchange. Most exchanges have multiple pools (e.g., REST request weight + order count + WebSocket message rate).
+
+There are two pool types:
+
+- **Rate pool** (`pool_type="rate"`) — Time-based token bucket. Tokens refill at a constant rate. When depleted, a gate closes and reopens on a timer. Used for request weight limits, message rate limits, etc.
+
+- **Quota pool** (`pool_type="quota"`) — Externally managed budget with no time-based refill. The exchange controls replenishment (e.g., Lighter's volume quota which is replenished by trading volume). When depleted, the gate closes and stays closed until the exchange reports positive remaining via `sync_from_exchange()`.
+
+### Endpoints
+
+An **endpoint** maps an API call to one or more pool costs. A single request can consume tokens from multiple pools simultaneously.
+
+```python
+# Creating an order consumes from three pools:
+"send_tx:create_order": EndpointCosts([
+    ("ws_messages", 1),      # 1 token from WS message rate pool
+    ("sendtx_rate", 1),      # 1 token from sendTx rate pool
+    ("volume_quota", 1),     # 1 token from volume quota pool
+])
+
+# Cancelling only consumes from two (no volume quota):
+"send_tx:cancel_order": EndpointCosts([
+    ("ws_messages", 1),
+    ("sendtx_rate", 1),
+])
+```
+
+### Gates
+
+Each pool has a **gate** (an `asyncio.Event`). When open, `acquire()` proceeds immediately. When closed, all requests for that pool block until the gate reopens.
+
+- **Rate pool gates** reopen automatically after a cooldown timer.
+- **Quota pool gates** never reopen on a timer — only when the exchange reports positive remaining via `sync_from_exchange()`, or on reconnection via `reset_gates()`.
+
+### Scopes
+
+Pools are scoped to what the exchange rate-limits by:
+
+- `"ip"` — Per IP address (REST API weight limits)
+- `"account"` — Per trading account
+- `"address"` — Per L1/wallet address (Lighter sendTx limits)
+
+The scope determines the backend storage key, enabling future cross-bot coordination via a shared Redis backend.
+
+## Defining Configuration
+
+Each connector declares its rate limit configuration using `PoolConfig`, `EndpointCosts`, and `ExchangeRateLimitConfig`. Use the `@rate_limit_config` registry decorator so the engine can be instantiated automatically.
+
+```python
+from qubx.connectors.registry import rate_limit_config
+from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, PoolConfig
+
+
+@rate_limit_config("myexchange")
+def create_my_rate_limit_config(
+    exchange_name: str = "MYEXCHANGE",
+    rate_limit_cooldown: float = 15.0,
+    gate_max_wait: float = 15.0,
+) -> ExchangeRateLimitConfig:
+    pools = {
+        # REST API weight pool — 1200 weight/min, scoped per IP
+        "rest_weight": PoolConfig(
+            name="rest_weight",
+            scope="ip",
+            capacity=1200,
+            refill_rate=1200 / 60.0,  # 20 tokens/sec
+            pool_type="rate",
+            cooldown=rate_limit_cooldown,
+        ),
+        # Order rate pool — 10 orders/sec, scoped per account
+        "orders": PoolConfig(
+            name="orders",
+            scope="account",
+            capacity=10,
+            refill_rate=10.0,
+            pool_type="rate",
+            cooldown=rate_limit_cooldown,
+        ),
+    }
+
+    endpoint_map = {
+        "fetch_candles": EndpointCosts([("rest_weight", 50)]),
+        "fetch_orderbook": EndpointCosts([("rest_weight", 100)]),
+        "create_order": EndpointCosts([("rest_weight", 1), ("orders", 1)]),
+        "cancel_order": EndpointCosts([("rest_weight", 1)]),
+    }
+
+    return ExchangeRateLimitConfig(
+        pools=pools,
+        endpoint_map=endpoint_map,
+        default_costs=EndpointCosts([("rest_weight", 10)]),
+        gate_max_wait=gate_max_wait,
+    )
+```
+
+### PoolConfig fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Pool identifier (must match key in `pools` dict) |
+| `scope` | What the limit is scoped to: `"ip"`, `"account"`, `"address"` |
+| `capacity` | Maximum tokens in the bucket |
+| `refill_rate` | Tokens replenished per second (0 for quota pools) |
+| `pool_type` | `"rate"` (time-based) or `"quota"` (externally managed) |
+| `cooldown` | Default seconds to close gate on rate limit hit |
+
+### ExchangeRateLimitConfig fields
+
+| Field | Description |
+|-------|-------------|
+| `pools` | Dict of pool name to `PoolConfig` |
+| `endpoint_map` | Dict of endpoint name to `EndpointCosts` |
+| `default_costs` | Fallback costs for unmapped endpoints |
+| `gate_max_wait` | Max seconds to wait for a closed gate before raising `RateLimitGateTimeout` |
+
+## Connector Integration
+
+### Acquiring budget before API calls
+
+Call `acquire(endpoint)` before every exchange request. It blocks until all pools for that endpoint have sufficient budget.
+
+```python
+# In your WebSocket manager or REST client:
+async def send_order(self, order_params):
+    if self._rate_limiter:
+        await self._rate_limiter.acquire("create_order")
+
+    await self._ws.send(order_params)
+```
+
+The engine iterates the endpoint's pool costs in order, acquiring from each pool. If any pool's gate is closed, `acquire()` blocks (for rate pools) or raises immediately (for quota pools).
+
+### Syncing state from exchange responses
+
+When the exchange reports actual usage in response headers or WebSocket messages, call `sync_from_exchange()` to correct drift between the model and reality.
+
+```python
+# From a REST response with rate limit headers:
+remaining = int(response.headers["X-RateLimit-Remaining"])
+limiter.sync_from_exchange("rest_weight", remaining=remaining)
+
+# From a WebSocket message with quota info:
+async def _handle_tx_response(self, message: dict):
+    if "volume_quota_remaining" in message and self._rate_limiter:
+        remaining = int(message["volume_quota_remaining"])
+        self._rate_limiter.sync_from_exchange("volume_quota", remaining=remaining)
+```
+
+For quota pools, `sync_from_exchange()` also:
+
+- **Reopens the gate** when remaining goes positive (the key fix for quota storms)
+- **Grows `capacity`** to `max(capacity, remaining)` when no explicit capacity is provided (tracks real account quota when the exchange only reports remaining)
+
+### Reporting rate limit hits
+
+When the exchange explicitly tells you you've been rate limited (HTTP 429, WebSocket error code), call `report_limit_hit()` to close gates:
+
+```python
+async def _handle_error(self, error: dict):
+    match error["code"]:
+        case 23000:
+            # General rate limit hit
+            self._rate_limiter.report_limit_hit(
+                pool_name="rest_weight",
+                reason=f"error 23000: {error['message']}",
+            )
+        case 30009:
+            # WebSocket message rate limit
+            self._rate_limiter.report_limit_hit(
+                pool_name="ws_messages",
+                reason="error 30009",
+            )
+```
+
+You can target a specific pool, an endpoint (closes all pools in its costs), or pass nothing to close all rate pools.
+
+### Resetting on reconnection
+
+Call `reset_gates()` when the WebSocket reconnects to clear stale gate state:
+
+```python
+async def connect(self):
+    await super().connect()
+    if self._rate_limiter:
+        self._rate_limiter.reset_gates()
+```
+
+## Handling RateLimitGateTimeout
+
+When a gate doesn't reopen in time (rate pools) or a quota pool is depleted, `acquire()` raises `RateLimitGateTimeout`. The exception has a `pool_name` attribute so connectors can implement pool-specific fallback logic.
+
+### Fallback pattern for quota pools
+
+Some exchanges allow limited operations even when quota is exhausted. For example, Lighter allows 1 free transaction per 15 seconds when volume quota is depleted. Model this as a separate rate pool with fallback logic:
+
+```python
+# In rate limit config — add a free-tx pool:
+"sendtx_free": PoolConfig(
+    name="sendtx_free",
+    scope="address",
+    capacity=1,
+    refill_rate=1.0 / 15.0,  # 1 free tx per 15s
+    pool_type="rate",
+    cooldown=15.0,
+),
+
+# Endpoint for fallback:
+"send_tx_free": EndpointCosts([("sendtx_free", 1)]),
+```
+
+```python
+# In the connector — catch and fall back:
+async def send_tx(self, tx_type, tx_info):
+    if self._rate_limiter:
+        endpoint = endpoint_for_tx_type(tx_type)
+        try:
+            await self._rate_limiter.acquire(endpoint)
+        except RateLimitGateTimeout as e:
+            if e.pool_name == "volume_quota" and is_quota_consuming(tx_type):
+                # ws_messages + sendtx_rate already consumed before
+                # volume_quota was checked, so only acquire free-tx budget
+                logger.info("Volume quota exhausted, using free sendTx allowance")
+                await self._rate_limiter.acquire("send_tx_free")
+            else:
+                raise
+
+    await self._ws.send(tx_info)
+```
+
+This pattern ensures that when quota is exhausted, orders still trickle through at the free rate instead of being completely blocked.
+
+## Metrics
+
+The engine collects per-pool metrics via `collect_metrics()`. Call it periodically and emit via the strategy context:
+
+```python
+for m in await rate_limiter.collect_metrics():
+    ctx.emitter.emit(m["name"], m["value"], m["tags"])
+```
+
+Available metrics (all tagged with `exchange`, `pool`, `scope`):
+
+| Metric | Description |
+|--------|-------------|
+| `rate_limit.remaining` | Current tokens available |
+| `rate_limit.capacity` | Pool capacity (grows for quota pools) |
+| `rate_limit.utilization` | `1 - remaining/capacity` |
+| `rate_limit.gate_closed` | 1.0 if gate is closed, 0.0 if open |
+| `rate_limit.hits` | Cumulative rate limit hits reported |
+| `rate_limit.wait_seconds` | Cumulative time spent waiting for budget |
+| `rate_limit.consumed` | Cumulative tokens consumed |
+
+## Architecture
+
+```
+ExchangeRateLimiter (engine.py)
+├── acquire(endpoint)          → delegates to pool.acquire()
+├── report_limit_hit()         → delegates to pool.close_gate()
+├── sync_from_exchange()       → delegates to pool.sync()
+├── reset_gates()              → delegates to pool.reset_gate()
+├── collect_metrics()          → delegates to pool.get_state()
+│
+├── RatePool (pools.py)        — time-based token bucket
+│   ├── acquire()              waits for gate, then backend.acquire()
+│   ├── close_gate()           clears gate, schedules timed reopen
+│   ├── sync()                 updates backend token count
+│   └── get_state()            reads remaining from backend
+│
+└── QuotaPool (pools.py)       — externally managed
+    ├── acquire()              fails fast if depleted (RateLimitGateTimeout)
+    ├── close_gate()           clears gate, NO timed reopen
+    ├── sync()                 updates remaining, reopens gate if positive
+    └── get_state()            returns in-memory remaining
+```
+
+The engine contains no pool-type branching — all behavior differences are encapsulated in the pool subclasses.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,9 @@ nav:
       - Deployment: tutorials/deployment.ipynb
       - QuestDB setup: tutorials/questdb-setup.md
       - Signal Export: tutorials/signal-export.md
+  - Connectors:
+      - Creating Connectors: connectors/creating-connectors.md
+      - Rate Limiting: connectors/rate-limiting.md
   - Development:
       - Contributing: development/contributing.md
       - Development Setup: development/setup.md

--- a/src/qubx/rate_limiting/engine.py
+++ b/src/qubx/rate_limiting/engine.py
@@ -1,9 +1,7 @@
-"""
-Exchange rate limiting engine.
+"""Exchange rate limiting engine.
 
-The central component that connectors interact with. Handles multi-pool
-token acquisition, gate mechanism for cooldowns, exchange state sync,
-and metric collection.
+The central component that connectors interact with. Delegates pool-specific
+behavior (gate management, acquisition, sync) to polymorphic pool objects.
 """
 
 import asyncio
@@ -13,11 +11,9 @@ from typing import Any
 from qubx import logger
 
 from .backend import InMemoryBackend, IRateLimitBackend
-from .config import ExchangeRateLimitConfig, PoolConfig
-
-
-class RateLimitGateTimeout(Exception):
-    """Raised when acquire() times out waiting for a gate to reopen."""
+from .config import ExchangeRateLimitConfig
+from .pools import BasePool, QuotaPool, RatePool
+from .pools import RateLimitGateTimeout as RateLimitGateTimeout  # re-export
 
 
 class ExchangeRateLimiter:
@@ -59,29 +55,18 @@ class ExchangeRateLimiter:
         """
         self._exchange = exchange
         self._config = config
-        self._backend = backend or InMemoryBackend()
         self._scope_ids = scope_ids or {}
         self._event_loop = event_loop
-
-        # Per-pool gates (asyncio.Event: set = open, clear = closed)
-        self._gates: dict[str, asyncio.Event] = {}
-        self._gate_tasks: dict[str, asyncio.Task] = {}
-        for pool_name in config.pools:
-            gate = asyncio.Event()
-            gate.set()
-            self._gates[pool_name] = gate
-
-        # Quota pools: externally-managed remaining count
-        self._quota_remaining: dict[str, float] = {}
-        for pool_name, pool in config.pools.items():
-            if pool.pool_type == "quota":
-                self._quota_remaining[pool_name] = pool.capacity
-
-        # Stats tracking
-        self._hits: dict[str, int] = {}
-        self._total_wait: dict[str, float] = {}
-        self._consumed: dict[str, float] = {}
         self._last_metrics_time = time.monotonic()
+
+        backend = backend or InMemoryBackend()
+        self._pools: dict[str, BasePool] = {}
+        for pool_name, pool_config in config.pools.items():
+            scope_id = self._scope_ids.get(pool_config.scope, "local")
+            if pool_config.pool_type == "quota":
+                self._pools[pool_name] = QuotaPool(pool_config, exchange, scope_id)
+            else:
+                self._pools[pool_name] = RatePool(pool_config, exchange, scope_id, backend)
 
     @property
     def exchange(self) -> str:
@@ -100,11 +85,6 @@ class ExchangeRateLimiter:
     def config(self) -> ExchangeRateLimitConfig:
         return self._config
 
-    def _key_for(self, pool: PoolConfig) -> str:
-        """Construct Redis/backend key for a pool based on its scope."""
-        scope_id = self._scope_ids.get(pool.scope, "local")
-        return f"ratelimit:{self._exchange}:{pool.name}:{scope_id}"
-
     def update_scope_id(self, scope: str, new_id: str) -> None:
         """Update scope identifier (e.g., when egress IP changes).
 
@@ -114,6 +94,9 @@ class ExchangeRateLimiter:
         if old_id != new_id:
             logger.info(f"Rate limiter {self._exchange}: {scope} scope changed {old_id} → {new_id}")
             self._scope_ids[scope] = new_id
+            for pool in self._pools.values():
+                if pool.config.scope == scope:
+                    pool.update_scope_id(new_id)
 
     async def acquire(self, endpoint: str, weight_override: float | None = None) -> None:
         """Wait until all pools for this endpoint have sufficient budget.
@@ -134,50 +117,11 @@ class ExchangeRateLimiter:
             return
 
         for i, (pool_name, weight) in enumerate(endpoint_costs.costs):
-            pool = self._config.pools.get(pool_name)
+            pool = self._pools.get(pool_name)
             if pool is None:
                 continue
-
             actual_weight = weight_override if (weight_override is not None and i == 0) else weight
-
-            # Wait for gate to be open
-            gate = self._gates.get(pool_name)
-            if gate is not None and not gate.is_set():
-                try:
-                    await asyncio.wait_for(gate.wait(), timeout=self._config.gate_max_wait)
-                except asyncio.TimeoutError:
-                    raise RateLimitGateTimeout(
-                        f"{self._exchange}: gate for pool '{pool_name}' did not reopen "
-                        f"within {self._config.gate_max_wait:.0f}s"
-                    ) from None
-
-            # For quota pools, check remaining (no time-based refill)
-            if pool.pool_type == "quota":
-                remaining = self._quota_remaining.get(pool_name, 0)
-                if remaining <= 0:
-                    # Gate should already be closed, but double-check
-                    self._close_gate(pool_name, pool.cooldown, "quota depleted")
-                    gate = self._gates.get(pool_name)
-                    if gate is not None:
-                        try:
-                            await asyncio.wait_for(gate.wait(), timeout=self._config.gate_max_wait)
-                        except asyncio.TimeoutError:
-                            raise RateLimitGateTimeout(
-                                f"{self._exchange}: quota pool '{pool_name}' depleted, "
-                                f"gate did not reopen within {self._config.gate_max_wait:.0f}s"
-                            ) from None
-                # Decrement quota locally
-                if pool_name in self._quota_remaining:
-                    self._quota_remaining[pool_name] = max(0, self._quota_remaining[pool_name] - actual_weight)
-                continue
-
-            # For rate pools, acquire from backend
-            key = self._key_for(pool)
-            wait_time = await self._backend.acquire(key, actual_weight, pool.capacity, pool.refill_rate)
-
-            # Track stats
-            self._total_wait[pool_name] = self._total_wait.get(pool_name, 0) + wait_time
-            self._consumed[pool_name] = self._consumed.get(pool_name, 0) + actual_weight
+            await pool.acquire(actual_weight, self._config.gate_max_wait)
 
     def report_limit_hit(
         self,
@@ -197,7 +141,7 @@ class ExchangeRateLimiter:
             retry_after: Seconds to wait (from Retry-After header)
             reason: Human-readable reason for logging
         """
-        pools_to_close = []
+        pools_to_close: list[str] = []
 
         if pool_name:
             pools_to_close.append(pool_name)
@@ -206,15 +150,17 @@ class ExchangeRateLimiter:
             pools_to_close = [p for p, _ in costs.costs]
         else:
             # Close all rate pools
-            pools_to_close = [name for name, pool in self._config.pools.items() if pool.pool_type == "rate"]
+            pools_to_close = [
+                name for name, pool in self._pools.items() if pool.config.pool_type == "rate"
+            ]
 
         for pname in pools_to_close:
-            pool = self._config.pools.get(pname)
+            pool = self._pools.get(pname)
             if pool is None:
                 continue
-            cooldown = retry_after if retry_after is not None else pool.cooldown
-            self._close_gate(pname, cooldown, reason or f"rate limit hit on {pname}")
-            self._hits[pname] = self._hits.get(pname, 0) + 1
+            cooldown = retry_after if retry_after is not None else pool.config.cooldown
+            pool.close_gate(cooldown, reason or f"rate limit hit on {pname}")
+            pool.hits += 1
 
     def sync_from_exchange(
         self,
@@ -235,11 +181,11 @@ class ExchangeRateLimiter:
             used: Used tokens reported by exchange (remaining = capacity - used)
             capacity: Total capacity reported by exchange (overrides config if provided)
         """
-        pool = self._config.pools.get(pool_name)
+        pool = self._pools.get(pool_name)
         if pool is None:
             return
 
-        actual_capacity = capacity or pool.capacity
+        actual_capacity = capacity or pool.config.capacity
 
         if remaining is not None:
             actual_remaining = remaining
@@ -248,77 +194,25 @@ class ExchangeRateLimiter:
         else:
             return
 
-        if pool.pool_type == "quota":
-            self._quota_remaining[pool_name] = actual_remaining
-            if actual_remaining <= 0:
-                self._close_gate(pool_name, pool.cooldown, f"exchange reports {pool_name} depleted")
-            return
+        pool.sync(actual_remaining, capacity)
 
-        # For rate pools, update backend
-        key = self._key_for(pool)
-        # Fire-and-forget since set_remaining may be async but we're in sync context
-        # Use a helper to run it
-        try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self._backend.set_remaining(key, actual_remaining))
-        except RuntimeError:
-            pass  # No running loop — skip sync (e.g., during shutdown)
+    def get_quota_remaining(self, pool_name: str) -> float:
+        """Get remaining budget for a quota pool.
 
-    def sync_quota(self, pool_name: str, remaining: float) -> None:
-        """Update externally-managed quota pool from exchange response.
-
-        Convenience wrapper for quota pools (e.g., Lighter volume quota
-        reported in sendTx responses).
-
-        Args:
-            pool_name: Quota pool name
-            remaining: Remaining quota reported by exchange
+        Returns 0 if pool doesn't exist or isn't a quota pool.
         """
-        self._quota_remaining[pool_name] = remaining
-        if remaining <= 0:
-            pool = self._config.pools.get(pool_name)
-            cooldown = pool.cooldown if pool else 15.0
-            self._close_gate(pool_name, cooldown, f"quota {pool_name} depleted (remaining={remaining})")
-
-    def _close_gate(self, pool_name: str, cooldown: float, reason: str) -> None:
-        """Close a pool's gate for the given cooldown period."""
-        gate = self._gates.get(pool_name)
-        if gate is None:
-            return
-
-        verb = "extended" if not gate.is_set() else "closed"
-        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{pool_name} ({cooldown:.1f}s): {reason}")
-        gate.clear()
-
-        # Cancel existing reopen task
-        old_task = self._gate_tasks.get(pool_name)
-        if old_task is not None and not old_task.done():
-            old_task.cancel()
-
-        self._gate_tasks[pool_name] = asyncio.ensure_future(self._reopen_gate_after(pool_name, cooldown))
-
-    async def _reopen_gate_after(self, pool_name: str, delay: float) -> None:
-        """Reopen a pool's gate after a cooldown delay."""
-        try:
-            await asyncio.sleep(delay)
-            gate = self._gates.get(pool_name)
-            if gate is not None:
-                gate.set()
-                logger.info(f"Rate limit gate reopened for {self._exchange}:{pool_name} after {delay:.1f}s")
-        except asyncio.CancelledError:
-            pass
+        pool = self._pools.get(pool_name)
+        if isinstance(pool, QuotaPool):
+            return pool.remaining
+        return 0
 
     def reset_gates(self) -> None:
         """Reopen all gates and cancel pending reopen tasks.
 
         Call on connection reset / reconnection.
         """
-        for pool_name, gate in self._gates.items():
-            gate.set()
-        for pool_name, task in self._gate_tasks.items():
-            if not task.done():
-                task.cancel()
-        self._gate_tasks.clear()
+        for pool in self._pools.values():
+            pool.reset_gate()
 
     def is_gate_closed(self, pool_name: str | None = None) -> bool:
         """Check if a gate is closed.
@@ -327,9 +221,9 @@ class ExchangeRateLimiter:
             pool_name: Specific pool, or None to check if ANY gate is closed
         """
         if pool_name:
-            gate = self._gates.get(pool_name)
-            return gate is not None and not gate.is_set()
-        return any(not gate.is_set() for gate in self._gates.values())
+            pool = self._pools.get(pool_name)
+            return pool is not None and pool.is_gate_closed
+        return any(pool.is_gate_closed for pool in self._pools.values())
 
     async def get_pool_state(self, pool_name: str) -> dict[str, Any] | None:
         """Get current state of a pool for monitoring.
@@ -337,32 +231,10 @@ class ExchangeRateLimiter:
         Returns:
             Dict with remaining, capacity, gate_closed, hits, etc. or None if pool doesn't exist
         """
-        pool = self._config.pools.get(pool_name)
+        pool = self._pools.get(pool_name)
         if pool is None:
             return None
-
-        if pool.pool_type == "quota":
-            remaining = self._quota_remaining.get(pool_name, 0)
-        else:
-            key = self._key_for(pool)
-            remaining = await self._backend.get_remaining(key, pool.capacity, pool.refill_rate)
-            if remaining is None:
-                remaining = pool.capacity
-
-        return {
-            "pool": pool_name,
-            "exchange": self._exchange,
-            "scope": pool.scope,
-            "scope_id": self._scope_ids.get(pool.scope, "local"),
-            "pool_type": pool.pool_type,
-            "remaining": remaining,
-            "capacity": pool.capacity,
-            "utilization": 1.0 - (remaining / pool.capacity) if pool.capacity > 0 else 0,
-            "gate_closed": self.is_gate_closed(pool_name),
-            "hits": self._hits.get(pool_name, 0),
-            "total_wait_s": self._total_wait.get(pool_name, 0),
-            "consumed": self._consumed.get(pool_name, 0),
-        }
+        return await pool.get_state()
 
     async def collect_metrics(self) -> list[dict[str, Any]]:
         """Collect current metrics for all pools.
@@ -374,7 +246,7 @@ class ExchangeRateLimiter:
                 ctx.emitter.emit(m["name"], m["value"], m["tags"])
         """
         metrics = []
-        for pool_name in self._config.pools:
+        for pool_name in self._pools:
             state = await self.get_pool_state(pool_name)
             if state is None:
                 continue
@@ -399,5 +271,5 @@ class ExchangeRateLimiter:
         return metrics
 
     def __repr__(self) -> str:
-        pools = ", ".join(f"{name}({pool.scope})" for name, pool in self._config.pools.items())
+        pools = ", ".join(f"{name}({pool.config.scope})" for name, pool in self._pools.items())
         return f"ExchangeRateLimiter({self._exchange}, pools=[{pools}])"

--- a/src/qubx/rate_limiting/pools.py
+++ b/src/qubx/rate_limiting/pools.py
@@ -1,0 +1,201 @@
+"""Pool implementations for the rate limiting engine.
+
+Each pool type encapsulates its own gate behavior, acquisition logic,
+sync mechanism, and metrics state. The engine delegates to pools
+polymorphically — no pool_type branching in the engine.
+"""
+
+import asyncio
+from typing import Any
+
+from qubx import logger
+
+from .backend import IRateLimitBackend
+from .config import PoolConfig
+
+
+class RateLimitGateTimeout(Exception):
+    """Raised when acquire() times out waiting for a gate to reopen."""
+
+    def __init__(self, message: str, pool_name: str | None = None):
+        super().__init__(message)
+        self.pool_name = pool_name
+
+
+class BasePool:
+    """Base pool with gate mechanism and metrics tracking."""
+
+    def __init__(self, config: PoolConfig, exchange: str, scope_id: str):
+        self._config = config
+        self._exchange = exchange
+        self._scope_id = scope_id
+        self._gate = asyncio.Event()
+        self._gate.set()
+        self._gate_task: asyncio.Task | None = None
+        self.hits: int = 0
+        self.total_wait: float = 0
+        self.consumed: float = 0
+
+    @property
+    def name(self) -> str:
+        return self._config.name
+
+    @property
+    def config(self) -> PoolConfig:
+        return self._config
+
+    @property
+    def scope_id(self) -> str:
+        return self._scope_id
+
+    @property
+    def is_gate_closed(self) -> bool:
+        return not self._gate.is_set()
+
+    def update_scope_id(self, scope_id: str) -> None:
+        self._scope_id = scope_id
+
+    async def acquire(self, weight: float, gate_max_wait: float) -> None:
+        raise NotImplementedError
+
+    def close_gate(self, cooldown: float, reason: str) -> None:
+        raise NotImplementedError
+
+    def sync(self, remaining: float, capacity: float | None = None) -> None:
+        raise NotImplementedError
+
+    def reset_gate(self) -> None:
+        """Reopen gate and cancel any pending reopen task."""
+        self._gate.set()
+        self._cancel_gate_task()
+
+    async def get_state(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _cancel_gate_task(self) -> None:
+        if self._gate_task is not None and not self._gate_task.done():
+            self._gate_task.cancel()
+        self._gate_task = None
+
+    def _base_state(self, remaining: float, capacity: float) -> dict[str, Any]:
+        return {
+            "pool": self.name,
+            "exchange": self._exchange,
+            "scope": self._config.scope,
+            "scope_id": self._scope_id,
+            "pool_type": self._config.pool_type,
+            "remaining": remaining,
+            "capacity": capacity,
+            "utilization": 1.0 - (remaining / capacity) if capacity > 0 else 0,
+            "gate_closed": self.is_gate_closed,
+            "hits": self.hits,
+            "total_wait_s": self.total_wait,
+            "consumed": self.consumed,
+        }
+
+
+class RatePool(BasePool):
+    """Time-based token bucket pool. Gate reopens on timer after cooldown."""
+
+    def __init__(self, config: PoolConfig, exchange: str, scope_id: str, backend: IRateLimitBackend):
+        super().__init__(config, exchange, scope_id)
+        self._backend = backend
+        self._key = self._make_key()
+
+    def _make_key(self) -> str:
+        return f"ratelimit:{self._exchange}:{self._config.name}:{self._scope_id}"
+
+    def update_scope_id(self, scope_id: str) -> None:
+        super().update_scope_id(scope_id)
+        self._key = self._make_key()
+
+    async def acquire(self, weight: float, gate_max_wait: float) -> None:
+        if not self._gate.is_set():
+            try:
+                await asyncio.wait_for(self._gate.wait(), timeout=gate_max_wait)
+            except asyncio.TimeoutError:
+                raise RateLimitGateTimeout(
+                    f"{self._exchange}: gate for pool '{self.name}' did not reopen "
+                    f"within {gate_max_wait:.0f}s",
+                    pool_name=self.name,
+                ) from None
+
+        wait_time = await self._backend.acquire(self._key, weight, self._config.capacity, self._config.refill_rate)
+        self.total_wait += wait_time
+        self.consumed += weight
+
+    def close_gate(self, cooldown: float, reason: str) -> None:
+        verb = "extended" if not self._gate.is_set() else "closed"
+        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name} ({cooldown:.1f}s): {reason}")
+        self._gate.clear()
+        self._cancel_gate_task()
+        self._gate_task = asyncio.ensure_future(self._reopen_after(cooldown))
+
+    async def _reopen_after(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+            self._gate.set()
+            logger.info(f"Rate limit gate reopened for {self._exchange}:{self.name} after {delay:.1f}s")
+        except asyncio.CancelledError:
+            pass
+
+    def sync(self, remaining: float, capacity: float | None = None) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._backend.set_remaining(self._key, remaining))
+        except RuntimeError:
+            pass  # No running loop — skip sync (e.g., during shutdown)
+
+    async def get_state(self) -> dict[str, Any]:
+        remaining = await self._backend.get_remaining(self._key, self._config.capacity, self._config.refill_rate)
+        if remaining is None:
+            remaining = self._config.capacity
+        return self._base_state(remaining, self._config.capacity)
+
+
+class QuotaPool(BasePool):
+    """Externally-managed quota pool. Gate reopens only via sync() or reset_gate()."""
+
+    def __init__(self, config: PoolConfig, exchange: str, scope_id: str):
+        super().__init__(config, exchange, scope_id)
+        self._remaining: float = config.capacity
+
+    @property
+    def remaining(self) -> float:
+        return self._remaining
+
+    async def acquire(self, weight: float, gate_max_wait: float) -> None:
+        if not self._gate.is_set() or self._remaining <= 0:
+            if self._remaining <= 0:
+                self.close_gate(self._config.cooldown, "quota depleted")
+            raise RateLimitGateTimeout(
+                f"{self._exchange}: quota pool '{self.name}' depleted",
+                pool_name=self.name,
+            )
+        self._remaining = max(0, self._remaining - weight)
+        self.consumed += weight
+
+    def close_gate(self, cooldown: float, reason: str) -> None:
+        verb = "extended" if not self._gate.is_set() else "closed"
+        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name} ({cooldown:.1f}s): {reason}")
+        self._gate.clear()
+        self._cancel_gate_task()
+
+    def sync(self, remaining: float, capacity: float | None = None) -> None:
+        self._remaining = remaining
+        if remaining <= 0:
+            self.close_gate(self._config.cooldown, f"quota {self.name} depleted (remaining={remaining})")
+        else:
+            # When no explicit capacity provided, grow capacity to track the
+            # real account quota (best approximation when exchange only reports remaining)
+            if capacity is None:
+                self._config.capacity = max(self._config.capacity, remaining)
+            if not self._gate.is_set():
+                self._cancel_gate_task()
+                self._gate.set()
+                logger.info(
+                    f"Rate limit gate reopened for {self._exchange}:{self.name} (remaining={remaining})"
+                )
+
+    async def get_state(self) -> dict[str, Any]:
+        return self._base_state(self._remaining, self._config.capacity)

--- a/tests/qubx/rate_limiting/test_engine.py
+++ b/tests/qubx/rate_limiting/test_engine.py
@@ -1,0 +1,165 @@
+"""Tests for the rate limiting engine — quota pool behavior."""
+
+import asyncio
+
+import pytest
+
+from qubx.rate_limiting import ExchangeRateLimiter, ExchangeRateLimitConfig, PoolConfig, EndpointCosts
+from qubx.rate_limiting.engine import RateLimitGateTimeout
+
+
+def _make_config(
+    quota_capacity: float = 1000,
+    cooldown: float = 0.5,
+    gate_max_wait: float = 1.0,
+) -> ExchangeRateLimitConfig:
+    """Create a minimal config with one rate pool and one quota pool."""
+    return ExchangeRateLimitConfig(
+        pools={
+            "rate_pool": PoolConfig(
+                name="rate_pool",
+                scope="ip",
+                capacity=100,
+                refill_rate=10.0,
+                pool_type="rate",
+                cooldown=cooldown,
+            ),
+            "quota_pool": PoolConfig(
+                name="quota_pool",
+                scope="address",
+                capacity=quota_capacity,
+                refill_rate=0,
+                pool_type="quota",
+                cooldown=cooldown,
+            ),
+        },
+        endpoint_map={
+            "use_quota": EndpointCosts([("rate_pool", 1), ("quota_pool", 1)]),
+            "use_rate_only": EndpointCosts([("rate_pool", 1)]),
+        },
+        default_costs=EndpointCosts([]),
+        gate_max_wait=gate_max_wait,
+    )
+
+
+class TestSyncQuotaReopensGate:
+    @pytest.mark.asyncio
+    async def test_sync_quota_reopens_gate_on_positive_remaining(self):
+        config = _make_config()
+        limiter = ExchangeRateLimiter("test", config)
+
+        # Deplete quota → gate closes
+        limiter.sync_from_exchange("quota_pool", remaining=0)
+        assert limiter.is_gate_closed("quota_pool")
+
+        # Sync with positive remaining → gate reopens
+        limiter.sync_from_exchange("quota_pool", remaining=50)
+        assert not limiter.is_gate_closed("quota_pool")
+
+    @pytest.mark.asyncio
+    async def test_sync_quota_closes_gate_on_zero(self):
+        config = _make_config()
+        limiter = ExchangeRateLimiter("test", config)
+
+        limiter.sync_from_exchange("quota_pool", remaining=0)
+        assert limiter.is_gate_closed("quota_pool")
+
+    @pytest.mark.asyncio
+    async def test_sync_quota_updates_capacity_when_remaining_exceeds_it(self):
+        config = _make_config(quota_capacity=1000)
+        limiter = ExchangeRateLimiter("test", config)
+
+        # Remaining exceeds initial capacity (account earned more quota)
+        limiter.sync_from_exchange("quota_pool", remaining=5000)
+        assert config.pools["quota_pool"].capacity == 5000
+
+        # Verify utilization is sane (not negative)
+        state = await limiter.get_pool_state("quota_pool")
+        assert state is not None
+        assert 0 <= state["utilization"] <= 1.0
+
+
+class TestQuotaPoolNoTimedGateReopen:
+    @pytest.mark.asyncio
+    async def test_quota_pool_gate_stays_closed(self):
+        """Quota pool gate should NOT reopen on a timer — only via sync_from_exchange."""
+        config = _make_config(cooldown=0.1)
+        limiter = ExchangeRateLimiter("test", config)
+
+        limiter.sync_from_exchange("quota_pool", remaining=0)
+        assert limiter.is_gate_closed("quota_pool")
+
+        # Wait longer than cooldown — gate should still be closed
+        await asyncio.sleep(0.3)
+        assert limiter.is_gate_closed("quota_pool")
+
+    @pytest.mark.asyncio
+    async def test_rate_pool_timed_gate_reopen(self):
+        """Rate pools should still get timer-based reopen (no regression)."""
+        config = _make_config(cooldown=0.2)
+        limiter = ExchangeRateLimiter("test", config)
+
+        limiter.report_limit_hit(pool_name="rate_pool", retry_after=0.2, reason="test")
+        assert limiter.is_gate_closed("rate_pool")
+
+        await asyncio.sleep(0.3)
+        assert not limiter.is_gate_closed("rate_pool")
+
+
+class TestQuotaAcquireFailsFast:
+    @pytest.mark.asyncio
+    async def test_quota_acquire_raises_immediately_when_depleted(self):
+        """Depleted quota pool should raise immediately, not wait gate_max_wait."""
+        config = _make_config(gate_max_wait=5.0)
+        limiter = ExchangeRateLimiter("test", config)
+
+        limiter.sync_from_exchange("quota_pool", remaining=0)
+
+        t0 = asyncio.get_event_loop().time()
+        with pytest.raises(RateLimitGateTimeout) as exc_info:
+            await limiter.acquire("use_quota")
+        elapsed = asyncio.get_event_loop().time() - t0
+
+        # Should be near-instant, not 5s
+        assert elapsed < 1.0
+        assert exc_info.value.pool_name == "quota_pool"
+
+
+class TestGateTimeoutHasPoolName:
+    @pytest.mark.asyncio
+    async def test_gate_timeout_has_pool_name(self):
+        config = _make_config(gate_max_wait=0.1, cooldown=5.0)
+        limiter = ExchangeRateLimiter("test", config)
+
+        # Close the rate pool gate with long cooldown
+        limiter.report_limit_hit(pool_name="rate_pool", retry_after=5.0, reason="test")
+
+        with pytest.raises(RateLimitGateTimeout) as exc_info:
+            await limiter.acquire("use_rate_only")
+
+        assert exc_info.value.pool_name == "rate_pool"
+
+    @pytest.mark.asyncio
+    async def test_quota_timeout_has_pool_name(self):
+        config = _make_config()
+        limiter = ExchangeRateLimiter("test", config)
+        limiter.sync_from_exchange("quota_pool", remaining=0)
+
+        with pytest.raises(RateLimitGateTimeout) as exc_info:
+            await limiter.acquire("use_quota")
+
+        assert exc_info.value.pool_name == "quota_pool"
+
+
+class TestSyncFromExchangeReopensQuotaGate:
+    @pytest.mark.asyncio
+    async def test_sync_from_exchange_reopens_quota_gate(self):
+        config = _make_config()
+        limiter = ExchangeRateLimiter("test", config)
+
+        limiter.sync_from_exchange("quota_pool", remaining=0)
+        assert limiter.is_gate_closed("quota_pool")
+
+        # sync_from_exchange with positive remaining reopens
+        limiter.sync_from_exchange("quota_pool", remaining=100)
+        assert not limiter.is_gate_closed("quota_pool")


### PR DESCRIPTION
## Summary

- **Fix quota pool gate storm**: Quota pool gates no longer reopen on a timer. They stay closed until the exchange reports positive remaining via `sync_from_exchange()` or `reset_gates()`. Eliminates the 15s open/close storm that blocked bot 779e5c9b for 6.5 hours.
- **Fail-fast for depleted quota pools**: `acquire()` raises `RateLimitGateTimeout` immediately (with `pool_name` attribute) instead of waiting `gate_max_wait`. Enables connector-level fallback logic.
- **Quota gate reopening**: `sync_from_exchange()` now reopens quota gates when remaining goes positive, and grows `pool.capacity` to track the real account quota.
- **Refactor into pool subclasses**: Extracted `RatePool` and `QuotaPool` from the engine into `pools.py`. All `if pool.pool_type == "quota"` branching removed from `ExchangeRateLimiter`.
- **Rate limiting docs**: New `docs/connectors/rate-limiting.md` covering concepts, configuration, integration, fallback patterns, and metrics. Added Connectors section to mkdocs nav.

## Test plan

- [x] `uv run pytest tests/qubx/rate_limiting/test_engine.py -v` — 9 tests covering sync reopen, gate stays closed, fail-fast, pool_name on timeout, capacity growth
- [ ] qubx_lighter tests pass against this branch (verified locally with editable install)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)