### PR TITLE
fix(ccxt): bump ccxt to 4.5.50 for Binance USDⓈ-M WS URL split

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ qubx = "qubx.cli.commands:main"
 # ============================================================
 [project.optional-dependencies]
 # Exchange connectors (ccxt-based)
-connectors = ["ccxt>=4.2.68,<5"]
+connectors = ["ccxt>=4.5.46,<5"]
 # Binance-specific (historical data utilities)
 binance = ["python-binance>=1.0.19,<2"]
 # Bitfinex-specific (custom API client)

--- a/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
@@ -105,7 +105,11 @@ class BinanceQV(CcxtFuturePatchMixin, cxp.binance):
         streamHash = channelName
         if symbolsDefined:
             streamHash = channelName + "::" + ",".join(symbols)
-        url = self.urls["api"]["ws"][rawMarketType] + "/" + self.stream(rawMarketType, streamHash)
+        url = (
+            self.get_ws_url(rawMarketType, self.get_future_ws_category(channelName))
+            + "/"
+            + self.stream(rawMarketType, streamHash)
+        )
         requestId = self.request_id(url)
         request: dict = {
             "method": "UNSUBSCRIBE",

--- a/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
@@ -4,7 +4,7 @@ import ccxt.pro as cxp
 import pandas as pd
 from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByTimestamp
 from ccxt.async_support.base.ws.client import Client
-from ccxt.base.errors import ArgumentsRequired, BadRequest, InsufficientFunds, NotSupported
+from ccxt.base.errors import BadRequest, InsufficientFunds
 from ccxt.base.precise import Precise
 from ccxt.base.types import (
     Any,
@@ -52,80 +52,19 @@ class BinanceQV(CcxtFuturePatchMixin, cxp.binance):
 
     async def un_watch_bids_asks(self, symbols: Strings = None, params: dict = {}) -> Any:
         """
-        unwatches best bid & ask for symbols
+        Unsubscribes from the bookTicker stream for the given symbols.
 
-        https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api#symbol-order-book-ticker
-        https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Book-Tickers-Stream
-        https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-market-streams/All-Book-Tickers-Stream
-
-        :param str[] symbols: unified symbol of the market to fetch the ticker for
-        :param dict [params]: extra parameters specific to the exchange API endpoint
-        :returns dict: a `ticker structure <https://docs.ccxt.com/#/?id=ticker-structure>`
+        Upstream ccxt ships un_watch_bids_asks as a NotSupported stub, but the
+        companion watch_multi_ticker_helper has a working isUnsubscribe branch
+        that mirrors the subscribe path exactly (URL, sub-hashes, request body).
+        Delegating keeps us aligned with upstream's 2026-04 USDⓈ-M URL split
+        (/public/ws) and avoids duplicating internals that have already been
+        refactored once (get_message_hash was removed in ccxt 4.5.20).
         """
         await self.load_markets()
-        methodName = "watchBidsAsks"
-        channelName = "bookTicker"
         symbols = self.market_symbols(symbols, None, True, False, True)
-        firstMarket = None
-        marketType = None
-        symbolsDefined = symbols is not None
-        if symbolsDefined:
-            firstMarket = self.market(symbols[0])
-        marketType, params = self.handle_market_type_and_params(methodName, firstMarket, params)
-        subType = None
-        subType, params = self.handle_sub_type_and_params(methodName, firstMarket, params)
-        rawMarketType = None
-        if self.isLinear(marketType, subType):
-            rawMarketType = "future"
-        elif self.isInverse(marketType, subType):
-            rawMarketType = "delivery"
-        elif marketType == "spot":
-            rawMarketType = marketType
-        else:
-            raise NotSupported(str(self.id) + " " + methodName + "() does not support options markets")
-        isBidAsk = True
-        subscriptionArgs = []
-        subMessageHashes = []
-        messageHashes = []
-        if symbolsDefined:
-            for i in range(0, len(symbols)):
-                symbol = symbols[i]
-                market = self.market(symbol)
-                subscriptionArgs.append(market["lowercaseId"] + "@" + channelName)
-                subMessageHashes.append(self.get_message_hash(channelName, market["symbol"], isBidAsk))
-                messageHashes.append("unsubscribe:bidsasks:" + symbol)
-        else:
-            if marketType == "spot":
-                raise ArgumentsRequired(
-                    str(self.id) + " " + methodName + "() requires symbols for this channel for spot markets"
-                )
-            subscriptionArgs.append("!" + channelName)
-            subMessageHashes.append(self.get_message_hash(channelName, None, isBidAsk))
-            messageHashes.append("unsubscribe:bidsasks")
-        streamHash = channelName
-        if symbolsDefined:
-            streamHash = channelName + "::" + ",".join(symbols)
-        url = (
-            self.get_ws_url(rawMarketType, self.get_future_ws_category(channelName))
-            + "/"
-            + self.stream(rawMarketType, streamHash)
-        )
-        requestId = self.request_id(url)
-        request: dict = {
-            "method": "UNSUBSCRIBE",
-            "params": subscriptionArgs,
-            "id": requestId,
-        }
-        subscription: dict = {
-            "unsubscribe": True,
-            "id": str(requestId),
-            "subMessageHashes": subMessageHashes,
-            "messageHashes": subMessageHashes,
-            "symbols": symbols,
-            "topic": "bidsasks",
-        }
-        return await self.watch_multiple(
-            url, subMessageHashes, self.extend(request, params), subMessageHashes, subscription
+        return await self.watch_multi_ticker_helper(
+            "watchBidsAsks", "bookTicker", symbols, params, isUnsubscribe=True
         )
 
     def parse_ohlcv(self, ohlcv, market=None):

--- a/tests/integration/connectors/ccxt/test_binance_bids_asks_integration.py
+++ b/tests/integration/connectors/ccxt/test_binance_bids_asks_integration.py
@@ -1,0 +1,86 @@
+"""Integration tests for Binance USDⓈ-M bids/asks subscribe + unsubscribe.
+
+Drives BinanceQVUSDM (our ccxt subclass) directly against live Binance
+WebSocket endpoints to validate end-to-end that:
+
+1. Subscribing via watch_bids_asks opens a WS client on the new
+   /public/ws URL (post-2026-04-23 migration, ccxt 4.5.44+).
+2. un_watch_bids_asks completes without AttributeError — the delegation
+   to watch_multi_ticker_helper(isUnsubscribe=True) is correct and
+   upstream's removal of get_message_hash does not affect us.
+3. After unsubscribe, the Binance WS peer stops emitting bookTicker frames
+   for the symbol (ack flow works).
+
+These hit the public mainnet WS (no auth needed) and are skipped by the
+default test run — opt in with `pytest -m integration`.
+"""
+
+import asyncio
+
+import pytest
+
+from qubx.connectors.ccxt.exchanges.binance.exchange import BinanceQVUSDM
+
+
+@pytest.mark.integration
+class TestBinanceBidsAsksSubscribeUnsubscribeIntegration:
+    """Round-trip subscribe → unsubscribe against real Binance USDⓈ-M WS."""
+
+    SYMBOL = "BTC/USDT:USDT"
+    FIRST_QUOTE_TIMEOUT_S = 20.0
+    POST_UNSUB_QUIET_WINDOW_S = 5.0
+
+    async def _run(self):
+        ex = BinanceQVUSDM({"options": {"defaultType": "future"}})
+        try:
+            await ex.load_markets()
+
+            # 1. Subscribe and wait for the first quote.
+            first = await asyncio.wait_for(
+                ex.watch_bids_asks([self.SYMBOL]),
+                timeout=self.FIRST_QUOTE_TIMEOUT_S,
+            )
+            # watch_bids_asks returns a dict keyed by symbol when given a list.
+            assert isinstance(first, dict) and self.SYMBOL in first, f"unexpected first payload: {first!r}"
+            quote = first[self.SYMBOL]
+            bid = float(quote["bid"])
+            ask = float(quote["ask"])
+            assert bid > 0 and ask > 0 and ask >= bid, f"nonsensical quote: bid={bid} ask={ask}"
+
+            # 2. The WS client the subscription is attached to MUST be on
+            #    the new /public/ws path — this is what Binance keeps alive
+            #    after 2026-04-23.
+            public_clients = [url for url in ex.clients if "fstream.binance.com/public/ws" in url]
+            legacy_clients = [url for url in ex.clients if url.rstrip("/").endswith("fstream.binance.com/ws")]
+            assert public_clients, f"no /public/ws WS client; saw {list(ex.clients)}"
+            assert not legacy_clients, f"legacy /ws URL still in use: {legacy_clients}"
+
+            # 3. Unsubscribe — this is the path that was broken by the
+            #    removed get_message_hash. If delegation is wrong, this
+            #    raises AttributeError (or hangs waiting for an ack that
+            #    never resolves a matching messageHash).
+            await asyncio.wait_for(ex.un_watch_bids_asks([self.SYMBOL]), timeout=10.0)
+
+            # 4. Post-unsubscribe: no new bookTicker frames for this symbol
+            #    should resolve on watch_bids_asks. We can't peek inside
+            #    ccxt's frame queue portably, so we prove absence by timing
+            #    out a fresh watch call over a short quiet window.
+            # NOTE: a fresh watch call after un_watch re-subscribes, which
+            # is the correct behaviour. So instead we assert that the ack
+            # flow cleaned up ccxt's subscription registry.
+            # Sub-message hashes for this symbol must be gone from every
+            # WS client we had.
+            remaining = [
+                h
+                for client in ex.clients.values()
+                for h in getattr(client, "subscriptions", {})
+                if "bidask:bookTicker@" + self.SYMBOL in h
+            ]
+            assert not remaining, (
+                f"un_watch_bids_asks did not evict subscription entry; leftover hashes: {remaining}"
+            )
+        finally:
+            await ex.close()
+
+    def test_subscribe_and_unsubscribe_bookticker(self):
+        asyncio.run(self._run())

--- a/tests/qubx/connectors/ccxt/test_binance_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_binance_exchange.py
@@ -6,6 +6,12 @@ Pins two related fixes:
 2. BinanceQV.un_watch_bids_asks delegation — upstream removed get_message_hash
    in 4.5.20, which broke the previous override; it now delegates to
    watch_multi_ticker_helper(isUnsubscribe=True).
+
+Everything here runs fully offline. `load_markets()` is bypassed because
+GitHub-hosted CI runners are blocked by Binance (HTTP 451 from
+fapi.binance.com/fapi/v1/exchangeInfo); instead we preseed two minimal
+USDⓈ-M market entries via `set_markets()` — the only thing the watch_*
+paths need from market data is `lowercaseId`/`symbol`/contract flags.
 """
 
 import asyncio
@@ -16,22 +22,66 @@ from qubx.connectors.ccxt.exchanges.binance.exchange import BinanceQVUSDM
 
 
 def run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+    return asyncio.run(coro)
+
+
+def _usdm_market(base: str, amount_precision: float, price_precision: float) -> dict:
+    """Minimal USDⓈ-M swap market dict that satisfies ccxt's downstream lookups."""
+    return {
+        "id": f"{base}USDT",
+        "lowercaseId": f"{base.lower()}usdt",
+        "symbol": f"{base}/USDT:USDT",
+        "base": base,
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": base,
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": False,
+        "margin": False,
+        "swap": True,
+        "future": False,
+        "option": False,
+        "contract": True,
+        "linear": True,
+        "inverse": False,
+        "subType": "linear",
+        "active": True,
+        "taker": 0.0004,
+        "maker": 0.0002,
+        "contractSize": 1.0,
+        "expiry": None,
+        "expiryDatetime": None,
+        "strike": None,
+        "optionType": None,
+        "precision": {"amount": amount_precision, "price": price_precision},
+        "limits": {
+            "amount": {"min": amount_precision, "max": None},
+            "price": {"min": None, "max": None},
+            "cost": {"min": None, "max": None},
+            "leverage": {"min": 1, "max": 125},
+        },
+        "info": {},
+        "created": None,
+        "marginModes": {"cross": True, "isolated": True},
+    }
+
+
+@pytest.fixture
+def offline_binance_usdm():
+    """BinanceQVUSDM with preseeded markets — no network calls."""
+    ex = BinanceQVUSDM({"options": {"defaultType": "future"}})
+    ex.set_markets([
+        _usdm_market("BTC", 0.001, 0.1),
+        _usdm_market("ETH", 0.001, 0.01),
+    ])
+    yield ex
+    run(ex.close())
 
 
 class TestBinanceUsdmWsUrlSplit:
     """Verify every Qubx-used futures subscription routes through the category-split URLs."""
-
-    @pytest.fixture
-    def exchange(self):
-        ex = BinanceQVUSDM({"options": {"defaultType": "future"}})
-
-        async def _load():
-            await ex.load_markets()
-
-        run(_load())
-        yield ex
-        run(ex.close())
 
     @staticmethod
     def _capture_ws_url(exchange, subscribe_coro_factory):
@@ -54,51 +104,52 @@ class TestBinanceUsdmWsUrlSplit:
         assert captured, "exchange.client(url) was never called"
         return captured[-1]
 
-    def test_book_ticker_routes_to_public_ws(self, exchange):
-        url = self._capture_ws_url(exchange, lambda: exchange.watch_bids_asks(["BTC/USDT:USDT"]))
+    def test_book_ticker_routes_to_public_ws(self, offline_binance_usdm):
+        ex = offline_binance_usdm
+        url = self._capture_ws_url(ex, lambda: ex.watch_bids_asks(["BTC/USDT:USDT"]))
         assert url.startswith("wss://fstream.binance.com/public/ws/"), url
 
-    def test_depth_routes_to_public_ws(self, exchange):
-        url = self._capture_ws_url(exchange, lambda: exchange.watch_order_book("BTC/USDT:USDT"))
+    def test_depth_routes_to_public_ws(self, offline_binance_usdm):
+        ex = offline_binance_usdm
+        url = self._capture_ws_url(ex, lambda: ex.watch_order_book("BTC/USDT:USDT"))
         assert url.startswith("wss://fstream.binance.com/public/ws/"), url
 
-    def test_agg_trade_routes_to_market_ws(self, exchange):
-        url = self._capture_ws_url(exchange, lambda: exchange.watch_trades("BTC/USDT:USDT"))
+    def test_agg_trade_routes_to_market_ws(self, offline_binance_usdm):
+        ex = offline_binance_usdm
+        url = self._capture_ws_url(ex, lambda: ex.watch_trades("BTC/USDT:USDT"))
         assert url.startswith("wss://fstream.binance.com/market/ws/"), url
 
-    def test_kline_routes_to_market_ws(self, exchange):
-        url = self._capture_ws_url(exchange, lambda: exchange.watch_ohlcv("BTC/USDT:USDT", "1m"))
+    def test_kline_routes_to_market_ws(self, offline_binance_usdm):
+        ex = offline_binance_usdm
+        url = self._capture_ws_url(ex, lambda: ex.watch_ohlcv("BTC/USDT:USDT", "1m"))
         assert url.startswith("wss://fstream.binance.com/market/ws/"), url
 
-    def test_ticker_routes_to_market_ws(self, exchange):
-        url = self._capture_ws_url(exchange, lambda: exchange.watch_ticker("BTC/USDT:USDT"))
+    def test_ticker_routes_to_market_ws(self, offline_binance_usdm):
+        ex = offline_binance_usdm
+        url = self._capture_ws_url(ex, lambda: ex.watch_ticker("BTC/USDT:USDT"))
         assert url.startswith("wss://fstream.binance.com/market/ws/"), url
 
-    def test_mark_price_routes_to_market_ws(self, exchange):
-        url = self._capture_ws_url(exchange, lambda: exchange.watch_mark_prices(["BTC/USDT:USDT"]))
+    def test_mark_price_routes_to_market_ws(self, offline_binance_usdm):
+        ex = offline_binance_usdm
+        url = self._capture_ws_url(ex, lambda: ex.watch_mark_prices(["BTC/USDT:USDT"]))
         assert url.startswith("wss://fstream.binance.com/market/ws/"), url
 
-    def test_private_ws_url_uses_split_path(self, exchange):
-        url = exchange.get_private_ws_url("future", "DUMMY_LISTEN_KEY")
+    def test_private_ws_url_uses_split_path(self, offline_binance_usdm):
+        url = offline_binance_usdm.get_private_ws_url("future", "DUMMY_LISTEN_KEY")
         assert url == "wss://fstream.binance.com/private/ws?listenKey=DUMMY_LISTEN_KEY"
 
-    def test_spot_and_delivery_hosts_are_unchanged(self, exchange):
+    def test_spot_and_delivery_hosts_are_unchanged(self, offline_binance_usdm):
         # Binance's migration only affects USDⓈ-M. Spot and Coin-M stay legacy.
-        assert exchange.get_ws_url("spot", "public") == "wss://stream.binance.com:9443/ws"
-        assert exchange.get_ws_url("delivery", "public") == "wss://dstream.binance.com/ws"
+        ex = offline_binance_usdm
+        assert ex.get_ws_url("spot", "public") == "wss://stream.binance.com:9443/ws"
+        assert ex.get_ws_url("delivery", "public") == "wss://dstream.binance.com/ws"
 
 
 class TestBinanceUnWatchBidsAsks:
     """Verify BinanceQV.un_watch_bids_asks delegates correctly to upstream's helper."""
 
-    @pytest.fixture
-    def exchange(self):
-        ex = BinanceQVUSDM({"options": {"defaultType": "future"}})
-        run(ex.load_markets())
-        yield ex
-        run(ex.close())
-
-    def test_un_watch_bids_asks_produces_correct_unsubscribe_request(self, exchange):
+    def test_un_watch_bids_asks_produces_correct_unsubscribe_request(self, offline_binance_usdm):
+        exchange = offline_binance_usdm
         captured = {}
 
         async def fake_watch_multiple(url, messageHashes, request, subscribeHashes, subscription):
@@ -140,10 +191,11 @@ class TestBinanceUnWatchBidsAsks:
             "unsubscribe::bidask:bookTicker@ETH/USDT:USDT",
         ]
 
-    def test_un_watch_bids_asks_does_not_call_removed_get_message_hash(self, exchange):
+    def test_un_watch_bids_asks_does_not_call_removed_get_message_hash(self, offline_binance_usdm):
         # Regression guard: get_message_hash was removed in ccxt 4.5.20 and the
         # previous override called it, raising AttributeError. Delegation path
         # must not rely on it.
+        exchange = offline_binance_usdm
         assert not hasattr(exchange, "get_message_hash")
 
         async def fake_watch_multiple(*args, **kwargs):

--- a/tests/qubx/connectors/ccxt/test_binance_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_binance_exchange.py
@@ -1,0 +1,153 @@
+"""Unit tests for Qubx's Binance exchange overrides.
+
+Pins two related fixes:
+1. Binance USDⓈ-M WebSocket URL split (/public, /market, /private) — rolled
+   out by Binance 2026-04-23. ccxt 4.5.44+ rewrites URLs at subscribe time.
+2. BinanceQV.un_watch_bids_asks delegation — upstream removed get_message_hash
+   in 4.5.20, which broke the previous override; it now delegates to
+   watch_multi_ticker_helper(isUnsubscribe=True).
+"""
+
+import asyncio
+
+import pytest
+
+from qubx.connectors.ccxt.exchanges.binance.exchange import BinanceQVUSDM
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+class TestBinanceUsdmWsUrlSplit:
+    """Verify every Qubx-used futures subscription routes through the category-split URLs."""
+
+    @pytest.fixture
+    def exchange(self):
+        ex = BinanceQVUSDM({"options": {"defaultType": "future"}})
+
+        async def _load():
+            await ex.load_markets()
+
+        run(_load())
+        yield ex
+        run(ex.close())
+
+    @staticmethod
+    def _capture_ws_url(exchange, subscribe_coro_factory):
+        captured = []
+
+        def capture(url):
+            captured.append(url)
+            raise RuntimeError("STOP_BEFORE_CONNECT")
+
+        exchange.client = capture
+
+        async def go():
+            try:
+                await subscribe_coro_factory()
+            except RuntimeError as e:
+                if str(e) != "STOP_BEFORE_CONNECT":
+                    raise
+
+        run(go())
+        assert captured, "exchange.client(url) was never called"
+        return captured[-1]
+
+    def test_book_ticker_routes_to_public_ws(self, exchange):
+        url = self._capture_ws_url(exchange, lambda: exchange.watch_bids_asks(["BTC/USDT:USDT"]))
+        assert url.startswith("wss://fstream.binance.com/public/ws/"), url
+
+    def test_depth_routes_to_public_ws(self, exchange):
+        url = self._capture_ws_url(exchange, lambda: exchange.watch_order_book("BTC/USDT:USDT"))
+        assert url.startswith("wss://fstream.binance.com/public/ws/"), url
+
+    def test_agg_trade_routes_to_market_ws(self, exchange):
+        url = self._capture_ws_url(exchange, lambda: exchange.watch_trades("BTC/USDT:USDT"))
+        assert url.startswith("wss://fstream.binance.com/market/ws/"), url
+
+    def test_kline_routes_to_market_ws(self, exchange):
+        url = self._capture_ws_url(exchange, lambda: exchange.watch_ohlcv("BTC/USDT:USDT", "1m"))
+        assert url.startswith("wss://fstream.binance.com/market/ws/"), url
+
+    def test_ticker_routes_to_market_ws(self, exchange):
+        url = self._capture_ws_url(exchange, lambda: exchange.watch_ticker("BTC/USDT:USDT"))
+        assert url.startswith("wss://fstream.binance.com/market/ws/"), url
+
+    def test_mark_price_routes_to_market_ws(self, exchange):
+        url = self._capture_ws_url(exchange, lambda: exchange.watch_mark_prices(["BTC/USDT:USDT"]))
+        assert url.startswith("wss://fstream.binance.com/market/ws/"), url
+
+    def test_private_ws_url_uses_split_path(self, exchange):
+        url = exchange.get_private_ws_url("future", "DUMMY_LISTEN_KEY")
+        assert url == "wss://fstream.binance.com/private/ws?listenKey=DUMMY_LISTEN_KEY"
+
+    def test_spot_and_delivery_hosts_are_unchanged(self, exchange):
+        # Binance's migration only affects USDⓈ-M. Spot and Coin-M stay legacy.
+        assert exchange.get_ws_url("spot", "public") == "wss://stream.binance.com:9443/ws"
+        assert exchange.get_ws_url("delivery", "public") == "wss://dstream.binance.com/ws"
+
+
+class TestBinanceUnWatchBidsAsks:
+    """Verify BinanceQV.un_watch_bids_asks delegates correctly to upstream's helper."""
+
+    @pytest.fixture
+    def exchange(self):
+        ex = BinanceQVUSDM({"options": {"defaultType": "future"}})
+        run(ex.load_markets())
+        yield ex
+        run(ex.close())
+
+    def test_un_watch_bids_asks_produces_correct_unsubscribe_request(self, exchange):
+        captured = {}
+
+        async def fake_watch_multiple(url, messageHashes, request, subscribeHashes, subscription):
+            captured.update(
+                url=url,
+                messageHashes=messageHashes,
+                request=request,
+                subscribeHashes=subscribeHashes,
+                subscription=subscription,
+            )
+            return "ACK"
+
+        exchange.watch_multiple = fake_watch_multiple
+
+        result = run(exchange.un_watch_bids_asks(["BTC/USDT:USDT", "ETH/USDT:USDT"]))
+
+        assert result == "ACK"
+
+        # URL must use the new /public/ws split path (post-2026-04-23 migration).
+        assert captured["url"].startswith("wss://fstream.binance.com/public/ws/")
+
+        # Request body is a Binance UNSUBSCRIBE with lowercase symbol@channel params.
+        assert captured["request"]["method"] == "UNSUBSCRIBE"
+        assert set(captured["request"]["params"]) == {"btcusdt@bookTicker", "ethusdt@bookTicker"}
+        assert isinstance(captured["request"]["id"], int)
+
+        # subscription.subMessageHashes must mirror what watch_bids_asks subscribe
+        # stored, so ccxt's client correctly evicts the subscription on ACK.
+        sub = captured["subscription"]
+        assert sub["unsubscribe"] is True
+        assert sub["subMessageHashes"] == [
+            "bidask:bookTicker@BTC/USDT:USDT",
+            "bidask:bookTicker@ETH/USDT:USDT",
+        ]
+
+        # messageHashes (what the returned future resolves on) use the unsubscribe:: prefix.
+        assert sub["messageHashes"] == [
+            "unsubscribe::bidask:bookTicker@BTC/USDT:USDT",
+            "unsubscribe::bidask:bookTicker@ETH/USDT:USDT",
+        ]
+
+    def test_un_watch_bids_asks_does_not_call_removed_get_message_hash(self, exchange):
+        # Regression guard: get_message_hash was removed in ccxt 4.5.20 and the
+        # previous override called it, raising AttributeError. Delegation path
+        # must not rely on it.
+        assert not hasattr(exchange, "get_message_hash")
+
+        async def fake_watch_multiple(*args, **kwargs):
+            return "ACK"
+
+        exchange.watch_multiple = fake_watch_multiple
+        run(exchange.un_watch_bids_asks(["BTC/USDT:USDT"]))

--- a/uv.lock
+++ b/uv.lock
@@ -272,7 +272,7 @@ wheels = [
 
 [[package]]
 name = "ccxt"
-version = "4.5.34"
+version = "4.5.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
@@ -285,9 +285,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/97/8c3fd0c4f88af310617632408a3f9a2c6db5e90e6172f474a3c6368bf9ce/ccxt-4.5.34.tar.gz", hash = "sha256:c32886b28f3f1ead121b43665734333ecf084758888bed0dfc98a020e578b08e", size = 5943098, upload-time = "2026-01-20T10:59:55.391Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/59/5d8d8822b65b097e7a17e2a0b8e0db34722b540c5229d2f8bc4e673b8cff/ccxt-4.5.50.tar.gz", hash = "sha256:db3214a2a73bc83699ad91001509797d555233544e0388863220151ff1f7547e", size = 6093796, upload-time = "2026-04-20T14:20:35.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/eb/7f6f0b252c701db93787ead15f8368138dde740cb1cd75b88ab9ca9027a4/ccxt-4.5.34-py2.py3-none-any.whl", hash = "sha256:fe0b02d77900eb2ae59a432257ae8c7705bf9df7adc77bc735b815d02688d1ba", size = 6441962, upload-time = "2026-01-20T10:59:52.812Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1a/033fad8e59bdc0ad28f5fe157b85b5ad9e5b9069cb0b169335a1ae76ee90/ccxt-4.5.50-py2.py3-none-any.whl", hash = "sha256:7f88d4f18ca68fbe9869ea5dbccdc66a53db3896ca376030c4cd12b0d3bdc324", size = 6590510, upload-time = "2026-04-20T14:20:32.087Z" },
 ]
 
 [[package]]
@@ -3769,7 +3769,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.10.11,<3.11" },
-    { name = "ccxt", marker = "extra == 'connectors'", specifier = ">=4.2.68,<5" },
+    { name = "ccxt", marker = "extra == 'connectors'", specifier = ">=4.5.46,<5" },
     { name = "click", specifier = ">=8.1.7,<9" },
     { name = "croniter", specifier = ">=2.0.5,<3" },
     { name = "dash", marker = "extra == 'viz'", specifier = ">=2.18.2,<3" },


### PR DESCRIPTION
## Summary

Binance retires the legacy USDⓈ-M futures WebSocket URL `wss://fstream.binance.com/ws` on **2026-04-23** and splits traffic across three category-specific paths ([notice](https://developers.binance.com/docs/derivatives/usds-margined-futures)):

| category  | path          | streams |
|-----------|---------------|---------|
| `public`  | `/public/ws`  | `depth`, `bookTicker`, `rpiDepth`, `trade` |
| `market`  | `/market/ws`  | `aggTrade`, `kline`, `ticker`, `markPrice`, `forceOrder`, `miniTicker`, … |
| `private` | `/private/ws` | user-data (`?listenKey=…`) |

ccxt added the URL-split logic at subscription time in [ccxt/ccxt#28091](https://github.com/ccxt/ccxt/pull/28091), first shipped in **4.5.44** (2026-03-17). Our lock was at **4.5.34** — pre-split.

This PR bumps ccxt and repairs the two Qubx-side sites that were breaking the split or had already silently broken:

1. **ccxt version bump**: `ccxt 4.5.34 → 4.5.50` (lock), floor `>=4.2.68 → >=4.5.46` in `pyproject.toml` (4.5.46 also carries the proxy/bridge fix from [ccxt/ccxt#28322](https://github.com/ccxt/ccxt/issues/28322)).
2. **`BinanceQV.un_watch_bids_asks` rewritten**: the previous 73-line override bypassed ccxt's URL rewrite *and* called `self.get_message_hash(...)`, a helper upstream removed in 4.5.20 (so this has silently been raising `AttributeError` on every dynamic unsubscribe for months — it's only hit on universe changes that drop symbols, hence "works in tests, fails in prod"). Replaced with a 5-line delegation to `watch_multi_ticker_helper(..., isUnsubscribe=True)`, which inherits URL-split handling, hash bookkeeping, and any future upstream changes.

## Verification

### Unit — `tests/qubx/connectors/ccxt/test_binance_exchange.py`
Pins URL-split routing for every Qubx-used futures subscription by intercepting `exchange.client(url)`:
```
bookTicker   → wss://fstream.binance.com/public/ws/...
depth        → wss://fstream.binance.com/public/ws/...
aggTrade     → wss://fstream.binance.com/market/ws/...
kline        → wss://fstream.binance.com/market/ws/...
ticker       → wss://fstream.binance.com/market/ws/...
markPrice    → wss://fstream.binance.com/market/ws/...
private (lk) → wss://fstream.binance.com/private/ws?listenKey=...
spot/coin-M  → legacy hosts (unaffected by Binance's change)
```
plus hash-shape and URL assertions on `un_watch_bids_asks`, and a regression guard that `get_message_hash` is gone.

### Integration — `tests/integration/connectors/ccxt/test_binance_bids_asks_integration.py`
`@pytest.mark.integration`. Drives `BinanceQVUSDM` against real Binance mainnet WS:
1. `watch_bids_asks(['BTC/USDT:USDT'])` returns a real quote within 20s.
2. `exchange.clients` contains a `/public/ws` URL and **no** legacy `/ws` URL.
3. `un_watch_bids_asks(['BTC/USDT:USDT'])` completes without `AttributeError` within 10s.
4. Subscription entry for `bidask:bookTicker@BTC/USDT:USDT` is evicted from every ccxt WS client (ack loop fired).

Green against live Binance:
```
$ uv run pytest tests/integration/connectors/ccxt/test_binance_bids_asks_integration.py -m integration
1 passed in 14.80s
```

### Unit suite
`just test` — **1318 passed, 5 skipped** (10 new, 0 regressed).

## Test plan

- [x] `just test` — 1318 passed, 5 skipped
- [x] Unit URL-split verification (6 subscription types + private + spot/delivery)
- [x] Unit un_watch_bids_asks delegation (URL, request body, sub-hash shapes, regression guard)
- [x] Integration subscribe/unsubscribe round-trip vs live Binance — passes
- [ ] Dev-channel release CI green
- [ ] Live smoke via platform bot before 2026-04-23