### PR TITLE
Review hardening — rejection boundary fix + SOLID/coupling cleanups (from the holistic review)

### DIFF
--- a/src/qubx/backtester/connector.py
+++ b/src/qubx/backtester/connector.py
@@ -15,7 +15,7 @@ from qubx.core.events import (
     OrderUpdatedEvent,
     OrderUpdateRejectedEvent,
 )
-from qubx.core.exceptions import OrderNotFound
+from qubx.core.exceptions import ExchangeError, InvalidOrder, InvalidOrderParameters, OrderNotFound
 from qubx.core.series import OrderBook, Quote, Trade, TradeArray
 
 
@@ -49,16 +49,32 @@ class SimulatedConnector:
         self.channel.send(event)
 
     def submit_order(self, request: OrderRequest) -> None:
-        report = self._exchange.place_order(
-            instrument=request.instrument,
-            order_side=request.side,
-            order_type=request.order_type,
-            amount=request.quantity,
-            price=request.price,
-            client_id=request.client_id,
-            time_in_force=request.time_in_force,
-            **(request.options or {}),
-        )
+        try:
+            report = self._exchange.place_order(
+                instrument=request.instrument,
+                order_side=request.side,
+                order_type=request.order_type,
+                amount=request.quantity,
+                price=request.price,
+                client_id=request.client_id,
+                time_in_force=request.time_in_force,
+                **(request.options or {}),
+            )
+        except (InvalidOrder, InvalidOrderParameters):
+            # Framework-side rejection (bad side/type/amount/price/TIF) — surface
+            # synchronously so the caller fixes it; never rides the channel.
+            raise
+        except ExchangeError as e:
+            # Venue verdict (e.g. a stop that would trigger immediately) — rides the
+            # channel as OrderRejectedEvent rather than raising. This is the connector
+            # rejection boundary: the same logical failure must take the same path
+            # everywhere, so venue refusals are always async events, not exceptions.
+            self.send(
+                OrderRejectedEvent(
+                    instrument=request.instrument, client_order_id=request.client_id, reason=str(e)
+                )
+            )
+            return
         self._emit_from_report(report)
 
     def cancel_order(self, *, client_order_id: str | None = None, venue_order_id: str | None = None) -> None:

--- a/src/qubx/backtester/runner.py
+++ b/src/qubx/backtester/runner.py
@@ -12,7 +12,7 @@ from qubx.core.account_manager import SimulationAccountManager
 from qubx.core.account_manager_config import AccountManagerConfig
 from qubx.core.basics import SW, Balance, DataType, Instrument, TransactionCostsCalculator
 from qubx.core.context import StrategyContext
-from qubx.core.events import ScheduledEvent, event_for_data_type
+from qubx.core.events import MARKET_DATA_TYPES, ScheduledEvent, event_for_data_type
 from qubx.core.exceptions import SimulationConfigError, SimulationError
 from qubx.core.helpers import extract_parameters_from_object, full_qualified_class_name
 from qubx.core.initializer import BasicStrategyInitializer
@@ -28,7 +28,6 @@ from qubx.core.interfaces import (
 )
 from qubx.core.loggers import StrategyLogging
 from qubx.core.lookups import lookup
-from qubx.core.mixins.processing import ProcessingManager
 from qubx.core.series import OrderBook, Quote, Trade, TradeArray
 from qubx.core.utils import time_delta_to_str
 from qubx.data.cache import CachedStorage, MemoryCache
@@ -259,14 +258,14 @@ class SimulationRunner:
         return cc.control.is_set()
 
     def _send_market_data(self, instrument: Instrument, data_type: str, data: Any, is_hist: bool) -> None:
-        # Live market-data types that have a typed event go on the channel as that event
-        # (routed to ProcessingManager.process_event). Historical batches and live types
-        # without a typed event (e.g. features/record) stay tuples on the __process_data
-        # path. The convertible set mirrors the process_data adapter so both producers and
-        # the adapter agree on what becomes a typed event.
+        # Live market-data types with a typed event go on the channel as that event
+        # (routed to process_event). Historical batches and live types without a typed
+        # event (e.g. features/record) stay tuples on the __process_data path. The
+        # convertible set (events.MARKET_DATA_TYPES) is shared with the process_data
+        # adapter so producer and adapter agree on what becomes a typed event.
         # TODO(account-mgmt): historical batches still ride the tuple/__process_data path;
         # PR10 revisits converting warmup data to typed historical events.
-        if is_hist or DataType.from_str(data_type)[0] not in ProcessingManager._LIVE_MARKET_DATA_TYPES:
+        if is_hist or DataType.from_str(data_type)[0] not in MARKET_DATA_TYPES:
             self.channel.send((instrument, data_type, data, is_hist))
         else:
             self.channel.send(event_for_data_type(data_type, instrument=instrument, payload=data))

--- a/src/qubx/core/account_manager.py
+++ b/src/qubx/core/account_manager.py
@@ -18,6 +18,7 @@ from qubx.core.basics import (
 from qubx.core.events import (
     AccountMessage,
     AccountSnapshotEvent,
+    BalanceUpdateEvent,
     FundingPaymentEvent,
     OrderAcceptedEvent,
     OrderCanceledEvent,
@@ -28,6 +29,7 @@ from qubx.core.events import (
     OrderRejectedEvent,
     OrderUpdatedEvent,
     OrderUpdateRejectedEvent,
+    PositionUpdateEvent,
     ReconcileDiff,
 )
 from qubx.core.exceptions import InvalidOrderTransition
@@ -87,6 +89,12 @@ class AccountManager:
         tcc: TransactionCostsCalculator | None = None,
     ):
         self._pm = pm
+        self._init_state(connectors=connectors, strategy=strategy, time=time, cfg=cfg, account_id=account_id, tcc=tcc)
+        self._register_ticks()
+
+    def _init_state(self, *, connectors, strategy, time, cfg, account_id, tcc) -> None:
+        # Shared field init for both the live and simulation managers, so the
+        # subclass can't silently drift from the parent's field set.
         self._connectors = connectors
         self._strategy = strategy
         self._time = time
@@ -99,12 +107,14 @@ class AccountManager:
         # (evict old buckets) in a later PR.
         self._applied_funding_buckets: dict[str, set] = {}
         self._ctx = None  # set via set_context once StrategyContext is built
+
+    def _register_ticks(self) -> None:
         if self._cfg.inflight_check_interval_ms > 0:
-            pm.schedule(_ms_to_cron(self._cfg.inflight_check_interval_ms), self._on_inflight_tick)
+            self._pm.schedule(_ms_to_cron(self._cfg.inflight_check_interval_ms), self._on_inflight_tick)
         if self._cfg.snapshot_check_interval_ms > 0:
-            pm.schedule(_ms_to_cron(self._cfg.snapshot_check_interval_ms), self._on_snapshot_tick)
+            self._pm.schedule(_ms_to_cron(self._cfg.snapshot_check_interval_ms), self._on_snapshot_tick)
         if self._cfg.liveness_check_interval_ms > 0:
-            pm.schedule(_ms_to_cron(self._cfg.liveness_check_interval_ms), self._on_liveness_tick)
+            self._pm.schedule(_ms_to_cron(self._cfg.liveness_check_interval_ms), self._on_liveness_tick)
 
     def set_context(self, ctx) -> None:
         """Wire the IStrategyContext after construction.
@@ -246,6 +256,14 @@ class AccountManager:
                 return self._handle_snapshot(state, event)
             case FundingPaymentEvent():
                 return self._handle_funding_payment(state, event)
+            case PositionUpdateEvent() | BalanceUpdateEvent():
+                # No connector emits these yet; positions/balances are derived from
+                # fills and corrected by snapshot reconcile. PM still fires the
+                # on_position_update/on_balance_update callback off the event payload.
+                # TODO(account-mgmt): apply venue WS position/balance to AccountState
+                # here (via _set_position/_update_balance) when the live connectors emit
+                # them (PR 7), with the same freshness/ratchet guard as snapshot reconcile.
+                return None
             case _:
                 logger.warning(f"unhandled AccountMessage: {type(event)}")
                 return None
@@ -841,13 +859,5 @@ class SimulationAccountManager(AccountManager):
         tcc: TransactionCostsCalculator | None = None,
     ):
         self._pm = None
-        self._connectors = connectors
-        self._strategy = strategy
-        self._time = time
-        self._cfg = cfg or AccountManagerConfig()
-        self.account_id = account_id
-        self._tcc = tcc
-        self._states = {ex: AccountState(exchange=ex) for ex in connectors}
-        self._liveness_unready_since = {}
-        self._applied_funding_buckets = {}
-        self._ctx = None
+        self._init_state(connectors=connectors, strategy=strategy, time=time, cfg=cfg, account_id=account_id, tcc=tcc)
+        # Backtest has no asyncio/WS/periodic scheduling — no ticks registered.

--- a/src/qubx/core/events.py
+++ b/src/qubx/core/events.py
@@ -208,6 +208,23 @@ class CustomEvent(ChannelMessage):
     payload: Any
 
 
+# Base DataTypes that map to a typed market-data event (the set event_for_data_type
+# converts). Producers and the process_data adapter share this constant to agree on
+# what becomes a typed event vs. what stays on the tuple path.
+MARKET_DATA_TYPES: frozenset = frozenset(
+    {
+        DataType.QUOTE,
+        DataType.TRADE,
+        DataType.ORDERBOOK,
+        DataType.OHLC,
+        DataType.FUNDING_RATE,
+        DataType.OPEN_INTEREST,
+        DataType.LIQUIDATION,
+        DataType.FUNDING_PAYMENT,
+    }
+)
+
+
 def event_for_data_type(
     data_type: str | DataType,
     *,

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -29,6 +29,7 @@ from qubx.core.basics import (
 from qubx.core.detectors import DelistingDetector, StaleDataDetector
 from qubx.core.errors import BaseErrorEvent
 from qubx.core.events import (
+    MARKET_DATA_TYPES,
     AccountMessage,
     AccountSnapshotEvent,
     BalanceUpdateEvent,
@@ -380,23 +381,9 @@ class ProcessingManager(IProcessingManager):
         for m in metrics:
             ctx.emitter.emit(m["name"], m["value"], m["tags"])
 
-    # Base DataTypes routed as typed market-data events.
-    _LIVE_MARKET_DATA_TYPES: frozenset = frozenset(
-        {
-            DataType.QUOTE,
-            DataType.TRADE,
-            DataType.ORDERBOOK,
-            DataType.OHLC,
-            DataType.FUNDING_RATE,
-            DataType.OPEN_INTEREST,
-            DataType.LIQUIDATION,
-            DataType.FUNDING_PAYMENT,
-        }
-    )
-
     def process_data(self, instrument: Instrument, d_type: str, data: Any, is_historical: bool) -> bool:
         base, params = DataType.from_str(d_type) if d_type else (None, {})
-        if not is_historical and base in self._LIVE_MARKET_DATA_TYPES:
+        if not is_historical and base in MARKET_DATA_TYPES:
             # OHLC arrives as the bare base type from the simulator; OhlcEvent needs a
             # timeframe, so label it with the cache's default before wrapping. (The
             # live OHLC cache buckets off the Bar itself, not this string — the

--- a/tests/qubx/backtester/test_simulated_connector.py
+++ b/tests/qubx/backtester/test_simulated_connector.py
@@ -22,7 +22,7 @@ from qubx.core.events import (
     OrderRejectedEvent,
     OrderUpdatedEvent,
 )
-from qubx.core.exceptions import QueueTimeout
+from qubx.core.exceptions import InvalidOrder, QueueTimeout
 from qubx.core.lookups import lookup
 from qubx.core.series import Quote
 from qubx.core.utils import recognize_time
@@ -300,6 +300,46 @@ def test_submit_stop_order_options_forwarded_to_ome(setup):
     order = next(iter(open_orders.values()))
     assert order.options.get(OPTION_FILL_AT_SIGNAL_PRICE) is True
     assert order.options.get(OPTION_AVOID_STOP_ORDER_PRICE_VALIDATION) is True
+
+
+def test_submit_would_trigger_stop_emits_rejected_not_raises(setup):
+    # A BUY STOP_MARKET below the ask "would trigger immediately" (OME: BUY triggers
+    # when ask >= stop price) — a venue verdict. Per the connector rejection boundary
+    # it must ride the channel as an OrderRejectedEvent, NOT raise out of submit_order.
+    conn, channel, _exchange, instr, _time = setup
+    request = OrderRequest(
+        client_id="qubx-stop-reject",
+        instrument=instr,
+        quantity=0.1,
+        price=31500.0,  # below ask 32001 -> BUY stop would trigger immediately
+        side="BUY",
+        order_type="STOP_MARKET",
+        time_in_force="gtc",
+    )
+    conn.submit_order(request)  # must not raise
+    events = _drain(channel)
+    rejects = [e for e in events if isinstance(e, OrderRejectedEvent)]
+    assert len(rejects) == 1, events
+    assert rejects[0].client_order_id == "qubx-stop-reject"
+    assert "would trigger" in rejects[0].reason.lower()
+    assert not any(isinstance(e, OrderAcceptedEvent) for e in events)
+
+
+def test_submit_invalid_amount_raises(setup):
+    # Framework-side rejection (amount <= 0) must raise synchronously — it is the
+    # caller's bug to fix, not a venue verdict that rides the channel.
+    conn, _channel, _exchange, instr, _time = setup
+    request = OrderRequest(
+        client_id="qubx-bad",
+        instrument=instr,
+        quantity=-1.0,
+        price=32000.0,
+        side="BUY",
+        order_type="LIMIT",
+        time_in_force="gtc",
+    )
+    with pytest.raises(InvalidOrder):
+        conn.submit_order(request)
 
 
 def test_stop_order_fills_at_signal_price_not_bbo(setup):

--- a/tests/qubx/core/test_typed_market_data_dispatch.py
+++ b/tests/qubx/core/test_typed_market_data_dispatch.py
@@ -197,7 +197,6 @@ def test_process_data_routes_live_market_data_through_process_event():
     instr = _instrument()
     quote = Quote(0, 100.0, 101.0, 1.0, 1.0)
     pm = Mock()
-    pm._LIVE_MARKET_DATA_TYPES = ProcessingManager._LIVE_MARKET_DATA_TYPES
     pm._context = Mock()
     pm._context.emitter = None
 
@@ -216,7 +215,6 @@ def test_process_data_historical_falls_to_legacy_path():
     instr = _instrument()
     quote = Quote(0, 100.0, 101.0, 1.0, 1.0)
     pm = Mock()
-    pm._LIVE_MARKET_DATA_TYPES = ProcessingManager._LIVE_MARKET_DATA_TYPES
     pm._context = Mock()
     pm._context.emitter = None
 


### PR DESCRIPTION
**Stacked on #296.** Addresses the actionable findings from the full architecture review of PRs #289–#296 (SOLID / DRY / coupling / design-doc conformance). Scoped to the one Critical bug + the three low-effort Important items; the larger refactors (PM god-object decomposition, the 3-way market-data match-table → registry) are deliberately deferred to PR 10 cleanup to avoid churning the stack.

## Fixes

**🔴 Critical — connector rejection boundary**
`SimulatedConnector.submit_order` wrapped `place_order` with no `try/except`, so a venue-verdict failure (e.g. a stop that *would trigger immediately* → `ExchangeError`, [ome.py:409](src/qubx/backtester/ome.py#L409)) escaped as a synchronous exception out of `ctx.trade()` instead of arriving as `on_order_rejected`. This violated the design's hard rejection-boundary rule and was untested (the resting-stop tests pass `avoid_stop_order_price_validation`). Now: venue-verdict `ExchangeError` → `OrderRejectedEvent` on the channel; framework-side `InvalidOrder`/`InvalidOrderParameters` still raise. + 2 tests (would-trigger stop emits-not-raises; invalid amount raises).

**🟠 Coupling / layering** — lifted the convertible market-data type set to a shared public constant `events.MARKET_DATA_TYPES`. `ProcessingManager` and the backtester `runner` now both import it, instead of `runner` reaching into `ProcessingManager._LIVE_MARKET_DATA_TYPES` (a private class attr) — removes the backtester→core-internals reach. Dropped the now-dead `ProcessingManager` import in `runner.py`.

**🟠 LSP / drift** — extracted `AccountManager._init_state()` + `_register_ticks()`. `SimulationAccountManager.__init__` was hand-duplicating the parent's entire field-init to skip tick scheduling (and had already drifted by one field). Both managers now share `_init_state`; only tick registration differs.

**🟠 OCP gap** — `apply()` now has an explicit `case PositionUpdateEvent() | BalanceUpdateEvent()` (was falling to the `case _` warning). No connector emits these yet — the strategy callback still fires off the event payload in PM; a `TODO(account-mgmt)` marks the PR 7 venue-WS state-application wiring.

## Design-doc back-ports (local-only docs, not committed)
- `§TradingManager.trade()`: corrected to **add-to-AM before submit + rollback-to-REJECTED on raise** (the doc's submit-then-add ordering would reintroduce phantom EXTERNAL orders for synchronous connectors — a latent bug the implementation already avoids).
- `§read-API get_orders`: documented the terminal-order filtering (live-only public view while terminals linger in the retention window).

## Verification
- **Full suite: 1660 passed, 7 skipped, 0 failed** (1658 + 2 new C1 tests). ruff clean across all changed files.
- **MACD parity OK** — signal set byte-identical to the baseline (116 signals); these changes are behavior-neutral for the backtester.
- `_LIVE_MARKET_DATA_TYPES` fully removed (now `events.MARKET_DATA_TYPES`).

## Review verdict recap (for context)
The holistic review found the architecture **sound and design-conformant**: clean 7-layer DAG, no import cycles, channel-decoupled connectors (no AM/PM back-refs), no cross-mixin private-state spaghetti, SOLID at every boundary, **zero undocumented deviations**. Deferred to PR 10: decompose `ProcessingManager` (extract `DataReadinessGate`/`StateSnapshotWriter`), collapse the 3 parallel market-data match tables into one registry, plus the existing connector-fidelity items (update_order fill-awareness, request_order_status) that land naturally with the CCXT port (PR 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)