### PR TITLE
feat(cli): walk up to workspace root for uv.lock during release-from-source

### DIFF
--- a/src/qubx/cli/release.py
+++ b/src/qubx/cli/release.py
@@ -780,7 +780,6 @@ def _find_source_root(pyproject_root: str, project_name: str) -> str | None:
     return None
 
 
-
 def _parse_uv_lock(uv_lock_path: str) -> dict[str, str]:
     """
     Parse uv.lock (TOML format) and return {normalized_name: version} dict.
@@ -1058,10 +1057,7 @@ def create_released_pack(
 
     # Parse uv.lock once as the single source of truth for versions.
     # If missing, generate it first.
-    uv_lock_path = os.path.join(pyproject_root, "uv.lock")
-    if not os.path.exists(uv_lock_path):
-        logger.info("uv.lock not found in source project, generating...")
-        _generate_lock_file(pyproject_root)
+    uv_lock_path = _resolve_source_lockfile(pyproject_root)
     lock_versions = _parse_uv_lock(uv_lock_path)
 
     # --- Step 1: Build strategy wheel (if custom code) ---
@@ -1339,6 +1335,52 @@ def _resolve_local_package_version(local_path: str, pkg_norm: str) -> str | None
     return None
 
 
+def _resolve_source_lockfile(pyproject_root: str) -> str:
+    """Locate the uv.lock for a source project, handling uv workspaces.
+
+    For a single-package project, uv.lock lives at the project root. For a
+    workspace member, uv only writes a single workspace-root lock — the member
+    directory has no uv.lock of its own. This helper picks the right one:
+
+    1. If `<pyproject_root>/uv.lock` exists, use it.
+    2. Otherwise, if `pyproject_root` is inside a uv workspace and the
+       workspace root has a uv.lock, use the workspace-root lock.
+    3. Otherwise, run `uv lock` from `pyproject_root` (which may write the lock
+       at the workspace root if `pyproject_root` is a member). Re-check both
+       locations and prefer whichever exists.
+
+    The returned path is what callers should hand to `_parse_uv_lock` /
+    `_parse_uv_lock_git_commits`. If neither location ends up populated, the
+    member-local path is returned so the caller can surface the missing-lock
+    warning via `_parse_uv_lock`.
+    """
+    member_lock = os.path.join(pyproject_root, "uv.lock")
+    if os.path.exists(member_lock):
+        return member_lock
+
+    workspace_root = _find_uv_workspace_root(pyproject_root)
+    if workspace_root and workspace_root != pyproject_root:
+        ws_lock = os.path.join(workspace_root, "uv.lock")
+        if os.path.exists(ws_lock):
+            logger.debug(f"Using workspace-root uv.lock at {ws_lock}")
+            return ws_lock
+
+    logger.info("uv.lock not found in source project, generating...")
+    _generate_lock_file(pyproject_root)
+
+    # `uv lock` for a workspace member writes the lock at the workspace root,
+    # not the member directory. Re-check both locations.
+    if os.path.exists(member_lock):
+        return member_lock
+    if workspace_root and workspace_root != pyproject_root:
+        ws_lock = os.path.join(workspace_root, "uv.lock")
+        if os.path.exists(ws_lock):
+            logger.debug(f"Using workspace-root uv.lock at {ws_lock}")
+            return ws_lock
+
+    return member_lock
+
+
 def _find_uv_workspace_root(start_dir: str) -> str | None:
     """Walk up from start_dir to find the nearest pyproject.toml with [tool.uv.workspace].
 
@@ -1536,7 +1578,9 @@ def _bundle_source_overrides(
                     shutil.rmtree(checkout_dir, ignore_errors=True)
                     os.makedirs(checkout_dir, exist_ok=True)
                     subprocess.run(["git", "clone", git_url, checkout_dir], check=True, capture_output=True, text=True)
-                    subprocess.run(["git", "checkout", commit_sha], cwd=checkout_dir, check=True, capture_output=True, text=True)
+                    subprocess.run(
+                        ["git", "checkout", commit_sha], cwd=checkout_dir, check=True, capture_output=True, text=True
+                    )
 
             # Honor [tool.uv.sources] `subdirectory` for monorepo git sources
             subdir = source.get("subdirectory")

--- a/tests/qubx/cli/release_test.py
+++ b/tests/qubx/cli/release_test.py
@@ -17,6 +17,7 @@ from qubx.cli.release import (
     _bundle_source_overrides,
     _find_uv_workspace_root,
     _find_workspace_member_for_package,
+    _resolve_source_lockfile,
     create_released_pack,
 )
 from qubx.core.series import OHLCV
@@ -280,9 +281,7 @@ class TestBundleSourceOverrides:
 
     @patch("qubx.cli.release._find_uv_git_checkout")
     @patch("subprocess.run")
-    def test_git_source_with_subdirectory_builds_from_subdir(
-        self, mock_run, mock_find_checkout, tmp_path
-    ):
+    def test_git_source_with_subdirectory_builds_from_subdir(self, mock_run, mock_find_checkout, tmp_path):
         """Git source with `subdirectory` must run `uv build` from <checkout>/<subdirectory>."""
         checkout_root = tmp_path / "cache" / "deadbeef"
         checkout_root.mkdir(parents=True)
@@ -304,15 +303,11 @@ class TestBundleSourceOverrides:
         assert mock_run.called, "uv build should be invoked for the git source"
         kwargs = mock_run.call_args.kwargs
         expected_cwd = str(checkout_root / "qubx-xdata")
-        assert kwargs["cwd"] == expected_cwd, (
-            f"Expected build cwd={expected_cwd!r}, got {kwargs['cwd']!r}"
-        )
+        assert kwargs["cwd"] == expected_cwd, f"Expected build cwd={expected_cwd!r}, got {kwargs['cwd']!r}"
 
     @patch("qubx.cli.release._find_uv_git_checkout")
     @patch("subprocess.run")
-    def test_git_source_without_subdirectory_builds_from_root(
-        self, mock_run, mock_find_checkout, tmp_path
-    ):
+    def test_git_source_without_subdirectory_builds_from_root(self, mock_run, mock_find_checkout, tmp_path):
         """Without `subdirectory`, `uv build` must run from the checkout root (unchanged)."""
         checkout_root = tmp_path / "cache" / "deadbeef"
         checkout_root.mkdir(parents=True)
@@ -577,3 +572,74 @@ class TestBundleSourceOverridesWorkspace:
         # Found on PyPI → resolved from registry, not bundled.
         assert bundled == []
         assert not mock_run.called
+
+
+class TestResolveSourceLockfile:
+    """Tests for `_resolve_source_lockfile` workspace-aware lockfile resolution."""
+
+    def test_single_package_uses_member_local_lock(self, tmp_path: Path):
+        # Single-package project: uv.lock at pyproject_root, no workspace.
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "single-pkg"\nversion = "0.1.0"\n')
+        member_lock = tmp_path / "uv.lock"
+        member_lock.write_text("# placeholder\n")
+
+        result = _resolve_source_lockfile(str(tmp_path))
+        assert result == str(member_lock)
+
+    def test_workspace_member_uses_workspace_root_lock(self, tmp_path: Path):
+        # Workspace root has uv.lock; member dir does NOT.
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "ws-root"\nversion = "0.0.0"\n\n[tool.uv.workspace]\nmembers = ["pkg-a"]\n'
+        )
+        ws_lock = tmp_path / "uv.lock"
+        ws_lock.write_text("# placeholder\n")
+
+        member_dir = tmp_path / "pkg-a"
+        member_dir.mkdir()
+        (member_dir / "pyproject.toml").write_text('[project]\nname = "pkg-a"\nversion = "0.1.0"\n')
+
+        result = _resolve_source_lockfile(str(member_dir))
+        # Should pick the workspace-root lock, not the missing member lock.
+        assert result == str(ws_lock)
+        assert not (member_dir / "uv.lock").exists()
+
+    def test_workspace_member_falls_through_to_generate_then_finds_workspace_lock(self, tmp_path: Path):
+        # Both locks missing initially. `uv lock` invocation is mocked to
+        # simulate uv writing the lock at the workspace root (typical
+        # behaviour for a workspace member).
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "ws-root"\nversion = "0.0.0"\n\n[tool.uv.workspace]\nmembers = ["pkg-a"]\n'
+        )
+
+        member_dir = tmp_path / "pkg-a"
+        member_dir.mkdir()
+        (member_dir / "pyproject.toml").write_text('[project]\nname = "pkg-a"\nversion = "0.1.0"\n')
+
+        ws_lock = tmp_path / "uv.lock"
+
+        def fake_generate(pyproject_root: str) -> None:
+            # Simulate `uv lock` running from the member: writes lock at the
+            # workspace root, not the member dir.
+            ws_lock.write_text("# placeholder\n")
+
+        with patch("qubx.cli.release._generate_lock_file", side_effect=fake_generate) as mock_gen:
+            result = _resolve_source_lockfile(str(member_dir))
+
+        assert mock_gen.called
+        # Resolution should still land on the workspace-root lock after generation.
+        assert result == str(ws_lock)
+        assert not (member_dir / "uv.lock").exists()
+
+    def test_single_package_missing_lock_generates_and_returns_member_lock(self, tmp_path: Path):
+        # No workspace. Initial lock missing → generate writes member-local lock.
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "single-pkg"\nversion = "0.1.0"\n')
+        member_lock = tmp_path / "uv.lock"
+
+        def fake_generate(pyproject_root: str) -> None:
+            member_lock.write_text("# placeholder\n")
+
+        with patch("qubx.cli.release._generate_lock_file", side_effect=fake_generate) as mock_gen:
+            result = _resolve_source_lockfile(str(tmp_path))
+
+        assert mock_gen.called
+        assert result == str(member_lock)


### PR DESCRIPTION
## Summary

Third fix in the `qubx release --from-sources` monorepo flow. After PR #280 (`subdirectory` field) and PR #281 (workspace bundler branch), one gap remained: `create_released_pack` reads `<pyproject_root>/uv.lock` but for a workspace member that file doesn't exist — uv only writes a single workspace-root lock.

With the lockfile missing or wrong:
- `_bundle_source_overrides` couldn't find versions for `workspace = true` deps
- Silently skipped bundling
- Generated release pyproject listed deps with no resolvable source
- Final `uv lock` against the release dir failed: `Because qubx-hyperliquid was not found in the package registry and e2e-driver==0.1.0 depends on qubx-hyperliquid...`

## Fix

Extracted lockfile resolution into `_resolve_source_lockfile(pyproject_root)`. When `<pyproject_root>/uv.lock` is missing, walk up to find the workspace root (via `_find_uv_workspace_root` from PR #281). If the workspace lock exists, use it. After `_generate_lock_file` runs, re-check both locations.

Single-package sources are unchanged (they have their own `uv.lock` at the project root).

## Test plan

- [x] Existing release tests pass (24 pre-existing release tests stay green).
- [x] New unit tests cover four paths in `TestResolveSourceLockfile`: single-package with existing lock, workspace member with workspace-root lock, workspace member with both locks initially missing (falls through generation, then finds workspace lock), and single-package with missing lock (generates member-local lock).
- [ ] Manual smoke after Qubx v1.4.3: rebuild xrelease/dev/hyperliquid/e2e-hyperliquid-testnet.yaml, expect `qubx-hyperliquid` and `qubx-lighter` wheels to appear in the release ZIP and the deployed bot to start cleanly.