### PR TITLE
feat: use exchange-reported portfolio value for total capital

### DIFF
--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -1432,12 +1432,14 @@ def _bundle_source_overrides(
                 continue
 
             checkout_dir = _find_uv_git_checkout(commit_sha)
+            cloned_locally = False
             if not checkout_dir:
                 # Cache miss — clone the repo at the exact commit
                 git_url = source["git"]
                 git_ref = source.get("tag") or source.get("branch") or commit_sha
                 logger.info(f"  {pkg_name}: cache miss, cloning {git_url} at {git_ref} ...")
                 checkout_dir = os.path.join(os.path.dirname(wheels_dir), f".git-clone-{pkg_norm}")
+                cloned_locally = True
                 try:
                     subprocess.run(
                         ["git", "clone", "--depth", "1", "--branch", git_ref, git_url, checkout_dir],
@@ -1473,6 +1475,9 @@ def _bundle_source_overrides(
                 logger.info(f"  Bundled {pkg_name}=={pkg_ver} from git")
             except subprocess.CalledProcessError as e:
                 logger.opt(colors=False).warning(f"  Failed to build wheel for {pkg_name}: {e.stderr or e}")
+            finally:
+                if cloned_locally and os.path.isdir(checkout_dir):
+                    shutil.rmtree(checkout_dir, ignore_errors=True)
 
     return bundled
 

--- a/src/qubx/connectors/ccxt/account.py
+++ b/src/qubx/connectors/ccxt/account.py
@@ -222,7 +222,10 @@ class CcxtAccountProcessor(BasicAccountProcessor):
             except Exception as e:
                 logger.warning(f"Failed to fetch balance data before polling started: {e}")
 
-        # sum of balances + market value of all positions on non spot/margin
+        if self._exchange_total_capital is not None:
+            return self._exchange_total_capital
+
+        # fallback: sum of balances + market value of all positions on non spot/margin
         _currency_to_value = {c: self._get_currency_value(b.total, c) for c, b in self._balances.items()}
         _positions_value = sum([p.market_value_funds for p in self._positions.values() if p.instrument.is_futures()])
         return sum(_currency_to_value.values()) + _positions_value
@@ -316,9 +319,32 @@ class CcxtAccountProcessor(BasicAccountProcessor):
             await self._subscribe_instruments(list(self._required_instruments))
             self._latest_instruments.update(self._required_instruments)
 
+    def _extract_portfolio_value(self, balances_raw: dict) -> float | None:
+        """Extract exchange-reported portfolio value (equity) from raw balance response.
+
+        Override in exchange-specific processors for non-standard responses.
+        Base implementation handles Binance futures (totalMarginBalance).
+
+        Returns:
+            Total equity as float, or None to fall back to computed value.
+        """
+        info = balances_raw.get("info", {})
+        val = info.get("totalMarginBalance")
+        if val is not None:
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                pass
+        return None
+
     async def _update_balance(self) -> None:
         """Fetch and update balances from exchange"""
         balances_raw = await self.exchange_manager.exchange.fetch_balance()
+
+        equity = self._extract_portfolio_value(balances_raw)
+        if equity is not None:
+            self._exchange_total_capital = equity
+
         balances = ccxt_convert_balance(balances_raw, self.exchange)
         current_balances = self.get_balances()
 

--- a/src/qubx/connectors/ccxt/exchanges/hyperliquid/account.py
+++ b/src/qubx/connectors/ccxt/exchanges/hyperliquid/account.py
@@ -23,6 +23,19 @@ class HyperliquidAccountProcessor(CcxtAccountProcessor):
     so we must subscribe to both channels separately.
     """
 
+    def _extract_portfolio_value(self, balances_raw: dict) -> float | None:
+        """Extract Hyperliquid account value from raw balance response."""
+        info = balances_raw.get("info", {})
+        for key in ("marginSummary", "crossMarginSummary"):
+            summary = info.get(key, {})
+            val = summary.get("accountValue")
+            if val is not None:
+                try:
+                    return float(val)
+                except (ValueError, TypeError):
+                    pass
+        return None
+
     async def _subscribe_instruments(self, instruments: list[Instrument]):
         """Override to filter out instruments from other exchanges (e.g., spot vs futures)."""
         # Filter instruments to only those belonging to this exchange

--- a/src/qubx/connectors/ccxt/exchanges/okx/account.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/account.py
@@ -57,14 +57,29 @@ class OkxAccountProcessor(CcxtAccountProcessor):
             ),
         )
 
+    def _extract_portfolio_value(self, balances_raw: dict) -> float | None:
+        """Extract OKX total equity from raw balance response."""
+        data = balances_raw.get("info", {}).get("data", [{}])[0]
+        total_eq = data.get("totalEq")
+        if total_eq is not None:
+            try:
+                return float(total_eq)
+            except (ValueError, TypeError):
+                pass
+        return None
+
     async def _update_balance(self) -> None:
-        """OKX balance override: use cashBal instead of eq (equity) to avoid double-counting unrealized PnL.
+        """OKX balance override: use cashBal for per-currency balances.
 
         CCXT maps OKX's `eq` (equity = cashBal + unrealizedPnL) to balance `total`.
-        Since get_total_capital() adds position market values (= unrealized PnL) on top,
-        using `eq` would double-count unrealized PnL. We use `cashBal` instead.
+        We use `cashBal` for individual currency balances, and extract `totalEq`
+        as the authoritative portfolio value via _extract_portfolio_value().
         """
         balances_raw = await self.exchange_manager.exchange.fetch_balance()
+
+        equity = self._extract_portfolio_value(balances_raw)
+        if equity is not None:
+            self._exchange_total_capital = equity
 
         # Extract cashBal from raw OKX response instead of CCXT-parsed eq
         balances: list[AssetBalance] = []

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -65,6 +65,7 @@ class BasicAccountProcessor(IAccountProcessor):
         self._locked_capital_by_order = dict()
         self._pending_order_requests = {}
         self._balances = {}
+        self._exchange_total_capital: float | None = None
         # Initialize with base currency balance
         self._balances[self.base_currency] = AssetBalance(
             exchange=self.exchange, currency=self.base_currency, free=initial_capital, locked=0.0, total=initial_capital
@@ -90,7 +91,9 @@ class BasicAccountProcessor(IAccountProcessor):
         return self.get_available_margin(exchange)
 
     def get_total_capital(self, exchange: str | None = None) -> float:
-        # sum of cash + market value of all positions
+        if self._exchange_total_capital is not None:
+            return self._exchange_total_capital
+        # fallback: sum of cash + market value of all positions
         _cash_amount = self._balances[self.base_currency].total
         _positions_value = sum([p.market_value_funds for p in self._positions.values()])
         return _cash_amount + _positions_value


### PR DESCRIPTION
## Summary

Use the exchange's authoritative equity/portfolio value for `get_total_capital()` in live trading instead of computing it from balance + position market values.

**Problem:** Timing mismatches between balance updates (from WS/polling) and position price updates (from trades/quotes) cause deviations from the real margin balance on the exchange. Our mark price may also differ from the exchange's.

**Fix:** Add `_exchange_total_capital` field to `BasicAccountProcessor`. When set by live connectors from exchange data, `get_total_capital()` returns it directly. Backtesting is unaffected (field stays None, computed value used).

- **BasicAccountProcessor**: new `_exchange_total_capital` field + check in `get_total_capital()`
- **CcxtAccountProcessor**: `_extract_portfolio_value()` hook called in `_update_balance()`. Base implementation extracts `totalMarginBalance` (Binance futures).
- **OKX**: override extracts `totalEq` from raw response
- **Hyperliquid**: override extracts `accountValue` from `marginSummary`
- **Bitfinex**: no change (fallback to computed, hook returns None)

## Test plan

- [x] `BasicAccountProcessor._exchange_total_capital` logic verified manually
- [x] Rate limiting tests still pass
- [ ] Smoke test on dev with Lighter bot — verify `get_total_capital()` matches exchange portfolio_value
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)