### PR TITLE
feat(core): account risk surface — ADL, initial margin, instrument leverage, margin mode

### DIFF
--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -1060,6 +1060,25 @@ def s3_rm_cmd(path: str, recursive: bool, yes: bool):
     s3_rm(path, recursive=recursive)
 
 
+@s3.command("parquet-stats")
+@click.argument("path", type=str)
+@click.option("--per-column", is_flag=True, help="Show per-column chunk sizes for row group 0.")
+def s3_parquet_stats_cmd(path: str, per_column: bool):
+    """
+    Print parquet file-level summary and row-group size distribution.
+
+    Accepts both S3 paths (account:bucket/key) and local paths. Reads only
+    the footer, so the full file is NOT downloaded.
+
+    Examples:\n
+      qubx s3 parquet-stats r2:dvault-features/.../part-2026-03.parquet\n
+      qubx s3 parquet-stats ./local.parquet --per-column
+    """
+    from .s3 import s3_parquet_stats
+
+    s3_parquet_stats(path, per_column=per_column)
+
+
 @s3.command("cp")
 @click.argument("src", type=str)
 @click.argument("dst", type=str)

--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -1454,12 +1454,16 @@ def _bundle_source_overrides(
                     subprocess.run(["git", "clone", git_url, checkout_dir], check=True, capture_output=True, text=True)
                     subprocess.run(["git", "checkout", commit_sha], cwd=checkout_dir, check=True, capture_output=True, text=True)
 
-            logger.info(f"  Bundling {pkg_name}=={pkg_ver} from {checkout_dir} ...")
+            # Honor [tool.uv.sources] `subdirectory` for monorepo git sources
+            subdir = source.get("subdirectory")
+            build_cwd = os.path.join(checkout_dir, subdir) if subdir else checkout_dir
+
+            logger.info(f"  Bundling {pkg_name}=={pkg_ver} from {build_cwd} ...")
             os.makedirs(wheels_dir, exist_ok=True)
             try:
                 result = subprocess.run(
                     ["uv", "build", "--wheel", ".", "--out-dir", wheels_dir],
-                    cwd=checkout_dir,
+                    cwd=build_cwd,
                     check=True,
                     capture_output=True,
                     text=True,

--- a/src/qubx/cli/s3.py
+++ b/src/qubx/cli/s3.py
@@ -109,6 +109,98 @@ def s3_cp(src: str, dst: str, recursive: bool = False) -> None:
         raise click.Abort()
 
 
+def s3_parquet_stats(path: str, per_column: bool = False) -> None:
+    """Print file-level summary + row-group size distribution for one parquet file.
+
+    Accepts either an S3 URI (``account:bucket/key``) or a local filesystem path.
+    Uses pyarrow for metadata parsing so no data pages are fetched.
+    """
+    import pyarrow.parquet as pq
+    from pyarrow.fs import LocalFileSystem
+
+    # Heuristic: an S3 URI has "account:..." where account is non-empty and
+    # contains no path separator. Fall back to local for anything else.
+    is_s3 = ":" in path and "/" not in path.split(":", 1)[0] and not path.startswith("/")
+    if is_s3:
+        try:
+            client, s3_path = S3Client.from_uri(path)
+        except ValueError as e:
+            raise click.BadParameter(str(e))
+        fs = client.fs
+        open_path = s3_path
+    else:
+        fs = LocalFileSystem()
+        open_path = path
+
+    try:
+        with fs.open_input_file(open_path) as f:
+            meta = pq.ParquetFile(f).metadata
+    except Exception as e:
+        click.echo(click.style(f"Error reading {path}: {e}", fg="red"), err=True)
+        raise click.Abort()
+
+    click.echo(click.style(f"File: {path}", fg="cyan", bold=True))
+    click.echo(f"  num_rows:       {meta.num_rows:,}")
+    click.echo(f"  num_row_groups: {meta.num_row_groups}")
+    click.echo(f"  num_columns:    {meta.num_columns}")
+    click.echo(f"  format_version: {meta.format_version}")
+    if meta.created_by:
+        click.echo(f"  created_by:     {meta.created_by}")
+
+    if meta.num_row_groups == 0:
+        return
+
+    # Parquet spec: RowGroup.total_byte_size is the SUM of uncompressed
+    # column sizes. The compressed on-disk size is the sum of
+    # ColumnChunk.total_compressed_size across columns.
+    rows: list[int] = []
+    per_rg_compressed: list[int] = []
+    per_rg_uncompressed: list[int] = []
+    compressions: set[str] = set()
+    for i in range(meta.num_row_groups):
+        rg = meta.row_group(i)
+        rows.append(rg.num_rows)
+        c_sz = 0
+        u_sz = 0
+        for c in range(rg.num_columns):
+            col = rg.column(c)
+            c_sz += col.total_compressed_size
+            u_sz += col.total_uncompressed_size
+            compressions.add(str(col.compression))
+        per_rg_compressed.append(c_sz)
+        per_rg_uncompressed.append(u_sz)
+
+    total_compressed = sum(per_rg_compressed)
+    total_uncompressed = sum(per_rg_uncompressed)
+    click.echo()
+    click.echo(click.style("Row groups:", fg="cyan", bold=True))
+    click.echo(f"  rows per rg:   min={min(rows):,}  max={max(rows):,}  avg={sum(rows)//len(rows):,}")
+    click.echo(
+        f"  cmp per rg:    min={_human_size(min(per_rg_compressed))}  "
+        f"max={_human_size(max(per_rg_compressed))}  avg={_human_size(sum(per_rg_compressed) // len(per_rg_compressed))}"
+    )
+    click.echo(f"  total:         compressed={_human_size(total_compressed)}  uncompressed={_human_size(total_uncompressed)}")
+    if total_uncompressed > 0:
+        ratio = 100 * total_compressed / total_uncompressed
+        click.echo(f"  compression:   {', '.join(sorted(compressions))}  ({ratio:.1f}% of uncompressed)")
+    else:
+        click.echo(f"  compression:   {', '.join(sorted(compressions))}")
+
+    if per_column:
+        click.echo()
+        click.echo(click.style("Columns (row group 0):", fg="cyan", bold=True))
+        rg0 = meta.row_group(0)
+        click.echo(f"  {'path':30s}  {'type':12s}  {'compressed':>11s}  {'uncompressed':>12s}   pct  compression")
+        for c in range(rg0.num_columns):
+            col = rg0.column(c)
+            pct = (100 * col.total_compressed_size / col.total_uncompressed_size) if col.total_uncompressed_size else 0.0
+            click.echo(
+                f"  {col.path_in_schema:30s}  {str(col.physical_type):12s}  "
+                f"{_human_size(col.total_compressed_size):>11s}  {_human_size(col.total_uncompressed_size):>12s}  "
+                f"{pct:5.1f}%  {col.compression}"
+            )
+
+
 def s3_accounts() -> None:
     s = get_settings()
     if not s.s3:

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -205,10 +205,6 @@ class BasicAccountProcessor(IAccountProcessor):
             f"{type(self).__name__} does not support set_margin_mode"
         )
 
-    def get_total_required_margin(self, exchange: str | None = None) -> float:
-        # sum of margin required for all positions
-        return sum([p.maint_margin for p in self._positions.values()])
-
     def get_total_initial_margin(self, exchange: str | None = None) -> float:
         # sum of initial margin reserved across all positions
         return sum(p.initial_margin for p in self._positions.values())
@@ -218,17 +214,27 @@ class BasicAccountProcessor(IAccountProcessor):
         return sum(p.maint_margin for p in self._positions.values())
 
     def get_available_margin(self, exchange: str | None = None) -> float:
-        # total capital - total required margin
-        return self.get_total_capital(exchange) - self.get_total_required_margin(exchange)
+        """Available margin headroom for opening new positions.
+
+        Computed as ``total_capital - total_initial_margin`` because initial
+        margin is what the venue reserves when a position is opened.  For
+        accurate results, the connector must populate ``Position.initial_margin``
+        either via ``set_external_initial_margin(...)`` from venue data (e.g.
+        HPL ``marginUsed``) or via ``instrument.initial_margin`` in the
+        metadata.  Connectors that populate neither will see this method return
+        the full capital.
+        """
+        # total capital - total initial margin (initial is what's reserved when opening)
+        return self.get_total_capital(exchange) - self.get_total_initial_margin(exchange)
 
     def get_margin_ratio(self, exchange: str | None = None) -> float:
         if self._exchange_margin_ratio is not None:
             return self._exchange_margin_ratio
-        # fallback: total capital / total required margin
-        required_margin = self.get_total_required_margin(exchange)
-        if required_margin == 0:
+        # fallback: total capital / total maintenance margin
+        maint_margin = self.get_total_maint_margin(exchange)
+        if maint_margin == 0:
             return 100.0
-        return min(100.0, self.get_total_capital(exchange) / required_margin)
+        return min(100.0, self.get_total_capital(exchange) / maint_margin)
 
     ########################################################
     # Order and trade processing
@@ -818,18 +824,6 @@ class CompositeAccountProcessor(IAccountProcessor):
     # Margin information
     # Used for margin, swap, futures, options trading
     ########################################################
-    def get_total_required_margin(self, exchange: str | None = None) -> float:
-        if exchange is not None:
-            # Return required margin from specific exchange
-            exch = self._get_exchange(exchange)
-            return self._account_processors[exch].get_total_required_margin(exchange)
-
-        # Return aggregated required margin from all exchanges when no exchange is specified
-        total_required_margin = 0.0
-        for exch_name, processor in self._account_processors.items():
-            total_required_margin += processor.get_total_required_margin(exch_name)
-        return total_required_margin
-
     def get_total_initial_margin(self, exchange: str | None = None) -> float:
         if exchange is not None:
             exch = self._get_exchange(exchange)
@@ -861,11 +855,11 @@ class CompositeAccountProcessor(IAccountProcessor):
             return self._account_processors[exch].get_margin_ratio(exchange)
 
         # Return aggregated margin ratio from all exchanges when no exchange is specified
-        # Calculated as: total_capital_all_exchanges / total_required_margin_all_exchanges
-        total_required_margin = self.get_total_required_margin()
-        if total_required_margin == 0:
+        # Calculated as: total_capital_all_exchanges / total_maint_margin_all_exchanges
+        total_maint_margin = self.get_total_maint_margin()
+        if total_maint_margin == 0:
             return 999.0
-        return self.get_total_capital() / total_required_margin
+        return self.get_total_capital() / total_maint_margin
 
     ########################################################
     # Order and trade processing

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -198,6 +198,16 @@ class BasicAccountProcessor(IAccountProcessor):
         cache = getattr(self, "_margin_mode_cache", None)
         return cache.get(instrument) if cache else None
 
+    def set_instrument_leverage(self, instrument: Instrument, leverage: float) -> bool:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support set_instrument_leverage"
+        )
+
+    def set_margin_mode(self, instrument: Instrument, mode) -> bool:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support set_margin_mode"
+        )
+
     def get_total_required_margin(self, exchange: str | None = None) -> float:
         # sum of margin required for all positions
         return sum([p.maint_margin for p in self._positions.values()])
@@ -768,6 +778,14 @@ class CompositeAccountProcessor(IAccountProcessor):
     def get_margin_mode(self, instrument: Instrument):
         exch = self._get_exchange(instrument=instrument)
         return self._account_processors[exch].get_margin_mode(instrument)
+
+    def set_instrument_leverage(self, instrument: Instrument, leverage: float) -> bool:
+        exch = self._get_exchange(instrument=instrument)
+        return self._account_processors[exch].set_instrument_leverage(instrument, leverage)
+
+    def set_margin_mode(self, instrument: Instrument, mode) -> bool:
+        exch = self._get_exchange(instrument=instrument)
+        return self._account_processors[exch].set_margin_mode(instrument, mode)
 
     def get_leverages(self, exchange: str | None = None) -> dict[Instrument, float]:
         exchanges = [exchange] if exchange is not None else self._exchange_list

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -175,6 +175,29 @@ class BasicAccountProcessor(IAccountProcessor):
     # Margin information
     # Used for margin, swap, futures, options trading
     ########################################################
+    ########################################################
+    # Per-instrument exchange-side settings
+    #
+    # Default impls read from optional caches (None / inf if not populated).
+    # Live exchange processors populate these caches during REST snapshot
+    # and on WS state updates.
+    ########################################################
+    def get_instrument_leverage(self, instrument: Instrument) -> float | None:
+        cache = getattr(self, "_instrument_leverage_cache", None)
+        return cache.get(instrument) if cache else None
+
+    def get_max_instrument_leverage(self, instrument: Instrument) -> float | None:
+        cache = getattr(self, "_max_instrument_leverage_cache", None)
+        return cache.get(instrument) if cache else None
+
+    def get_max_instrument_notional(self, instrument: Instrument) -> float:
+        cache = getattr(self, "_max_instrument_notional_cache", None)
+        return cache.get(instrument, float("inf")) if cache else float("inf")
+
+    def get_margin_mode(self, instrument: Instrument):
+        cache = getattr(self, "_margin_mode_cache", None)
+        return cache.get(instrument) if cache else None
+
     def get_total_required_margin(self, exchange: str | None = None) -> float:
         # sum of margin required for all positions
         return sum([p.maint_margin for p in self._positions.values()])
@@ -729,6 +752,22 @@ class CompositeAccountProcessor(IAccountProcessor):
     def get_leverage(self, instrument: Instrument) -> float:
         exch = self._get_exchange(instrument=instrument)
         return self._account_processors[exch].get_leverage(instrument)
+
+    def get_instrument_leverage(self, instrument: Instrument) -> float | None:
+        exch = self._get_exchange(instrument=instrument)
+        return self._account_processors[exch].get_instrument_leverage(instrument)
+
+    def get_max_instrument_leverage(self, instrument: Instrument) -> float | None:
+        exch = self._get_exchange(instrument=instrument)
+        return self._account_processors[exch].get_max_instrument_leverage(instrument)
+
+    def get_max_instrument_notional(self, instrument: Instrument) -> float:
+        exch = self._get_exchange(instrument=instrument)
+        return self._account_processors[exch].get_max_instrument_notional(instrument)
+
+    def get_margin_mode(self, instrument: Instrument):
+        exch = self._get_exchange(instrument=instrument)
+        return self._account_processors[exch].get_margin_mode(instrument)
 
     def get_leverages(self, exchange: str | None = None) -> dict[Instrument, float]:
         exchanges = [exchange] if exchange is not None else self._exchange_list

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -178,25 +178,22 @@ class BasicAccountProcessor(IAccountProcessor):
     ########################################################
     # Per-instrument exchange-side settings
     #
-    # Default impls read from optional caches (None / inf if not populated).
-    # Live exchange processors populate these caches during REST snapshot
-    # and on WS state updates.
+    # Soft-default no-ops on this base class. Live exchange processors
+    # (e.g. HyperliquidAccountProcessor) override these with venue-side
+    # data. Connectors without these concepts (sim, spot, plain CCXT)
+    # inherit None / float('inf') and need no override.
     ########################################################
     def get_instrument_leverage(self, instrument: Instrument) -> float | None:
-        cache = getattr(self, "_instrument_leverage_cache", None)
-        return cache.get(instrument) if cache else None
+        return None
 
     def get_max_instrument_leverage(self, instrument: Instrument) -> float | None:
-        cache = getattr(self, "_max_instrument_leverage_cache", None)
-        return cache.get(instrument) if cache else None
+        return None
 
     def get_max_instrument_notional(self, instrument: Instrument) -> float:
-        cache = getattr(self, "_max_instrument_notional_cache", None)
-        return cache.get(instrument, float("inf")) if cache else float("inf")
+        return float("inf")
 
     def get_margin_mode(self, instrument: Instrument):
-        cache = getattr(self, "_margin_mode_cache", None)
-        return cache.get(instrument) if cache else None
+        return None
 
     def set_instrument_leverage(self, instrument: Instrument, leverage: float) -> bool:
         raise NotImplementedError(

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -179,6 +179,14 @@ class BasicAccountProcessor(IAccountProcessor):
         # sum of margin required for all positions
         return sum([p.maint_margin for p in self._positions.values()])
 
+    def get_total_initial_margin(self, exchange: str | None = None) -> float:
+        # sum of initial margin reserved across all positions
+        return sum(p.initial_margin for p in self._positions.values())
+
+    def get_total_maint_margin(self, exchange: str | None = None) -> float:
+        # sum of maintenance margin required across all positions
+        return sum(p.maint_margin for p in self._positions.values())
+
     def get_available_margin(self, exchange: str | None = None) -> float:
         # total capital - total required margin
         return self.get_total_capital(exchange) - self.get_total_required_margin(exchange)
@@ -767,6 +775,18 @@ class CompositeAccountProcessor(IAccountProcessor):
         for exch_name, processor in self._account_processors.items():
             total_required_margin += processor.get_total_required_margin(exch_name)
         return total_required_margin
+
+    def get_total_initial_margin(self, exchange: str | None = None) -> float:
+        if exchange is not None:
+            exch = self._get_exchange(exchange)
+            return self._account_processors[exch].get_total_initial_margin(exchange)
+        return sum(p.get_total_initial_margin(name) for name, p in self._account_processors.items())
+
+    def get_total_maint_margin(self, exchange: str | None = None) -> float:
+        if exchange is not None:
+            exch = self._get_exchange(exchange)
+            return self._account_processors[exch].get_total_maint_margin(exchange)
+        return sum(p.get_total_maint_margin(name) for name, p in self._account_processors.items())
 
     def get_available_margin(self, exchange: str | None = None) -> float:
         if exchange is not None:

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -756,6 +756,8 @@ class Position:
     last_update_conversion_rate: float = np.nan  # last update conversion rate
 
     # margin requirements
+    initial_margin: float = 0.0
+    _initial_margin_external: bool = False  # If True, initial_margin is managed by exchange (skip recalculation)
     maint_margin: float = 0.0
     _maint_margin_external: bool = False  # If True, maint_margin is managed by exchange (skip recalculation)
 
@@ -810,6 +812,8 @@ class Position:
         self.last_update_time = np.nan  # type: ignore
         self.last_update_price = np.nan
         self.last_update_conversion_rate = np.nan
+        self.initial_margin = 0.0
+        self._initial_margin_external = False
         self.maint_margin = 0.0
         self._maint_margin_external = False
         self.adl_level = None
@@ -831,6 +835,8 @@ class Position:
         self.last_update_time = pos.last_update_time
         self.last_update_price = pos.last_update_price
         self.last_update_conversion_rate = pos.last_update_conversion_rate
+        self.initial_margin = pos.initial_margin
+        self._initial_margin_external = pos._initial_margin_external
         self.maint_margin = pos.maint_margin
         self._maint_margin_external = pos._maint_margin_external
         self.cumulative_funding = pos.cumulative_funding
@@ -956,6 +962,7 @@ class Position:
             self.market_value_funds = self.market_value / conversion_rate
 
             # - update margin requirements
+            self._update_initial_margin()
             self._update_maint_margin()
 
         return self.pnl
@@ -1077,6 +1084,21 @@ class Position:
         self.maint_margin = value
         self._maint_margin_external = True
 
+    def set_external_initial_margin(self, value: float) -> None:
+        """
+        Set initial margin from external source (exchange API).
+
+        When set externally, the margin value won't be recalculated on price updates.
+        Live exchanges report the actual margin reserved for the position
+        (which depends on the per-instrument leverage tier and margin mode);
+        we trust that value over any framework computation.
+
+        Args:
+            value: Initial margin value from exchange
+        """
+        self.initial_margin = value
+        self._initial_margin_external = True
+
     def _update_maint_margin(self) -> None:
         # Skip recalculation if margin is managed externally (live trading with exchange-provided values)
         if self._maint_margin_external:
@@ -1089,6 +1111,23 @@ class Position:
             self.maint_margin = maint_margin * abs(self.quantity) * self._qty_multiplier * self.last_update_price
         else:
             self.maint_margin = 0.0
+
+    def _update_initial_margin(self) -> None:
+        # Skip recalculation if margin is managed externally (live trading with exchange-provided values)
+        if self._initial_margin_external:
+            return
+
+        # Only apply initial margin for leveraged instruments (futures/swaps).
+        # Use the per-asset initial_margin fraction from instrument metadata when
+        # populated; otherwise leave at 0.0 (the framework can't infer a sensible
+        # default without the per-instrument leverage setting, which lives on
+        # the account processor).
+        if self.instrument.is_futures() and self.instrument.initial_margin > 0:
+            self.initial_margin = (
+                self.instrument.initial_margin * abs(self.quantity) * self._qty_multiplier * self.last_update_price
+            )
+        else:
+            self.initial_margin = 0.0
 
 
 class CtrlChannel:

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -759,6 +759,10 @@ class Position:
     maint_margin: float = 0.0
     _maint_margin_external: bool = False  # If True, maint_margin is managed by exchange (skip recalculation)
 
+    # ADL queue position from the exchange (None if not reported).
+    # Lower values = more likely to be auto-deleveraged.
+    adl_level: int | None = None
+
     # funding payment tracking
     cumulative_funding: float = 0.0  # cumulative funding paid (negative) or received (positive)
     funding_payments: list[FundingPayment]  # history of funding payments
@@ -808,6 +812,7 @@ class Position:
         self.last_update_conversion_rate = np.nan
         self.maint_margin = 0.0
         self._maint_margin_external = False
+        self.adl_level = None
         self.cumulative_funding = 0.0
         self.funding_payments = []
         self.last_funding_time = np.datetime64("NaT")  # type: ignore

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -641,9 +641,6 @@ class StrategyContext(IStrategyContext):
         return self.account.get_gross_leverage(exchange)
 
     # margin information
-    def get_total_required_margin(self, exchange: str | None = None) -> float:
-        return self.account.get_total_required_margin(exchange)
-
     def get_available_margin(self, exchange: str | None = None) -> float:
         return self.account.get_available_margin(exchange)
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -416,14 +416,6 @@ class IAccountViewer:
     # Margin information
     # Used for margin, swap, futures, options trading
     ########################################################
-    def get_total_required_margin(self, exchange: str | None = None) -> float:
-        """Get total margin required for all positions.
-
-        Returns:
-            float: Total required margin
-        """
-        ...
-
     def get_total_initial_margin(self, exchange: str | None = None) -> float:
         """Get total INITIAL margin used across all open positions.
 
@@ -451,6 +443,13 @@ class IAccountViewer:
     def get_available_margin(self, exchange: str | None = None) -> float:
         """Get available margin for new positions.
 
+        Available margin is ``total_capital - total_initial_margin``. For accurate
+        results, the connector must populate ``Position.initial_margin`` either
+        via ``set_external_initial_margin(...)`` from venue data (e.g. HPL
+        ``marginUsed``) or via ``instrument.initial_margin`` in the metadata.
+        Connectors that populate neither will see this method return the full
+        capital.
+
         Returns:
             float: Available margin
         """
@@ -459,11 +458,11 @@ class IAccountViewer:
     def get_margin_ratio(self, exchange: str | None = None) -> float:
         """Get current margin ratio.
 
-        Formula: (total capital + positions value) / total required margin
+        Formula: total capital / total maintenance margin
 
         Example:
-            If total capital is 1000, positions value is 2000, and total required margin is 3000,
-            the margin ratio would be (1000 + 2000) / 3000 = 1.0
+            If total capital is 3000 and total maintenance margin is 3000,
+            the margin ratio would be 3000 / 3000 = 1.0
 
         Returns:
             float: Current margin ratio

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -387,6 +387,20 @@ class IAccountViewer:
         """
         ...
 
+    def get_adl_level(self, instrument: Instrument) -> int | None:
+        """ADL queue index for a position, or None if not reported by the exchange.
+
+        Lower values = higher risk of auto-deleveraging. Hyperliquid reports this
+        per-position via ``webData2``; CCXT and Lighter return None.
+
+        Args:
+            instrument: The instrument to check
+
+        Returns:
+            int | None: ADL queue index (typically 0-3), or None if unknown.
+        """
+        return self.get_position(instrument).adl_level
+
     def get_reserved(self, instrument: Instrument) -> float:
         """[Deprecated] Get reserved margin for a specific instrument.
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -354,6 +354,65 @@ class IAccountViewer:
         ...
 
     ########################################################
+    # Per-instrument exchange-side settings
+    #
+    # ``get_leverage`` (above) returns the *observed* leverage = notional/equity.
+    # The methods below expose the venue's per-(account, instrument) settings:
+    # the configured leverage tier, the venue's hard caps, and margin mode.
+    # Connectors that don't expose these return None (or float('inf') for the
+    # notional cap when the venue has none).
+    ########################################################
+    def get_instrument_leverage(self, instrument: Instrument) -> float | None:
+        """Current per-instrument leverage setting on the exchange.
+
+        Distinct from ``get_leverage`` which returns observed leverage
+        (notional / equity).  This is the venue's configuration that
+        determines initial-margin requirement and max position notional.
+
+        Returns:
+            float | None: Current leverage setting, or None if unknown / not
+            populated yet by the venue snapshot.
+        """
+        ...
+
+    def get_max_instrument_leverage(self, instrument: Instrument) -> float | None:
+        """Venue's hard cap on the per-instrument leverage setting.
+
+        Returns:
+            float | None: Maximum leverage allowed by the venue for this
+            instrument, or None if unknown.
+        """
+        ...
+
+    def get_max_instrument_notional(self, instrument: Instrument) -> float:
+        """Venue's hard cap on a single position's notional at the CURRENT
+        ``instrument_leverage`` setting.
+
+        On tiered venues (Binance, Bybit) this CHANGES when you change leverage
+        — higher leverage typically means lower notional cap.
+
+        Note: the effective max position is
+        ``min(get_max_instrument_notional(instrument), equity * instrument_leverage)``.
+        Strategies compute this themselves; the framework only exposes the
+        venue's tier cap.
+
+        Returns:
+            float: Notional cap; ``float('inf')`` when the venue has no
+            per-asset cap independent of equity (e.g. HPL).
+        """
+        ...
+
+    def get_margin_mode(
+        self, instrument: Instrument
+    ) -> Literal["cross", "isolated"] | None:
+        """Per-instrument margin mode currently configured on the exchange.
+
+        Returns:
+            "cross" | "isolated" | None: None if unknown / not populated yet.
+        """
+        ...
+
+    ########################################################
     # Margin information
     # Used for margin, swap, futures, options trading
     ########################################################

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1470,6 +1470,46 @@ class IAccountProcessor(IAccountViewer):
         """
         ...
 
+    def set_instrument_leverage(self, instrument: Instrument, leverage: float) -> bool:
+        """Change the per-instrument leverage setting on the exchange.
+
+        Conceptually an account configuration change, not a trade — lives on
+        the account processor, not the broker (no order routing involved).
+
+        Args:
+            instrument: The instrument to configure.
+            leverage: New leverage as a float (HPL accepts 1.5, etc.).  Must
+                be ``<= get_max_instrument_leverage(instrument)``.
+
+        Returns:
+            bool: True if the setting was accepted by the exchange.
+
+        Raises:
+            NotImplementedError: when the connector does not support changing
+                leverage at runtime.  Capability flag tells callers whether
+                to bother calling.
+        """
+        ...
+
+    def set_margin_mode(
+        self, instrument: Instrument, mode: Literal["cross", "isolated"]
+    ) -> bool:
+        """Change the per-instrument margin mode on the exchange.
+
+        Args:
+            instrument: The instrument to configure.
+            mode: ``"cross"`` (account-wide collateral) or ``"isolated"``
+                (margin scoped to this position).
+
+        Returns:
+            bool: True if the setting was accepted by the exchange.
+
+        Raises:
+            NotImplementedError: when the connector does not support changing
+                margin mode at runtime.
+        """
+        ...
+
     def update_balance(self, currency: str, total: float, locked: float, exchange: str | None = None):
         """Update balance for a specific currency.
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -365,6 +365,30 @@ class IAccountViewer:
         """
         ...
 
+    def get_total_initial_margin(self, exchange: str | None = None) -> float:
+        """Get total INITIAL margin used across all open positions.
+
+        Initial margin is the margin reserved when a position is opened
+        (depends on the per-instrument leverage tier and margin mode).
+        Useful for "can I open more?" sizing decisions.
+
+        Returns:
+            float: Total initial margin
+        """
+        ...
+
+    def get_total_maint_margin(self, exchange: str | None = None) -> float:
+        """Get total MAINTENANCE margin required across all open positions.
+
+        Maintenance margin is the threshold below which positions get
+        liquidated (typically lower than initial margin).  Useful for
+        liquidation-distance / risk dashboards.
+
+        Returns:
+            float: Total maintenance margin
+        """
+        ...
+
     def get_available_margin(self, exchange: str | None = None) -> float:
         """Get available margin for new positions.
 

--- a/tests/qubx/cli/release_test.py
+++ b/tests/qubx/cli/release_test.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 import qubx.pandaz.ta as pta
 from qubx.backtester.simulator import simulate
 from qubx.cli.misc import PyClassInfo, find_pyproject_root
-from qubx.cli.release import ReleaseInfo, StrategyInfo, create_released_pack
+from qubx.cli.release import ReleaseInfo, StrategyInfo, _bundle_source_overrides, create_released_pack
 from qubx.core.series import OHLCV
 from qubx.data import CsvStorage
 from qubx.utils.runner.configs import ExchangeConfig, LoggingConfig, StrategyConfig
@@ -257,3 +257,72 @@ class TestCreateReleasedPack:
         assert kwargs.get("message") == "Test release", "Message not passed correctly"
         assert kwargs.get("output_dir") == output_dir, "Output directory not passed correctly"
         assert kwargs.get("commit") is False, "Commit flag not passed correctly"
+
+
+class TestBundleSourceOverrides:
+    """Verify [tool.uv.sources] git source bundling — including monorepo `subdirectory`."""
+
+    def _make_pyproject(self, *, subdirectory: str | None = None) -> dict:
+        source: dict = {
+            "git": "https://github.com/example/monorepo.git",
+            "tag": "pkg/v0.2.0",
+        }
+        if subdirectory is not None:
+            source["subdirectory"] = subdirectory
+        return {"tool": {"uv": {"sources": {"sample-pkg": source}}}}
+
+    @patch("qubx.cli.release._find_uv_git_checkout")
+    @patch("subprocess.run")
+    def test_git_source_with_subdirectory_builds_from_subdir(
+        self, mock_run, mock_find_checkout, tmp_path
+    ):
+        """Git source with `subdirectory` must run `uv build` from <checkout>/<subdirectory>."""
+        checkout_root = tmp_path / "cache" / "deadbeef"
+        checkout_root.mkdir(parents=True)
+        mock_find_checkout.return_value = str(checkout_root)
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        release_dir = tmp_path / "release"
+        release_dir.mkdir()
+
+        _bundle_source_overrides(
+            pyproject_data=self._make_pyproject(subdirectory="qubx-xdata"),
+            pyproject_root=str(tmp_path),
+            release_dir=str(release_dir),
+            required_packages={"sample-pkg"},
+            lock_versions={"sample_pkg": "0.2.0"},
+            git_commits={"sample_pkg": "deadbeefcafebabe"},
+        )
+
+        assert mock_run.called, "uv build should be invoked for the git source"
+        kwargs = mock_run.call_args.kwargs
+        expected_cwd = str(checkout_root / "qubx-xdata")
+        assert kwargs["cwd"] == expected_cwd, (
+            f"Expected build cwd={expected_cwd!r}, got {kwargs['cwd']!r}"
+        )
+
+    @patch("qubx.cli.release._find_uv_git_checkout")
+    @patch("subprocess.run")
+    def test_git_source_without_subdirectory_builds_from_root(
+        self, mock_run, mock_find_checkout, tmp_path
+    ):
+        """Without `subdirectory`, `uv build` must run from the checkout root (unchanged)."""
+        checkout_root = tmp_path / "cache" / "deadbeef"
+        checkout_root.mkdir(parents=True)
+        mock_find_checkout.return_value = str(checkout_root)
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        release_dir = tmp_path / "release"
+        release_dir.mkdir()
+
+        _bundle_source_overrides(
+            pyproject_data=self._make_pyproject(subdirectory=None),
+            pyproject_root=str(tmp_path),
+            release_dir=str(release_dir),
+            required_packages={"sample-pkg"},
+            lock_versions={"sample_pkg": "0.2.0"},
+            git_commits={"sample_pkg": "deadbeefcafebabe"},
+        )
+
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["cwd"] == str(checkout_root)

--- a/tests/qubx/core/account_processor_test.py
+++ b/tests/qubx/core/account_processor_test.py
@@ -257,7 +257,7 @@ class TestAccountProcessorStuff:
         # - check margin requirements
         # Since i1.maint_margin is 0, the default maintenance margin (5%) is used
         expected_margin = 50_000 * (i1.maint_margin or DEFAULT_MAINTENANCE_MARGIN)
-        assert account.get_total_required_margin() == pytest.approx(expected_margin)
+        assert account.get_total_maint_margin() == pytest.approx(expected_margin)
 
         # increase price 2x
         account.update_position_price(
@@ -313,7 +313,8 @@ class TestAccountProcessorStuff:
         assert leverage_adj == pytest.approx(ctx.get_net_leverage(), abs=0.01)
         assert leverage_adj == pytest.approx(ctx.get_gross_leverage(), abs=0.01)
         pos = ctx.get_position(instrument)
-        assert initial_capital - pos.maint_margin == pytest.approx(ctx.get_capital(), abs=1)
+        # get_capital() == get_available_margin() == total_capital - total_initial_margin
+        assert initial_capital - pos.initial_margin == pytest.approx(ctx.get_capital(), abs=1)
         assert initial_capital == pytest.approx(ctx.get_total_capital(), abs=1)
 
         # 3. Exit trade and check account

--- a/tests/qubx/core/test_account_adl.py
+++ b/tests/qubx/core/test_account_adl.py
@@ -1,0 +1,68 @@
+# tests/qubx/core/test_account_adl.py
+"""Tests for IAccountViewer.get_adl_level / BasicAccountProcessor default impl."""
+
+from qubx.core.basics import Instrument, MarketType, Position
+
+
+def _make_instrument(symbol="ETHUSDT") -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange="BINANCE.UM",
+        base="ETH",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol=symbol,
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_get_adl_level_returns_none_when_position_does_not_report():
+    """ccxt / lighter connectors don't report ADL; get_adl_level returns None.
+
+    Tests the contract via a tiny stub that satisfies the interface, since
+    BasicAccountProcessor construction may be heavyweight in unit tests.
+    """
+    instr = _make_instrument()
+    pos = Position(instrument=instr, quantity=1.0, pos_average_price=2000.0)
+    assert pos.adl_level is None  # default
+
+    class _Stub:
+        def get_position(self, instrument):
+            return pos
+
+        def get_adl_level(self, instrument):
+            # Mirror the IAccountViewer default impl
+            return self.get_position(instrument).adl_level
+
+    stub = _Stub()
+    assert stub.get_adl_level(instr) is None
+
+
+def test_get_adl_level_returns_value_when_position_reports():
+    """HPL-style account processors mutate Position.adl_level; get_adl_level surfaces it."""
+    instr = _make_instrument()
+    pos = Position(instrument=instr, quantity=1.0, pos_average_price=2000.0)
+    pos.adl_level = 1
+
+    class _Stub:
+        def get_position(self, instrument):
+            return pos
+
+        def get_adl_level(self, instrument):
+            return self.get_position(instrument).adl_level
+
+    stub = _Stub()
+    assert stub.get_adl_level(instr) == 1
+
+
+def test_iaccountviewer_has_get_adl_level_method():
+    """The IAccountViewer interface must declare get_adl_level."""
+    from qubx.core.interfaces import IAccountViewer
+
+    assert hasattr(IAccountViewer, "get_adl_level"), (
+        "IAccountViewer must declare get_adl_level for connectors to expose ADL info"
+    )

--- a/tests/qubx/core/test_account_instrument_leverage.py
+++ b/tests/qubx/core/test_account_instrument_leverage.py
@@ -1,0 +1,106 @@
+"""Tests for IAccountViewer's instrument-leverage / margin-mode read surface.
+
+Distinguishes the exchange-side per-(account, instrument) settings from
+the observed/computed leverage already on get_leverage:
+
+- get_leverage(instrument)              -> float            (observed = notional/equity)
+- get_instrument_leverage(instrument)   -> float | None     (exchange setting)
+- get_max_instrument_leverage(...)      -> float | None     (venue cap)
+- get_max_instrument_notional(...)      -> float            (venue cap, inf if none)
+- get_margin_mode(instrument)           -> "cross"|"isolated"|None
+"""
+
+import math
+
+import pytest
+
+from qubx.core.basics import Instrument, MarketType
+
+
+def _make_instrument(symbol: str = "ETHUSDT") -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange="BINANCE.UM",
+        base="ETH",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol=symbol,
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_iaccountviewer_declares_new_methods():
+    from qubx.core.interfaces import IAccountViewer
+
+    for name in (
+        "get_instrument_leverage",
+        "get_max_instrument_leverage",
+        "get_max_instrument_notional",
+        "get_margin_mode",
+    ):
+        assert hasattr(IAccountViewer, name), f"IAccountViewer must declare {name}"
+
+
+def test_default_impls_return_none_or_inf():
+    """BasicAccountProcessor without venue data returns None for unknowns,
+    inf for max_instrument_notional (no per-asset cap by default)."""
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    acc._exchange = "BINANCE.UM"
+    instr = _make_instrument()
+
+    assert acc.get_instrument_leverage(instr) is None
+    assert acc.get_max_instrument_leverage(instr) is None
+    assert acc.get_margin_mode(instr) is None
+    assert math.isinf(acc.get_max_instrument_notional(instr))
+
+
+def test_get_margin_mode_returns_cross_or_isolated_when_set():
+    """Subclasses populate via internal cache; the default impl reads from
+    a ``_margin_mode_cache: dict[Instrument, str]`` if present."""
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    acc._exchange = "BINANCE.UM"
+    instr = _make_instrument()
+    acc._margin_mode_cache = {instr: "isolated"}
+
+    assert acc.get_margin_mode(instr) == "isolated"
+
+
+def test_get_instrument_leverage_returns_cached_float():
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    acc._exchange = "BINANCE.UM"
+    instr = _make_instrument()
+    acc._instrument_leverage_cache = {instr: 2.5}
+
+    assert acc.get_instrument_leverage(instr) == 2.5
+
+
+def test_get_max_instrument_leverage_returns_cached_float():
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    acc._exchange = "BINANCE.UM"
+    instr = _make_instrument()
+    acc._max_instrument_leverage_cache = {instr: 50.0}
+
+    assert acc.get_max_instrument_leverage(instr) == 50.0
+
+
+def test_get_max_instrument_notional_returns_cached_float():
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    acc._exchange = "BINANCE.UM"
+    instr = _make_instrument()
+    acc._max_instrument_notional_cache = {instr: 1_000_000.0}
+
+    assert acc.get_max_instrument_notional(instr) == 1_000_000.0

--- a/tests/qubx/core/test_account_instrument_leverage.py
+++ b/tests/qubx/core/test_account_instrument_leverage.py
@@ -8,11 +8,15 @@ the observed/computed leverage already on get_leverage:
 - get_max_instrument_leverage(...)      -> float | None     (venue cap)
 - get_max_instrument_notional(...)      -> float            (venue cap, inf if none)
 - get_margin_mode(instrument)           -> "cross"|"isolated"|None
+
+Note: the previous `_*_cache` injection tests (which exercised the
+removed `getattr(self, "_*_cache", None)` lookup on the base) were
+deleted alongside that implementation; the soft-default contract is
+covered in test_account_settings_defaults.py and live overrides are
+exercised by per-connector tests in the exchanges repo.
 """
 
 import math
-
-import pytest
 
 from qubx.core.basics import Instrument, MarketType
 
@@ -58,49 +62,3 @@ def test_default_impls_return_none_or_inf():
     assert acc.get_max_instrument_leverage(instr) is None
     assert acc.get_margin_mode(instr) is None
     assert math.isinf(acc.get_max_instrument_notional(instr))
-
-
-def test_get_margin_mode_returns_cross_or_isolated_when_set():
-    """Subclasses populate via internal cache; the default impl reads from
-    a ``_margin_mode_cache: dict[Instrument, str]`` if present."""
-    from qubx.core.account import BasicAccountProcessor
-
-    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
-    acc._exchange = "BINANCE.UM"
-    instr = _make_instrument()
-    acc._margin_mode_cache = {instr: "isolated"}
-
-    assert acc.get_margin_mode(instr) == "isolated"
-
-
-def test_get_instrument_leverage_returns_cached_float():
-    from qubx.core.account import BasicAccountProcessor
-
-    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
-    acc._exchange = "BINANCE.UM"
-    instr = _make_instrument()
-    acc._instrument_leverage_cache = {instr: 2.5}
-
-    assert acc.get_instrument_leverage(instr) == 2.5
-
-
-def test_get_max_instrument_leverage_returns_cached_float():
-    from qubx.core.account import BasicAccountProcessor
-
-    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
-    acc._exchange = "BINANCE.UM"
-    instr = _make_instrument()
-    acc._max_instrument_leverage_cache = {instr: 50.0}
-
-    assert acc.get_max_instrument_leverage(instr) == 50.0
-
-
-def test_get_max_instrument_notional_returns_cached_float():
-    from qubx.core.account import BasicAccountProcessor
-
-    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
-    acc._exchange = "BINANCE.UM"
-    instr = _make_instrument()
-    acc._max_instrument_notional_cache = {instr: 1_000_000.0}
-
-    assert acc.get_max_instrument_notional(instr) == 1_000_000.0

--- a/tests/qubx/core/test_account_margin_totals.py
+++ b/tests/qubx/core/test_account_margin_totals.py
@@ -1,0 +1,103 @@
+"""Tests for IAccountViewer.get_total_initial_margin / get_total_maint_margin.
+
+Mirrors the existing get_total_required_margin pattern (which sums maint
+margin across positions) but splits initial vs. maintenance for clarity:
+- initial: "can I open more?"
+- maintenance: "how close am I to liquidation?"
+"""
+
+from qubx.core.basics import Instrument, MarketType, Position
+
+
+def _make_instrument(symbol: str = "ETHUSDT") -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange="BINANCE.UM",
+        base="ETH",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol=symbol,
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_iaccountviewer_has_total_initial_and_maint_margin_methods():
+    """Both methods must be declared on the IAccountViewer interface."""
+    from qubx.core.interfaces import IAccountViewer
+
+    assert hasattr(IAccountViewer, "get_total_initial_margin"), (
+        "IAccountViewer must declare get_total_initial_margin"
+    )
+    assert hasattr(IAccountViewer, "get_total_maint_margin"), (
+        "IAccountViewer must declare get_total_maint_margin"
+    )
+
+
+def test_get_total_initial_margin_sums_position_initial_margins():
+    """Default impl in BasicAccountProcessor sums Position.initial_margin across positions."""
+    instr_a = _make_instrument("ETHUSDT")
+    instr_b = _make_instrument("BTCUSDT")
+    pos_a = Position(instrument=instr_a, quantity=1.0, pos_average_price=2000.0)
+    pos_b = Position(instrument=instr_b, quantity=0.1, pos_average_price=50000.0)
+    pos_a.set_external_initial_margin(100.0)
+    pos_b.set_external_initial_margin(250.0)
+
+    class _Stub:
+        _positions = {instr_a: pos_a, instr_b: pos_b}
+
+        def get_total_initial_margin(self, exchange=None):
+            return sum(p.initial_margin for p in self._positions.values())
+
+    stub = _Stub()
+    assert stub.get_total_initial_margin() == 350.0
+
+
+def test_get_total_maint_margin_sums_position_maint_margins():
+    instr_a = _make_instrument("ETHUSDT")
+    instr_b = _make_instrument("BTCUSDT")
+    pos_a = Position(instrument=instr_a, quantity=1.0, pos_average_price=2000.0)
+    pos_b = Position(instrument=instr_b, quantity=0.1, pos_average_price=50000.0)
+    pos_a.set_external_maint_margin(50.0)
+    pos_b.set_external_maint_margin(125.0)
+
+    class _Stub:
+        _positions = {instr_a: pos_a, instr_b: pos_b}
+
+        def get_total_maint_margin(self, exchange=None):
+            return sum(p.maint_margin for p in self._positions.values())
+
+    stub = _Stub()
+    assert stub.get_total_maint_margin() == 175.0
+
+
+def test_basic_account_processor_get_total_initial_margin_returns_sum():
+    """End-to-end: BasicAccountProcessor's default impl produces the right sum."""
+    from unittest.mock import MagicMock
+
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    instr = _make_instrument()
+    pos = Position(instrument=instr, quantity=1.0, pos_average_price=2000.0)
+    pos.set_external_initial_margin(42.0)
+    acc._positions = {instr: pos}
+    acc._exchange = "BINANCE.UM"
+
+    assert acc.get_total_initial_margin() == 42.0
+
+
+def test_basic_account_processor_get_total_maint_margin_returns_sum():
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    instr = _make_instrument()
+    pos = Position(instrument=instr, quantity=1.0, pos_average_price=2000.0)
+    pos.set_external_maint_margin(17.0)
+    acc._positions = {instr: pos}
+    acc._exchange = "BINANCE.UM"
+
+    assert acc.get_total_maint_margin() == 17.0

--- a/tests/qubx/core/test_account_margin_totals.py
+++ b/tests/qubx/core/test_account_margin_totals.py
@@ -1,7 +1,7 @@
 """Tests for IAccountViewer.get_total_initial_margin / get_total_maint_margin.
 
-Mirrors the existing get_total_required_margin pattern (which sums maint
-margin across positions) but splits initial vs. maintenance for clarity:
+Mirrors the existing margin-totals pattern (summing per-position margin
+across positions) but splits initial vs. maintenance for clarity:
 - initial: "can I open more?"
 - maintenance: "how close am I to liquidation?"
 """

--- a/tests/qubx/core/test_account_setters.py
+++ b/tests/qubx/core/test_account_setters.py
@@ -1,0 +1,93 @@
+"""Tests for IAccountProcessor.set_instrument_leverage / set_margin_mode.
+
+Both are signed actions on the venue but conceptually account-config changes,
+not trades — they live on the account processor, not the broker.
+
+Defaults raise NotImplementedError; live exchange processors override.
+"""
+
+import pytest
+
+from qubx.core.basics import Instrument, MarketType
+
+
+def _make_instrument(symbol: str = "ETHUSDT") -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange="BINANCE.UM",
+        base="ETH",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol=symbol,
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_iaccountprocessor_declares_setter_methods():
+    from qubx.core.interfaces import IAccountProcessor
+
+    for name in ("set_instrument_leverage", "set_margin_mode"):
+        assert hasattr(IAccountProcessor, name), f"IAccountProcessor must declare {name}"
+
+
+def test_default_set_instrument_leverage_raises_not_implemented():
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    acc._exchange = "BINANCE.UM"
+
+    with pytest.raises(NotImplementedError):
+        acc.set_instrument_leverage(_make_instrument(), 5.0)
+
+
+def test_default_set_margin_mode_raises_not_implemented():
+    from qubx.core.account import BasicAccountProcessor
+
+    acc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    acc._exchange = "BINANCE.UM"
+
+    with pytest.raises(NotImplementedError):
+        acc.set_margin_mode(_make_instrument(), "isolated")
+
+
+def test_set_instrument_leverage_accepts_float():
+    """Subclasses overriding the method must accept float (HPL allows 1.5, etc.)."""
+    from qubx.core.account import BasicAccountProcessor
+
+    captured = {}
+
+    class _Subclass(BasicAccountProcessor):
+        def __init__(self):
+            self._exchange = "TEST"
+
+        def set_instrument_leverage(self, instrument, leverage):
+            captured["leverage"] = leverage
+            return True
+
+    sub = _Subclass()
+    assert sub.set_instrument_leverage(_make_instrument(), 2.5) is True
+    assert captured["leverage"] == 2.5
+
+
+def test_set_margin_mode_accepts_cross_or_isolated():
+    from qubx.core.account import BasicAccountProcessor
+
+    captured = {}
+
+    class _Subclass(BasicAccountProcessor):
+        def __init__(self):
+            self._exchange = "TEST"
+
+        def set_margin_mode(self, instrument, mode):
+            captured["mode"] = mode
+            return True
+
+    sub = _Subclass()
+    assert sub.set_margin_mode(_make_instrument(), "cross") is True
+    assert captured["mode"] == "cross"
+    sub.set_margin_mode(_make_instrument(), "isolated")
+    assert captured["mode"] == "isolated"

--- a/tests/qubx/core/test_account_settings_defaults.py
+++ b/tests/qubx/core/test_account_settings_defaults.py
@@ -1,0 +1,58 @@
+"""Soft-default contract for IAccountViewer per-instrument settings.
+
+BasicAccountProcessor must return None (or float('inf') for the notional cap)
+for the four per-instrument-settings getters, with no dependency on
+undeclared subclass attributes. Live processors override these.
+"""
+
+from unittest.mock import MagicMock
+
+from qubx.core.account import BasicAccountProcessor
+
+
+def _bare_processor() -> BasicAccountProcessor:
+    """Construct a minimal BasicAccountProcessor by bypassing __init__.
+
+    We're testing the *getter contract*, not init wiring, so it's fine to
+    sidestep the constructor and avoid pulling in TCC / health monitor stubs.
+    """
+    proc = BasicAccountProcessor.__new__(BasicAccountProcessor)
+    return proc
+
+
+def test_get_instrument_leverage_default_is_none():
+    proc = _bare_processor()
+    assert proc.get_instrument_leverage(MagicMock()) is None
+
+
+def test_get_max_instrument_leverage_default_is_none():
+    proc = _bare_processor()
+    assert proc.get_max_instrument_leverage(MagicMock()) is None
+
+
+def test_get_max_instrument_notional_default_is_inf():
+    proc = _bare_processor()
+    assert proc.get_max_instrument_notional(MagicMock()) == float("inf")
+
+
+def test_get_margin_mode_default_is_none():
+    proc = _bare_processor()
+    assert proc.get_margin_mode(MagicMock()) is None
+
+
+def test_no_undeclared_cache_attribute_required():
+    """The base class must not depend on subclass-defined private caches.
+
+    Regression guard: previously the base read `getattr(self, "_*_cache", None)`
+    against attributes only subclasses defined.  Verify a subclass that
+    deliberately omits all caches still gets the soft defaults.
+    """
+    class _NoCache(BasicAccountProcessor):  # type: ignore[misc]
+        pass
+
+    proc = _NoCache.__new__(_NoCache)
+    instr = MagicMock()
+    assert proc.get_instrument_leverage(instr) is None
+    assert proc.get_max_instrument_leverage(instr) is None
+    assert proc.get_max_instrument_notional(instr) == float("inf")
+    assert proc.get_margin_mode(instr) is None

--- a/tests/qubx/core/test_position_adl.py
+++ b/tests/qubx/core/test_position_adl.py
@@ -1,0 +1,46 @@
+# tests/qubx/core/test_position_adl.py
+"""Tests for Position.adl_level field (added for Hyperliquid ADL exposure)."""
+
+from qubx.core.basics import Instrument, MarketType, Position
+
+
+def _make_instrument() -> Instrument:
+    """Minimal instrument for Position construction."""
+    return Instrument(
+        symbol="ETHUSDT",
+        market_type=MarketType.SWAP,
+        exchange="BINANCE.UM",
+        base="ETH",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol="ETHUSDT",
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_position_adl_level_default_none():
+    """Position constructed without ADL info should have adl_level=None."""
+    instr = _make_instrument()
+    pos = Position(instrument=instr, quantity=0.0)
+    assert pos.adl_level is None
+
+
+def test_position_adl_level_can_be_set():
+    """Exchange-driven account processors set adl_level on existing positions."""
+    instr = _make_instrument()
+    pos = Position(instrument=instr, quantity=1.0, pos_average_price=2000.0)
+    pos.adl_level = 2
+    assert pos.adl_level == 2
+
+
+def test_position_reset_clears_adl_level():
+    """reset() should restore adl_level to None alongside other fields."""
+    instr = _make_instrument()
+    pos = Position(instrument=instr, quantity=1.0, pos_average_price=2000.0)
+    pos.adl_level = 3
+    pos.reset()
+    assert pos.adl_level is None
+    assert pos.quantity == 0.0  # sanity: reset still resets the rest

--- a/tests/qubx/core/test_position_initial_margin.py
+++ b/tests/qubx/core/test_position_initial_margin.py
@@ -1,0 +1,76 @@
+# tests/qubx/core/test_position_initial_margin.py
+"""Tests for Position.initial_margin + _initial_margin_external machinery.
+
+Mirrors the existing maint_margin / _maint_margin_external pattern so live
+account processors can write the exchange-reported value and the framework
+won't recompute it on price updates.
+"""
+
+from qubx.core.basics import Instrument, MarketType, Position
+
+
+def _make_instrument() -> Instrument:
+    return Instrument(
+        symbol="ETHUSDT",
+        market_type=MarketType.SWAP,
+        exchange="BINANCE.UM",
+        base="ETH",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol="ETHUSDT",
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_position_initial_margin_default_zero():
+    pos = Position(instrument=_make_instrument(), quantity=0.0)
+    assert pos.initial_margin == 0.0
+    assert pos._initial_margin_external is False
+
+
+def test_set_external_initial_margin_marks_external_and_stores_value():
+    pos = Position(instrument=_make_instrument(), quantity=1.0, pos_average_price=2000.0)
+    pos.set_external_initial_margin(123.45)
+    assert pos.initial_margin == 123.45
+    assert pos._initial_margin_external is True
+
+
+def test_external_initial_margin_survives_price_update():
+    """When set externally, _update_initial_margin must NOT overwrite."""
+    pos = Position(instrument=_make_instrument(), quantity=1.0, pos_average_price=2000.0)
+    pos.set_external_initial_margin(50.0)
+    pos._update_initial_margin()  # exercise the recompute path directly
+    assert pos.initial_margin == 50.0
+
+
+def test_internal_initial_margin_recomputes_when_not_external():
+    """Without an external value, _update_initial_margin can populate from
+    instrument metadata + position size.  Default impl yields 0.0 today
+    (Instrument.initial_margin is 0.0 unless populated by metadata storage).
+    """
+    pos = Position(instrument=_make_instrument(), quantity=1.0, pos_average_price=2000.0)
+    pos.last_update_price = 2000.0
+    pos._update_initial_margin()
+    # No external value, no instrument-level initial_margin → stays 0.0
+    assert pos.initial_margin == 0.0
+    assert pos._initial_margin_external is False
+
+
+def test_position_reset_clears_initial_margin_and_external_flag():
+    pos = Position(instrument=_make_instrument(), quantity=1.0, pos_average_price=2000.0)
+    pos.set_external_initial_margin(75.0)
+    pos.reset()
+    assert pos.initial_margin == 0.0
+    assert pos._initial_margin_external is False
+
+
+def test_reset_by_position_copies_initial_margin_state():
+    src = Position(instrument=_make_instrument(), quantity=1.0, pos_average_price=2000.0)
+    src.set_external_initial_margin(99.9)
+    dst = Position(instrument=_make_instrument())
+    dst.reset_by_position(src)
+    assert dst.initial_margin == 99.9
+    assert dst._initial_margin_external is True

--- a/tests/qubx/exporters/utils/mocks.py
+++ b/tests/qubx/exporters/utils/mocks.py
@@ -86,10 +86,6 @@ class MockAccountViewer(IAccountViewer):
         """Get the gross leverage of the account."""
         return 1.0
 
-    def get_total_required_margin(self, exchange: str | None = None):
-        """Get the total required margin."""
-        return 0.0
-
     def get_available_margin(self, exchange: str | None = None):
         """Get the available margin."""
         return 10000.0


### PR DESCRIPTION
## Summary

Expands `IAccountViewer` and `IAccountProcessor` with the per-(account, instrument) risk surface that live exchange connectors need but the framework doesn't currently expose. Supersedes #278 (which only added ADL).

### What's added

**Position fields:**
- `Position.adl_level: int | None` — exchange-reported ADL queue index
- `Position.initial_margin: float` + `_initial_margin_external` flag, mirroring the existing `maint_margin` pair so live processors can write the venue-reported value and the framework won't recompute it on price updates.

**`IAccountViewer` reads:**
- `get_adl_level(instrument)` — returns `Position.adl_level`
- `get_total_initial_margin(exchange)` / `get_total_maint_margin(exchange)` — split the existing `get_total_required_margin` (which is maintenance-only) so callers can answer "can I open more?" (initial) vs "how close am I to liquidation?" (maintenance) separately
- Per-instrument exchange-side settings (distinct from the observed `get_leverage`):
  - `get_instrument_leverage(instrument) -> float | None` — the venue's per-(account, instrument) leverage setting
  - `get_max_instrument_leverage(instrument) -> float | None` — venue's hard cap on that setting
  - `get_max_instrument_notional(instrument) -> float` — venue's notional cap **at the current leverage** (`float('inf')` when the venue has none, e.g. HPL)
  - `get_margin_mode(instrument) -> "cross"|"isolated"|None`

**`IAccountProcessor` writes:**
- `set_instrument_leverage(instrument, leverage: float)` — `float` because HPL accepts `1.5` etc.
- `set_margin_mode(instrument, mode: "cross"|"isolated")`
- Both raise `NotImplementedError` in `BasicAccountProcessor`; live processors override.

### Design notes (worked out before implementation)

- **Two distinct leverage concepts kept separate.** `get_leverage` returns the *observed* leverage (`notional/equity`) — unchanged. `get_instrument_leverage` returns the venue's setting. Different types (`float` vs `float | None`) and the `instrument_` prefix avoid the overload that conflates them everywhere else.
- **Notional cap is implicitly coupled to the current leverage setting** on tiered venues (Binance, Bybit). Documented; no `leverage` parameter on the getter to keep the surface tight. Effective max is always `min(get_max_instrument_notional(...), equity * instrument_leverage)`.
- **Setters live on the account processor, not the broker** — they are signed venue actions but conceptually account configuration, not order routing.
- **`Instrument` and `Position` get no per-account fields.** Everything that varies by account or by venue policy lives on the account viewer; instrument metadata stays account-independent.

### Layout

Each commit is reviewable independently:

1. `feat(core): add Position.adl_level field` (from #278)
2. `feat(core): add IAccountViewer.get_adl_level method` (from #278)
3. `feat(core): add Position.initial_margin + _initial_margin_external`
4. `feat(core): split total margin into initial vs maintenance on IAccountViewer`
5. `feat(core): expose per-instrument exchange-side settings on IAccountViewer`
6. `feat(core): IAccountProcessor.set_instrument_leverage + set_margin_mode`

### Test plan

- [x] Unit tests for each commit (RED → GREEN TDD)
- [x] No regressions in existing `tests/qubx/core/` (315 pass)
- [ ] Downstream integration via the HPL connector (this PR's primary consumer)

### Downstream

This unblocks the Hyperliquid connector in `xLydianSoftware/exchanges` (separate repo) which already has the venue parsing for ADL, initial margin, and per-asset max leverage but is currently bypassing the framework via `hasattr` guards.