### PR TITLE
PR 6 — Phase 5: TradingManager + ProcessingManager dual-path (framework, additive)

### DIFF
--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -456,9 +456,14 @@ class ProcessingManager(IProcessingManager):
             case OrderUpdateRejectedEvent():
                 self._safe_call(self._strategy.on_order_update_rejected, updated, event.reason)
             case PositionUpdateEvent():
-                self._safe_call(self._strategy.on_position_update, updated)
+                # Pass the event payload directly — AM.apply has no PositionUpdate/Balance
+                # case yet (returns None). TODO(account-mgmt): when live connectors emit
+                # these (CCXT/HPL/Lighter PRs), add AM.apply cases that update AccountState
+                # (_set_position/_update_balance) + route them in _get_state_for_event
+                # (PositionUpdate by position.instrument, BalanceUpdate by balance.exchange).
+                self._safe_call(self._strategy.on_position_update, event.position)
             case BalanceUpdateEvent():
-                self._safe_call(self._strategy.on_balance_update, updated)
+                self._safe_call(self._strategy.on_balance_update, event.balance)
             case FundingPaymentEvent():
                 self._safe_call(self._strategy.on_funding_payment, event.payment)
             case AccountSnapshotEvent():
@@ -476,6 +481,7 @@ class ProcessingManager(IProcessingManager):
             try:
                 quote = self._market_data.quote(instrument)
                 if quote is not None:
+                    # TODO(account-mgmt): AccountManager must satisfy the IAccountViewer surface (account_id/get_base_currency/get_positions/get_balances) before the exporter/emitter run live.
                     self._exporter.export_position_changes(
                         time=self._time_provider.time(),
                         instrument=instrument,
@@ -488,6 +494,7 @@ class ProcessingManager(IProcessingManager):
         self._universe_manager.on_alter_position(instrument)
         if getattr(self._context, "emitter", None) is not None:
             try:
+                # TODO(account-mgmt): AccountManager must satisfy the IAccountViewer surface (account_id/get_base_currency/get_positions/get_balances) before the exporter/emitter run live.
                 self._context.emitter.emit_deals(
                     time=self._time_provider.time(),
                     instrument=instrument,

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -10,6 +10,7 @@ from qubx import logger
 
 if TYPE_CHECKING:
     from qubx.utils.throttler import InstrumentThrottler
+from qubx.core.account_manager import AccountManager
 from qubx.core.basics import (
     DataType,
     Deal,
@@ -26,9 +27,33 @@ from qubx.core.basics import (
     dt_64,
     td_64,
 )
+from qubx.core.connector import IConnector
 from qubx.core.detectors import DelistingDetector, StaleDataDetector
 from qubx.core.errors import BaseErrorEvent
-from qubx.core.exceptions import StrategyExceededMaxNumberOfRuntimeFailuresError
+from qubx.core.events import (
+    AccountMessage,
+    AccountSnapshotEvent,
+    BalanceUpdateEvent,
+    ChannelMessage,
+    CustomEvent,
+    ErrorEvent,
+    FundingPaymentEvent,
+    MarketDataMessage,
+    OrderAcceptedEvent,
+    OrderBookEvent,
+    OrderCanceledEvent,
+    OrderCancelRejectedEvent,
+    OrderExpiredEvent,
+    OrderFilledEvent,
+    OrderPartiallyFilledEvent,
+    OrderRejectedEvent,
+    OrderUpdatedEvent,
+    OrderUpdateRejectedEvent,
+    PositionUpdateEvent,
+    QuoteEvent,
+    TradeEvent,
+)
+from qubx.core.exceptions import InvalidOrderTransition, StrategyExceededMaxNumberOfRuntimeFailuresError
 from qubx.core.helpers import BasicScheduler, process_schedule_spec
 from qubx.core.interfaces import (
     IAccountProcessor,
@@ -76,6 +101,13 @@ class ProcessingManager(IProcessingManager):
     _handlers: dict[str, Callable[["ProcessingManager", Instrument, str, Any], TriggerEvent | None]]
     _strategy_name: str
 
+    # New IConnector + AccountManager dispatch path (additive, dormant until the
+    # backtester activation PR routes typed ChannelMessage events here). Defaults
+    # keep the existing context.py construction unchanged.
+    _connectors: dict[str, IConnector]
+    _account_manager: AccountManager | None
+    _metrics: Any | None
+
     _trigger_on_time_event: bool = False
     _fit_is_running: bool = False
     _warmup_finished_is_running: bool = False
@@ -117,6 +149,9 @@ class ProcessingManager(IProcessingManager):
         delisting_detector: DelistingDetector,
         exporter: ITradeDataExport | None = None,
         data_throttler: "InstrumentThrottler | None" = None,
+        connectors: dict[str, IConnector] | None = None,
+        account_manager: AccountManager | None = None,
+        metrics: Any | None = None,
     ):
         self._context = context
         self._strategy = strategy
@@ -134,6 +169,9 @@ class ProcessingManager(IProcessingManager):
         self._health_monitor = health_monitor
         self._delisting_detector = delisting_detector
         self._data_throttler = data_throttler
+        self._connectors = connectors or {}
+        self._account_manager = account_manager
+        self._metrics = metrics
         self._cache = market_data.get_market_data_cache()
 
         # Initialize stale data detector with default disabled state
@@ -341,6 +379,126 @@ class ProcessingManager(IProcessingManager):
             if self._context.emitter is not None:
                 self._context.emitter.notify(self._context)
         return should_stop
+
+    def process_event(self, event: ChannelMessage) -> None:
+        """New typed-event entry point (dual-path with the legacy process_data).
+
+        The channel-pull loop discriminates by isinstance(msg, ChannelMessage);
+        legacy tuple-emitting paths keep flowing through process_data. Wiring of
+        this entry into the runtime loop happens in the backtester activation PR.
+        """
+        if isinstance(event, MarketDataMessage):
+            self._dispatch_market_data(event)
+            return
+        if isinstance(event, AccountMessage):
+            self._dispatch_account(event)
+            return
+        if isinstance(event, ErrorEvent):
+            self._safe_call(self._strategy.on_error, event.error)
+            return
+        if isinstance(event, CustomEvent):
+            self._safe_call(self._strategy.on_event, event)
+            return
+        logger.warning(f"unknown event type: {type(event)}")
+
+    def _dispatch_market_data(self, event: MarketDataMessage) -> None:
+        if isinstance(event, QuoteEvent):
+            if self._account_manager is not None:
+                self._account_manager.on_market_quote(event.instrument, event.quote)
+            self._safe_call(self._strategy.on_quote, event.instrument, event.quote)
+        elif isinstance(event, TradeEvent):
+            self._safe_call(self._strategy.on_trade, event.instrument, event.trade)
+        elif isinstance(event, OrderBookEvent):
+            self._safe_call(self._strategy.on_orderbook, event.instrument, event.orderbook)
+
+    def _dispatch_account(self, event: AccountMessage) -> None:
+        assert self._account_manager is not None
+        try:
+            updated = self._account_manager.apply(event)
+        except InvalidOrderTransition as e:
+            logger.warning(f"invalid transition: {e}; skipping")
+            return
+        except Exception:
+            logger.exception(f"AM.apply raised on {type(event).__name__}")
+            self._inc_metric("account_manager_apply_errors", {"event": type(event).__name__})
+            return
+        self._safe_fire_account_callback(event, updated)
+
+    def _safe_call(self, fn, *args) -> None:
+        try:
+            fn(self._context, *args)
+        except Exception:
+            name = getattr(fn, "__name__", repr(fn))
+            logger.exception(f"strategy callback {name} raised")
+            self._inc_metric("strategy_callback_errors", {"callback": name})
+
+    def _inc_metric(self, name: str, labels: dict[str, str]) -> None:
+        if self._metrics is not None:
+            self._metrics.inc(name, labels=labels)
+
+    def _safe_fire_account_callback(self, event, updated) -> None:
+        match event:
+            case OrderPartiallyFilledEvent():
+                self._safe_call(self._strategy.on_order_partially_filled, updated, event.fill)
+                self._notify_downstream_fill(event.instrument, updated, event.fill)
+            case OrderFilledEvent():
+                self._safe_call(self._strategy.on_order_filled, updated, event.fill)
+                self._notify_downstream_fill(event.instrument, updated, event.fill)
+            case OrderAcceptedEvent():
+                self._safe_call(self._strategy.on_order_accepted, updated)
+            case OrderCanceledEvent():
+                self._safe_call(self._strategy.on_order_canceled, updated)
+            case OrderExpiredEvent():
+                self._safe_call(self._strategy.on_order_expired, updated)
+            case OrderUpdatedEvent():
+                self._safe_call(self._strategy.on_order_updated, updated)
+            case OrderRejectedEvent():
+                self._safe_call(self._strategy.on_order_rejected, updated, event.reason)
+            case OrderCancelRejectedEvent():
+                self._safe_call(self._strategy.on_order_cancel_rejected, updated, event.reason)
+            case OrderUpdateRejectedEvent():
+                self._safe_call(self._strategy.on_order_update_rejected, updated, event.reason)
+            case PositionUpdateEvent():
+                self._safe_call(self._strategy.on_position_update, updated)
+            case BalanceUpdateEvent():
+                self._safe_call(self._strategy.on_balance_update, updated)
+            case FundingPaymentEvent():
+                self._safe_call(self._strategy.on_funding_payment, event.payment)
+            case AccountSnapshotEvent():
+                pass
+            case _:
+                logger.warning(f"unhandled AccountMessage callback: {type(event)}")
+
+    def _notify_downstream_fill(self, instrument: Instrument, order: Order, fill: Deal) -> None:
+        try:
+            self._position_gathering.on_execution_report(self._context, instrument, fill)
+            self._get_tracker_for(instrument).on_execution_report(self._context, instrument, fill)
+        except Exception:
+            logger.exception("downstream fill consumer raised")
+        if self._exporter is not None:
+            try:
+                quote = self._market_data.quote(instrument)
+                if quote is not None:
+                    self._exporter.export_position_changes(
+                        time=self._time_provider.time(),
+                        instrument=instrument,
+                        price=quote.mid_price(),
+                        account=self._account_manager,
+                        metadata=None,
+                    )
+            except Exception:
+                logger.exception("exporter raised")
+        self._universe_manager.on_alter_position(instrument)
+        if getattr(self._context, "emitter", None) is not None:
+            try:
+                self._context.emitter.emit_deals(
+                    time=self._time_provider.time(),
+                    instrument=instrument,
+                    deals=[fill],
+                    account=self._account_manager,
+                )
+            except Exception:
+                logger.exception("emitter raised")
 
     def is_fitted(self) -> bool:
         return self._context._strategy_state.is_on_fit_called

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -40,7 +40,6 @@ from qubx.core.events import (
     FundingPaymentEvent,
     MarketDataMessage,
     OrderAcceptedEvent,
-    OrderBookEvent,
     OrderCanceledEvent,
     OrderCancelRejectedEvent,
     OrderExpiredEvent,
@@ -51,7 +50,6 @@ from qubx.core.events import (
     OrderUpdateRejectedEvent,
     PositionUpdateEvent,
     QuoteEvent,
-    TradeEvent,
 )
 from qubx.core.exceptions import InvalidOrderTransition, StrategyExceededMaxNumberOfRuntimeFailuresError
 from qubx.core.helpers import BasicScheduler, process_schedule_spec
@@ -402,14 +400,13 @@ class ProcessingManager(IProcessingManager):
         logger.warning(f"unknown event type: {type(event)}")
 
     def _dispatch_market_data(self, event: MarketDataMessage) -> None:
-        if isinstance(event, QuoteEvent):
-            if self._account_manager is not None:
-                self._account_manager.on_market_quote(event.instrument, event.quote)
-            self._safe_call(self._strategy.on_quote, event.instrument, event.quote)
-        elif isinstance(event, TradeEvent):
-            self._safe_call(self._strategy.on_trade, event.instrument, event.trade)
-        elif isinstance(event, OrderBookEvent):
-            self._safe_call(self._strategy.on_orderbook, event.instrument, event.orderbook)
+        # Market data through the typed path does ONLY AM mark-to-market. The
+        # strategy's market-data delivery stays on the existing on_market_data ->
+        # signals path; the redesign does not change market-data dispatch. IStrategy
+        # has no on_quote/on_trade/on_orderbook (only on_market_data(MarketEvent)),
+        # and re-routing here would bypass signal processing.
+        if isinstance(event, QuoteEvent) and self._account_manager is not None:
+            self._account_manager.on_market_quote(event.instrument, event.quote)
 
     def _dispatch_account(self, event: AccountMessage) -> None:
         assert self._account_manager is not None

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -1,8 +1,19 @@
 from typing import Any, cast
 
 from qubx import logger
-from qubx.core.basics import Instrument, MarketType, Order, OrderRequest, OrderSide, OrderType
-from qubx.core.exceptions import InvalidOrderSize, OrderNotFound
+from qubx.core.account_manager import AccountManager
+from qubx.core.basics import (
+    Instrument,
+    MarketType,
+    Order,
+    OrderOrigin,
+    OrderRequest,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+)
+from qubx.core.connector import IConnector
+from qubx.core.exceptions import InvalidOrderSize, OrderAlreadyTerminal, OrderNotFound
 from qubx.core.interfaces import (
     IAccountProcessor,
     IBroker,
@@ -76,6 +87,12 @@ class TradingManager(ITradingManager):
     _client_id_store: ClientIdStore
     _exchange_to_broker: dict[str, IBroker]
 
+    # New IConnector + AccountManager path (additive, dormant until the backtester
+    # activation PR wires connectors into the context). Defaults keep the existing
+    # broker/account construction in context.py unchanged.
+    _connectors: dict[str, IConnector]
+    _account_manager: AccountManager | None
+
     def __init__(
         self,
         context: IStrategyContext,
@@ -83,6 +100,8 @@ class TradingManager(ITradingManager):
         account: IAccountProcessor,
         health_monitor: IHealthMonitor,
         strategy_name: str,
+        connectors: dict[str, IConnector] | None = None,
+        account_manager: AccountManager | None = None,
     ) -> None:
         self._context = context
         self._brokers = brokers
@@ -91,6 +110,8 @@ class TradingManager(ITradingManager):
         self._strategy_name = strategy_name
         self._client_id_store = ClientIdStore()
         self._exchange_to_broker = {broker.exchange(): broker for broker in brokers}
+        self._connectors = connectors or {}
+        self._account_manager = account_manager
 
     def trade(
         self,
@@ -101,6 +122,9 @@ class TradingManager(ITradingManager):
         client_id: str | None = None,
         **options,
     ) -> Order | None:
+        if self._has_connector(instrument.exchange) and self._account_manager is not None:
+            return self._trade_via_connector(instrument, amount, price, time_in_force, client_id, **options)
+
         size_adj = self._adjust_size(instrument, amount)
         side = self._get_side(amount)
         type = self._get_order_type(instrument, price, options)
@@ -138,6 +162,101 @@ class TradingManager(ITradingManager):
             self._account.process_order_request(request)
 
         return order
+
+    def _trade_via_connector(
+        self,
+        instrument: Instrument,
+        amount: float,
+        price: float | None,
+        time_in_force: str,
+        client_id: str | None,
+        **options,
+    ) -> Order:
+        size_adj = self._adjust_size(instrument, amount)
+        side = self._get_side(amount)
+        type_ = self._get_order_type(instrument, price, options)
+        price = self._adjust_price(instrument, price, amount)
+        base_cid = client_id or self._client_id_store.generate_id(self._context, instrument.symbol)
+        connector = self._get_connector(instrument.exchange)
+        cid = connector.make_client_id(base_cid)
+
+        order = Order(
+            client_order_id=cid,
+            venue_order_id=None,
+            origin=OrderOrigin.FRAMEWORK,
+            type=cast(OrderType, type_.upper()),
+            instrument=instrument,
+            time=self._context.time(),
+            quantity=size_adj,
+            price=price or 0.0,
+            side=side,
+            status=OrderStatus.SUBMITTED,
+            time_in_force=time_in_force,
+            reduce_only=options.get("reduce_only", False),
+            post_only=options.get("post_only", False),
+            options=options,
+        )
+
+        if self._health_monitor:
+            self._health_monitor.record_order_submit_request(
+                exchange=instrument.exchange,
+                client_id=cid,
+                event_time=self._context.time(),
+            )
+
+        request = OrderRequest(
+            client_id=cid,
+            instrument=instrument,
+            quantity=size_adj,
+            price=price,
+            order_type=cast(OrderType, type_.upper()),
+            side=side,
+            time_in_force=time_in_force,
+            options=options,
+        )
+
+        # A synchronous raise from submit_order means no add_order call, so the
+        # AccountManager cache never holds an order the venue rejected outright.
+        connector.submit_order(request)
+        assert self._account_manager is not None
+        self._account_manager.add_order(connector.exchange_name, order)
+        return order
+
+    def cancel(self, order_or_cid) -> None:
+        assert self._account_manager is not None
+        cid = order_or_cid.client_order_id if hasattr(order_or_cid, "client_order_id") else order_or_cid
+        order = self._account_manager.get_order(cid)
+        if order is None:
+            raise OrderNotFound(cid)
+        # Idempotent: cancelling an already-settled or in-flight-cancel order is a no-op.
+        if order.status.is_terminal() or order.status is OrderStatus.PENDING_CANCEL:
+            return
+        exchange = order.instrument.exchange
+        self._account_manager.transition_order(exchange, cid, OrderStatus.PENDING_CANCEL)
+        self._get_connector(exchange).cancel_order(
+            client_order_id=order.client_order_id,
+            venue_order_id=order.venue_order_id,
+        )
+
+    def update(self, order_or_cid, *, price: float | None = None, quantity: float | None = None) -> None:
+        assert self._account_manager is not None
+        cid = order_or_cid.client_order_id if hasattr(order_or_cid, "client_order_id") else order_or_cid
+        order = self._account_manager.get_order(cid)
+        if order is None:
+            raise OrderNotFound(cid)
+        # Unlike cancel, updating a settled order is meaningful misuse, not a no-op.
+        if order.status.is_terminal():
+            raise OrderAlreadyTerminal(cid, order.status)
+        if order.status is OrderStatus.PENDING_UPDATE:
+            return
+        exchange = order.instrument.exchange
+        self._account_manager.transition_order(exchange, cid, OrderStatus.PENDING_UPDATE)
+        self._get_connector(exchange).update_order(
+            client_order_id=order.client_order_id,
+            venue_order_id=order.venue_order_id,
+            price=price,
+            quantity=quantity,
+        )
 
     def trade_async(
         self,
@@ -604,3 +723,15 @@ class TradingManager(ITradingManager):
         if exchange in EXCHANGE_MAPPINGS and EXCHANGE_MAPPINGS[exchange] in self._exchange_to_broker:
             return self._exchange_to_broker[EXCHANGE_MAPPINGS[exchange]]
         raise ValueError(f"Broker for exchange {exchange} not found")
+
+    def _has_connector(self, exchange: str) -> bool:
+        return exchange in self._connectors or (
+            exchange in EXCHANGE_MAPPINGS and EXCHANGE_MAPPINGS[exchange] in self._connectors
+        )
+
+    def _get_connector(self, exchange: str) -> IConnector:
+        if exchange in self._connectors:
+            return self._connectors[exchange]
+        if exchange in EXCHANGE_MAPPINGS and EXCHANGE_MAPPINGS[exchange] in self._connectors:
+            return self._connectors[EXCHANGE_MAPPINGS[exchange]]
+        raise ValueError(f"Connector for exchange {exchange} not found")

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -232,6 +232,7 @@ class TradingManager(ITradingManager):
         if order.status.is_terminal() or order.status is OrderStatus.PENDING_CANCEL:
             return
         exchange = order.instrument.exchange
+        # TODO(account-mgmt): exchange-key convention — add_order keys AM state by connector.exchange_name; transition_order looks up self._states[exchange] unmapped. Reconcile the key convention (EXCHANGE_MAPPINGS) when the activation PR wires connectors.
         self._account_manager.transition_order(exchange, cid, OrderStatus.PENDING_CANCEL)
         self._get_connector(exchange).cancel_order(
             client_order_id=order.client_order_id,
@@ -250,6 +251,7 @@ class TradingManager(ITradingManager):
         if order.status is OrderStatus.PENDING_UPDATE:
             return
         exchange = order.instrument.exchange
+        # TODO(account-mgmt): exchange-key convention — add_order keys AM state by connector.exchange_name; transition_order looks up self._states[exchange] unmapped. Reconcile the key convention (EXCHANGE_MAPPINGS) when the activation PR wires connectors.
         self._account_manager.transition_order(exchange, cid, OrderStatus.PENDING_UPDATE)
         self._get_connector(exchange).update_order(
             client_order_id=order.client_order_id,

--- a/tests/qubx/core/mixins/test_processing_dispatch.py
+++ b/tests/qubx/core/mixins/test_processing_dispatch.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from qubx.core.basics import Deal
+from qubx.core.events import (
+    OrderAcceptedEvent,
+    OrderFilledEvent,
+    QuoteEvent,
+)
+
+
+def _pm():
+    from qubx.core.mixins.processing import ProcessingManager
+
+    pm = ProcessingManager.__new__(ProcessingManager)
+    pm._strategy = MagicMock()
+    pm._account_manager = MagicMock()
+    pm._metrics = MagicMock()
+    pm._context = MagicMock()
+    pm._position_gathering = MagicMock()
+    pm._exporter = None
+    pm._universe_manager = MagicMock()
+    pm._market_data = MagicMock()
+    pm._position_tracker = MagicMock()
+    pm._init_stage_position_tracker = MagicMock()
+    pm._instruments_in_init_stage = set()
+    pm._time_provider = MagicMock()
+    return pm
+
+
+def test_quote_event_calls_on_market_quote_then_strategy():
+    pm = _pm()
+    pm.process_event(QuoteEvent(instrument=None, quote=MagicMock()))
+    pm._account_manager.apply.assert_not_called()
+    pm._account_manager.on_market_quote.assert_called_once()
+    pm._strategy.on_quote.assert_called_once()
+
+
+def test_filled_event_routes_through_am_then_strategy():
+    pm = _pm()
+    updated = MagicMock()
+    pm._account_manager.apply.return_value = updated
+    pm._account_manager.get_position.return_value = MagicMock()
+    fill = Deal(
+        trade_id="t1",
+        order_id="V1",
+        time=np.datetime64("now"),
+        amount=1.0,
+        price=50_000.0,
+        aggressive=True,
+    )
+    pm.process_event(
+        OrderFilledEvent(
+            instrument=MagicMock(),
+            client_order_id="cid",
+            venue_order_id="V1",
+            fill=fill,
+        )
+    )
+    pm._account_manager.apply.assert_called_once()
+    pm._strategy.on_order_filled.assert_called_once()
+
+
+def test_callback_exception_does_not_halt_dispatch():
+    pm = _pm()
+    pm._strategy.on_order_accepted.side_effect = RuntimeError("boom")
+    pm._account_manager.apply.return_value = MagicMock()
+    pm.process_event(
+        OrderAcceptedEvent(
+            instrument=MagicMock(),
+            client_order_id="c",
+            venue_order_id="V",
+            accepted_at=np.datetime64("now"),
+        )
+    )
+    pm._metrics.inc.assert_called()

--- a/tests/qubx/core/mixins/test_processing_dispatch.py
+++ b/tests/qubx/core/mixins/test_processing_dispatch.py
@@ -4,8 +4,10 @@ import numpy as np
 
 from qubx.core.basics import Deal
 from qubx.core.events import (
+    BalanceUpdateEvent,
     OrderAcceptedEvent,
     OrderFilledEvent,
+    PositionUpdateEvent,
     QuoteEvent,
 )
 
@@ -74,3 +76,34 @@ def test_callback_exception_does_not_halt_dispatch():
         )
     )
     pm._metrics.inc.assert_called()
+
+
+def test_position_update_event_passes_payload_not_none():
+    """PositionUpdateEvent must deliver event.position to on_position_update, not None.
+
+    AM.apply has no case for PositionUpdateEvent (returns None). The fix passes
+    event.position directly so the strategy receives the real payload.
+    """
+    pm = _pm()
+    # AM.apply returns None — the dormant code path before the fix
+    pm._account_manager.apply.return_value = None
+
+    sentinel_position = MagicMock(name="sentinel_position")
+    evt = PositionUpdateEvent(instrument=MagicMock(), position=sentinel_position)
+
+    pm.process_event(evt)
+
+    pm._strategy.on_position_update.assert_called_once_with(pm._context, sentinel_position)
+
+
+def test_balance_update_event_passes_payload_not_none():
+    """BalanceUpdateEvent must deliver event.balance to on_balance_update, not None."""
+    pm = _pm()
+    pm._account_manager.apply.return_value = None
+
+    sentinel_balance = MagicMock(name="sentinel_balance")
+    evt = BalanceUpdateEvent(instrument=None, balance=sentinel_balance)
+
+    pm.process_event(evt)
+
+    pm._strategy.on_balance_update.assert_called_once_with(pm._context, sentinel_balance)

--- a/tests/qubx/core/mixins/test_processing_dispatch.py
+++ b/tests/qubx/core/mixins/test_processing_dispatch.py
@@ -29,12 +29,11 @@ def _pm():
     return pm
 
 
-def test_quote_event_calls_on_market_quote_then_strategy():
+def test_quote_event_marks_to_market_only():
     pm = _pm()
     pm.process_event(QuoteEvent(instrument=None, quote=MagicMock()))
     pm._account_manager.apply.assert_not_called()
     pm._account_manager.on_market_quote.assert_called_once()
-    pm._strategy.on_quote.assert_called_once()
 
 
 def test_filled_event_routes_through_am_then_strategy():

--- a/tests/qubx/core/mixins/test_trading_manager.py
+++ b/tests/qubx/core/mixins/test_trading_manager.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from qubx.core.basics import OrderOrigin, OrderStatus
+from qubx.core.exceptions import OrderAlreadyTerminal
+from qubx.core.mixins.trading import TradingManager
+
+
+class _Stub:
+    def generate_id(self, ctx, symbol):
+        return f"qubx-{symbol}-1"
+
+
+class _Ctx:
+    def time(self):
+        return np.datetime64("2026-05-28")
+
+
+def _setup():
+    am = MagicMock()
+    connector = MagicMock()
+    connector.exchange_name = "binance"
+    connector.make_client_id = lambda s: s
+    instrument = MagicMock(exchange="binance", symbol="BTCUSDT")
+    # Instrument size/price adjustment is mocked through pass-through methods so
+    # the test focuses on the new connector/AM path, not rounding logic.
+    instrument.round_size_down = lambda x: x
+    instrument.round_size_up = lambda x: x
+    instrument.round_price_down = lambda x: x
+    instrument.round_price_up = lambda x: x
+    instrument.min_size = 0.0
+    instrument.min_notional = 0.0
+    instrument.lot_size = 0.0
+    instrument.quantity_multiplier = 1.0
+    tm = TradingManager.__new__(TradingManager)
+    tm._account_manager = am
+    tm._connectors = {"binance": connector}
+    tm._context = _Ctx()
+    tm._client_id_store = _Stub()
+    tm._health_monitor = MagicMock()
+    # The shared size-adjustment helpers read the old _account for reduce-only
+    # checks; a mock keeps them inert so the test isolates the new connector path.
+    tm._account = MagicMock()
+    tm._account.get_position.return_value = MagicMock(quantity=0.0)
+    return tm, am, connector, instrument
+
+
+def test_trade_builds_submitted_and_calls_connector_then_am():
+    tm, am, connector, inst = _setup()
+    order = tm.trade(inst, amount=1.0, price=50_000.0)
+    assert order.status is OrderStatus.SUBMITTED
+    assert order.client_order_id == "qubx-BTCUSDT-1"
+    assert order.origin is OrderOrigin.FRAMEWORK
+    connector.submit_order.assert_called_once()
+    am.add_order.assert_called_once_with("binance", order)
+
+
+def test_cancel_terminal_is_noop():
+    tm, am, connector, inst = _setup()
+    am.get_order.return_value = MagicMock(
+        status=OrderStatus.FILLED, instrument=inst, client_order_id="c",
+    )
+    tm.cancel("c")
+    connector.cancel_order.assert_not_called()
+
+
+def test_update_terminal_raises():
+    tm, am, connector, inst = _setup()
+    am.get_order.return_value = MagicMock(
+        status=OrderStatus.FILLED, instrument=inst, client_order_id="c",
+    )
+    with pytest.raises(OrderAlreadyTerminal):
+        tm.update("c", price=51_000.0)


### PR DESCRIPTION
**Stacked on #293 → #292 → #291 → #290 → #289.** Base is `am/05-simulated-connector`.

## Re-scoped (please note)
Split from the backtester end-to-end switch for risk/reviewability. **This PR ships only the framework dual-path logic** — `TradingManager`/`ProcessingManager` gain the new `IConnector`+`AccountManager` path *alongside* the retained old broker/account path, unit-tested with mocks. **Nothing switches at runtime** (no runner wiring, no deletions): `context.py`/runner/trackers are untouched, new `__init__` params default to None, so every exchange takes the OLD path. The full suite — backtester *and* live — stays green. The actual backtester activation (runner wiring, typed events, delete `SimulatedBroker`/`SimulatedAccountProcessor`, paper) is the **next PR**.

## What's in it (4 commits)
- `feat(trading): dual-path TradingManager` — optional `connectors`/`account_manager`; `_has_connector`/`_get_connector` (EXCHANGE_MAPPINGS fallback); `trade` branches to `_trade_via_connector` (build `Order(SUBMITTED, FRAMEWORK)` → `make_client_id` → `connector.submit_order` → `account_manager.add_order`, sync-raise skips add_order); new `cancel`/`update` (idempotent on terminal/PENDING_*, `update` raises `OrderAlreadyTerminal`). Legacy `trade`/`cancel_order`/`update_order`/async untouched.
- `feat(processing): typed-event dispatch with isolated callbacks` — `process_event` + `_dispatch_market_data`/`_dispatch_account`/`_safe_fire_account_callback`/`_safe_call`/`_notify_downstream_fill`/`_inc_metric`. AM.apply in one try/except (`InvalidOrderTransition`→log+skip; broad→log+metric); each strategy callback in its own try/except (never halts). Downstream fill consumers reused as-is (already single-`Deal`). Legacy `_handlers`/`process_data`/`_handle_order`/`_handle_deals` retained.
- `fix(processing): typed market-data path does AM mark-to-market only` — review fix: the typed path only feeds `AccountManager.on_market_quote` on `QuoteEvent`; it does NOT fire strategy market-data callbacks. The redesign does not change market-data dispatch — strategies keep their existing `on_market_data`→signals path (IStrategy has no `on_quote`/`on_trade`/`on_orderbook`, and re-routing would bypass signal processing).
- `fix(processing): pass position/balance payload to callbacks; mark activation TODOs` — review fix: `on_position_update`/`on_balance_update` now get `event.position`/`event.balance` (not the `None` that AM.apply returns for those events).

## Review (two-stage, both ran)
- **Spec-compliance:** ✅ old path 100% intact (verified `context.py`/runner/trackers zero-diff), dual-path detection correct, account dispatch + callback isolation correct, downstream signatures real. Found the market-data-dispatch defect → fixed.
- **Code-quality:** "needs minor work, not blocking" — dual-path is clean and cleanly-deletable later; found the position/balance-callback `None` bug → fixed.

## Tracked for the activation PR (grep `TODO(account-mgmt)`)
- `AccountManager` must satisfy the `IAccountViewer` surface (`account_id`/`get_base_currency`/`get_positions`/`get_balances`) before the exporter/emitter run live.
- Exchange-key convention: `add_order` keys AM state by `connector.exchange_name`; `transition_order` looks up `self._states[exchange]` unmapped — reconcile when wiring connectors.
- AM.apply needs `PositionUpdateEvent`/`BalanceUpdateEvent` cases (state update + routing) when live connectors emit them.
- The channel-pull loop (in `context.py`) must route `isinstance(msg, ChannelMessage)` → `process_event`.

## Tests
`1611 passed, 5 skipped` — full suite green. New: `test_trading_manager.py`, `test_processing_dispatch.py` (new-path trade/cancel/update; QuoteEvent MtM-only; OrderFilled→AM→callback; callback-exception isolation; position/balance payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)