### PR TITLE
feat(cli): release.source.subdirectory for monorepo sources

### DIFF
--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -711,10 +711,24 @@ def release_from_source(
             commited_files=[],
         )
 
+        # Resolve pyproject_root: if subdirectory is declared in config.release.source,
+        # the strategy lives inside a subpath of the clone (monorepo / uv workspace
+        # layout). Otherwise the strategy lives at the clone root (single-package layout).
+        source = stg_config.release.source
+        if source.subdirectory:
+            pyproject_root = os.path.join(str(clone_dir), source.subdirectory)
+            if not os.path.exists(os.path.join(pyproject_root, "pyproject.toml")):
+                raise FileNotFoundError(
+                    f"Configured release.source.subdirectory={source.subdirectory!r} "
+                    f"does not contain a pyproject.toml: {pyproject_root}"
+                )
+        else:
+            pyproject_root = str(clone_dir)
+
         create_released_pack(
             stg_info=stg_info,
             git_info=git_info,
-            pyproject_root=str(clone_dir),
+            pyproject_root=pyproject_root,
             output_dir=output_dir,
             config_file=cloned_config,
         )

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from qubx.core.interfaces import IStrategy
 
@@ -237,6 +237,31 @@ class ReleaseSourceConfig(StrictBaseModel):
 
     ref: str
     """Git ref to build from — tag, branch, or commit SHA."""
+
+    subdirectory: str | None = None
+    """Optional subpath within the source repo where the strategy's package
+    lives. Required for monorepo sources where the workspace root has no
+    Python project (e.g., uv workspaces). When set, the release wheel build
+    runs from ``<clone>/<subdirectory>`` instead of the workspace root.
+
+    Example: ``subdirectory: "e2e-driver"`` for a strategy living in
+    ``xLydianSoftware/exchanges/e2e-driver/``.
+
+    Must be a relative path; absolute paths or paths that escape the clone
+    via ``..`` are rejected at parse time."""
+
+    @field_validator("subdirectory")
+    @classmethod
+    def _validate_subdirectory(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if os.path.isabs(v):
+            raise ValueError(f"subdirectory must be a relative path, got {v!r}")
+        # Reject `..` segments to keep the build path inside the clone.
+        parts = os.path.normpath(v).split(os.sep)
+        if any(p == ".." for p in parts):
+            raise ValueError(f"subdirectory must not escape the clone via '..', got {v!r}")
+        return os.path.normpath(v)
 
 
 class ReleasePlatformConfig(StrictBaseModel):

--- a/tests/qubx/cli/release_test.py
+++ b/tests/qubx/cli/release_test.py
@@ -14,7 +14,7 @@ from qubx.cli.misc import PyClassInfo, find_pyproject_root
 from qubx.cli.release import ReleaseInfo, StrategyInfo, _bundle_source_overrides, create_released_pack
 from qubx.core.series import OHLCV
 from qubx.data import CsvStorage
-from qubx.utils.runner.configs import ExchangeConfig, LoggingConfig, StrategyConfig
+from qubx.utils.runner.configs import ExchangeConfig, LoggingConfig, ReleaseSourceConfig, StrategyConfig
 
 # Add tests/strategies to the path
 sys.path.append(str(Path(__file__).parent.parent.parent.parent / "tests" / "strategies" / "macd_crossover" / "src"))
@@ -326,3 +326,68 @@ class TestBundleSourceOverrides:
 
         kwargs = mock_run.call_args.kwargs
         assert kwargs["cwd"] == str(checkout_root)
+
+
+class TestReleaseSourceConfigSubdirectory:
+    """Tests for the optional `subdirectory` field on ``ReleaseSourceConfig``.
+
+    The field lets monorepo / uv-workspace source repos point ``qubx release
+    --from-sources`` at the workspace member that owns the strategy's
+    pyproject.toml.
+    """
+
+    def test_subdirectory_optional_defaults_to_none(self):
+        """Existing single-package configs (no subdirectory) parse unchanged."""
+        cfg = ReleaseSourceConfig(repo="xLydianSoftware/foo", ref="main")
+        assert cfg.subdirectory is None
+
+    def test_subdirectory_accepts_relative_path(self):
+        """Relative subpath is preserved verbatim after normalisation."""
+        cfg = ReleaseSourceConfig(
+            repo="xLydianSoftware/exchanges",
+            ref="main",
+            subdirectory="e2e-driver",
+        )
+        assert cfg.subdirectory == "e2e-driver"
+
+    def test_subdirectory_accepts_nested_relative_path(self):
+        cfg = ReleaseSourceConfig(
+            repo="xLydianSoftware/exchanges",
+            ref="main",
+            subdirectory="packages/strategy",
+        )
+        # normpath uses os.sep; on POSIX this is "/", which is what we expect.
+        assert cfg.subdirectory == os.path.normpath("packages/strategy")
+
+    def test_subdirectory_normalises_trailing_slash(self):
+        """`e2e-driver/` should be stored as `e2e-driver` via normpath."""
+        cfg = ReleaseSourceConfig(
+            repo="xLydianSoftware/exchanges",
+            ref="main",
+            subdirectory="e2e-driver/",
+        )
+        assert cfg.subdirectory == "e2e-driver"
+
+    def test_subdirectory_rejects_absolute_path(self):
+        with pytest.raises(ValueError, match="relative"):
+            ReleaseSourceConfig(
+                repo="xLydianSoftware/exchanges",
+                ref="main",
+                subdirectory="/abs/path",
+            )
+
+    def test_subdirectory_rejects_dotdot_escape(self):
+        with pytest.raises(ValueError, match=r"\.\."):
+            ReleaseSourceConfig(
+                repo="xLydianSoftware/exchanges",
+                ref="main",
+                subdirectory="../escape",
+            )
+
+    def test_subdirectory_rejects_nested_dotdot_escape(self):
+        with pytest.raises(ValueError, match=r"\.\."):
+            ReleaseSourceConfig(
+                repo="xLydianSoftware/exchanges",
+                ref="main",
+                subdirectory="ok/../../escape",
+            )


### PR DESCRIPTION
## Summary

Adds an optional `subdirectory` field on `ReleaseSourceConfig`. When set, `qubx release --from-sources` builds the wheel from `<clone>/<subdirectory>` instead of the clone root.

Required for monorepo / uv-workspace sources where the workspace root has no Python project (only `[tool.uv.workspace]`).

```yaml
release:
  source:
    repo: xLydianSoftware/exchanges
    ref: main
    subdirectory: e2e-driver   # NEW — points at the workspace member
```

## Why

`release_from_source` (release.py:717) hardcoded `pyproject_root=str(clone_dir)` for the wheel build. For `xLydianSoftware/exchanges` — a uv workspace with members `conformance` / `lighter` / `hyperliquid` / `e2e-driver` / `e2e` — the workspace root `pyproject.toml` declares only the workspace and dev deps, no `[project]` block. `uv build --wheel .` from there falls through to setuptools auto-discovery, which fails:

```
× Failed to build
│ `/home/runner/_work/xrelease/xrelease/.releases/sources/xLydianSoftware_exchanges_main`
├─▶ The build backend returned an error
╰─▶ Call to setuptools.build_meta:__legacy__.build_wheel failed
```

Real failure on the connector e2e harness: see [xrelease run 25607588897](https://github.com/xLydianSoftware/xrelease/actions/runs/25607588897/job/75172076779).

## What changed

- `ReleaseSourceConfig.subdirectory: str | None = None` (optional).
- pydantic validator rejects absolute paths and `..` escapes; normalises trailing slashes.
- `release_from_source` uses the subdirectory when set, falls back to the clone root when unset (existing single-package configs unaffected).
- Raises `FileNotFoundError` if the configured subdirectory has no `pyproject.toml` — fail-fast for typos.

## Test plan

- [x] Unit tests on `ReleaseSourceConfig`: accepts relative path, rejects absolute / `..`, defaults to None, normalises trailing slash.
- [x] Existing release tests pass unchanged.
- [ ] After merge + new Qubx release: bump qubx in xrelease's GH Action, re-trigger `xrelease/dev/hyperliquid/e2e-hyperliquid-testnet.yaml`, expect the wheel to build cleanly from `exchanges/e2e-driver/`.