### PR TITLE
feat(loggers): event-driven position logging + optional intervals

### DIFF
--- a/src/qubx/core/loggers.py
+++ b/src/qubx/core/loggers.py
@@ -356,7 +356,7 @@ class StrategyLogging:
         num_exec_records_to_write=1,  # in live let's write every execution
         num_signals_records_to_write=1,
         heartbeat_freq: str | None = None,
-        positions_log_on_change: bool = True,
+        positions_log_on_change: bool = False,
     ) -> None:
         # - instantiate loggers
         if logs_writer:

--- a/src/qubx/core/loggers.py
+++ b/src/qubx/core/loggers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pandas as pd
 
 from qubx import logger
 from qubx.core.basics import (
@@ -100,27 +101,34 @@ class PositionsDumper(_BaseIntervalDumper):
             self.positions[p.instrument] = p
         return self
 
+    @staticmethod
+    def _position_row(instrument: Instrument, position: Position, timestamp: np.datetime64) -> dict[str, Any]:
+        return {
+            "timestamp": str(timestamp),
+            "symbol": instrument.symbol,
+            "exchange": instrument.exchange,
+            "market_type": instrument.market_type,
+            "pnl_quoted": position.pnl,
+            "funding_pnl_quoted": position.cumulative_funding,
+            "realized_pnl_quoted": position.r_pnl,
+            "quantity": position.quantity,
+            "notional": position.notional_value,
+            "avg_position_price": position.position_avg_price if position.quantity != 0.0 else 0.0,
+            "current_price": position.last_update_price,
+            "market_value_quoted": position.market_value_funds,
+            "commissions_quoted": position.commissions,
+        }
+
     def dump(self, interval_start_time: np.datetime64, actual_timestamp: np.datetime64):
-        data = []
-        for i, p in self.positions.items():
-            data.append(
-                {
-                    "timestamp": str(actual_timestamp),
-                    "symbol": i.symbol,
-                    "exchange": i.exchange,
-                    "market_type": i.market_type,
-                    "pnl_quoted": p.pnl,
-                    "funding_pnl_quoted": p.cumulative_funding,
-                    "realized_pnl_quoted": p.r_pnl,
-                    "quantity": p.quantity,
-                    "notional": p.notional_value,
-                    "avg_position_price": p.position_avg_price if p.quantity != 0.0 else 0.0,
-                    "current_price": p.last_update_price,
-                    "market_value_quoted": p.market_value_funds,
-                    "commissions_quoted": p.commissions,
-                }
-            )
+        data = [self._position_row(i, p, actual_timestamp) for i, p in self.positions.items()]
         self._writer.write_data("positions", data)
+
+    def dump_instrument(self, instrument: Instrument, timestamp: np.datetime64) -> None:
+        """Write a single position snapshot row for ``instrument`` (used for on-fill event logging)."""
+        position = self.positions.get(instrument)
+        if position is None:
+            return
+        self._writer.write_data("positions", [self._position_row(instrument, position, timestamp)])
 
 
 class PortfolioLogger(PositionsDumper):
@@ -343,11 +351,12 @@ class StrategyLogging:
     def __init__(
         self,
         logs_writer: LogsWriter | None = None,
-        positions_log_freq: str = "1Min",
-        portfolio_log_freq: str = "5Min",
+        positions_log_freq: str | None = "1Min",
+        portfolio_log_freq: str | None = "5Min",
         num_exec_records_to_write=1,  # in live let's write every execution
         num_signals_records_to_write=1,
         heartbeat_freq: str | None = None,
+        positions_log_on_change: bool = True,
     ) -> None:
         # - instantiate loggers
         if logs_writer:
@@ -367,13 +376,16 @@ class StrategyLogging:
             if num_signals_records_to_write >= 1:
                 self.signals_logger = SignalsAndTargetsLogger(logs_writer, num_signals_records_to_write)
 
-            # - balance logger
-            self.balance_logger = BalanceLogger(logs_writer, positions_log_freq)
+            # - balance logger (tracks positions_log_freq when set, otherwise portfolio_log_freq)
+            balance_freq = positions_log_freq or portfolio_log_freq
+            if balance_freq:
+                self.balance_logger = BalanceLogger(logs_writer, balance_freq)
         else:
             logger.warning("Log writer is not defined - strategy activity will not be saved !")
 
         self.logs_writer = logs_writer
         self.heartbeat_freq = convert_tf_str_td64(heartbeat_freq) if heartbeat_freq else None
+        self.positions_log_on_change = positions_log_on_change
 
     def initialize(
         self,
@@ -431,6 +443,10 @@ class StrategyLogging:
     def save_deals(self, instrument: Instrument, deals: list[Deal]):
         if self.executions_logger:
             self.executions_logger.record_deals(instrument, deals)
+        if self.positions_log_on_change and self.positions_dumper and deals:
+            latest_deal_time = max(d.time for d in deals)
+            ts = latest_deal_time.as_unit("ns").asm8 if isinstance(latest_deal_time, pd.Timestamp) else latest_deal_time
+            self.positions_dumper.dump_instrument(instrument, ts)
 
     def save_targets(self, targets: list[TargetPosition]):
         if self.signals_logger and targets:

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -108,7 +108,7 @@ class LoggingConfig(StrictBaseModel):
     logger: str
     position_interval: str | None = None
     portfolio_interval: str | None = None
-    position_log_on_change: bool = True
+    position_log_on_change: bool = False
     args: dict = Field(default_factory=dict)
     heartbeat_interval: str | None = None
 

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -106,8 +106,9 @@ class WarmupConfig(StrictBaseModel):
 
 class LoggingConfig(StrictBaseModel):
     logger: str
-    position_interval: str
-    portfolio_interval: str
+    position_interval: str | None = None
+    portfolio_interval: str | None = None
+    position_log_on_change: bool = True
     args: dict = Field(default_factory=dict)
     heartbeat_interval: str | None = None
 

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -693,6 +693,7 @@ def _setup_strategy_logging(
         positions_log_freq=log_config.position_interval,
         portfolio_log_freq=log_config.portfolio_interval,
         heartbeat_freq=log_config.heartbeat_interval,
+        positions_log_on_change=log_config.position_log_on_change,
     )
     return stg_logging
 

--- a/tests/qubx/core/loggers_test.py
+++ b/tests/qubx/core/loggers_test.py
@@ -13,6 +13,7 @@ from qubx.core.loggers import (
     ExecutionsLogger,
     LogsWriter,
     PositionsDumper,
+    StrategyLogging,
 )
 from qubx.core.lookups import lookup
 from qubx.loggers.csv import CsvFileLogsWriter
@@ -154,6 +155,106 @@ class TestPortfolioLoggers:
         # Cleanup: close writer and remove temporary directory
         writer.close()
         shutil.rmtree(test_dir, ignore_errors=True)
+
+    def test_dump_instrument_writes_single_row(self):
+        btc = lookup.find_symbol("BINANCE", "BTCUSDT")
+        eth = lookup.find_symbol("BINANCE", "ETHUSDT")
+        assert btc is not None and eth is not None
+        pos_btc = Position(btc)
+        pos_eth = Position(eth)
+        pos_btc.change_position_by(_DT(0), 0.05, 63000)
+        pos_eth.change_position_by(_DT(0), 0.5, 3200)
+
+        captured: list[tuple[str, list[dict]]] = []
+
+        class _CapturingWriter(LogsWriter):
+            def write_data(self, log_type: str, data: list[dict]):
+                captured.append((log_type, data))
+
+        dumper = PositionsDumper(_CapturingWriter("acc", "strat", "run"), "1Sec").attach_positions(pos_btc, pos_eth)
+
+        dumper.dump_instrument(btc, _DT(1))
+        assert len(captured) == 1
+        log_type, data = captured[0]
+        assert log_type == "positions"
+        assert len(data) == 1
+        assert data[0]["symbol"] == "BTCUSDT"
+        assert data[0]["quantity"] == pos_btc.quantity
+
+        # Unknown instrument is a no-op.
+        unknown = lookup.find_symbol("BINANCE", "SOLUSDT")
+        assert unknown is not None
+        dumper.dump_instrument(unknown, _DT(2))
+        assert len(captured) == 1
+
+    def test_save_deals_triggers_on_change_dump(self):
+        btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert btc is not None
+        pos = Position(btc)
+        pos.change_position_by(_DT(0), 0.1, 50000)
+
+        captured: list[tuple[str, list[dict]]] = []
+
+        class _CapturingWriter(LogsWriter):
+            def write_data(self, log_type: str, data: list[dict]):
+                captured.append((log_type, data))
+
+        writer = _CapturingWriter("acc", "strat", "run")
+        logging = StrategyLogging(
+            logs_writer=writer,
+            positions_log_freq="1Min",
+            portfolio_log_freq=None,
+            positions_log_on_change=True,
+        )
+        assert logging.positions_dumper is not None
+        logging.positions_dumper.attach_positions(pos)
+
+        logging.save_deals(btc, [Deal("1", "o1", _DT(5), 0.1, 50050, False)])
+
+        position_writes = [d for t, d in captured if t == "positions"]
+        assert len(position_writes) == 1
+        assert position_writes[0][0]["symbol"] == "BTCUSDT"
+
+    def test_save_deals_respects_flag_off(self):
+        btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert btc is not None
+        pos = Position(btc)
+        pos.change_position_by(_DT(0), 0.1, 50000)
+
+        captured: list[tuple[str, list[dict]]] = []
+
+        class _CapturingWriter(LogsWriter):
+            def write_data(self, log_type: str, data: list[dict]):
+                captured.append((log_type, data))
+
+        logging = StrategyLogging(
+            logs_writer=_CapturingWriter("acc", "strat", "run"),
+            positions_log_freq="1Min",
+            portfolio_log_freq=None,
+            positions_log_on_change=False,
+        )
+        assert logging.positions_dumper is not None
+        logging.positions_dumper.attach_positions(pos)
+
+        logging.save_deals(btc, [Deal("1", "o1", _DT(5), 0.1, 50050, False)])
+
+        assert not any(t == "positions" for t, _ in captured)
+
+    def test_strategy_logging_disables_loggers_when_none(self):
+        captured: list[tuple[str, list[dict]]] = []
+
+        class _CapturingWriter(LogsWriter):
+            def write_data(self, log_type: str, data: list[dict]):
+                captured.append((log_type, data))
+
+        logging = StrategyLogging(
+            logs_writer=_CapturingWriter("acc", "strat", "run"),
+            positions_log_freq=None,
+            portfolio_log_freq=None,
+        )
+        assert logging.positions_dumper is None
+        assert logging.portfolio_logger is None
+        assert logging.balance_logger is None
 
     def test_balance_logger(self):
         writer = ConsolePositionsWriter("Account1", "Strategy1", "test-run-id-0")

--- a/tests/qubx/core/loggers_test.py
+++ b/tests/qubx/core/loggers_test.py
@@ -240,6 +240,31 @@ class TestPortfolioLoggers:
 
         assert not any(t == "positions" for t, _ in captured)
 
+    def test_save_deals_defaults_to_off(self):
+        btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert btc is not None
+        pos = Position(btc)
+        pos.change_position_by(_DT(0), 0.1, 50000)
+
+        captured: list[tuple[str, list[dict]]] = []
+
+        class _CapturingWriter(LogsWriter):
+            def write_data(self, log_type: str, data: list[dict]):
+                captured.append((log_type, data))
+
+        # Omit positions_log_on_change to exercise the default (False: unchanged behavior).
+        logging = StrategyLogging(
+            logs_writer=_CapturingWriter("acc", "strat", "run"),
+            positions_log_freq="1Min",
+            portfolio_log_freq=None,
+        )
+        assert logging.positions_dumper is not None
+        logging.positions_dumper.attach_positions(pos)
+
+        logging.save_deals(btc, [Deal("1", "o1", _DT(5), 0.1, 50050, False)])
+
+        assert not any(t == "positions" for t, _ in captured)
+
     def test_strategy_logging_disables_loggers_when_none(self):
         captured: list[tuple[str, list[dict]]] = []
 


### PR DESCRIPTION
## Summary

Reduce write volume of per-minute position/portfolio snapshots while keeping a useful audit trail. Two related knobs on the logging config:

1. **`position_interval` / `portfolio_interval` become optional** (`str | None = None`). Omitting or setting to `null` in YAML disables the corresponding dumper. The runtime already guarded both with `if positions_log_freq:` — only the Pydantic schema stood in the way.

2. **New `position_log_on_change: bool = False`** — opt-in. When set, `StrategyLogging.save_deals()` writes a single-instrument position snapshot to the positions log on every fill, via a new `PositionsDumper.dump_instrument(instrument, ts)` helper. Combined with a coarser `position_interval` heartbeat (e.g. `15Min`), this captures every real position change without flooding Postgres with unchanged snapshots.

Defaulting the flag to `False` keeps simulations and external Qubx users on their current behavior. Downstream consumers (e.g. the xLydian platform) can flip it to `true` in their logging preset.

## Why

Platform-side context (xLydianSoftware/xlydian-platform#97): Qubx's `PostgresLogsWriter` writes ~22k rows/day/bot to `qubx_logs_positions` at 1-min cadence × ~15 instruments, plus another ~4k/day to `qubx_logs_portfolio` — both mostly unchanged state. The platform doesn't read `qubx_logs_portfolio` at all, and `qubx_logs_positions` is only consumed by `PostgresPositionRestorer` which needs just the latest row per instrument. Moving to event-driven + a slow heartbeat lets us keep Postgres eternal without unbounded growth.

## Changes

- `src/qubx/utils/runner/configs.py`: `LoggingConfig.position_interval` / `portfolio_interval` → `str | None = None`; new `position_log_on_change: bool = False`.
- `src/qubx/core/loggers.py`:
  - Factored `_position_row` out of `PositionsDumper.dump()` so interval and event paths share schema.
  - New `PositionsDumper.dump_instrument(instrument, timestamp)` — writes one row for one instrument (no-op if not attached).
  - `StrategyLogging.__init__` accepts `positions_log_freq: str | None` and `positions_log_on_change: bool = False`; balance logger now falls back to `portfolio_log_freq` when positions is disabled, and is skipped entirely if both are None.
  - `StrategyLogging.save_deals()` also calls `positions_dumper.dump_instrument(instrument, latest_deal_time)` when the flag is set.
- `src/qubx/utils/runner/runner.py`: threads `position_log_on_change` through to `StrategyLogging`.

## Test plan

- [x] `tests/qubx/core/loggers_test.py` — 5 new cases covering dump_instrument, on-change hook, flag off, default-off, and all-None intervals.
- [x] `pytest tests/qubx/core/` — all passing.
- [x] `pytest tests/qubx/utils/runner/ tests/qubx/cli/ tests/qubx/test_infer_restorer.py` — all passing.

Backward-compatible: existing callers pass explicit string intervals and get identical behavior; `position_log_on_change` defaults to `False` so no behavior change unless explicitly opted in.