### PR TITLE
fix(ccxt): wire rate limiter into warmup + live fetch paths (#264)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
     # Data & numerics
-    "numpy>=1.26.3",
+    # NumPy 2.0 broke the C-API ABI. Our Cython extensions (qubx.core.series, etc.)
+    # are built against 1.x and won't import under 2.x without a rebuild. Bump the
+    # upper bound when we rebuild wheels against numpy 2.x.
+    "numpy>=1.26.3,<2",
     "pandas>=2.2.2,<3",
     "pyarrow>=15.0.0",
     "scipy>=1.12.0,<2",
@@ -107,7 +110,10 @@ requires = [
     "hatchling>=1.21.0",
     "hatch-vcs>=0.4.0",
     "setuptools>=61.0",
-    "numpy>=1.26.3",
+    # Keep build-time numpy aligned with the runtime bound — Cython extensions
+    # compiled against numpy 2.x are ABI-incompatible with a numpy 1.x runtime
+    # (and vice versa). See runtime dependency note above.
+    "numpy>=1.26.3,<2",
     "cython==3.0.8",
     "toml>=0.10.2",
 ]

--- a/src/qubx/connectors/ccxt/exchange_manager.py
+++ b/src/qubx/connectors/ccxt/exchange_manager.py
@@ -271,20 +271,55 @@ class ExchangeManager:
         logger.info(f"Rate limiter attached to {self._exchange_name}")
 
     def _apply_rate_limiter_to_exchange(self, exchange: cxp.Exchange) -> None:
-        """Disable CCXT's built-in rate limiter and install our throttle override."""
+        """Install our throttle and response-header-sync hooks on *exchange*.
+
+        Two hooks are installed per exchange:
+
+        1. **Throttle (pre-request)** — replaces CCXT's built-in throttle so every
+           REST call blocks on our token bucket first. ``acquire`` forwards the
+           CCXT-provided cost to the limiter as ``weight_override``.
+
+        2. **Response hook (post-request)** — wraps CCXT's ``on_rest_response`` to
+           invoke the exchange-specific header parser (OKX ``x-ratelimit-*``,
+           Binance ``X-MBX-USED-WEIGHT-1M``, etc.). The parser calls
+           ``rate_limiter.sync_from_exchange`` so our modeled budget tracks the
+           exchange's reported usage. Unlike ``CcxtStorage``'s best-effort sync,
+           this path runs atomically inside CCXT's fetch pipeline — no
+           concurrent-fetch race on ``last_response_headers``.
+
+        Both hooks are reapplied automatically after exchange recreation via
+        ``register_recreation_callback`` in :meth:`attach_rate_limiter`.
+        """
         rate_limiter = getattr(self, "_rate_limiter", None)
         if rate_limiter is None:
             return
 
-        # Keep enableRateLimit=True so CCXT calls self.throttle(cost) in fetch2()
-        # We override the throttle method to use our rate limiter instead of CCXT's built-in
+        # 1) Throttle override — pre-request acquisition.
         exchange.enableRateLimit = True
+
         async def _rate_limit_throttle(cost=None):
             if cost is None:
                 cost = 1.0
             await rate_limiter.acquire("ccxt_rest", weight_override=float(cost))
 
         exchange.throttle = _rate_limit_throttle
+
+        # 2) Response hook — post-response state sync.
+        from qubx.connectors.ccxt.rate_limits import get_header_parser
+
+        parser = get_header_parser(getattr(exchange, "id", ""))
+        if parser is not None:
+            _orig_on_rest = exchange.on_rest_response
+
+            def _header_sync_hook(code, reason, url, method, headers, body, req_headers, req_body):
+                try:
+                    if headers:
+                        parser(headers, rate_limiter)
+                except Exception as e:
+                    logger.debug(f"[{self._exchange_name}] header sync failed (non-fatal): {e}")
+                return _orig_on_rest(code, reason, url, method, headers, body, req_headers, req_body)
+
+            exchange.on_rest_response = _header_sync_hook
 
     @property
     def rate_limiter(self):

--- a/src/qubx/connectors/ccxt/rate_limits.py
+++ b/src/qubx/connectors/ccxt/rate_limits.py
@@ -277,3 +277,21 @@ def get_header_parser(exchange_name: str):
     """Get the response header parser for an exchange."""
     name = exchange_name.lower().split(".")[0]
     return HEADER_PARSERS.get(name)
+
+
+# NOTE: As of #264 these parsers are invoked from two fetch paths:
+#
+#   * ``qubx.data.storages.ccxt._sync_rate_limiter_from_response_headers`` after
+#     each successful OHLCV page fetch. Best-effort — ``last_response_headers`` is
+#     an exchange-wide attribute so under concurrent fetches the read may be from a
+#     neighboring request. Since all concurrent requests drain the same IP-scoped
+#     budget, an approximate reading is still strictly better than no sync.
+#
+#   * ``qubx.connectors.ccxt.exchange_manager.ExchangeManager._apply_rate_limiter_to_exchange``
+#     via CCXT's ``on_rest_response`` hook. This one is atomic per-request (the
+#     hook runs inside CCXT's fetch pipeline with the actual response headers), so
+#     the live path gets exact sync rather than best-effort.
+#
+# Both code paths call the parser, which in turn calls
+# ``rate_limiter.sync_from_exchange(...)`` to pin the modeled budget to the
+# server-reported remaining.

--- a/src/qubx/data/storages/ccxt.py
+++ b/src/qubx/data/storages/ccxt.py
@@ -35,9 +35,11 @@ Supported data types
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Iterator
+import random
+from collections.abc import Awaitable, Callable, Iterator
 from typing import Any, cast
 
+import ccxt
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -272,6 +274,149 @@ class CcxtReader(IReader):
         pass
 
 
+_T = Any  # explicit alias keeps the retry helper signature readable
+
+# retry defaults — conservative. tuned for warmup OHLCV bursts where transient
+# RateLimitExceeded / NetworkError are the dominant failure modes (see #264).
+_RETRY_MAX_ATTEMPTS = 5
+_RETRY_BASE_DELAY_S = 1.0
+_RETRY_MAX_DELAY_S = 30.0
+_RETRY_JITTER_S = 1.0
+
+
+def _sync_rate_limiter_from_response_headers(ccxt_ex: Any, rate_limiter: Any) -> None:
+    """
+    Best-effort sync of the rate limiter's modeled state from the exchange's
+    last HTTP response headers.
+
+    Without this, the client-side token bucket flies blind to:
+        * cross-process / cross-bot contention on the same IP or account,
+        * drift between our ``PoolConfig`` and the exchange's real limits,
+        * pre-existing budget debt at process start.
+
+    This is a *best-effort* correction because ``ccxt_ex.last_response_headers``
+    is exchange-wide, not per-request — under concurrent fetches the attribute
+    may have been overwritten between the awaited response and this read.
+    That is acceptable in practice: every concurrent request drains the same
+    IP-scoped budget, so whatever remaining value we read is approximately
+    correct, and the limiter converges on subsequent syncs.
+
+    Any exception (missing attr, malformed header, parser bug) is swallowed
+    at DEBUG — header sync must never break a fetch.
+    """
+    if rate_limiter is None:
+        return
+    try:
+        from qubx.connectors.ccxt.rate_limits import get_header_parser
+
+        parser = get_header_parser(getattr(ccxt_ex, "id", ""))
+        if parser is None:
+            return
+        headers = getattr(ccxt_ex, "last_response_headers", None)
+        if not headers:
+            return
+        parser(headers, rate_limiter)
+    except Exception as e:
+        logger.debug(f"[CCXT] header sync failed (non-fatal): {e}")
+
+
+class CcxtFetchExhausted(RuntimeError):
+    """
+    Raised when one or more symbols exhaust all retry attempts during a
+    multi-symbol fetch. The caller cannot silently proceed with partial data,
+    because downstream indicators may compute nonsense on zero bars and
+    propagate into corrupt live state (see #264).
+
+    The ``failures`` attribute maps ``qubx_sym -> last_exception`` so callers
+    can log or dispatch based on specific failures.
+    """
+
+    def __init__(self, failures: dict[str, BaseException], total_requested: int) -> None:
+        self.failures = failures
+        self.total_requested = total_requested
+        failed_symbols = sorted(failures.keys())
+        preview = ", ".join(
+            f"{s}={type(failures[s]).__name__}" for s in failed_symbols[:5]
+        )
+        more = f" (+{len(failed_symbols) - 5} more)" if len(failed_symbols) > 5 else ""
+        super().__init__(
+            f"OHLCV fetch exhausted retries for {len(failures)}/{total_requested} "
+            f"symbols: {preview}{more}"
+        )
+
+
+async def _retryable_fetch(
+    call: Callable[[], Awaitable[_T]],
+    *,
+    rate_limiter: Any = None,
+    rate_limiter_endpoint: str = "ccxt_rest",
+    max_attempts: int = _RETRY_MAX_ATTEMPTS,
+    base_delay: float = _RETRY_BASE_DELAY_S,
+    max_delay: float = _RETRY_MAX_DELAY_S,
+    jitter: float = _RETRY_JITTER_S,
+    context: str = "",
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> _T:
+    """
+    Invoke ``call()`` with exponential backoff + jitter on transient CCXT errors.
+
+    Retryable errors:
+        * ``ccxt.RateLimitExceeded`` — exchange-level 429 / OKX 50011.
+        * ``ccxt.NetworkError`` (parent; also covers ``ExchangeNotAvailable``
+          and ``OnMaintenance``).
+        * ``asyncio.TimeoutError``.
+
+    Everything else (``ccxt.ExchangeError`` and subclasses like ``BadSymbol``,
+    ``AuthenticationError``, plus any non-CCXT exception) is re-raised
+    immediately — permanent errors should not consume retry budget.
+
+    The rate-limiter interaction is handled here in two stages per attempt:
+        1. ``acquire(endpoint)`` before each call to block while the gate is closed.
+        2. ``report_limit_hit(endpoint=...)`` on ``RateLimitExceeded`` so the
+           gate closes for ``cooldown`` seconds, pausing all concurrent callers.
+
+    Args:
+        call: Zero-arg callable returning the coroutine to invoke.
+        rate_limiter: Optional ``ExchangeRateLimiter``; if provided, calls are
+            gated and rate-limit hits are reported back to it.
+        rate_limiter_endpoint: Endpoint name used for ``acquire`` /
+            ``report_limit_hit`` lookups.
+        max_attempts: Total attempts including the initial one.
+        base_delay: First retry delay in seconds; doubles each attempt.
+        max_delay: Cap on the exponential delay.
+        jitter: Uniform jitter (0..jitter) added to each delay.
+        context: Short human label included in log lines (e.g. ``"OKX BTCUSDT"``).
+        sleep: Async sleep function (injectable for tests).
+
+    Raises:
+        The last retryable exception once ``max_attempts`` is exhausted.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, max_attempts + 1):
+        if rate_limiter is not None:
+            await rate_limiter.acquire(rate_limiter_endpoint)
+        try:
+            return await call()
+        except (ccxt.NetworkError, asyncio.TimeoutError) as e:
+            last_exc = e
+            if isinstance(e, ccxt.RateLimitExceeded) and rate_limiter is not None:
+                rate_limiter.report_limit_hit(
+                    endpoint=rate_limiter_endpoint,
+                    reason=(f"{context}: " if context else "") + str(e)[:120],
+                )
+            if attempt >= max_attempts:
+                break
+            delay = min(base_delay * (2 ** (attempt - 1)), max_delay) + random.uniform(0, jitter)
+            logger.warning(
+                f"[CCXT] transient error on {context or 'fetch'} "
+                f"(attempt {attempt}/{max_attempts}): {type(e).__name__}: {e}; "
+                f"retrying in {delay:.2f}s"
+            )
+            await sleep(delay)
+    assert last_exc is not None  # unreachable: the loop always raises or returns
+    raise last_exc
+
+
 @storage("ccxt")
 class CcxtStorage(IStorage):
     """
@@ -315,10 +460,20 @@ class CcxtStorage(IStorage):
         max_bars: int = 10_000,
         max_history: str = "3650d",
         rate_limiters: dict | None = None,
+        retry_max_attempts: int = _RETRY_MAX_ATTEMPTS,
+        retry_base_delay: float = _RETRY_BASE_DELAY_S,
+        retry_max_delay: float = _RETRY_MAX_DELAY_S,
+        retry_jitter: float = _RETRY_JITTER_S,
+        strict_fetch: bool = True,
     ) -> None:
         self._max_bars = max_bars
         self._max_history = to_timedelta(max_history)
         self._rate_limiters = rate_limiters or {}
+        self._retry_max_attempts = retry_max_attempts
+        self._retry_base_delay = retry_base_delay
+        self._retry_max_delay = retry_max_delay
+        self._retry_jitter = retry_jitter
+        self._strict_fetch = strict_fetch
         # - shared async loop (created from first exchange connection)
         self._loop = None
         self._capabilities = None
@@ -484,13 +639,31 @@ class CcxtStorage(IStorage):
         all_items: list = []
         current_since = since
 
-        # Get rate limiter for this exchange (if available)
+        # Get rate limiter for this exchange (if available). Retry + backoff + rate-limit
+        # acquisition are all encapsulated inside ``_retryable_fetch`` so this loop stays
+        # focused on pagination.
         _rl = self._get_rate_limiter(ccxt_ex)
+        _ex_id = getattr(ccxt_ex, "id", "ccxt")
 
         for _ in range(max_pages):
-            if _rl:
-                await _rl.acquire("ccxt_rest")
-            batch = await method(since=current_since, limit=limit, **method_kwargs)
+            _since = current_since  # capture for the closure below
+
+            async def _do_page() -> list:
+                batch = await method(since=_since, limit=limit, **method_kwargs)
+                # Best-effort: keep our modeled budget in sync with what the exchange
+                # actually reports — see ``_sync_rate_limiter_from_response_headers``.
+                _sync_rate_limiter_from_response_headers(ccxt_ex, _rl)
+                return batch
+
+            batch = await _retryable_fetch(
+                _do_page,
+                rate_limiter=_rl,
+                max_attempts=self._retry_max_attempts,
+                base_delay=self._retry_base_delay,
+                max_delay=self._retry_max_delay,
+                jitter=self._retry_jitter,
+                context=f"{_ex_id} {method_kwargs.get('symbol', '?')}",
+            )
             if not batch:
                 break
             for item in batch:
@@ -543,7 +716,24 @@ class CcxtStorage(IStorage):
     ) -> dict[str, list]:
         """
         Concurrent OHLCV fetch for multiple instruments with bounded concurrency.
-        Returns ``{qubx_sym: raw_candles}``.
+
+        Per-symbol results go through ``_async_paginated_fetch`` which already
+        retries transient errors with backoff. If retries are exhausted, behavior
+        depends on ``self._strict_fetch``:
+
+        * ``strict_fetch=True`` (default) — logs ERROR per symbol and raises
+          :class:`CcxtFetchExhausted` listing all failures. This prevents
+          downstream indicators from computing on zero bars (see #264).
+        * ``strict_fetch=False`` — logs WARNING per symbol and returns ``[]``
+          for that symbol. Kept for backwards compatibility and use cases
+          where partial data is acceptable.
+
+        Returns:
+            ``{qubx_sym: raw_candles}`` on full or partial success.
+
+        Raises:
+            CcxtFetchExhausted: when any symbol exhausts retries and
+                ``strict_fetch`` is True.
         """
         sem = asyncio.Semaphore(5)  # max 5 concurrent fetches
 
@@ -553,14 +743,26 @@ class CcxtStorage(IStorage):
 
         coros = [_fetch_with_sem(ccxt_sym, exc_tf, since, until) for ccxt_sym, _ in instruments_info]
         results = await asyncio.gather(*coros, return_exceptions=True)
+
         out: dict[str, list] = {}
-        for i, result in enumerate(results):
-            _, qubx_sym = instruments_info[i]
-            if isinstance(result, Exception):
-                logger.warning(f"[CCXT] Failed to fetch OHLCV for {qubx_sym}: {result}")
+        failures: dict[str, BaseException] = {}
+        for (_, qubx_sym), result in zip(instruments_info, results):
+            if isinstance(result, BaseException):
+                failures[qubx_sym] = result
                 out[qubx_sym] = []
             else:
                 out[qubx_sym] = cast(list, result)
+
+        if failures:
+            _ex_id = getattr(ccxt_ex, "id", "ccxt")
+            for qubx_sym, exc in failures.items():
+                logger.error(
+                    f"[CCXT] {_ex_id}: OHLCV fetch for {qubx_sym} exhausted retries — "
+                    f"{type(exc).__name__}: {exc}"
+                )
+            if self._strict_fetch:
+                raise CcxtFetchExhausted(failures, total_requested=len(instruments_info))
+
         return out
 
     def _ccxt_sym_to_qubx(self, ccxt_symbol: str) -> str:

--- a/src/qubx/trackers/riskctrl.py
+++ b/src/qubx/trackers/riskctrl.py
@@ -794,9 +794,11 @@ class AtrRiskTracker(GenericRiskControllerDecorator):
     def calculate_risks(self, ctx: IStrategyContext, quote: Quote | None, signal: Signal) -> Signal | None:
         volatility = self._get_volatility(ctx, signal.instrument)
 
-        if len(volatility) < 2 or ((last_volatility := volatility[1]) is None or not np.isfinite(last_volatility)):
+        last_volatility = volatility[1] if len(volatility) >= 2 else None
+        if last_volatility is None or not np.isfinite(last_volatility) or last_volatility <= 0:
             logger.debug(
-                f"[<y>{self._full_name}</y>(<g>{signal.instrument}</g>)] :: not enough ATR data, skipping risk calculation"
+                f"[<y>{self._full_name}</y>(<g>{signal.instrument}</g>)] :: "
+                f"ATR unusable (value={last_volatility!r}), skipping risk calculation"
             )
             return None
 

--- a/src/qubx/trackers/sizers.py
+++ b/src/qubx/trackers/sizers.py
@@ -113,6 +113,14 @@ class FixedRiskSizer(IPositionSizer):
                     if (_entry := self.get_signal_entry_price(ctx, signal)) is None:
                         continue
 
+                    _stop_distance = abs(signal.stop / _entry - 1)
+                    if _stop_distance <= 0 or not np.isfinite(_stop_distance):
+                        logger.warning(
+                            f" >>> {self.__class__.__name__}: degenerate stop/entry for "
+                            f"{signal.instrument.symbol} (entry={_entry}, stop={signal.stop}) - skipping"
+                        )
+                        continue
+
                     # - hey, we can't trade using negative balance ;)
                     _cap = max(ctx.get_total_capital() if self.reinvest_profit else ctx.get_capital(), 0)
                     _scale = abs(signal.signal) if self.scale_by_signal else 1
@@ -122,7 +130,7 @@ class FixedRiskSizer(IPositionSizer):
                     _notional_per_contract = _entry * signal.instrument.quantity_multiplier
                     target_position_size = (
                         _direction
-                        *min((_cap * self.max_cap_in_risk) / abs(signal.stop / _entry - 1), self.max_allowed_position_quoted) / _notional_per_contract
+                        *min((_cap * self.max_cap_in_risk) / _stop_distance, self.max_allowed_position_quoted) / _notional_per_contract
                         / (len(ctx.instruments) if self.divide_by_symbols else 1)
                         * _scale
                     )
@@ -237,6 +245,14 @@ class FixedRiskSizerWithConstantCapital(IPositionSizer):
                     if (_entry := self.get_signal_entry_price(ctx, signal)) is None:
                         continue
 
+                    _stop_distance = abs(signal.stop / _entry - 1)
+                    if _stop_distance <= 0 or not np.isfinite(_stop_distance):
+                        logger.warning(
+                            f" >>> {self.__class__.__name__}: degenerate stop/entry for {signal.instrument.symbol} "
+                            f"(entry={_entry}, stop={signal.stop}) - skipping"
+                        )
+                        continue
+
                     # - just use same fixed capital
                     _cap = self.capital / (len(ctx.instruments) if self.divide_by_symbols else 1)
 
@@ -245,7 +261,7 @@ class FixedRiskSizerWithConstantCapital(IPositionSizer):
                     _notional_per_contract = _entry * signal.instrument.quantity_multiplier
                     target_position_size = (
                         _direction * min(
-                            (_cap * self.max_cap_in_risk) / abs(signal.stop / _entry - 1),
+                            (_cap * self.max_cap_in_risk) / _stop_distance,
                             self.max_allowed_position_quoted
                         ) / _notional_per_contract
                     )

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -80,6 +80,27 @@ from .accounts import AccountConfigurationManager
 INVERSE_EXCHANGE_MAPPINGS = {mapping: exchange for exchange, mapping in EXCHANGE_MAPPINGS.items()}
 
 
+def _inject_warmup_rate_limiters(warmup: WarmupConfig | None, rate_limiters: dict | None) -> None:
+    """
+    Inject rate limiters into warmup storage configs.
+
+    Mirrors the aux_configs injection done in ``create_strategy_context`` — without this,
+    warmup data fetches (e.g. via ``CcxtStorage``) bypass the per-exchange rate limiter
+    and can be rate-limited by the exchange with no retry, producing empty bars and
+    corrupting downstream indicators (see xLydianSoftware/Qubx#264).
+
+    Args:
+        warmup: Warmup config. If None or no rate_limiters, this is a no-op.
+        rate_limiters: Dict of rate limiters keyed by exchange name (from ``RateLimitManager``).
+    """
+    if warmup is None or not rate_limiters:
+        return
+    warmup.data.args["rate_limiters"] = rate_limiters
+    for typed_cfg in warmup.custom_data or []:
+        for sc in typed_cfg.storages:
+            sc.args["rate_limiters"] = rate_limiters
+
+
 def _cleanup_event_loop(loop: asyncio.AbstractEventLoop | None) -> None:
     """
     Cleanup the shared event loop.
@@ -1027,6 +1048,11 @@ def _run_warmup(
         return
 
     logger.info(f"<yellow>Warmup start time: {warmup_start_time}</yellow>")
+
+    # - inject rate limiters into warmup storage configs (for CcxtStorage, LighterStorage, etc.)
+    #   mirrors the aux_configs injection done in create_strategy_context.
+    #   without this, warmup OHLCV fetches bypass the configured per-exchange rate limiter.
+    _inject_warmup_rate_limiters(warmup, getattr(ctx, "_rate_limiters", None))
 
     # - resolve warmup data sources (mirrors SimulationConfig layout)
     # - warmup.data is required (StorageConfig, not None) so construct_storage always returns IStorage

--- a/tests/qubx/connectors/ccxt/test_exchange_manager.py
+++ b/tests/qubx/connectors/ccxt/test_exchange_manager.py
@@ -368,3 +368,143 @@ class TestExchangeManagerIntegration:
 
         # Verify exception handler was set up
         mock_exchange.asyncio_loop.set_exception_handler.assert_called()
+
+
+# ─── rate-limiter wiring tests (xLydianSoftware/Qubx#264) ─────────────────────
+
+
+def _make_bare_mock_exchange(id: str = "okx") -> Mock:
+    """A Mock that mimics enough of a CCXT exchange for ``attach_rate_limiter`` to run."""
+    mock = Mock()
+    mock.id = id
+    mock.name = id
+    mock.asyncio_loop = Mock()
+    # Must be explicit attributes, not auto-generated Mock children, so we can
+    # detect whether attach_rate_limiter replaced them.
+    mock.throttle = Mock(name="throttle_original")
+    mock.on_rest_response = Mock(name="on_rest_response_original")
+    return mock
+
+
+def _make_manager(exchange) -> ExchangeManager:
+    return ExchangeManager(
+        exchange_name=exchange.id,
+        factory_params={"exchange": exchange.id},
+        initial_exchange=exchange,
+        health_monitor=DummyHealthMonitor(),
+        time_provider=LiveTimeProvider(),
+    )
+
+
+class TestExchangeManagerRateLimiterWiring:
+    def test_attach_rate_limiter_overrides_throttle(self):
+        mock_exchange = _make_bare_mock_exchange("okx")
+        original_throttle = mock_exchange.throttle
+        manager = _make_manager(mock_exchange)
+
+        rate_limiter = Mock()
+        manager.attach_rate_limiter(rate_limiter)
+
+        assert mock_exchange.throttle is not original_throttle
+        assert mock_exchange.enableRateLimit is True
+
+    def test_attach_rate_limiter_installs_header_sync_for_known_exchange(self):
+        """For OKX (known exchange), on_rest_response is wrapped."""
+        mock_exchange = _make_bare_mock_exchange("okx")
+        original_on_rest = mock_exchange.on_rest_response
+        manager = _make_manager(mock_exchange)
+
+        rate_limiter = Mock()
+        manager.attach_rate_limiter(rate_limiter)
+
+        assert mock_exchange.on_rest_response is not original_on_rest
+
+    def test_header_sync_hook_calls_parser_and_preserves_original(self):
+        """When the hook fires, parser is called with the headers AND the original
+        ``on_rest_response`` is still invoked so CCXT's own logic runs."""
+        mock_exchange = _make_bare_mock_exchange("okx")
+        original_on_rest = mock_exchange.on_rest_response
+        original_on_rest.return_value = "orig-return-value"
+        manager = _make_manager(mock_exchange)
+
+        rate_limiter = Mock()
+        manager.attach_rate_limiter(rate_limiter)
+
+        # Call the installed hook with a representative OKX response
+        headers = {"x-ratelimit-remaining": "15"}
+        result = mock_exchange.on_rest_response(
+            200, "OK", "https://okx", "GET", headers, "{}", {}, None,
+        )
+
+        # Original still called and its return value preserved
+        original_on_rest.assert_called_once_with(
+            200, "OK", "https://okx", "GET", headers, "{}", {}, None,
+        )
+        assert result == "orig-return-value"
+
+        # Parser should have called sync_from_exchange with the parsed remaining
+        rate_limiter.sync_from_exchange.assert_called_once()
+        _args, kwargs = rate_limiter.sync_from_exchange.call_args
+        assert kwargs.get("remaining") == 15.0
+
+    def test_header_sync_hook_tolerates_parser_failure(self):
+        """A buggy parser must not break the response pipeline."""
+        mock_exchange = _make_bare_mock_exchange("okx")
+        original_on_rest = mock_exchange.on_rest_response
+        original_on_rest.return_value = None
+        manager = _make_manager(mock_exchange)
+
+        rate_limiter = Mock()
+
+        with patch(
+            "qubx.connectors.ccxt.rate_limits.parse_okx_headers",
+            side_effect=RuntimeError("simulated parser bug"),
+        ):
+            manager.attach_rate_limiter(rate_limiter)
+            # Should not raise despite the broken parser
+            mock_exchange.on_rest_response(
+                200, "OK", "u", "GET", {"x-ratelimit-remaining": "10"}, "{}", {}, None,
+            )
+
+        # Original still called even when parser raised
+        original_on_rest.assert_called_once()
+
+    def test_unknown_exchange_skips_header_sync(self):
+        """For an exchange with no registered parser, on_rest_response stays untouched."""
+        mock_exchange = _make_bare_mock_exchange("exchange-without-a-parser")
+        original_on_rest = mock_exchange.on_rest_response
+        manager = _make_manager(mock_exchange)
+
+        rate_limiter = Mock()
+        manager.attach_rate_limiter(rate_limiter)
+
+        # throttle is still overridden even for unknown exchanges
+        assert mock_exchange.enableRateLimit is True
+        # but on_rest_response is not wrapped
+        assert mock_exchange.on_rest_response is original_on_rest
+
+    def test_wiring_reapplies_after_recreation(self):
+        """Both throttle and on_rest_response are reapplied on exchange recreation."""
+        first_exchange = _make_bare_mock_exchange("okx")
+        manager = _make_manager(first_exchange)
+
+        rate_limiter = Mock()
+        manager.attach_rate_limiter(rate_limiter)
+        first_wrapped_on_rest = first_exchange.on_rest_response
+        first_wrapped_throttle = first_exchange.throttle
+
+        # Simulate recreation: swap in a new exchange then fire registered callbacks
+        second_exchange = _make_bare_mock_exchange("okx")
+        original_on_rest_second = second_exchange.on_rest_response
+        original_throttle_second = second_exchange.throttle
+        manager._exchange = second_exchange
+        for cb in manager._recreation_callbacks:
+            cb()
+
+        # First exchange's hooks unchanged
+        assert first_exchange.on_rest_response is first_wrapped_on_rest
+        assert first_exchange.throttle is first_wrapped_throttle
+        # Second exchange got its own wrappers (both replaced)
+        assert second_exchange.enableRateLimit is True
+        assert second_exchange.on_rest_response is not original_on_rest_second
+        assert second_exchange.throttle is not original_throttle_second

--- a/tests/qubx/data/test_ccxt_storage_rate_limit.py
+++ b/tests/qubx/data/test_ccxt_storage_rate_limit.py
@@ -1,0 +1,1056 @@
+"""
+Stress tests for CcxtStorage rate-limit behavior — xLydianSoftware/Qubx#264.
+
+The production incident that motivated this file:
+    At warmup start the exchange (OKX) rate-limited 5 of ~20 symbols with
+    ``50011 Too Many Requests``. The CcxtStorage layer did not apply the
+    configured rate limiter (it was never injected into the warmup data
+    storage), did not retry, and silently returned ``[]``. Downstream ATR
+    couldn't compute, FixedRiskSizer produced inf-sized targets, and live
+    state was corrupted.
+
+The tests in this file exercise the warmup OHLCV fetch path against a
+``FakeCcxtExchange`` that enforces its own req/sec budget. They verify:
+
+1. **Positive path** — with the rate limiter attached, concurrent multi-symbol
+   fetches never trigger the exchange's 429 budget.
+
+2. **Negative control** — without the rate limiter, the same load bursts past
+   the budget and triggers 429s. This proves the mock is exercising the
+   code path and that the positive test isn't vacuously passing.
+
+3. **Wiring regression** — every page fetch goes through ``limiter.acquire``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from typing import Any
+from unittest.mock import Mock
+
+import ccxt
+import pytest
+
+from qubx.connectors.ccxt.exchange_manager import ExchangeManager
+from qubx.core.basics import LiveTimeProvider
+from qubx.data.storages.ccxt import CcxtFetchExhausted, CcxtStorage, _retryable_fetch
+from qubx.health.dummy import DummyHealthMonitor
+from qubx.rate_limiting import (
+    EndpointCosts,
+    ExchangeRateLimitConfig,
+    ExchangeRateLimiter,
+    PoolConfig,
+)
+
+TF_MS = 3_600_000  # 1h in milliseconds
+
+
+class FakeCcxtExchange:
+    """
+    Minimal CCXT-like async exchange with a strict sliding-window req/s budget.
+
+    Raises ``ccxt.RateLimitExceeded`` when arrival rate exceeds ``max_rps``
+    over the last ``window_sec``. Every ``fetch_ohlcv`` call is counted
+    regardless of whether it's rejected, so ``call_count`` reflects traffic
+    pressure while ``rate_limit_hits`` reflects failures.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_rps: float,
+        window_sec: float = 1.0,
+        bars_per_page: int = 10,
+        latency_ms: float = 5.0,
+        id: str = "fake",
+        server_budget: int | None = None,
+    ) -> None:
+        self.id = id
+        self.name = id
+        self.max_rps = max_rps
+        self.window_sec = window_sec
+        self.bars_per_page = bars_per_page
+        self._latency_s = latency_ms / 1000.0
+        self._arrivals: list[float] = []
+        self.call_count = 0
+        self.rate_limit_hits = 0
+        # Server-reported budget, exposed to callers via ``last_response_headers``
+        # to drive ``_sync_rate_limiter_from_response_headers``. When set, each
+        # successful call decrements it so the header value reflects real usage.
+        self._server_budget = server_budget
+        self.last_response_headers: dict[str, str] = {}
+        # CCXT-side hooks — real CCXT invokes ``self.throttle(cost)`` inside
+        # ``fetch2()`` and ``self.on_rest_response(...)`` after the HTTP response.
+        # Defaults are no-ops; ``ExchangeManager.attach_rate_limiter`` replaces
+        # them with versions that acquire from / sync to our rate limiter.
+        self.enableRateLimit = True
+        self.throttle = self._default_throttle
+        self.on_rest_response = self._default_on_rest_response
+        # ExchangeManager reads ``asyncio_loop.set_exception_handler`` during init —
+        # provide a Mock so that path is satisfied without a real loop.
+        self.asyncio_loop: Any = Mock()
+
+    async def _default_throttle(self, cost: float | None = None) -> None:
+        return None
+
+    def _default_on_rest_response(
+        self, code, reason, url, method, headers, body, req_headers, req_body
+    ) -> None:
+        return None
+
+    async def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str,
+        since: int | None = None,
+        limit: int | None = None,
+        **_: Any,
+    ) -> list[list[float]]:
+        self.call_count += 1
+        # 1) Pre-request throttle (CCXT calls this inside fetch2). If ExchangeManager
+        #    is attached, this acquires a token from the shared rate limiter.
+        await self.throttle(1.0)
+
+        now = time.monotonic()
+        # drop arrivals outside the sliding window
+        cutoff = now - self.window_sec
+        self._arrivals = [t for t in self._arrivals if t > cutoff]
+        if len(self._arrivals) >= self.max_rps * self.window_sec:
+            self.rate_limit_hits += 1
+            raise ccxt.RateLimitExceeded(
+                f"fake: Too Many Requests "
+                f"({len(self._arrivals)}/{int(self.max_rps * self.window_sec)} "
+                f"in {self.window_sec}s)"
+            )
+        self._arrivals.append(now)
+        await asyncio.sleep(self._latency_s)
+
+        # Publish rate-limit headers as a real exchange would.
+        if self._server_budget is not None:
+            self._server_budget = max(0, self._server_budget - 1)
+            self.last_response_headers = {
+                # OKX style
+                "x-ratelimit-remaining": str(self._server_budget),
+                # Binance style
+                "x-mbx-used-weight-1m": str(max(0, 1200 - self._server_budget)),
+            }
+
+        # 2) Post-response hook (CCXT calls this inside fetch2 after headers are
+        #    parsed). If ExchangeManager is attached, this invokes the header parser
+        #    which calls ``rate_limiter.sync_from_exchange(...)``.
+        self.on_rest_response(
+            200, "OK", f"https://fake/{symbol}", "GET",
+            self.last_response_headers, "{}", {}, None,
+        )
+
+        # Simulate OKX-style behavior: cap each page at ``bars_per_page`` regardless of
+        # caller's ``limit`` — forces pagination to iterate.
+        n = min(limit or self.bars_per_page, self.bars_per_page)
+        start = since or 0
+        return [
+            [start + i * TF_MS, 50_000.0, 50_100.0, 49_900.0, 50_050.0, 100.0]
+            for i in range(n)
+        ]
+
+
+def _build_rate_limiter(*, capacity: int, refill_rate: float, cooldown: float = 0.2) -> ExchangeRateLimiter:
+    """Single-pool IP-scoped rate limiter on the ``ccxt_rest`` endpoint."""
+    config = ExchangeRateLimitConfig(
+        pools={
+            "ccxt_rest": PoolConfig(
+                "ccxt_rest", "ip", capacity, refill_rate, cooldown=cooldown
+            ),
+        },
+        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        default_costs=EndpointCosts([("ccxt_rest", 1)]),
+    )
+    return ExchangeRateLimiter("FAKE.X", config)
+
+
+def _build_storage(
+    *,
+    exchange: FakeCcxtExchange,
+    limiter: ExchangeRateLimiter | None,
+    retry_max_attempts: int = 5,
+    retry_base_delay: float = 0.0,
+    retry_jitter: float = 0.0,
+    strict_fetch: bool = False,
+) -> CcxtStorage:
+    """
+    Wire a FakeCcxtExchange into a CcxtStorage without touching the network.
+
+    Retry defaults are zeroed so tests don't spend real wall-clock time in
+    backoff. Production defaults live on the ``CcxtStorage`` constructor.
+
+    ``strict_fetch`` defaults to False here so that tests which deliberately
+    trigger 429s (the negative control in ``TestCcxtStorageRateLimitBudget``)
+    don't explode with ``CcxtFetchExhausted``; each test opts-in when it
+    wants the strict behavior.
+    """
+    storage = CcxtStorage(
+        retry_max_attempts=retry_max_attempts,
+        retry_base_delay=retry_base_delay,
+        retry_jitter=retry_jitter,
+        strict_fetch=strict_fetch,
+    )
+    storage._exchanges = {"FAKE.X": exchange}  # type: ignore[assignment]
+    storage._rate_limiters = {"FAKE.X": limiter} if limiter is not None else {}
+    return storage
+
+
+def _bar_span(n_bars: int) -> tuple[int, int]:
+    """Pick a [since, until] window that forces exactly n_bars across pagination."""
+    since = 1_700_000_000_000  # arbitrary fixed epoch-ms
+    until = since + (n_bars - 1) * TF_MS
+    return since, until
+
+
+def _instruments(*qubx_syms: str) -> list[tuple[str, str]]:
+    """Build a list of (ccxt_symbol, qubx_symbol) tuples for the multi-fetch entry point."""
+    return [(f"{s[:-4]}/{s[-4:]}", s) for s in qubx_syms]
+
+
+# ─── tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestCcxtStorageRateLimitBudget:
+    """
+    Target scenario: 3 symbols × 5 pages each = 15 fetch calls. The mock
+    enforces a 10 req/s budget over a 1-s sliding window. The rate limiter is
+    configured to 5 tokens burst + 5/s refill — strictly below the mock's
+    threshold so a correctly-applied limiter never trips the mock.
+
+    Under the default ``asyncio.Semaphore(5)`` (concurrency, not rate) the
+    unprotected path bursts ~5 calls per few milliseconds and blows past 10
+    in 1 s, so the negative control does trip the mock. If it ever stopped
+    doing so the positive test would be vacuously passing — hence the paired
+    control.
+    """
+
+    BARS_PER_PAGE = 10
+    PAGES_PER_SYMBOL = 5
+    SYMBOLS = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+
+    MOCK_BUDGET_RPS = 10.0
+    LIMITER_CAPACITY = 5
+    LIMITER_REFILL_RPS = 5.0
+
+    def _spans(self) -> tuple[int, int]:
+        return _bar_span(self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL)
+
+    def _fake_exchange(self) -> FakeCcxtExchange:
+        return FakeCcxtExchange(
+            max_rps=self.MOCK_BUDGET_RPS,
+            window_sec=1.0,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=5.0,
+        )
+
+    async def test_rate_limiter_prevents_429_under_concurrent_load(self):
+        fake = self._fake_exchange()
+        limiter = _build_rate_limiter(
+            capacity=self.LIMITER_CAPACITY, refill_rate=self.LIMITER_REFILL_RPS
+        )
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        since, until = self._spans()
+        result = await storage._async_fetch_ohlcv_multi(
+            fake, _instruments(*self.SYMBOLS), "1h", since, until
+        )
+
+        assert set(result.keys()) == set(self.SYMBOLS)
+        for sym in self.SYMBOLS:
+            assert len(result[sym]) >= self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL, (
+                f"{sym}: got {len(result[sym])} bars, "
+                f"expected ≥ {self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL} — "
+                "rate-limiter may have forced a premature exit"
+            )
+        assert fake.rate_limit_hits == 0, (
+            f"rate limiter failed to prevent 429s: "
+            f"{fake.rate_limit_hits} hits out of {fake.call_count} calls"
+        )
+
+    async def test_without_rate_limiter_triggers_429s(self):
+        """Negative control: same load without the limiter overwhelms the budget."""
+        fake = self._fake_exchange()
+        storage = _build_storage(exchange=fake, limiter=None)
+
+        since, until = self._spans()
+        # ``gather(return_exceptions=True)`` inside the storage swallows 429s into [],
+        # which is exactly the silent-degradation bug from #264. We only care here
+        # that the mock *observed* the 429 pressure.
+        await storage._async_fetch_ohlcv_multi(
+            fake, _instruments(*self.SYMBOLS), "1h", since, until
+        )
+
+        assert fake.rate_limit_hits > 0, (
+            "test harness is broken: without rate limiter the mock should observe "
+            f"429s, but got 0 (call_count={fake.call_count})"
+        )
+
+    async def test_limiter_acquire_called_for_every_page_fetch(self, monkeypatch):
+        fake = self._fake_exchange()
+        limiter = _build_rate_limiter(
+            capacity=self.LIMITER_CAPACITY, refill_rate=self.LIMITER_REFILL_RPS
+        )
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        acquire_calls: list[str] = []
+        real_acquire = limiter.acquire
+
+        async def _spy(endpoint: str, **kw):
+            acquire_calls.append(endpoint)
+            await real_acquire(endpoint, **kw)
+
+        monkeypatch.setattr(limiter, "acquire", _spy)
+
+        since, until = self._spans()
+        await storage._async_fetch_ohlcv_multi(
+            fake, _instruments(*self.SYMBOLS), "1h", since, until
+        )
+
+        expected_min = len(self.SYMBOLS) * self.PAGES_PER_SYMBOL
+        assert len(acquire_calls) >= expected_min, (
+            f"expected ≥{expected_min} acquire calls, got {len(acquire_calls)}"
+        )
+        assert all(e == "ccxt_rest" for e in acquire_calls), (
+            f"unexpected endpoints: {set(acquire_calls) - {'ccxt_rest'}}"
+        )
+
+
+# ─── retry helper unit tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestRetryableFetch:
+    """
+    Exercises the ``_retryable_fetch`` helper directly, using an injected
+    ``sleep`` to keep the tests deterministic (no wall-clock waits).
+    """
+
+    async def _no_sleep(self, _delay: float) -> None:
+        return None
+
+    async def test_returns_result_on_first_attempt(self):
+        calls = 0
+
+        async def call():
+            nonlocal calls
+            calls += 1
+            return "ok"
+
+        result = await _retryable_fetch(call, sleep=self._no_sleep)
+        assert result == "ok"
+        assert calls == 1
+
+    async def test_retries_then_succeeds_on_rate_limit(self):
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise ccxt.RateLimitExceeded(f"attempt {attempts}: too many")
+            return "eventually"
+
+        result = await _retryable_fetch(
+            call, max_attempts=5, base_delay=0.0, jitter=0.0, sleep=self._no_sleep
+        )
+        assert result == "eventually"
+        assert attempts == 3
+
+    async def test_retries_on_generic_network_error(self):
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise ccxt.NetworkError("transient DNS blip")
+            return 42
+
+        result = await _retryable_fetch(
+            call, max_attempts=3, base_delay=0.0, jitter=0.0, sleep=self._no_sleep
+        )
+        assert result == 42
+        assert attempts == 2
+
+    async def test_retries_on_timeout_error(self):
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise asyncio.TimeoutError()
+            return "done"
+
+        result = await _retryable_fetch(
+            call, max_attempts=3, base_delay=0.0, jitter=0.0, sleep=self._no_sleep
+        )
+        assert result == "done"
+        assert attempts == 2
+
+    async def test_exhausts_attempts_and_raises_last_error(self):
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            raise ccxt.RateLimitExceeded(f"attempt {attempts}")
+
+        with pytest.raises(ccxt.RateLimitExceeded, match="attempt 4"):
+            await _retryable_fetch(
+                call, max_attempts=4, base_delay=0.0, jitter=0.0, sleep=self._no_sleep
+            )
+        assert attempts == 4
+
+    async def test_permanent_error_is_not_retried(self):
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            raise ccxt.BadSymbol("unknown symbol XYZ")
+
+        with pytest.raises(ccxt.BadSymbol):
+            await _retryable_fetch(
+                call, max_attempts=5, base_delay=0.0, jitter=0.0, sleep=self._no_sleep
+            )
+        assert attempts == 1  # no retries on permanent error
+
+    async def test_non_ccxt_exception_is_not_retried(self):
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            raise ValueError("programmer error")
+
+        with pytest.raises(ValueError):
+            await _retryable_fetch(
+                call, max_attempts=5, base_delay=0.0, jitter=0.0, sleep=self._no_sleep
+            )
+        assert attempts == 1
+
+    async def test_acquires_rate_limiter_before_each_attempt(self):
+        attempts = 0
+        acquire_count = 0
+
+        class _Limiter:
+            async def acquire(self, endpoint: str) -> None:
+                nonlocal acquire_count
+                acquire_count += 1
+
+            def report_limit_hit(self, **kw: Any) -> None:
+                pass
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise ccxt.NetworkError("boom")
+            return "ok"
+
+        result = await _retryable_fetch(
+            call,
+            rate_limiter=_Limiter(),
+            max_attempts=5,
+            base_delay=0.0,
+            jitter=0.0,
+            sleep=self._no_sleep,
+        )
+        assert result == "ok"
+        assert attempts == 3
+        assert acquire_count == 3  # once per attempt
+
+    async def test_reports_rate_limit_hit_to_limiter(self):
+        hits: list[dict[str, Any]] = []
+
+        class _Limiter:
+            async def acquire(self, endpoint: str) -> None:
+                pass
+
+            def report_limit_hit(self, **kw: Any) -> None:
+                hits.append(kw)
+
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise ccxt.RateLimitExceeded("50011: Too Many Requests")
+            return "ok"
+
+        await _retryable_fetch(
+            call,
+            rate_limiter=_Limiter(),
+            rate_limiter_endpoint="ccxt_rest",
+            context="OKX BTCUSDT",
+            max_attempts=3,
+            base_delay=0.0,
+            jitter=0.0,
+            sleep=self._no_sleep,
+        )
+        assert len(hits) == 1
+        assert hits[0]["endpoint"] == "ccxt_rest"
+        assert "OKX BTCUSDT" in hits[0]["reason"]
+
+    async def test_non_rate_limit_errors_do_not_report_to_limiter(self):
+        """NetworkError but not RateLimitExceeded should retry without closing the gate."""
+        hits: list[dict] = []
+
+        class _Limiter:
+            async def acquire(self, endpoint: str) -> None:
+                pass
+
+            def report_limit_hit(self, **kw: Any) -> None:
+                hits.append(kw)
+
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 2:
+                raise ccxt.NetworkError("DNS glitch")
+            return "ok"
+
+        await _retryable_fetch(
+            call, rate_limiter=_Limiter(), max_attempts=3, base_delay=0.0, jitter=0.0,
+            sleep=self._no_sleep,
+        )
+        assert hits == []
+
+    async def test_backoff_delays_are_exponential_with_cap(self):
+        """Delay sequence should be base * 2^(attempt-1), capped at max_delay."""
+        delays: list[float] = []
+
+        async def capture_sleep(d: float) -> None:
+            delays.append(d)
+
+        attempts = 0
+
+        async def call():
+            nonlocal attempts
+            attempts += 1
+            raise ccxt.NetworkError(f"attempt {attempts}")
+
+        with pytest.raises(ccxt.NetworkError):
+            await _retryable_fetch(
+                call,
+                max_attempts=6,
+                base_delay=1.0,
+                max_delay=8.0,
+                jitter=0.0,
+                sleep=capture_sleep,
+            )
+        # attempts 1..5 each sleep before next (attempt 6 fails-final, no sleep).
+        # expected base*2^0, base*2^1, ..., capped at max_delay
+        assert delays == [1.0, 2.0, 4.0, 8.0, 8.0]
+
+
+# ─── end-to-end flaky exchange test (task #3) ────────────────────────────────
+
+
+class FlakyFakeExchange(FakeCcxtExchange):
+    """
+    Fake exchange that randomly fails a configurable fraction of ``fetch_ohlcv``
+    calls with ``ccxt.RateLimitExceeded`` (independent of the req/s budget).
+    Used to verify that retry logic drives every symbol to completion.
+    """
+
+    def __init__(
+        self,
+        *,
+        failure_rate: float,
+        seed: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._rng = random.Random(seed)
+        self._failure_rate = failure_rate
+        self.injected_failures = 0
+
+    async def fetch_ohlcv(self, *args: Any, **kwargs: Any) -> list[list[float]]:
+        # Budget-check and normal fetch first — if the real budget trips, let it propagate.
+        if self._rng.random() < self._failure_rate:
+            self.call_count += 1       # this is a real request attempt from the exchange's POV
+            self.injected_failures += 1
+            raise ccxt.RateLimitExceeded(
+                f"flaky: injected 50011 at call #{self.call_count}"
+            )
+        return await super().fetch_ohlcv(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+class TestCcxtStorageFlakyExchangeRetries:
+    """
+    End-to-end retry behavior: the exchange rejects ~40% of fetch calls with
+    a RateLimitExceeded. Every symbol must still return full OHLCV after the
+    retry loop takes over.
+    """
+
+    BARS_PER_PAGE = 10
+    PAGES_PER_SYMBOL = 3
+    SYMBOLS = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+
+    def _spans(self) -> tuple[int, int]:
+        return _bar_span(self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL)
+
+    async def test_all_symbols_succeed_despite_flaky_exchange(self):
+        flaky = FlakyFakeExchange(
+            failure_rate=0.4,
+            seed=1234,
+            max_rps=1000,  # effectively unlimited; we want to isolate injected failures
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=1.0,
+        )
+        # Rate limiter with a generous bucket — not the subject under test here.
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=flaky, limiter=limiter)
+
+        since, until = self._spans()
+        result = await storage._async_fetch_ohlcv_multi(
+            flaky, _instruments(*self.SYMBOLS), "1h", since, until
+        )
+
+        assert flaky.injected_failures > 0, (
+            "test harness: failure injection is expected to fire at least once"
+        )
+        for sym in self.SYMBOLS:
+            assert len(result[sym]) >= self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL, (
+                f"{sym}: got {len(result[sym])} bars despite retry — injected={flaky.injected_failures} "
+                f"total_calls={flaky.call_count}"
+            )
+
+    async def test_persistent_failures_raise_explicitly_in_strict_mode(self):
+        """In strict_fetch mode (default for warmup), exhausted retries raise
+        :class:`CcxtFetchExhausted` — callers can't silently proceed on zero bars.
+        This is the primary fix for the #264 silent-degradation bug.
+        """
+        flaky = FlakyFakeExchange(
+            failure_rate=1.0,  # 100% — every call rejected
+            seed=7,
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=flaky, limiter=limiter, strict_fetch=True)
+
+        since, until = self._spans()
+        with pytest.raises(CcxtFetchExhausted) as excinfo:
+            await storage._async_fetch_ohlcv_multi(
+                flaky, _instruments(*self.SYMBOLS), "1h", since, until
+            )
+
+        assert set(excinfo.value.failures) == set(self.SYMBOLS)
+        assert excinfo.value.total_requested == len(self.SYMBOLS)
+        # each symbol should report a RateLimitExceeded as its cause
+        for sym, exc in excinfo.value.failures.items():
+            assert isinstance(exc, ccxt.RateLimitExceeded), (
+                f"{sym}: expected RateLimitExceeded, got {type(exc).__name__}"
+            )
+
+    async def test_lenient_mode_returns_empty_on_exhaustion(self):
+        """With ``strict_fetch=False`` the old behavior is preserved: failed
+        symbols get ``[]`` and the caller can inspect logs to diagnose.
+        """
+        flaky = FlakyFakeExchange(
+            failure_rate=1.0,
+            seed=7,
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=flaky, limiter=limiter, strict_fetch=False)
+
+        since, until = self._spans()
+        result = await storage._async_fetch_ohlcv_multi(
+            flaky, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+
+        assert result == {"BTCUSDT": []}
+        from qubx.data.storages.ccxt import _RETRY_MAX_ATTEMPTS
+        assert flaky.call_count == _RETRY_MAX_ATTEMPTS, (
+            f"expected exactly {_RETRY_MAX_ATTEMPTS} attempts, got {flaky.call_count}"
+        )
+
+    async def test_partial_failure_raises_in_strict_mode(self):
+        """Even if *some* symbols succeed, strict mode raises for the failing ones.
+        The ``failures`` map on the exception names exactly the problem symbols.
+        """
+        # Seeded rng + 50% rate + the scheduled symbol order → deterministic mix
+        flaky = FlakyFakeExchange(
+            failure_rate=1.0,
+            seed=11,
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+        )
+        # Patch: fail only for one specific symbol to get a partial outcome.
+        original_fetch = flaky.fetch_ohlcv
+
+        async def selective_fetch(symbol, timeframe, **kw):
+            if symbol == "LINK/USDT":
+                flaky.call_count += 1
+                flaky.injected_failures += 1
+                raise ccxt.RateLimitExceeded("flaky: LINK/USDT always fails")
+            return await FakeCcxtExchange.fetch_ohlcv(flaky, symbol, timeframe, **kw)
+
+        flaky.fetch_ohlcv = selective_fetch  # type: ignore[assignment]
+
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=flaky, limiter=limiter, strict_fetch=True)
+
+        since, until = self._spans()
+        with pytest.raises(CcxtFetchExhausted) as excinfo:
+            await storage._async_fetch_ohlcv_multi(
+                flaky,
+                [("BTC/USDT", "BTCUSDT"), ("LINK/USDT", "LINKUSDT"), ("ETH/USDT", "ETHUSDT")],
+                "1h", since, until,
+            )
+
+        # only LINKUSDT failed; others completed normally (proof failures dict is precise)
+        assert set(excinfo.value.failures) == {"LINKUSDT"}
+        assert excinfo.value.total_requested == 3
+
+
+# ─── response-header sync (Option C from the #264 investigation) ─────────────
+
+
+@pytest.mark.asyncio
+class TestResponseHeaderSync:
+    """
+    Verify that ``_sync_rate_limiter_from_response_headers`` is invoked for every
+    successful page fetch and that the rate limiter's modeled state is updated
+    from the exchange-reported budget.
+
+    The sync is best-effort — when concurrency is in play the exchange-wide
+    ``last_response_headers`` attribute may be read from a different request than
+    our own. We don't test that race here (it's accepted in the design); we only
+    verify that the wiring happens and that the parser is invoked with real values.
+    """
+
+    BARS_PER_PAGE = 10
+    PAGES_PER_SYMBOL = 3
+
+    def _spans(self) -> tuple[int, int]:
+        return _bar_span(self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL)
+
+    async def test_okx_headers_drive_sync_from_exchange(self):
+        starting_budget = 20
+        fake = FakeCcxtExchange(
+            id="okx",
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+            server_budget=starting_budget,
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        sync_calls: list[dict[str, Any]] = []
+        real_sync = limiter.sync_from_exchange
+
+        def _spy_sync(pool_name: str, **kw: Any) -> None:
+            sync_calls.append({"pool_name": pool_name, **kw})
+            real_sync(pool_name, **kw)
+
+        limiter.sync_from_exchange = _spy_sync  # type: ignore[method-assign]
+
+        since, until = self._spans()
+        await storage._async_fetch_ohlcv_multi(
+            fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+
+        # Sync happens once per successful page. Pagination issues at least
+        # ``PAGES_PER_SYMBOL`` pages for the requested window (and sometimes one
+        # extra tail page due to the ``last_ts + 1`` cursor bump — we only care
+        # that it's > 1 and matches the exchange's actual call count).
+        assert len(sync_calls) == fake.call_count
+        assert len(sync_calls) >= self.PAGES_PER_SYMBOL
+        # each call targets the rest pool with a numeric remaining budget.
+        for call in sync_calls:
+            assert call["pool_name"] == "ccxt_rest"
+            assert "remaining" in call and call["remaining"] >= 0
+        # budget decrements monotonically and by exactly one per successful call.
+        remainings = [c["remaining"] for c in sync_calls]
+        assert remainings == sorted(remainings, reverse=True), (
+            f"expected monotonically-decreasing remaining, got {remainings}"
+        )
+        assert remainings[-1] == starting_budget - fake.call_count
+
+    async def test_unknown_exchange_skips_sync_silently(self):
+        """If the exchange id has no registered parser, sync is a no-op (no error)."""
+        fake = FakeCcxtExchange(
+            id="exchange-without-a-parser",
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+            server_budget=20,
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        sync_calls: list[Any] = []
+        limiter.sync_from_exchange = lambda *a, **kw: sync_calls.append((a, kw))  # type: ignore[method-assign]
+
+        since, until = self._spans()
+        result = await storage._async_fetch_ohlcv_multi(
+            fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+        # fetch still succeeded; sync just didn't happen
+        assert len(result["BTCUSDT"]) >= self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL
+        assert sync_calls == []
+
+    async def test_empty_headers_skip_sync_silently(self):
+        """When the exchange hasn't populated headers yet, sync is a no-op."""
+        fake = FakeCcxtExchange(
+            id="okx",
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+            server_budget=None,  # disables header publishing
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        sync_calls: list[Any] = []
+        limiter.sync_from_exchange = lambda *a, **kw: sync_calls.append((a, kw))  # type: ignore[method-assign]
+
+        since, until = self._spans()
+        await storage._async_fetch_ohlcv_multi(
+            fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+        assert sync_calls == []
+
+    async def test_parser_exception_is_swallowed(self, monkeypatch):
+        """A buggy parser must not break the fetch — failures are DEBUG-level."""
+        from qubx.connectors.ccxt import rate_limits
+
+        def _broken_parser(headers: dict, rl: Any) -> None:
+            raise RuntimeError("simulated parser bug")
+
+        monkeypatch.setitem(rate_limits.HEADER_PARSERS, "okx", _broken_parser)
+
+        fake = FakeCcxtExchange(
+            id="okx",
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+            server_budget=20,
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        since, until = self._spans()
+        # Should complete normally despite the broken parser.
+        result = await storage._async_fetch_ohlcv_multi(
+            fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+        assert len(result["BTCUSDT"]) >= self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL
+
+    async def test_no_rate_limiter_skips_sync(self):
+        """When no limiter is attached, don't even attempt to parse headers."""
+        fake = FakeCcxtExchange(
+            id="okx",
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+            server_budget=20,
+        )
+        storage = _build_storage(exchange=fake, limiter=None)
+
+        since, until = self._spans()
+        # Exercise the code path — should simply not error.
+        result = await storage._async_fetch_ohlcv_multi(
+            fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+        assert len(result["BTCUSDT"]) >= self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL
+
+
+# ─── cross-subsystem E2E stress test (xLydianSoftware/Qubx#264) ──────────────
+
+
+@pytest.mark.asyncio
+class TestRateLimiterE2ECrossSubsystem:
+    """
+    Full-stack stress test of the rate limiter with BOTH consumers:
+
+    * ``CcxtStorage`` (warmup / historical REST fetch path, test-wired directly).
+    * ``ExchangeManager`` (live REST path, attaches its throttle + on_rest_response
+      hooks to the shared fake exchange).
+
+    Both hang on the same ``ExchangeRateLimiter`` instance and the same budget-
+    enforcing ``FakeCcxtExchange``. Fires concurrent REST traffic from both paths
+    and verifies end-to-end:
+
+    * Combined arrival rate never trips the exchange's 429 budget.
+    * ``limiter.acquire`` fires for every request across both paths (throttle
+      side on ExchangeManager, CcxtStorage-internal acquire for storage side).
+    * ``on_rest_response`` hook fires with correct headers for every
+      ExchangeManager-originated response.
+    * ``limiter.sync_from_exchange`` is called from both paths and decrements
+      a shared remaining-budget view.
+
+    The test is self-contained — no network, no real CCXT exchange instance.
+    """
+
+    async def test_shared_limiter_across_storage_and_manager(self):
+        # --- Budget design -----------------------------------------------------
+        # Mock exchange: 20 req/s budget. Limiter: 5 burst + 5/s refill, so peak
+        # throughput over any 1s window is ≤ 10 (half of the mock's 20/s threshold).
+        # Gap must stay generous: scheduling jitter can make the limiter's sliding
+        # throughput briefly higher than its steady refill rate.
+        fake = FakeCcxtExchange(
+            id="okx",
+            max_rps=20,
+            window_sec=1.0,
+            bars_per_page=10,
+            latency_ms=2.0,
+            server_budget=1_000,
+        )
+        limiter = _build_rate_limiter(capacity=5, refill_rate=5.0, cooldown=0.2)
+
+        # --- CcxtStorage side --------------------------------------------------
+        storage = _build_storage(exchange=fake, limiter=limiter)
+        # Spy on limiter.acquire to count how many times each path hit the bucket.
+        acquire_count = 0
+        real_acquire = limiter.acquire
+
+        async def _spy_acquire(endpoint, **kw):
+            nonlocal acquire_count
+            acquire_count += 1
+            await real_acquire(endpoint, **kw)
+
+        limiter.acquire = _spy_acquire  # type: ignore[method-assign]
+
+        sync_count = 0
+        real_sync = limiter.sync_from_exchange
+
+        def _spy_sync(pool_name, **kw):
+            nonlocal sync_count
+            sync_count += 1
+            real_sync(pool_name, **kw)
+
+        limiter.sync_from_exchange = _spy_sync  # type: ignore[method-assign]
+
+        # --- ExchangeManager side ---------------------------------------------
+        # Wire the same limiter via the real attach_rate_limiter code path.
+        # This replaces fake.throttle with one that calls limiter.acquire, and
+        # wraps fake.on_rest_response with the header-sync hook.
+        manager = ExchangeManager(
+            exchange_name="okx",
+            factory_params={"exchange": "okx"},
+            initial_exchange=fake,
+            health_monitor=DummyHealthMonitor(),
+            time_provider=LiveTimeProvider(),
+        )
+        manager.attach_rate_limiter(limiter)
+
+        # --- Concurrent traffic -----------------------------------------------
+        storage_symbols = _instruments("BTCUSDT", "ETHUSDT", "SOLUSDT")
+        since = 1_700_000_000_000
+        until = since + 29 * TF_MS  # ~3 pages per symbol
+
+        async def storage_worker() -> dict[str, list]:
+            return await storage._async_fetch_ohlcv_multi(
+                fake, storage_symbols, "1h", since, until
+            )
+
+        async def manager_worker() -> int:
+            """Burst 10 direct REST calls through the ExchangeManager-wrapped exchange."""
+            hits = 0
+            for i in range(10):
+                bars = await manager.exchange.fetch_ohlcv(
+                    f"BTC/USDT", "1h", since=since + i * TF_MS, limit=1,
+                )
+                hits += len(bars)
+            return hits
+
+        storage_result, manager_bars = await asyncio.gather(
+            storage_worker(), manager_worker()
+        )
+
+        # --- Assertions -------------------------------------------------------
+        # Exchange was never rate-limited — the token bucket stayed below budget.
+        assert fake.rate_limit_hits == 0, (
+            f"rate-limiter failed to protect the exchange: "
+            f"{fake.rate_limit_hits} 429s observed out of {fake.call_count} calls"
+        )
+        # Both paths produced data.
+        assert set(storage_result) == {"BTCUSDT", "ETHUSDT", "SOLUSDT"}
+        for sym, bars in storage_result.items():
+            assert len(bars) > 0, f"storage path: no bars for {sym}"
+        assert manager_bars > 0, "manager path: no bars returned"
+
+        # Every exchange call must have gone through the limiter's acquire() —
+        # either via CcxtStorage's pre-fetch acquire or via the ExchangeManager-
+        # attached throttle override.
+        assert acquire_count >= fake.call_count, (
+            f"acquire fired {acquire_count} times for {fake.call_count} exchange "
+            "calls — some requests bypassed the limiter"
+        )
+
+        # Header sync must have fired for every successful call (both paths feed
+        # the same limiter): once per ExchangeManager call via on_rest_response,
+        # once per CcxtStorage page via best-effort last_response_headers read.
+        assert sync_count >= fake.call_count, (
+            f"sync_from_exchange fired {sync_count} times for {fake.call_count} "
+            "calls — some responses did not drive limiter sync"
+        )
+
+    async def test_exchange_manager_path_alone_stays_under_budget(self):
+        """Isolate the live path: rapid-fire REST calls through ExchangeManager.throttle
+        must never exceed the exchange's budget.
+
+        Budget gap matters: rate limiter's peak throughput (burst + refill over the
+        mock's window) must stay strictly below the mock's budget, otherwise natural
+        scheduling jitter will tip us over. Mock 20/s with limiter at 3 burst + 3/s
+        keeps peak throughput ≤ 6/s over any 1-second window.
+        """
+        fake = FakeCcxtExchange(
+            id="okx",
+            max_rps=20,
+            window_sec=1.0,
+            bars_per_page=1,
+            latency_ms=1.0,
+            server_budget=200,
+        )
+        limiter = _build_rate_limiter(capacity=3, refill_rate=3.0, cooldown=0.2)
+
+        manager = ExchangeManager(
+            exchange_name="okx",
+            factory_params={"exchange": "okx"},
+            initial_exchange=fake,
+            health_monitor=DummyHealthMonitor(),
+            time_provider=LiveTimeProvider(),
+        )
+        manager.attach_rate_limiter(limiter)
+
+        # Fire 20 concurrent requests — well above the mock's 10 req/s.
+        N = 20
+        results = await asyncio.gather(
+            *[
+                manager.exchange.fetch_ohlcv("BTC/USDT", "1h", since=1, limit=1)
+                for _ in range(N)
+            ],
+            return_exceptions=True,
+        )
+
+        # All completed without raising.
+        assert all(not isinstance(r, BaseException) for r in results), (
+            f"some fetches raised: {[r for r in results if isinstance(r, BaseException)]}"
+        )
+        assert fake.rate_limit_hits == 0, (
+            f"ExchangeManager path leaked {fake.rate_limit_hits} 429s — throttle "
+            "override did not prevent budget breach"
+        )
+        assert fake.call_count == N

--- a/tests/qubx/utils/runner/test_warmup_rate_limiter_injection.py
+++ b/tests/qubx/utils/runner/test_warmup_rate_limiter_injection.py
@@ -1,0 +1,75 @@
+"""
+Regression tests for xLydianSoftware/Qubx#264.
+
+Verifies that rate limiters are injected into warmup storage configs so that
+warmup OHLCV fetches are subject to the same per-exchange rate-limit budget as
+the live path. Without this, transient exchange rate limits at warmup start
+can leave an instrument with zero bars, which cascades through indicators to
+corrupted live state (see issue for the production incident).
+"""
+
+from unittest.mock import MagicMock
+
+from qubx.utils.runner.configs import StorageConfig, TypedStorageConfig, WarmupConfig
+from qubx.utils.runner.runner import _inject_warmup_rate_limiters
+
+
+def _make_warmup(custom_data: list[TypedStorageConfig] | None = None) -> WarmupConfig:
+    return WarmupConfig(
+        data=StorageConfig(storage="ccxt", args={}),
+        custom_data=custom_data or [],
+    )
+
+
+class TestInjectWarmupRateLimiters:
+    def test_injects_into_primary_data_storage_args(self):
+        warmup = _make_warmup()
+        rate_limiters = {"OKX.F": MagicMock(name="OKX.F-rl")}
+
+        _inject_warmup_rate_limiters(warmup, rate_limiters)
+
+        assert warmup.data.args["rate_limiters"] is rate_limiters
+
+    def test_injects_into_every_custom_data_storage(self):
+        custom = [
+            TypedStorageConfig(
+                data_type=["ohlc(1h)"],
+                storages=[
+                    StorageConfig(storage="ccxt", args={}),
+                    StorageConfig(storage="mqdb", args={"host": "nebula"}),
+                ],
+            ),
+            TypedStorageConfig(
+                data_type="trades",
+                storages=[StorageConfig(storage="ccxt", args={})],
+            ),
+        ]
+        warmup = _make_warmup(custom_data=custom)
+        rate_limiters = {"BINANCE.UM": MagicMock(name="binance-rl")}
+
+        _inject_warmup_rate_limiters(warmup, rate_limiters)
+
+        for typed_cfg in warmup.custom_data:
+            for sc in typed_cfg.storages:
+                assert sc.args["rate_limiters"] is rate_limiters
+
+    def test_none_warmup_is_noop(self):
+        # Should not raise when warmup config is missing entirely
+        _inject_warmup_rate_limiters(None, {"X": MagicMock()})
+
+    def test_none_or_empty_rate_limiters_is_noop(self):
+        warmup = _make_warmup()
+        _inject_warmup_rate_limiters(warmup, None)
+        _inject_warmup_rate_limiters(warmup, {})
+        assert "rate_limiters" not in warmup.data.args
+
+    def test_preserves_existing_args(self):
+        warmup = WarmupConfig(
+            data=StorageConfig(storage="ccxt", args={"max_history": "30d"}),
+        )
+        rate_limiters = {"OKX.F": MagicMock()}
+
+        _inject_warmup_rate_limiters(warmup, rate_limiters)
+
+        assert warmup.data.args["max_history"] == "30d"
+        assert warmup.data.args["rate_limiters"] is rate_limiters

--- a/uv.lock
+++ b/uv.lock
@@ -3718,7 +3718,7 @@ requires-dist = [
     { name = "msgspec", specifier = ">=0.18.6,<1" },
     { name = "ntplib", specifier = ">=0.4.0,<1" },
     { name = "numba", specifier = ">=0.59.1,<1" },
-    { name = "numpy", specifier = ">=1.26.3" },
+    { name = "numpy", specifier = ">=1.26.3,<2" },
     { name = "orjson", specifier = ">=3.10.15,<4" },
     { name = "pandas", specifier = ">=2.2.2,<3" },
     { name = "plotly", marker = "extra == 'viz'", specifier = ">=5.22.0,<6" },


### PR DESCRIPTION
## Summary

Fixes #264. Wires the rate limiter end-to-end into both the warmup OHLCV fetch path (`CcxtStorage`) and the live REST path (`ExchangeManager`), adds retry/backoff, defense-in-depth guards, response-header sync, and a full stress-test harness.

Production incident that motivated this: a warmup burst on OKX rate-limited 5 of 20 symbols, the fetcher silently returned `[]` for them, ATR computed to 0, `FixedRiskSizer` produced `inf`-sized targets, and live state was corrupted (`capital=nan`).

## What changed

### Primary (runner wiring)
- **`utils/runner/runner.py`**: inject `rate_limiters` into `warmup.data` storage configs — previously only aux storages got this, so the warmup `CcxtStorage` bypassed the limiter entirely. This was the direct root cause of the production incident.

### Storage path (warmup / history)
- **`data/storages/ccxt.py`**:
  - New `_retryable_fetch` helper — exponential backoff + jitter on `ccxt.NetworkError` (covers `RateLimitExceeded`, `ExchangeNotAvailable`, `OnMaintenance`) and `asyncio.TimeoutError`. `ExchangeError` subclasses (permanent) re-raise immediately.
  - New `CcxtFetchExhausted` exception with per-symbol `failures` map.
  - `strict_fetch=True` default — raises loudly when any symbol exhausts retries. `strict_fetch=False` preserves the old lenient behavior for ad-hoc history queries.
  - `_sync_rate_limiter_from_response_headers` after each successful page — best-effort sync via the exchange's `HEADER_PARSERS` using `last_response_headers`.

### Live path (ExchangeManager)
- **`connectors/ccxt/exchange_manager.py`**: install a second hook on `on_rest_response` alongside the throttle override. Atomic per-request (no concurrent-fetch race), drives the same `sync_from_exchange` path. Survives exchange recreation.

### Defense-in-depth (from the earlier `08590438` commit on this branch)
- `FixedRiskSizer` / `FixedRiskSizerWithConstantCapital`: skip with warning when `abs(stop/entry - 1)` is non-positive or non-finite — prevents inf targets even if an upstream tracker misbehaves.
- `AtrRiskTracker`: extended the ATR-unusable guard to reject `last_volatility <= 0` (was only rejecting `None` / non-finite). Prevents `stop = entry - stop_risk * 0 = entry`.

### Packaging
- `numpy<2` upper bound. Qubx's Cython is compiled against numpy 1.26.x; downstream consumers resolving to numpy 2.x hit `numpy.core.multiarray failed to import`.

## Tests (63 new + existing untouched)

- `tests/qubx/data/test_ccxt_storage_rate_limit.py` (23 tests): budget-respecting stress, retry helper units, flaky-exchange end-to-end, strict/lenient modes, response-header sync, and a cross-subsystem E2E that shares a single limiter between `CcxtStorage` and `ExchangeManager`.
- `tests/qubx/utils/runner/test_warmup_rate_limiter_injection.py` (5 tests): regression for the runner-side injection helper.
- `tests/qubx/connectors/ccxt/test_exchange_manager.py` (6 new): throttle override, header-sync installation for known exchanges, parser-failure tolerance, and re-application after exchange recreation.

Regression check across `tests/qubx/data/`, `tests/qubx/rate_limiting/`, `tests/qubx/trackers/`, `tests/qubx/utils/runner/`, `tests/qubx/connectors/ccxt/`: 393 passed, 5 skipped (pre-existing), 0 failures.

## Test plan

- [x] Unit tests pass (`uv run pytest tests/qubx/data/ tests/qubx/rate_limiting/ tests/qubx/trackers/ tests/qubx/utils/runner/ tests/qubx/connectors/ccxt/`)
- [x] End-to-end stress against live BINANCE.UM (28 symbols, 7d × 1h warmup, full warmup → sim → live-mode transition, 2 heartbeats observed, zero rate-limit errors, both `rl-stress` lifecycle markers fired)
- [ ] CI green on `fix/issue-264`

## Follow-ups (not in this PR)

- Rebuild Qubx wheels against numpy 2.x and relax the upper bound.
- If cross-process budget contention emerges on shared IPs, the storage-side header sync's best-effort race can be tightened with a CCXT `on_rest_response` hook (the mechanism used on the live path).
