### PR TITLE
feat: OKX real-time balance WS stream and exchange margin ratio

### DIFF
--- a/src/qubx/connectors/ccxt/exchanges/okx/account.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/account.py
@@ -18,7 +18,34 @@ class OkxAccountProcessor(CcxtAccountProcessor):
     so we must subscribe to both channels separately:
     - orders channel: for order status updates (watch_orders)
     - trades channel: for trade/fill updates (watch_my_trades)
+
+    Balance streaming: uses watch_balance WS to get real-time totalEq updates
+    instead of relying solely on 30s polling.
     """
+
+    def start(self):
+        super().start()
+        if self._is_running and not self.exchange_manager.exchange.isSandboxModeEnabled:
+            self._polling_tasks["balance_ws"] = self._loop.submit(self._watch_balance_stream())
+
+    async def _watch_balance_stream(self):
+        """Stream balance updates via WS to get real-time totalEq."""
+
+        async def _watch():
+            balances_raw = await self.exchange_manager.exchange.watch_balance()
+            equity = self._extract_portfolio_value(balances_raw)
+            if equity is not None:
+                self._exchange_total_capital = equity
+            margin_ratio = self._extract_margin_ratio(balances_raw)
+            if margin_ratio is not None:
+                self._exchange_margin_ratio = margin_ratio
+
+        await self._listen_to_stream(
+            subscriber=_watch,
+            exchange=self.exchange_manager.exchange,
+            channel=self.channel,
+            name="okx_balance_ws",
+        )
 
     async def _subscribe_executions(self, name: str, channel: CtrlChannel):
         logger.info("<yellow>[OKX]</yellow> Subscribing to executions (orders + trades)")
@@ -57,11 +84,31 @@ class OkxAccountProcessor(CcxtAccountProcessor):
             ),
         )
 
+    def _get_account_data(self, balances_raw: dict) -> dict:
+        """Get the OKX account data dict from info.data[0]."""
+        return balances_raw.get("info", {}).get("data", [{}])[0]
+
+    def _extract_margin_ratio(self, balances_raw: dict) -> float | None:
+        """Extract OKX margin ratio from the base currency detail entry.
+
+        The account-level mgnRatio is empty; the real value is per-currency in details.
+        We use the base currency's mgnRatio as the account margin ratio.
+        """
+        details = self._get_account_data(balances_raw).get("details", [])
+        for detail in details:
+            if detail.get("ccy", "").upper() == self.base_currency.upper():
+                val = detail.get("mgnRatio")
+                if val is not None and val != "":
+                    try:
+                        return float(val)
+                    except (ValueError, TypeError):
+                        pass
+        return None
+
     def _extract_portfolio_value(self, balances_raw: dict) -> float | None:
-        """Extract OKX total equity from raw balance response."""
-        data = balances_raw.get("info", {}).get("data", [{}])[0]
-        total_eq = data.get("totalEq")
-        if total_eq is not None:
+        """Extract OKX total equity from info.data[0].totalEq."""
+        total_eq = self._get_account_data(balances_raw).get("totalEq")
+        if total_eq is not None and total_eq != "":
             try:
                 return float(total_eq)
             except (ValueError, TypeError):
@@ -80,6 +127,10 @@ class OkxAccountProcessor(CcxtAccountProcessor):
         equity = self._extract_portfolio_value(balances_raw)
         if equity is not None:
             self._exchange_total_capital = equity
+
+        margin_ratio = self._extract_margin_ratio(balances_raw)
+        if margin_ratio is not None:
+            self._exchange_margin_ratio = margin_ratio
 
         # Extract cashBal from raw OKX response instead of CCXT-parsed eq
         balances: list[AssetBalance] = []

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -66,6 +66,7 @@ class BasicAccountProcessor(IAccountProcessor):
         self._pending_order_requests = {}
         self._balances = {}
         self._exchange_total_capital: float | None = None
+        self._exchange_margin_ratio: float | None = None
         # Initialize with base currency balance
         self._balances[self.base_currency] = AssetBalance(
             exchange=self.exchange, currency=self.base_currency, free=initial_capital, locked=0.0, total=initial_capital
@@ -183,7 +184,9 @@ class BasicAccountProcessor(IAccountProcessor):
         return self.get_total_capital(exchange) - self.get_total_required_margin(exchange)
 
     def get_margin_ratio(self, exchange: str | None = None) -> float:
-        # total capital / total required margin
+        if self._exchange_margin_ratio is not None:
+            return self._exchange_margin_ratio
+        # fallback: total capital / total required margin
         required_margin = self.get_total_required_margin(exchange)
         if required_margin == 0:
             return 100.0

--- a/src/qubx/core/utils.pyx
+++ b/src/qubx/core/utils.pyx
@@ -8,6 +8,12 @@ NS = 1_000_000_000
 
 cpdef recognize_time(time):
     if isinstance(time, str):
+        # Strip timezone suffix (e.g. 'Z', '+00:00') — np.datetime64 expects tz-naive ISO strings.
+        # All incoming timestamps are assumed UTC.
+        if time.endswith('Z') or time.endswith('z'):
+            time = time[:-1]
+        elif '+' in time[10:]:
+            time = time[:time.rindex('+')]
         return np.datetime64(time, 'ns')
     elif isinstance(time, np.datetime64):
         return time


### PR DESCRIPTION
- Add watch_balance WS stream to OKX account processor for real-time totalEq and mgnRatio updates instead of relying on 30s polling alone
- Add _exchange_margin_ratio to BasicAccountProcessor, used by get_margin_ratio() when the exchange provides its own value
- Extract margin ratio from OKX per-currency details (base currency entry) since the account-level mgnRatio field is empty
- Fix numpy timezone warnings by stripping tz suffix in recognize_time()