### PR TITLE
feat(account): dedup funding payments per (instrument, interval) bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src/qubx/_version.py
 experiments/logs/
 tests/**/logs/
 logs/
+.worktrees/
 experiments/configs/.env*
 .vscode/numbered-bookmarks.json
 debug/

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -67,6 +67,10 @@ class BasicAccountProcessor(IAccountProcessor):
         self._balances = {}
         self._exchange_total_capital: float | None = None
         self._exchange_margin_ratio: float | None = None
+        # Idempotency key per booked funding event: (instrument, bucket_start_ns).
+        # Collapses duplicates when funding arrives from multiple sources (e.g.
+        # venue WS user-events push and a synthetic market-data stream).
+        self._applied_funding_buckets: set[tuple[Instrument, int]] = set()
         # Initialize with base currency balance
         self._balances[self.base_currency] = AssetBalance(
             exchange=self.exchange, currency=self.base_currency, free=initial_capital, locked=0.0, total=initial_capital
@@ -472,6 +476,11 @@ class BasicAccountProcessor(IAccountProcessor):
     def process_funding_payment(self, instrument: Instrument, funding_payment: FundingPayment) -> None:
         """Process funding payment for an instrument.
 
+        Idempotent at the (instrument, funding-interval bucket) granularity:
+        a second call for the same bucket is a no-op. This lets two independent
+        sources (e.g. venue user-events WS and a synthetic market-data stream)
+        co-exist without double-booking funding against the account.
+
         Args:
             instrument: Instrument the funding payment applies to
             funding_payment: Funding payment event to process
@@ -479,6 +488,12 @@ class BasicAccountProcessor(IAccountProcessor):
         pos = self._positions.get(instrument)
 
         if pos is None or not instrument.is_futures():
+            return
+
+        bucket_ns = funding_payment.funding_interval_hours * 3600 * 1_000_000_000
+        bucket_start = (int(funding_payment.time) // bucket_ns) * bucket_ns
+        bucket_key = (instrument, bucket_start)
+        if bucket_key in self._applied_funding_buckets:
             return
 
         # Get current market price for funding calculation
@@ -493,6 +508,21 @@ class BasicAccountProcessor(IAccountProcessor):
         # For futures contracts, funding affects the settlement currency balance
         self._ensure_balance(instrument.settle)
         self._balances[instrument.settle] += funding_amount
+
+        self._applied_funding_buckets.add(bucket_key)
+        self._trim_funding_buckets()
+
+    def _trim_funding_buckets(self, max_age_days: int = 7, threshold: int = 1024) -> None:
+        """Bound `_applied_funding_buckets` so long-running bots don't grow it unboundedly.
+
+        Triggers only after the set exceeds `threshold` entries; then drops any
+        bucket older than `max_age_days` relative to the most recent bucket seen.
+        """
+        if len(self._applied_funding_buckets) < threshold:
+            return
+        max_ns = max(b for _, b in self._applied_funding_buckets)
+        cutoff_ns = max_ns - max_age_days * 86400 * 1_000_000_000
+        self._applied_funding_buckets = {k for k in self._applied_funding_buckets if k[1] >= cutoff_ns}
 
         # logger.debug(
         #     f"  [<y>{self.__class__.__name__}</y>(<g>{instrument}</g>)] :: "

--- a/tests/qubx/core/account_processor_test.py
+++ b/tests/qubx/core/account_processor_test.py
@@ -19,6 +19,7 @@ from qubx.core.basics import (
     ZERO_COSTS,
     AssetBalance,
     DataType,
+    FundingPayment,
     Instrument,
     Position,
     RestoredState,
@@ -462,3 +463,134 @@ class TestMergeRestoredAccounting:
         assert pos.commissions == 123.45
         assert pos.r_pnl == 5000.0
         assert pos.cumulative_funding == -100.0
+
+
+class TestProcessFundingPaymentDedup:
+    """Funding payment idempotency.
+
+    Live setups can receive the same funding event from two independent sources
+    (e.g. venue WS userEvents *and* a synthetic xdata funding_payment stream).
+    `process_funding_payment` must collapse duplicates to a single booking per
+    (instrument, funding interval bucket) so balances and cumulative_funding
+    don't double-count.
+    """
+
+    def _make_account_with_long_position(
+        self, instrument: Instrument, qty: float = 1.0, price: float = 50_000.0, capital: float = 100_000.0
+    ) -> BasicAccountProcessor:
+        account = BasicAccountProcessor(
+            account_id="test",
+            time_provider=DummyTimeProvider(),
+            base_currency="USDT",
+            health_monitor=DummyHealthMonitor(),
+            exchange="BINANCE.UM",
+            tcc=ZERO_COSTS,
+            initial_capital=capital,
+        )
+        pos = Position(instrument=instrument, quantity=qty, pos_average_price=price, r_pnl=0.0)
+        pos.position_avg_price_funds = price  # used as mark fallback in process_funding_payment
+        account._positions[instrument] = pos
+        return account
+
+    def test_duplicate_same_bucket_applied_once(self):
+        """Two events landing in the same funding bucket book funding only once."""
+        btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert btc is not None
+        account = self._make_account_with_long_position(btc)
+        settle_currency = btc.settle  # USDT
+
+        # First event: hourly bucket aligned at 12:00:00.
+        fp1 = FundingPayment(
+            time=np.datetime64("2026-05-11T12:00:00", "ns").astype(np.int64),
+            funding_rate=0.0001,
+            funding_interval_hours=1,
+        )
+        # Second event: same bucket, sub-second offset (mimics venue push vs synthetic boundary skew).
+        fp1_dup = FundingPayment(
+            time=np.datetime64("2026-05-11T12:00:03.500000000", "ns").astype(np.int64),
+            funding_rate=0.0001,
+            funding_interval_hours=1,
+        )
+
+        account.process_funding_payment(btc, fp1)
+        account.process_funding_payment(btc, fp1_dup)
+
+        # qty * mark_price * rate = 1 * 50_000 * 0.0001 = 5; long pays -> -5.
+        assert account.get_balance(settle_currency).total == pytest.approx(100_000.0 - 5.0)
+        pos = account.get_position(btc)
+        assert pos.cumulative_funding == pytest.approx(-5.0)
+        assert len(pos.funding_payments) == 1
+
+    def test_different_buckets_both_applied(self):
+        """Events in different funding buckets both book independently."""
+        btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert btc is not None
+        account = self._make_account_with_long_position(btc)
+        settle_currency = btc.settle
+
+        fp_12 = FundingPayment(
+            time=np.datetime64("2026-05-11T12:00:00", "ns").astype(np.int64),
+            funding_rate=0.0001,
+            funding_interval_hours=1,
+        )
+        fp_13 = FundingPayment(
+            time=np.datetime64("2026-05-11T13:00:00", "ns").astype(np.int64),
+            funding_rate=0.0001,
+            funding_interval_hours=1,
+        )
+
+        account.process_funding_payment(btc, fp_12)
+        account.process_funding_payment(btc, fp_13)
+
+        assert account.get_balance(settle_currency).total == pytest.approx(100_000.0 - 10.0)
+        assert account.get_position(btc).cumulative_funding == pytest.approx(-10.0)
+        assert len(account.get_position(btc).funding_payments) == 2
+
+    def test_dedup_is_per_instrument(self):
+        """Same bucket but different instruments must each book."""
+        btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        eth = lookup.find_symbol("BINANCE.UM", "ETHUSDT")
+        assert btc is not None and eth is not None
+        account = BasicAccountProcessor(
+            account_id="test",
+            time_provider=DummyTimeProvider(),
+            base_currency="USDT",
+            health_monitor=DummyHealthMonitor(),
+            exchange="BINANCE.UM",
+            tcc=ZERO_COSTS,
+            initial_capital=100_000.0,
+        )
+        btc_pos = Position(instrument=btc, quantity=1.0, pos_average_price=50_000.0, r_pnl=0.0)
+        btc_pos.position_avg_price_funds = 50_000.0
+        eth_pos = Position(instrument=eth, quantity=10.0, pos_average_price=3_000.0, r_pnl=0.0)
+        eth_pos.position_avg_price_funds = 3_000.0
+        account._positions[btc] = btc_pos
+        account._positions[eth] = eth_pos
+
+        t = np.datetime64("2026-05-11T12:00:00", "ns").astype(np.int64)
+        account.process_funding_payment(btc, FundingPayment(time=t, funding_rate=0.0001, funding_interval_hours=1))
+        account.process_funding_payment(eth, FundingPayment(time=t, funding_rate=0.0001, funding_interval_hours=1))
+
+        # BTC: 1 * 50_000 * 0.0001 = 5; ETH: 10 * 3_000 * 0.0001 = 3. Total = -8.
+        assert account.get_balance("USDT").total == pytest.approx(100_000.0 - 8.0)
+        assert account.get_position(btc).cumulative_funding == pytest.approx(-5.0)
+        assert account.get_position(eth).cumulative_funding == pytest.approx(-3.0)
+
+    def test_bucket_set_is_bounded(self):
+        """Bucket cache stays bounded for long-running bots."""
+        btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert btc is not None
+        account = self._make_account_with_long_position(btc)
+
+        # Feed many hourly funding events spanning several months. Threshold (1024)
+        # triggers a prune that retains only the most recent 7 days = 168 buckets.
+        base = np.datetime64("2026-01-01T00:00:00", "ns").astype(np.int64)
+        hour_ns = 3600 * 1_000_000_000
+        for i in range(2000):
+            account.process_funding_payment(
+                btc,
+                FundingPayment(time=base + i * hour_ns, funding_rate=0.0001, funding_interval_hours=1),
+            )
+
+        # Post-prune size should be << total bookings; tolerate up to threshold+window.
+        assert len(account._applied_funding_buckets) <= 1024


### PR DESCRIPTION
## Summary
- `BasicAccountProcessor.process_funding_payment` becomes idempotent at the `(instrument, funding-interval bucket)` granularity, so live setups where funding is booked from both a venue user-events WS push AND a synthetic xdata `funding_payment` market-data stream no longer double-count each hourly/8h funding against the account.
- Bucket key = `(instrument, floor(funding_payment.time, funding_interval_hours))`. Tolerates sub-second skew between sources at the boundary.
- Bounded memory: trim entries older than 7 days once the set exceeds 1024 buckets.

## Why
Connector flow (e.g. Hyperliquid): `_on_user_events` calls `process_funding_payment` directly from the venue push. Strategy subscription flow: xdata-sourced `funding_payment` arrives via the channel and `ProcessingManager._handle_funding_payment` also calls `account.process_funding_payment`. Both compute the same amount (`qty * mark * rate`), so without dedup the account books ~2x — balance, `cumulative_funding`, `r_pnl`, `pnl` all drift.

## Test plan
- [x] `pytest tests/qubx/core/account_processor_test.py::TestProcessFundingPaymentDedup` — 4 new tests: same-bucket dedup, different-bucket apply, per-instrument scoping, bounded memory.
- [x] `pytest tests/qubx/core/test_position_funding.py tests/qubx/core/test_funding_payment_subscription.py` — existing suite, unchanged behavior.
- [x] `pytest tests/qubx/backtester/` — 78 passing.
- [x] `ruff check && ruff format --check` clean on touched files.

Drive-by: adds `.worktrees/` to `.gitignore` so local git worktrees don't show up as untracked.