### PR TITLE
fix(release): honor `subdirectory` for git sources in [tool.uv.sources]

### DIFF
--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -1454,12 +1454,16 @@ def _bundle_source_overrides(
                     subprocess.run(["git", "clone", git_url, checkout_dir], check=True, capture_output=True, text=True)
                     subprocess.run(["git", "checkout", commit_sha], cwd=checkout_dir, check=True, capture_output=True, text=True)
 
-            logger.info(f"  Bundling {pkg_name}=={pkg_ver} from {checkout_dir} ...")
+            # Honor [tool.uv.sources] `subdirectory` for monorepo git sources
+            subdir = source.get("subdirectory")
+            build_cwd = os.path.join(checkout_dir, subdir) if subdir else checkout_dir
+
+            logger.info(f"  Bundling {pkg_name}=={pkg_ver} from {build_cwd} ...")
             os.makedirs(wheels_dir, exist_ok=True)
             try:
                 result = subprocess.run(
                     ["uv", "build", "--wheel", ".", "--out-dir", wheels_dir],
-                    cwd=checkout_dir,
+                    cwd=build_cwd,
                     check=True,
                     capture_output=True,
                     text=True,

--- a/tests/qubx/cli/release_test.py
+++ b/tests/qubx/cli/release_test.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 import qubx.pandaz.ta as pta
 from qubx.backtester.simulator import simulate
 from qubx.cli.misc import PyClassInfo, find_pyproject_root
-from qubx.cli.release import ReleaseInfo, StrategyInfo, create_released_pack
+from qubx.cli.release import ReleaseInfo, StrategyInfo, _bundle_source_overrides, create_released_pack
 from qubx.core.series import OHLCV
 from qubx.data import CsvStorage
 from qubx.utils.runner.configs import ExchangeConfig, LoggingConfig, StrategyConfig
@@ -257,3 +257,72 @@ class TestCreateReleasedPack:
         assert kwargs.get("message") == "Test release", "Message not passed correctly"
         assert kwargs.get("output_dir") == output_dir, "Output directory not passed correctly"
         assert kwargs.get("commit") is False, "Commit flag not passed correctly"
+
+
+class TestBundleSourceOverrides:
+    """Verify [tool.uv.sources] git source bundling — including monorepo `subdirectory`."""
+
+    def _make_pyproject(self, *, subdirectory: str | None = None) -> dict:
+        source: dict = {
+            "git": "https://github.com/example/monorepo.git",
+            "tag": "pkg/v0.2.0",
+        }
+        if subdirectory is not None:
+            source["subdirectory"] = subdirectory
+        return {"tool": {"uv": {"sources": {"sample-pkg": source}}}}
+
+    @patch("qubx.cli.release._find_uv_git_checkout")
+    @patch("subprocess.run")
+    def test_git_source_with_subdirectory_builds_from_subdir(
+        self, mock_run, mock_find_checkout, tmp_path
+    ):
+        """Git source with `subdirectory` must run `uv build` from <checkout>/<subdirectory>."""
+        checkout_root = tmp_path / "cache" / "deadbeef"
+        checkout_root.mkdir(parents=True)
+        mock_find_checkout.return_value = str(checkout_root)
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        release_dir = tmp_path / "release"
+        release_dir.mkdir()
+
+        _bundle_source_overrides(
+            pyproject_data=self._make_pyproject(subdirectory="qubx-xdata"),
+            pyproject_root=str(tmp_path),
+            release_dir=str(release_dir),
+            required_packages={"sample-pkg"},
+            lock_versions={"sample_pkg": "0.2.0"},
+            git_commits={"sample_pkg": "deadbeefcafebabe"},
+        )
+
+        assert mock_run.called, "uv build should be invoked for the git source"
+        kwargs = mock_run.call_args.kwargs
+        expected_cwd = str(checkout_root / "qubx-xdata")
+        assert kwargs["cwd"] == expected_cwd, (
+            f"Expected build cwd={expected_cwd!r}, got {kwargs['cwd']!r}"
+        )
+
+    @patch("qubx.cli.release._find_uv_git_checkout")
+    @patch("subprocess.run")
+    def test_git_source_without_subdirectory_builds_from_root(
+        self, mock_run, mock_find_checkout, tmp_path
+    ):
+        """Without `subdirectory`, `uv build` must run from the checkout root (unchanged)."""
+        checkout_root = tmp_path / "cache" / "deadbeef"
+        checkout_root.mkdir(parents=True)
+        mock_find_checkout.return_value = str(checkout_root)
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        release_dir = tmp_path / "release"
+        release_dir.mkdir()
+
+        _bundle_source_overrides(
+            pyproject_data=self._make_pyproject(subdirectory=None),
+            pyproject_root=str(tmp_path),
+            release_dir=str(release_dir),
+            required_packages={"sample-pkg"},
+            lock_versions={"sample_pkg": "0.2.0"},
+            git_commits={"sample_pkg": "deadbeefcafebabe"},
+        )
+
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["cwd"] == str(checkout_root)


### PR DESCRIPTION
## Summary
- `_bundle_source_overrides` now reads `subdirectory` from `[tool.uv.sources]` when bundling a git source, and runs `uv build --wheel` from `<checkout>/<subdirectory>` instead of the repo root.
- Unblocks consuming monorepo subpackages (e.g. `qubx-xdata` lives at `xrust/qubx-xdata/`) without the wheel build silently failing and breaking the downstream `uv lock`.
- Adds two unit tests covering both the subdir and root cases.

## Why
Strategies depending on `qubx-xdata` from xrust use:
\`\`\`toml
qubx-xdata = { git = "https://github.com/xLydianSoftware/xrust.git", tag = "qubx_xdata/v0.2.0", subdirectory = "qubx-xdata" }
\`\`\`
Today the release CI fails:
\`\`\`
Bundling qubx-xdata==0.2.0 from <cache>/<commit> ...
WARNING | Failed to build wheel for qubx-xdata: × <cache>/<commit> does not appear to be a Python project,
         as neither pyproject.toml nor setup.py are present
...
Generating uv.lock file...
ERROR | uv lock stderr: Because qubx-xdata was not found in the package registry and your project
       depends on qubx-xdata==0.2.0, requirements are unsatisfiable.
\`\`\`
Run: https://github.com/xLydianSoftware/xrelease/actions/runs/24916231880/job/72968779982

## Test plan
- [x] `uv run pytest tests/qubx/cli/release_test.py -v` — all 6 tests pass (4 existing + 2 new).
- [ ] After merge, re-run the xrelease GH Action for `dev/binance/unimble-combo.yaml` to confirm xdata is bundled and the ZIP builds.