### PR TITLE
feat(cli): bundle workspace = true sources in release flow

### DIFF
--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -1339,6 +1339,76 @@ def _resolve_local_package_version(local_path: str, pkg_norm: str) -> str | None
     return None
 
 
+def _find_uv_workspace_root(start_dir: str) -> str | None:
+    """Walk up from start_dir to find the nearest pyproject.toml with [tool.uv.workspace].
+
+    Returns the directory path, or None if no workspace root is found within the
+    parent chain (stops at filesystem root).
+    """
+    import toml
+
+    cur = os.path.abspath(start_dir)
+    while True:
+        candidate = os.path.join(cur, "pyproject.toml")
+        if os.path.exists(candidate):
+            try:
+                with open(candidate) as f:
+                    data = toml.load(f)
+                if data.get("tool", {}).get("uv", {}).get("workspace"):
+                    return cur
+            except Exception:
+                pass
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return None
+        cur = parent
+
+
+def _find_workspace_member_for_package(workspace_root: str, pkg_name: str) -> str | None:
+    """Locate the workspace member directory whose pyproject's project.name matches pkg_name.
+
+    Comparison is PEP-503 normalised (lowercase, hyphens/underscores collapsed). Returns
+    the absolute member path, or None if no matching member is found.
+
+    Members may be listed as exact paths or glob patterns; we resolve each via
+    glob.glob (relative to the workspace root) and check pyproject.toml in each.
+    """
+    import glob
+
+    import toml
+
+    # Normalise the target package name (PEP 503)
+    target = pkg_name.lower().replace("_", "-")
+
+    workspace_pyproject = os.path.join(workspace_root, "pyproject.toml")
+    try:
+        with open(workspace_pyproject) as f:
+            data = toml.load(f)
+    except Exception:
+        return None
+
+    members = data.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
+    if not members:
+        return None
+
+    for member_pattern in members:
+        # Resolve glob (uv supports `packages/*` patterns)
+        for member_path in glob.glob(os.path.join(workspace_root, member_pattern)):
+            member_pyproject = os.path.join(member_path, "pyproject.toml")
+            if not os.path.isfile(member_pyproject):
+                continue
+            try:
+                with open(member_pyproject) as f:
+                    member_data = toml.load(f)
+                member_name = (member_data.get("project", {}) or {}).get("name", "")
+                if member_name.lower().replace("_", "-") == target:
+                    return os.path.abspath(member_path)
+            except Exception:
+                continue
+
+    return None
+
+
 def _bundle_source_overrides(
     pyproject_data: dict,
     pyproject_root: str,
@@ -1496,6 +1566,53 @@ def _bundle_source_overrides(
             finally:
                 if cloned_locally and os.path.isdir(checkout_dir):
                     shutil.rmtree(checkout_dir, ignore_errors=True)
+
+        elif source.get("workspace") is True:
+            if not pkg_ver:
+                logger.warning(f"  {pkg_name} not found in uv.lock, skipping bundle")
+                continue
+
+            workspace_root = _find_uv_workspace_root(pyproject_root)
+            if workspace_root is None:
+                logger.warning(
+                    f"  {pkg_name}: declared as `workspace = true` but no workspace root "
+                    f"found above {pyproject_root}, skipping bundle"
+                )
+                continue
+
+            member_path = _find_workspace_member_for_package(workspace_root, pkg_name)
+            if member_path is None:
+                logger.warning(
+                    f"  {pkg_name}: declared as `workspace = true` but no workspace member "
+                    f"in {workspace_root} matches the package name, skipping bundle"
+                )
+                continue
+
+            if _version_exists_on_pypi(pkg_name, pkg_ver):
+                logger.info(f"  {pkg_name}=={pkg_ver} found on public PyPI, will resolve from registry")
+                continue
+
+            logger.info(f"  Bundling {pkg_name}=={pkg_ver} from workspace member {member_path} ...")
+            os.makedirs(wheels_dir, exist_ok=True)
+            try:
+                result = subprocess.run(
+                    ["uv", "build", "--wheel", ".", "--out-dir", wheels_dir],
+                    cwd=member_path,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                logger.debug(f"uv build stdout: {result.stdout}")
+                for whl in os.listdir(wheels_dir):
+                    if whl.lower().startswith(pkg_norm) and "none-any" not in whl:
+                        logger.warning(
+                            f"  {whl} is platform-specific. "
+                            "Ensure the container architecture matches the build machine."
+                        )
+                bundled.append(pkg_name.lower())
+                logger.info(f"  Bundled {pkg_name}")
+            except subprocess.CalledProcessError as e:
+                logger.opt(colors=False).warning(f"  Failed to build wheel for {pkg_name}: {e.stderr or e}")
 
     return bundled
 

--- a/tests/qubx/cli/release_test.py
+++ b/tests/qubx/cli/release_test.py
@@ -11,7 +11,14 @@ from click.testing import CliRunner
 import qubx.pandaz.ta as pta
 from qubx.backtester.simulator import simulate
 from qubx.cli.misc import PyClassInfo, find_pyproject_root
-from qubx.cli.release import ReleaseInfo, StrategyInfo, _bundle_source_overrides, create_released_pack
+from qubx.cli.release import (
+    ReleaseInfo,
+    StrategyInfo,
+    _bundle_source_overrides,
+    _find_uv_workspace_root,
+    _find_workspace_member_for_package,
+    create_released_pack,
+)
 from qubx.core.series import OHLCV
 from qubx.data import CsvStorage
 from qubx.utils.runner.configs import ExchangeConfig, LoggingConfig, ReleaseSourceConfig, StrategyConfig
@@ -391,3 +398,182 @@ class TestReleaseSourceConfigSubdirectory:
                 ref="main",
                 subdirectory="ok/../../escape",
             )
+
+
+class TestWorkspaceHelpers:
+    """Tests for `_find_uv_workspace_root` and `_find_workspace_member_for_package`."""
+
+    @staticmethod
+    def _write_workspace_root(tmp_path: Path, members: list[str]) -> None:
+        members_repr = ", ".join(f'"{m}"' for m in members)
+        (tmp_path / "pyproject.toml").write_text(
+            f'[project]\nname = "ws-root"\nversion = "0.0.0"\n\n[tool.uv.workspace]\nmembers = [{members_repr}]\n'
+        )
+
+    @staticmethod
+    def _write_member(member_dir: Path, project_name: str) -> None:
+        member_dir.mkdir(parents=True, exist_ok=True)
+        (member_dir / "pyproject.toml").write_text(f'[project]\nname = "{project_name}"\nversion = "0.1.0"\n')
+
+    def test_find_uv_workspace_root_walks_up_from_member(self, tmp_path: Path):
+        self._write_workspace_root(tmp_path, ["pkg-a"])
+        member = tmp_path / "pkg-a"
+        self._write_member(member, "pkg-a")
+
+        # Walk up from the member directory
+        result = _find_uv_workspace_root(str(member))
+        assert result == str(tmp_path.resolve())
+
+    def test_find_uv_workspace_root_walks_up_from_nested_subdir(self, tmp_path: Path):
+        self._write_workspace_root(tmp_path, ["pkg-a"])
+        member = tmp_path / "pkg-a"
+        self._write_member(member, "pkg-a")
+        nested = member / "src" / "pkg_a"
+        nested.mkdir(parents=True)
+
+        result = _find_uv_workspace_root(str(nested))
+        assert result == str(tmp_path.resolve())
+
+    def test_find_uv_workspace_root_returns_none_when_no_workspace(self, tmp_path: Path):
+        # A bare pyproject.toml without [tool.uv.workspace] should not match.
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "standalone"\nversion = "0.1.0"\n')
+        sub = tmp_path / "src"
+        sub.mkdir()
+        result = _find_uv_workspace_root(str(sub))
+        assert result is None
+
+    def test_find_workspace_member_resolves_by_exact_name(self, tmp_path: Path):
+        self._write_workspace_root(tmp_path, ["pkg-a"])
+        member = tmp_path / "pkg-a"
+        self._write_member(member, "pkg-a")
+
+        result = _find_workspace_member_for_package(str(tmp_path), "pkg-a")
+        assert result == str(member.resolve())
+
+    def test_find_workspace_member_handles_underscore_normalisation(self, tmp_path: Path):
+        self._write_workspace_root(tmp_path, ["pkg-a"])
+        member = tmp_path / "pkg-a"
+        self._write_member(member, "pkg-a")
+
+        # Search with underscored name should still resolve
+        result = _find_workspace_member_for_package(str(tmp_path), "pkg_a")
+        assert result == str(member.resolve())
+
+    def test_find_workspace_member_returns_none_for_unknown_package(self, tmp_path: Path):
+        self._write_workspace_root(tmp_path, ["pkg-a"])
+        self._write_member(tmp_path / "pkg-a", "pkg-a")
+
+        result = _find_workspace_member_for_package(str(tmp_path), "missing-pkg")
+        assert result is None
+
+    def test_find_workspace_member_handles_glob_patterns(self, tmp_path: Path):
+        self._write_workspace_root(tmp_path, ["pkgs/*"])
+        member = tmp_path / "pkgs" / "sub"
+        self._write_member(member, "sub")
+
+        result = _find_workspace_member_for_package(str(tmp_path), "sub")
+        assert result == str(member.resolve())
+
+    def test_find_workspace_member_returns_none_when_no_members_listed(self, tmp_path: Path):
+        # workspace section but empty members list
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "ws-root"\nversion = "0.0.0"\n\n[tool.uv.workspace]\nmembers = []\n'
+        )
+        result = _find_workspace_member_for_package(str(tmp_path), "anything")
+        assert result is None
+
+
+class TestBundleSourceOverridesWorkspace:
+    """Verify [tool.uv.sources] `workspace = true` bundling."""
+
+    @patch("qubx.cli.release._version_exists_on_pypi", return_value=False)
+    @patch("subprocess.run")
+    def test_workspace_source_builds_from_member_dir(self, mock_run, _mock_pypi, tmp_path: Path):
+        # Set up a workspace with a member that owns the package being bundled.
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "ws-root"\nversion = "0.0.0"\n\n[tool.uv.workspace]\nmembers = ["pkg-a", "consumer"]\n'
+        )
+
+        member_dir = tmp_path / "pkg-a"
+        member_dir.mkdir()
+        (member_dir / "pyproject.toml").write_text('[project]\nname = "pkg-a"\nversion = "0.2.0"\n')
+
+        # Consumer is the strategy's own pyproject (the pyproject_root passed to
+        # _bundle_source_overrides). It declares pkg-a as a workspace source.
+        consumer_dir = tmp_path / "consumer"
+        consumer_dir.mkdir()
+        (consumer_dir / "pyproject.toml").write_text('[project]\nname = "consumer"\nversion = "0.1.0"\n')
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        release_dir = tmp_path / "release"
+        release_dir.mkdir()
+
+        bundled = _bundle_source_overrides(
+            pyproject_data={"tool": {"uv": {"sources": {"pkg-a": {"workspace": True}}}}},
+            pyproject_root=str(consumer_dir),
+            release_dir=str(release_dir),
+            required_packages={"pkg-a"},
+            lock_versions={"pkg_a": "0.2.0"},
+            git_commits={},
+        )
+
+        assert bundled == ["pkg-a"]
+        assert mock_run.called
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["cwd"] == str(member_dir.resolve())
+        # uv build invoked with wheel + out-dir
+        args = mock_run.call_args.args[0]
+        assert args[:4] == ["uv", "build", "--wheel", "."]
+
+    @patch("qubx.cli.release._version_exists_on_pypi", return_value=False)
+    @patch("subprocess.run")
+    def test_workspace_source_skips_when_no_workspace_root(self, mock_run, _mock_pypi, tmp_path: Path):
+        # A consumer with no surrounding workspace root.
+        consumer_dir = tmp_path / "consumer"
+        consumer_dir.mkdir()
+        (consumer_dir / "pyproject.toml").write_text('[project]\nname = "consumer"\nversion = "0.1.0"\n')
+
+        release_dir = tmp_path / "release"
+        release_dir.mkdir()
+
+        bundled = _bundle_source_overrides(
+            pyproject_data={"tool": {"uv": {"sources": {"pkg-a": {"workspace": True}}}}},
+            pyproject_root=str(consumer_dir),
+            release_dir=str(release_dir),
+            required_packages={"pkg-a"},
+            lock_versions={"pkg_a": "0.2.0"},
+            git_commits={},
+        )
+
+        assert bundled == []
+        assert not mock_run.called
+
+    @patch("qubx.cli.release._version_exists_on_pypi", return_value=True)
+    @patch("subprocess.run")
+    def test_workspace_source_skips_when_version_on_public_pypi(self, mock_run, _mock_pypi, tmp_path: Path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "ws-root"\nversion = "0.0.0"\n\n[tool.uv.workspace]\nmembers = ["pkg-a", "consumer"]\n'
+        )
+        member_dir = tmp_path / "pkg-a"
+        member_dir.mkdir()
+        (member_dir / "pyproject.toml").write_text('[project]\nname = "pkg-a"\nversion = "0.2.0"\n')
+        consumer_dir = tmp_path / "consumer"
+        consumer_dir.mkdir()
+        (consumer_dir / "pyproject.toml").write_text('[project]\nname = "consumer"\nversion = "0.1.0"\n')
+
+        release_dir = tmp_path / "release"
+        release_dir.mkdir()
+
+        bundled = _bundle_source_overrides(
+            pyproject_data={"tool": {"uv": {"sources": {"pkg-a": {"workspace": True}}}}},
+            pyproject_root=str(consumer_dir),
+            release_dir=str(release_dir),
+            required_packages={"pkg-a"},
+            lock_versions={"pkg_a": "0.2.0"},
+            git_commits={},
+        )
+
+        # Found on PyPI → resolved from registry, not bundled.
+        assert bundled == []
+        assert not mock_run.called


### PR DESCRIPTION
## Summary

Adds a `workspace = true` branch to `_bundle_source_overrides`. Strategies in a uv workspace that depend on sibling workspace-member packages can now have those wheels bundled into the release ZIP — same shape as the existing `path` / `index` / `git` branches.

## Why

xLydianSoftware/exchanges is a uv workspace with members `conformance` / `lighter` / `hyperliquid` / `e2e-driver` / `e2e`. The `e2e-driver` strategy needs `qubx-hyperliquid` as a plugin connector; the natural declaration is:

\`\`\`toml
[project.optional-dependencies]
hyperliquid = ["qubx-hyperliquid"]

[tool.uv.sources]
qubx-hyperliquid = { workspace = true }
\`\`\`

uv rejects `path` overrides on workspace members ("Workspace members must be declared as workspace sources"), so `workspace = true` was the only valid declaration — but `_bundle_source_overrides` had no branch for it, silently skipping. Result: deployed bot pod crashed on `Data provider 'hyperliquid' is not registered`.

## What changed

- `_bundle_source_overrides`: new `elif source.get("workspace") is True` branch. Walks up to find the workspace root, locates the matching member by PEP-503-normalised project.name, builds the wheel from that member directory.
- Two helpers: `_find_uv_workspace_root` (walks up looking for `[tool.uv.workspace]`) and `_find_workspace_member_for_package` (resolves member path by package name, handles glob patterns in `members` list).

## Test plan

- [x] New unit tests for both helpers: walk-up resolution, hyphen/underscore normalisation, glob patterns, missing-workspace fallback.
- [x] Three new branch tests for `_bundle_source_overrides`: builds-from-member, skips when no workspace root, skips when version on public PyPI.
- [x] Existing release tests pass unchanged (24 tests in release_test.py, 77 across tests/qubx/cli/).
- [x] Ruff check clean on touched files; ruff format leaves a small number of pre-existing collapses untouched (matches the convention from PR #280).
- [ ] Manual smoke: rebuild xrelease/dev/hyperliquid/e2e-hyperliquid-testnet.yaml after this Qubx version ships, expect the release ZIP to include qubx_hyperliquid-X.Y.Z-...whl.