### PR TITLE
fix(control): sanitize NaN/±Inf at the response boundary

### DIFF
--- a/src/qubx/control/server.py
+++ b/src/qubx/control/server.py
@@ -11,6 +11,7 @@ Endpoints:
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import threading
 from queue import Queue
@@ -18,12 +19,56 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from qubx import logger
 
 from .executor import ActionExecutor
 from .types import ActionDef
+
+
+def _json_safe(value: Any) -> Any:
+    """Recursively replace non-finite floats (NaN, ±Inf) with ``None``.
+
+    Strategy state pulled from accounts and positions can carry NaN
+    sentinels — e.g. ``Position.last_update_price`` defaults to ``np.nan``
+    until a Quote/Trade tick has set it, which leaves universe entries that
+    were added then immediately removed (or kept around past a remove,
+    by design at ``qubx/core/mixins/universe.py``) with NaN price fields.
+    Starlette's ``JSONResponse.render`` calls ``json.dumps(..., allow_nan=False)``
+    and raises ``ValueError: Out of range float values are not JSON compliant: nan``,
+    surfacing as 500s on every ``get_state`` / ``get_positions`` call.
+
+    We sanitize at the response boundary so:
+      1. Action authors don't have to remember per-field rounding helpers.
+      2. Both shipped builtins and user-defined ``@action`` methods are
+         covered with a single rule.
+      3. Every endpoint on the control server inherits the behaviour
+         (health/ready/list_actions/exec_action — current and future).
+
+    NaN/Inf become ``null`` in the wire format. Callers that genuinely
+    need to distinguish "missing tick" from "explicit zero" should
+    surface that distinction through their own field naming, not through
+    NaN sentinels in JSON.
+    """
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return value
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+class NanSafeJSONResponse(JSONResponse):
+    """JSONResponse that maps non-finite floats to ``null`` before serializing."""
+
+    def render(self, content: Any) -> bytes:
+        return super().render(_json_safe(content))
+
 
 if TYPE_CHECKING:
     from qubx.core.context import StrategyContext
@@ -75,7 +120,12 @@ class ControlServer:
         self._thread: threading.Thread | None = None
         self._server: uvicorn.Server | None = None
 
-        self._app = FastAPI(title="Qubx Bot Control", docs_url=None, redoc_url=None)
+        self._app = FastAPI(
+            title="Qubx Bot Control",
+            docs_url=None,
+            redoc_url=None,
+            default_response_class=NanSafeJSONResponse,
+        )
         self._register_routes()
 
     def attach_context(self, ctx: StrategyContext):

--- a/tests/qubx/control/test_server.py
+++ b/tests/qubx/control/test_server.py
@@ -1,9 +1,10 @@
+import math
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-from qubx.control.server import ControlServer
+from qubx.control.server import ControlServer, _json_safe
 
 
 def _make_mock_ctx():
@@ -158,3 +159,61 @@ class TestExecEndpoint:
             assert "type" in param
             assert "description" in param
             assert "required" in param
+
+
+class TestJsonSafe:
+    """``_json_safe`` strips NaN/±Inf at the response boundary."""
+
+    def test_finite_floats_pass_through(self):
+        assert _json_safe(1.5) == 1.5
+        assert _json_safe(0.0) == 0.0
+        assert _json_safe(-1e9) == -1e9
+
+    def test_nan_becomes_none(self):
+        assert _json_safe(float("nan")) is None
+
+    def test_inf_becomes_none(self):
+        assert _json_safe(float("inf")) is None
+        assert _json_safe(float("-inf")) is None
+
+    def test_walks_nested_dicts(self):
+        out = _json_safe({"price": float("nan"), "qty": 0.5, "nested": {"pnl": float("inf")}})
+        assert out == {"price": None, "qty": 0.5, "nested": {"pnl": None}}
+
+    def test_walks_lists_and_tuples(self):
+        assert _json_safe([1.0, float("nan"), 3.0]) == [1.0, None, 3.0]
+        # Tuples normalize to lists for JSON purposes (which matches Starlette's encoder).
+        assert _json_safe((float("nan"),)) == [None]
+
+    def test_non_float_values_untouched(self):
+        assert _json_safe("hello") == "hello"
+        assert _json_safe(42) == 42
+        assert _json_safe(None) is None
+        assert _json_safe(True) is True
+
+
+class TestNanSafeWireFormat:
+    """End-to-end: a NaN in any action's return is serialized as null."""
+
+    def test_get_positions_with_nan_market_price_returns_null(self, server_with_ctx):
+        # Simulate the universe-add-then-remove residual: position kept in the
+        # account map but no Quote/Trade has updated last_update_price yet.
+        client, ctx = server_with_ctx
+        instr = MagicMock()
+        instr.__str__ = lambda self: "SOLUSDT"
+        pos = MagicMock()
+        pos.quantity = 0.0
+        pos.position_avg_price = 0.0
+        pos.last_update_price = math.nan
+        pos.unrealized_pnl.return_value = math.nan
+        pos.r_pnl = 0.0
+        pos.market_value_funds = math.nan
+        ctx.get_positions.return_value = {instr: pos}
+
+        resp = client.post("/actions/get_positions", json={"params": {}})
+        # Without _json_safe this 500s on Starlette's allow_nan=False JSON dump.
+        assert resp.status_code == 200
+        sol = resp.json()["data"]["positions"]["SOLUSDT"]
+        assert sol["market_price"] is None
+        assert sol["unrealized_pnl"] is None
+        assert sol["market_value"] is None


### PR DESCRIPTION
## Summary

- Adds `NanSafeJSONResponse` (a `fastapi.responses.JSONResponse` subclass) whose `render()` walks the content tree and replaces NaN / ±Inf floats with `None` before delegating to the parent.
- Wires it as the FastAPI app's `default_response_class` on `ControlServer`, so every endpoint inherits the behaviour — `/health`, `/ready`, `/actions`, `/actions/{name}`, plus any future routes — without per-action discipline. Builtin actions and user-defined `@action` methods are both covered.

## Why

`Position.last_update_price` defaults to `np.nan` until a Quote/Trade tick has set it. Universe entries that get added then immediately removed (or kept past a remove, by design at `qubx/core/mixins/universe.py`) leave the position record with NaN price fields. Phantom positions synthesized by some connectors' WS history-replay paths can do the same.

Starlette's `JSONResponse.render` calls `json.dumps(..., allow_nan=False)` and raises:

> `ValueError: Out of range float values are not JSON compliant: nan`

which surfaces as 500s on every `get_state` / `get_positions` call. In the `exchanges/` e2e harness this also poisons the autouse cleanup (which reads positions to verify clean state), marks the suite as dirty, and skips every downstream test.

NaN/Inf become `null` on the wire — the cheapest signal for "value not yet available" we can express in JSON.

## Test plan

- [x] `tests/qubx/control/test_server.py::TestJsonSafe` — `_json_safe` direct: finite passthrough, NaN/Inf → None, nested dicts/lists/tuples, non-floats untouched (6 tests).
- [x] `tests/qubx/control/test_server.py::TestNanSafeWireFormat::test_get_positions_with_nan_market_price_returns_null` — end-to-end: post `/actions/get_positions` with a position whose `last_update_price` is NaN, assert 200 with `market_price: null`.
- [x] All 20 tests in `test_server.py` pass.