### PR TITLE
Q1: account-manager redesign — additive core + state machine

### DIFF
--- a/ACCOUNT_MANAGEMENT_PLAN.md
+++ b/ACCOUNT_MANAGEMENT_PLAN.md
@@ -1,0 +1,178 @@
+# Account management redesign — Qubx rollout plan
+
+Qubx-side rollout of the account-management redesign. This doc covers only the work
+that lands in **this repo** (`qubx`), plus the coordination touchpoints where qubx meets
+the exchanges repo and the downstream release. The exchanges-repo PR sequence (E1–E3) and
+venue-adapter internals are out of scope here — they live in the exchanges repo.
+
+See `account-management-design` for the full architecture (event hierarchy, `AccountManager`,
+state machine, `IConnector` contract, conformance suite, decided defaults).
+
+## Approach
+
+- **No feature flag.** All work happens on a long-lived `feat/*` branch. Intermediate PRs
+  against that branch are allowed to leave branch CI red. The final coordinated merge restores
+  green. The cost of a flag (`QUBX_USE_NEW_ACCOUNT=1`-style gates threaded through
+  `StrategyContext` and dispatch) is not worth paying when nothing on `main` depends on the branch.
+- `main` stays green throughout the rollout. Non-redesign work (bug fixes, features, security
+  patches) lands on `main` independently. The feature branch periodically rebases / merges `main`
+  into itself to stay current.
+
+## Branch layout
+
+| Repo | Branch | Off |
+|---|---|---|
+| `qubx` | `feat/account-manager-redesign` | `main` |
+
+The branch stays alive for weeks and takes multiple small, independently reviewable PRs.
+`main` is untouched until the coordinated merge at the end.
+
+**Branch CI stays red from Q2 until Q4.** This is intentional — the migration window has
+half-built state. Q3 greens the backtester but CCXT conformance keeps broad CI red until Q4
+brings the live path home. Use the new test suite (Q1 state-machine tests + Q3 backtester
+strategy tests) as the green signal during that window rather than broad CI.
+
+## PR sequence (`feat/account-manager-redesign`)
+
+| # | Scope | Branch CI |
+|---|---|---|
+| **Q1** | Add new modules: event hierarchy (`ChannelMessage` / `AccountMessage` / `MarketDataMessage` + all leaves), `AccountState`, `AccountManager`, `SimulationAccountManager`, `_ms_to_cron`, `IConnector` Protocol. No callers yet. Unit tests for `AccountManager` + state machine (the most bug-prone part — heavy coverage here, in-process, no I/O). | **Green** (additive only). |
+| **Q2** | Replace `TradingManager` + `ProcessingManager` + `StrategyContext` wiring with the new path. `ctx.trade` returns `Order(SUBMITTED)`; `ctx.cancel` / `ctx.update` become void. Old `IBroker` / `IAccountProcessor` still exist but unused. `SimulatedBroker` / `SimulatedAccountProcessor` tests break here. | **Red** (backtester + simulated connector tests fail; expected). |
+| **Q3** | Migrate `SimulatedConnector` + `SimulationAccountManager` wiring. Backtester runs on the new path. Backtester strategy-level tests for the full lifecycle (submit→fill, cancel happy/rejected, update happy/rejected, stuck-order recovery). | Green for backtester; CCXT connector still red. |
+| **Q4** | Migrate CCXT connector to `IConnector`. Run the exchanges-repo conformance suite (via git source) against the backtester in-process for fast feedback, then Binance testnet manually. | **Green**. |
+| **Q5** | Strategy-side audit across downstream strategy repos. Run the migration greps from `account-management-design#Migration`. Delete `IBroker`, `IAccountProcessor`, `BasicAccountProcessor`, `CompositeAccountProcessor`, `process_order_request`, `send_order_async` and friends. Tag release candidate. | **Green**. |
+
+Each PR is independently reviewable. Q1 lands without breaking anything. Q2 deliberately
+breaks things on the branch and won't recover until Q3. Q4 brings the live path home. Q5 is
+the cleanup + audit pass.
+
+## Test layering (qubx-owned layers)
+
+Two qubx-owned test layers (the third, exchanges conformance, lives in the exchanges repo).
+No duplication across layers.
+
+- **qubx core** — `tests/qubx/core/account_manager_test.py` (lands in Q1). Pure unit tests
+  against `AccountManager` + `AccountState` with a mock connector. State machine transition
+  table, illegal-transition raises, `pre_pending_status` capture/clear, fill dedup via
+  `trade_id`, snapshot reconcile rules (grace window, freshness check),
+  `_inflight_index` / `_pending_evict_index` membership.
+  **The state machine is the bug-magnet — test it heavily here, in-process, no I/O.**
+  State-machine tests live in qubx core (not exchanges/conformance); they need no connector at all.
+
+- **qubx backtester** — `tests/qubx/backtester/` (lands in Q3). `SimulatedConnector` +
+  `SimulationAccountManager` strategy-level tests. End-to-end lifecycle assertions per the 17
+  conformance scenarios in `account-management-design#Conformance test suite`. The backtester
+  is the de facto in-process conformance host — fast, deterministic, no testnet creds.
+  **Stuck-order-recovery scenario wiring:** configure the `SimulatedConnector` to withhold the
+  ack for a submitted order (simulate venue silence), arm the in-flight sweep for that test
+  (`register_inflight_tick=True`), then advance simulated time past the thresholds (≥5s age, ≥2s
+  tick). `SimulationRunner`'s time pump fires the `SimulatedScheduler` → `_sweep_stuck_inflight`
+  → `request_order_status` → the connector replies `'open'` (`SUBMITTED→ACCEPTED`) or keeps
+  failing (`SUBMITTED→REJECTED` after N retries). Fully in-process and deterministic.
+
+**Bonus:** the exchanges conformance suite is parameterized on `connector_factory`. In E1 a
+`--target=simulated|testnet` pytest option lets it point at qubx's `SimulatedConnector` for
+in-process smoke before pushing to testnet — near-zero extra CI minutes, faster local iteration.
+
+## Cross-repo dependency (qubx side)
+
+The exchanges repo depends on qubx (not the reverse), so qubx drives the cadence:
+
+- No pre-release publishing to PyPI from the feature branch. Avoids polluting PyPI with N
+  `2.0.0.devX` versions that nothing on `main` consumes. The final coordinated merge cuts a
+  single clean `2.0.0`.
+- The exchanges branch pins qubx via a git source in its `pyproject.toml`, pinned to a
+  **specific commit SHA** of `feat/account-manager-redesign` (not the branch name) so unrelated
+  commits on the qubx branch don't break exchanges CI unpredictably:
+
+  ```toml
+  [tool.uv.sources]
+  qubx = { git = "https://github.com/xLydianSoftware/Qubx", rev = "<qubx-branch-commit-sha>" }
+  ```
+
+  The SHA is bumped deliberately when fresher qubx code is wanted downstream. Note: the
+  exchanges-side E1 PR (which imports the new types) must land **after** qubx Q1 merges to the
+  qubx branch.
+
+## Coordinated merge (qubx steps)
+
+1. **Merge qubx branch → `main`.** Triggers the Qubx release pipeline → cuts `2.0.0` (or
+   whatever the next major is, per conventional-commit auto-bump).
+2. Exchanges branch then bumps `qubx[connectors]>=2.0.0` and removes the `[tool.uv.sources]`
+   override (exchanges-repo step, downstream of #1).
+3. Merge exchanges branch → `main`; tag connector releases (`qubx-hyperliquid`, `qubx-lighter`)
+   — exchanges-repo steps.
+4. Re-release affected strategies via `xrelease` pinned to qubx `2.0.0`.
+
+## Pre-decided choices (qubx)
+
+- **No feature flag in `StrategyContext`.** Branch + git-source override gives the safety;
+  flag-gated dispatch is dead weight.
+- **No pre-release PyPI publishing from the feature branch.** Git source only. One clean
+  release at merge.
+- **`AccountState` is single-writer — mutated only on the dispatch thread.** Verified against
+  current qubx: there is exactly one loop thread (`ProcessorThread` in live, `context.py:402-405`;
+  the main thread in sim, no thread spawned). Strategy callbacks run synchronously inside that
+  loop, so `ctx.trade` → `TradingManager.trade` mutates the account inline *on that same thread*
+  (`trading.py:133-138`), and `apply(event)` runs on it too (both drain from the same
+  `channel.receive()` loop). The `[sync] add_order` and `apply(event)` arrows in the diagram are
+  therefore serialized, never concurrent — which is why the legacy `AccountProcessor` needs no
+  locks and the new `AccountManager` needs none either. **Connectors are event producers only:**
+  their background REST/WS asyncio loops never touch `AccountState`; they call `self.send(...)`
+  onto the thread-safe `Channel` (`queue.Queue`), and the dispatch thread is the sole consumer
+  and sole writer. Make this a stated contract in the design: *"`AccountState` is mutated only on
+  the dispatch thread; connectors emit events to the Channel and never mutate state directly."*
+  Residual caveat — the invariant is single-*writer*, not single-*accessor*: any reader on
+  another thread (external dashboard, health endpoint, off-thread logger) is the only thing that
+  could observe torn state. In current qubx this is a non-issue because logging is itself driven
+  by scheduled events that fire on the dispatch thread. If the platform runner ever reads
+  `ctx.positions` from its own thread, *that read* — not the writes — is what would need guarding.
+- **`SimulationAccountManager(AccountManager)` subclass** for backtest. The in-flight stuck-order
+  sweep is **opt-in, not hard-skipped**: by default the sim does not auto-arm it (the
+  `SimulatedConnector` acks/fills deterministically, so there are never genuinely stuck in-flight
+  orders, and an auto-armed sweep would be overhead and a nondeterminism risk). Expose it as a
+  parameter (e.g. `register_inflight_tick=False` default, `True` for the recovery test) so the Q3
+  stuck-order-recovery scenario can drive it deterministically. The tick is pumped the same way
+  every other periodic check is in backtest — by `SimulatedScheduler` (`backtester/utils.py`, a
+  `BasicScheduler` subclass with no watcher thread) advanced from `SimulationRunner`'s time loop
+  (`runner.py:236-240`): before each data point at `t`, `while t >= scheduler.next_expected_event_time():
+  set_time(next); check_and_run_tasks()`. So a 2s cron tick fires deterministically as simulated
+  time crosses each boundary — no wall clock, fully reproducible. (Live path: `pm.schedule` →
+  `BasicScheduler` watcher thread → `_trigger` only `channel.send(...)` at `helpers.py:347`; the
+  sweep itself still runs on the dispatch thread.) Decided in
+  `account-management-design#Backtester migration`.
+- **State-machine tests live in qubx core**, not exchanges/conformance.
+- **Branch CI stays red from Q2 until Q4** (Q3 greens the backtester; CCXT conformance keeps
+  broad CI red until Q4). Don't gate progress on broad CI green during the migration window; use
+  the Q1 state-machine tests + Q3 backtester strategy tests as the green signal.
+
+## Open questions to align before opening Q1
+
+1. **Branch trigger safety in Qubx CI.** `.github/workflows/` has special handling for `dev`
+   and `main` (publishes to PyPI, builds Docker images, deploys docs). Confirm `feat/*` branches
+   don't accidentally trigger a release. If they might, prefix the branch or scope the workflow
+   triggers explicitly.
+2. **Legacy interface tests during Q2.** `test_account_processor_test.py` and
+   `test_trading_test.py` test the legacy interfaces and will be the most visible "this is red"
+   signals. Options:
+   - Delete them in Q2 (the interfaces go away in Q5 anyway).
+   - Mark them `@pytest.mark.skip("migrating in Q5")` and delete in Q5.
+
+   **Recommendation: skip-mark.** Gives back the CI green signal earlier and makes the deletion
+   an obvious follow-up.
+3. **xlydian-platform runner.** The platform's session runner constructs `StrategyContext` from
+   a config. The constructor signature changes (now takes `connectors: dict[str, IConnector]`
+   and a single `AccountManager` instead of separate broker/account dicts). Either:
+   - (a) Land a parallel platform PR coordinated with the Qubx 2.0.0 release, or
+   - (b) Pin the platform to qubx 1.x until a platform-side adapter lands separately.
+4. **xrelease compatibility.** All strategy ZIPs on the platform are built against the 1.x `ctx`
+   API. Once Qubx 2.0.0 ships, running strategies must be re-released or pinned to 1.x:
+   - **Lockstep**: re-release everything in the deploy window, or
+   - **Strategy-by-strategy**: roll forward per strategy — slower but safer per-blast-radius.
+
+## References
+
+- `account-management-design` — full architecture (event hierarchy, `AccountManager`, state
+  machine, `IConnector` contract, conformance suite, decided defaults).
+- `excalidraw/account-management` — sequence diagrams (submit / cancel / update / stuck-order recovery).
+- `.github/workflows/` — Qubx CI config (`ci.yml`, `integration-tests.yml`, `e2e-tests.yml`).

--- a/src/qubx/core/account_manager/__init__.py
+++ b/src/qubx/core/account_manager/__init__.py
@@ -1,0 +1,7 @@
+"""
+New-design account management (Q1 of the account-manager redesign).
+
+Additive package with no callers yet. Houses the typed event hierarchy, the order
+state machine, ``AccountState``, ``AccountManager`` / ``SimulationAccountManager``,
+and the ``IConnector`` protocol. See ``ACCOUNT_MANAGEMENT_PLAN.md`` at the repo root.
+"""

--- a/src/qubx/core/account_manager/connector.py
+++ b/src/qubx/core/account_manager/connector.py
@@ -1,0 +1,81 @@
+"""
+``IConnector`` — the per-exchange connector contract for the redesign.
+
+A connector owns the venue session (REST + WS), turns ``ctx.trade/cancel/update`` calls
+into venue requests, and emits typed ``AccountMessage`` events onto the Channel. It never
+mutates ``AccountState`` directly — it is an event *producer*; the dispatch thread is the
+sole consumer/writer (see ``ACCOUNT_MANAGEMENT_PLAN.md``).
+
+All command methods are fire-and-forget: they dispatch REST/WS work on the connector's own
+loop and return immediately. ``submit_order`` may raise *synchronously* on a framework-side
+rejection (invalid params, not connected, duplicate cid, open-order cap); venue-side
+rejections instead come back later as ``OrderRejectedEvent``.
+
+Derived from the ``account-management`` excalidraw + the connector-contract spec referenced
+by the rollout plan (no design doc was available; confirm signatures against it).
+"""
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+from qubx.core.basics import OrderRequest
+
+ModifyPattern = Literal["in_place", "replace"]
+
+
+@dataclass
+class ConnectorCapabilities:
+    """
+    Per-venue capability flags consumed by the conformance suite and AccountManager.
+
+    - ``modify_pattern``: ``in_place`` (Binance/OKX/Gate — venue_id unchanged) vs
+      ``replace`` (HPL — modify is cancel-old + new; venue_id changes, connector collapses
+      the pair into a single ``OrderUpdatedEvent``).
+    - ``cancel_by_cloid_supported``: cancel-by-client-order-id (vs only by venue id).
+    - ``native_snapshot_push``: venue pushes account snapshots without an explicit request.
+    - ``synthesized_trade_id_supported``: connector can synthesize stable trade ids for
+      fill dedup when the venue omits them.
+    """
+
+    modify_pattern: ModifyPattern = "in_place"
+    cancel_by_cloid_supported: bool = False
+    native_snapshot_push: bool = False
+    synthesized_trade_id_supported: bool = False
+
+
+@runtime_checkable
+class IConnector(Protocol):
+    """Venue connector contract. Implementations live in the exchanges repo."""
+
+    exchange: str
+    capabilities: ConnectorCapabilities
+
+    def connect(self) -> None:
+        """Open the venue session, subscribe to order/deal WS, emit initial snapshot."""
+        ...
+
+    def submit_order(self, request: OrderRequest) -> None:
+        """Fire the submit in the background; raise synchronously on framework rejection."""
+        ...
+
+    def cancel_order(self, client_order_id: str, venue_order_id: str | None = None) -> None:
+        """Request a cancel (by venue id when present, else by cloid). Fire-and-forget."""
+        ...
+
+    def update_order(
+        self,
+        client_order_id: str,
+        venue_order_id: str | None = None,
+        price: float | None = None,
+        quantity: float | None = None,
+    ) -> None:
+        """Request a modify. Fire-and-forget."""
+        ...
+
+    def request_order_status(self, client_order_id: str, venue_order_id: str | None = None) -> None:
+        """Schedule an async venue status query; result comes back as a typed event."""
+        ...
+
+    def request_snapshot(self) -> None:
+        """Schedule an async account snapshot; result comes back as ``AccountSnapshotEvent``."""
+        ...

--- a/src/qubx/core/account_manager/events.py
+++ b/src/qubx/core/account_manager/events.py
@@ -1,0 +1,106 @@
+"""
+Typed event hierarchy for the account-management redesign.
+
+Everything that flows on the ``Channel`` is a ``ChannelMessage``. The redesign splits
+these into two families:
+
+  - ``AccountMessage`` — account / order-lifecycle events emitted by connectors
+    (``IConnector.send(...)``) and consumed by ``AccountManager.apply(event)``.
+  - ``MarketDataMessage`` — market data (quotes, trades, ohlc, ...).
+
+Q1 scope is the account side: this module defines the order-lifecycle leaves and the
+account snapshot. ``MarketDataMessage`` is declared as the sibling category base only —
+market-data leaves continue to travel the existing qubx market-data path for now and are
+not part of this PR. Field shapes are derived from the ``account-management`` excalidraw
+order flows (no design doc was available; confirm names against it).
+"""
+
+from dataclasses import dataclass, field
+
+from qubx.core.account_manager.state import ManagedOrder
+from qubx.core.basics import AssetBalance, Deal, Position, dt_64
+
+
+@dataclass(frozen=True)
+class ChannelMessage:
+    """Base for everything that travels on the Channel."""
+
+
+@dataclass(frozen=True)
+class MarketDataMessage(ChannelMessage):
+    """Sibling category base for market data (leaves out of Q1 scope)."""
+
+
+@dataclass(frozen=True)
+class AccountMessage(ChannelMessage):
+    """Base for account / order-lifecycle events."""
+
+
+@dataclass(frozen=True)
+class OrderEvent(AccountMessage):
+    """Base for events about a single order, addressed by its ``client_id`` (cid)."""
+
+    client_id: str
+    timestamp: dt_64 | None = None
+
+
+@dataclass(frozen=True)
+class OrderAcceptedEvent(OrderEvent):
+    """Venue acknowledged the order; ``venue_id`` is now known."""
+
+    venue_id: str | None = None
+
+
+@dataclass(frozen=True)
+class OrderRejectedEvent(OrderEvent):
+    """Venue or framework rejected the order (or it never appeared after retries)."""
+
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class OrderFilledEvent(OrderEvent):
+    """A (partial or full) fill arrived; ``fill`` carries the trade (``fill.id`` = trade id)."""
+
+    fill: Deal | None = None
+
+
+@dataclass(frozen=True)
+class OrderCanceledEvent(OrderEvent):
+    """Venue acknowledged the cancel."""
+
+
+@dataclass(frozen=True)
+class OrderCancelRejectedEvent(OrderEvent):
+    """Venue rejected the cancel (e.g. order not found / already terminal)."""
+
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class OrderUpdatedEvent(OrderEvent):
+    """Venue confirmed a modify. For replace-style venues ``venue_id`` may change."""
+
+    venue_id: str | None = None
+    price: float | None = None
+    quantity: float | None = None
+
+
+@dataclass(frozen=True)
+class OrderUpdateRejectedEvent(OrderEvent):
+    """Venue rejected a modify; the underlying order stays alive with prior params."""
+
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class AccountSnapshotEvent(AccountMessage):
+    """
+    Full account snapshot emitted by a connector at ``connect()`` (and on demand via
+    ``request_snapshot``). Used by ``AccountManager`` to reconcile state.
+    """
+
+    orders: list[ManagedOrder] = field(default_factory=list)
+    positions: list[Position] = field(default_factory=list)
+    balances: list[AssetBalance] = field(default_factory=list)
+    timestamp: dt_64 | None = None

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -1,0 +1,376 @@
+"""
+``AccountManager`` — applies typed account events to ``AccountState`` through the order
+state machine, and sweeps stuck in-flight orders.
+
+It is the sole writer of ``AccountState`` and runs entirely on the dispatch thread
+(connectors only *produce* events onto the Channel; see ``ACCOUNT_MANAGEMENT_PLAN.md``).
+Behaviour is derived from the ``account-management`` excalidraw flows (submit / cancel /
+update / stuck-order recovery); a few rules are judgement calls, flagged inline.
+"""
+
+import numpy as np
+
+from qubx import logger
+from qubx.core.account_manager.connector import IConnector
+from qubx.core.account_manager.events import (
+    AccountMessage,
+    AccountSnapshotEvent,
+    OrderAcceptedEvent,
+    OrderCanceledEvent,
+    OrderCancelRejectedEvent,
+    OrderFilledEvent,
+    OrderRejectedEvent,
+    OrderUpdatedEvent,
+    OrderUpdateRejectedEvent,
+)
+from qubx.core.account_manager.scheduling import _ms_to_cron
+from qubx.core.account_manager.state import AccountState, ManagedOrder
+from qubx.core.account_manager.state_machine import (
+    PENDING_STATES,
+    OrderState,
+    is_pending,
+    is_terminal,
+    transition,
+)
+from qubx.core.basics import ITimeProvider, dt_64
+
+_EPS = 1e-12
+
+
+class AccountManager:
+    """Event-driven owner of ``AccountState``."""
+
+    def __init__(
+        self,
+        state: AccountState | None = None,
+        connectors: dict[str, IConnector] | None = None,
+        time_provider: ITimeProvider | None = None,
+        min_inflight_age_sec: float = 5.0,
+        max_inflight_retries: int = 5,
+        evict_grace_sec: float = 30.0,
+        tombstone_ttl_sec: float = 3600.0,
+        inflight_tick_interval_ms: int = 2000,
+    ):
+        self.state = state if state is not None else AccountState()
+        self._connectors = connectors or {}
+        self._time = time_provider
+        self.min_inflight_age_sec = min_inflight_age_sec
+        self.max_inflight_retries = max_inflight_retries
+        self.evict_grace_sec = evict_grace_sec
+        self.tombstone_ttl_sec = tombstone_ttl_sec
+        self.inflight_tick_interval_ms = inflight_tick_interval_ms
+
+        self._dispatch = {
+            OrderAcceptedEvent: self._on_accepted,
+            OrderRejectedEvent: self._on_rejected,
+            OrderFilledEvent: self._on_filled,
+            OrderCanceledEvent: self._on_canceled,
+            OrderCancelRejectedEvent: self._on_cancel_rejected,
+            OrderUpdatedEvent: self._on_updated,
+            OrderUpdateRejectedEvent: self._on_update_rejected,
+            AccountSnapshotEvent: self._on_snapshot,
+        }
+
+    # -- public API ---------------------------------------------------------------------
+
+    def get_order(self, cid: str) -> ManagedOrder | None:
+        return self.state.active_orders.get(cid)
+
+    def add_order(self, order: ManagedOrder) -> None:
+        """Register a freshly-submitted order (SUBMITTED) in the cache and in-flight index."""
+        now = self._now()
+        if order.created_at is None:
+            order.created_at = now
+        order.last_updated_at = now
+        order.status = OrderState.SUBMITTED
+        prev = self.state.active_orders.get(order.client_id)
+        if prev is not None:
+            logger.warning(f"[AccountManager] add_order overwriting live order for cid={order.client_id}")
+            # drop the replaced order's stale venue-id mapping so the index can't dangle
+            if prev.venue_id and self.state._venue_id_index.get(prev.venue_id) == order.client_id:
+                del self.state._venue_id_index[prev.venue_id]
+        self.state.active_orders[order.client_id] = order
+        self.state._inflight_index.add(order.client_id)
+
+    def apply(self, event: AccountMessage) -> None:
+        """Dispatch an account event to its handler. Unknown event types are ignored."""
+        handler = self._dispatch.get(type(event))
+        if handler is None:
+            logger.debug(f"[AccountManager] ignoring unhandled event type {type(event).__name__}")
+            return
+        try:
+            handler(event)
+        except Exception as e:
+            # one malformed event/ordering must not take down the dispatch loop
+            cid = getattr(event, "client_id", "?")
+            logger.warning(f"[AccountManager] dropping {type(event).__name__} for cid={cid}: {e!r}")
+
+    def transition_order(self, cid: str, target: OrderState) -> None:
+        """
+        Move an order into a PENDING_* state on a strategy-issued cancel/update, capturing
+        ``pre_pending_status`` so a venue rejection can revert it.
+        """
+        o = self.get_order(cid)
+        if o is None:
+            return
+        if target in PENDING_STATES and not is_pending(o.status):
+            o.pre_pending_status = o.status
+        self._set_status(o, target)
+
+    @property
+    def should_register_inflight_tick(self) -> bool:
+        """Whether the wiring layer should arm the stuck-order sweep on the scheduler."""
+        return True
+
+    def inflight_tick_cron(self) -> str:
+        """Cron expression for the in-flight sweep, for ``scheduler.schedule_event``."""
+        return _ms_to_cron(self.inflight_tick_interval_ms)
+
+    def on_inflight_tick(self, ctx=None) -> None:
+        """Scheduler callback (registered via ``_ms_to_cron`` in live)."""
+        self._sweep_stuck_inflight()
+
+    def evict_terminal(self, now: dt_64 | None = None) -> None:
+        """
+        Drop terminal orders whose grace window has elapsed: the heavy order object is
+        removed from ``active_orders`` (and the venue index), but the cid is kept as a
+        tombstone in ``_pending_evict_index`` so late events / snapshots can't resurrect it.
+        """
+        now = now if now is not None else self._now()
+        if now is None:
+            return
+        ttl = np.timedelta64(int(self.tombstone_ttl_sec * 1e9), "ns")
+        for cid, evict_at in list(self.state._pending_evict_index.items()):
+            if evict_at is None or evict_at > now:
+                continue
+            # past the grace window: drop the heavy order object, keep the cid as a tombstone
+            o = self.state.active_orders.pop(cid, None)
+            if o is not None and o.venue_id and self.state._venue_id_index.get(o.venue_id) == cid:
+                del self.state._venue_id_index[o.venue_id]
+            self.state._inflight_index.discard(cid)
+            # past the tombstone TTL: purge the tombstone too, so the index can't grow unbounded
+            if now - evict_at > ttl:
+                del self.state._pending_evict_index[cid]
+
+    # -- event handlers -----------------------------------------------------------------
+
+    def _on_accepted(self, ev: OrderAcceptedEvent) -> None:
+        o = self.get_order(ev.client_id)
+        if o is None or is_terminal(o.status):
+            return
+        if ev.venue_id:
+            self._set_venue_id(o, ev.venue_id)
+        if o.status in (OrderState.SUBMITTED, OrderState.STALE):
+            # a genuine ack of a fresh submit, or a late ack that resurrects a quarantined order
+            o.retry_count = 0
+            self._set_status(o, OrderState.ACCEPTED)
+        # For a PENDING_* order an "accepted/open" status response means the cancel/update
+        # hasn't taken effect; do NOT reset retry_count here (that would livelock the sweep),
+        # let retries exhaust and the give-up path revert it.
+
+    def _on_rejected(self, ev: OrderRejectedEvent) -> None:
+        o = self.get_order(ev.client_id)
+        if o is None or is_terminal(o.status):
+            return
+        self._set_status(o, OrderState.REJECTED)
+        o.pre_pending_status = None
+
+    def _on_filled(self, ev: OrderFilledEvent) -> None:
+        o = self.get_order(ev.client_id)
+        if o is None or ev.fill is None:
+            return
+        if is_terminal(o.status):
+            # late fill racing a terminal (e.g. fill after CANCELED) — ignore, don't resurrect.
+            # NOTE: a fill after CANCELED also signals the cancel was wrong; deeper reconcile is a follow-up.
+            logger.debug(f"[AccountManager] ignoring fill {ev.fill.id} on terminal order cid={o.client_id}")
+            return
+        tid = ev.fill.id
+        if tid in o.fill_trade_ids:  # dedup replayed fills by trade id
+            return
+        o.fill_trade_ids.add(tid)
+        o.filled_quantity += abs(ev.fill.amount)
+        target = (
+            OrderState.FILLED
+            if o.filled_quantity >= abs(o.quantity) - _EPS
+            else OrderState.PARTIALLY_FILLED
+        )
+        self._set_status(o, target)
+        if is_terminal(target):
+            o.pre_pending_status = None
+
+    def _on_canceled(self, ev: OrderCanceledEvent) -> None:
+        o = self.get_order(ev.client_id)
+        if o is None or is_terminal(o.status):
+            return
+        self._set_status(o, OrderState.CANCELED)
+        o.pre_pending_status = None
+
+    def _on_cancel_rejected(self, ev: OrderCancelRejectedEvent) -> None:
+        o = self.get_order(ev.client_id)
+        if o is None or o.status != OrderState.PENDING_CANCEL:
+            return
+        self._revert_pending(o)
+
+    def _on_updated(self, ev: OrderUpdatedEvent) -> None:
+        o = self.get_order(ev.client_id)
+        if o is None:
+            return
+        if o.status != OrderState.PENDING_UPDATE:
+            # unsolicited / duplicate update confirm — ignore rather than mutate a non-updating order
+            logger.debug(f"[AccountManager] ignoring update for cid={o.client_id} in status {o.status.value}")
+            return
+        if ev.venue_id and ev.venue_id != o.venue_id:  # replace-style modify re-keys venue id
+            self._set_venue_id(o, ev.venue_id)
+        if ev.price is not None:
+            o.price = ev.price
+        if ev.quantity is not None:
+            o.quantity = ev.quantity
+        # re-evaluate completeness: a quantity shrink to the filled size finalizes the order
+        if o.filled_quantity > _EPS and o.filled_quantity >= abs(o.quantity) - _EPS:
+            target = OrderState.FILLED
+        elif o.filled_quantity > _EPS:
+            target = OrderState.PARTIALLY_FILLED
+        else:
+            target = OrderState.ACCEPTED
+        self._set_status(o, target)
+        o.pre_pending_status = None
+
+    def _on_update_rejected(self, ev: OrderUpdateRejectedEvent) -> None:
+        o = self.get_order(ev.client_id)
+        if o is None or o.status != OrderState.PENDING_UPDATE:
+            return
+        self._revert_pending(o)
+
+    def _on_snapshot(self, ev: AccountSnapshotEvent) -> None:
+        self._reconcile_snapshot(ev)
+
+    # -- stuck-order sweep --------------------------------------------------------------
+
+    def _sweep_stuck_inflight(self, now: dt_64 | None = None) -> None:
+        now = now if now is not None else self._now()
+        if now is None:
+            return
+        for cid in list(self.state._inflight_index):
+            o = self.state.active_orders.get(cid)
+            if o is None or o.last_updated_at is None:
+                continue
+            try:
+                age = (now - o.last_updated_at) / np.timedelta64(1, "s")
+                if age < self.min_inflight_age_sec:
+                    continue  # too young to be considered stuck
+                if o.retry_count >= self.max_inflight_retries:
+                    self._give_up_stuck_order(o)
+                    continue
+                conn = self._connectors.get(o.instrument.exchange)
+                if conn is not None:
+                    conn.request_order_status(o.client_id, o.venue_id)
+                o.retry_count += 1
+            except Exception as e:  # one bad order must not abort the whole sweep
+                logger.warning(f"[AccountManager] sweep error for cid={cid}: {e}")
+
+    def _give_up_stuck_order(self, o: ManagedOrder) -> None:
+        """No venue ack after N status queries: quarantine a never-confirmed submit; revert a stuck pending."""
+        if o.status == OrderState.SUBMITTED:
+            # never confirmed — but it may be live at the venue, so DO NOT auto-reject.
+            # Quarantine in STALE and wait for an authoritative signal (late event / snapshot).
+            self._set_status(o, OrderState.STALE)
+            o.pre_pending_status = None
+        else:
+            # PENDING_CANCEL / PENDING_UPDATE: the cancel/modify never acked, but the underlying
+            # order is presumed still live at the venue -> revert to its pre-pending status
+            self._revert_pending(o)
+            o.retry_count = 0
+
+    # -- snapshot reconcile (minimal; grace + freshness only) ---------------------------
+
+    def _reconcile_snapshot(self, ev: AccountSnapshotEvent) -> None:
+        snap_ts = ev.timestamp
+        for snap_o in ev.orders:
+            if not isinstance(snap_o, ManagedOrder):
+                logger.warning(f"[AccountManager] snapshot order of unexpected type {type(snap_o).__name__}; skipping")
+                continue
+            cid = snap_o.client_id
+            existing = self.state.active_orders.get(cid)
+            # grace window: do not resurrect an order we just terminalized
+            if existing is None and cid in self.state._pending_evict_index:
+                continue
+            if existing is None:
+                self.state.active_orders[cid] = snap_o
+                if snap_o.venue_id:
+                    self.state._venue_id_index[snap_o.venue_id] = cid
+                # an adopted order awaiting a venue verdict must be sweep-eligible
+                if snap_o.status == OrderState.SUBMITTED or snap_o.status in PENDING_STATES:
+                    self.state._inflight_index.add(cid)
+                else:
+                    self.state._inflight_index.discard(cid)
+                continue
+            # freshness: a locally newer update wins over a stale snapshot
+            if (
+                snap_ts is not None
+                and existing.last_updated_at is not None
+                and existing.last_updated_at > snap_ts
+            ):
+                continue
+            # (further field-level reconcile is a follow-up; minimal merge keeps venue id)
+            if snap_o.venue_id and existing.venue_id is None:
+                self._set_venue_id(existing, snap_o.venue_id)
+
+    # -- internals ----------------------------------------------------------------------
+
+    def _now(self) -> dt_64 | None:
+        return self._time.time() if self._time is not None else None
+
+    def _set_venue_id(self, o: ManagedOrder, venue_id: str) -> None:
+        if o.venue_id and o.venue_id in self.state._venue_id_index:
+            del self.state._venue_id_index[o.venue_id]
+        o.venue_id = venue_id
+        self.state._venue_id_index[venue_id] = o.client_id
+
+    def _revert_pending(self, o: ManagedOrder) -> None:
+        target = o.pre_pending_status if o.pre_pending_status is not None else self._previous_status_before_pending(o)
+        self._set_status(o, target)
+        o.pre_pending_status = None
+
+    def _previous_status_before_pending(self, o: ManagedOrder) -> OrderState:
+        """Fallback revert target when ``pre_pending_status`` is unavailable (e.g. post-snapshot)."""
+        if o.filled_quantity > _EPS:
+            return OrderState.PARTIALLY_FILLED
+        if o.venue_id is None:
+            return OrderState.SUBMITTED
+        return OrderState.ACCEPTED
+
+    def _set_status(self, o: ManagedOrder, new_status: OrderState) -> None:
+        if new_status != o.status:
+            transition(o.status, new_status)  # validate; raises IllegalOrderTransition
+            o.status = new_status
+        o.last_updated_at = self._now()
+        cid = o.client_id
+        if new_status == OrderState.SUBMITTED or new_status in PENDING_STATES:
+            self.state._inflight_index.add(cid)
+        else:
+            self.state._inflight_index.discard(cid)
+        if is_terminal(new_status):
+            now = self._now()
+            self.state._pending_evict_index[cid] = (
+                now + np.timedelta64(int(self.evict_grace_sec * 1e9), "ns") if now is not None else now
+            )
+
+
+class SimulationAccountManager(AccountManager):
+    """
+    Backtest variant of ``AccountManager``.
+
+    The ``SimulatedConnector`` acks/fills deterministically, so there are never genuinely
+    stuck in-flight orders — the wall-clock sweep is therefore **opt-in** (off by default)
+    to avoid overhead and nondeterminism. The Q3 stuck-order-recovery conformance test sets
+    ``register_inflight_tick=True`` and drives the sweep via the ``SimulatedScheduler``.
+    See ``ACCOUNT_MANAGEMENT_PLAN.md``.
+    """
+
+    def __init__(self, *args, register_inflight_tick: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._register_inflight_tick = register_inflight_tick
+
+    @property
+    def should_register_inflight_tick(self) -> bool:
+        return self._register_inflight_tick

--- a/src/qubx/core/account_manager/scheduling.py
+++ b/src/qubx/core/account_manager/scheduling.py
@@ -1,0 +1,38 @@
+"""
+Scheduling helpers for the account-management redesign.
+
+``_ms_to_cron`` converts a millisecond interval into a cron expression the qubx
+scheduler (``BasicScheduler`` / ``SimulatedScheduler``, both ``croniter``-backed) can
+register. It targets the sub-minute in-flight stuck-order tick; for intervals above one
+minute use ``qubx.utils.time.interval_to_cron``.
+
+The qubx scheduler uses 6-field cron with the seconds field LAST (e.g. ``"* * * * * */2"``
+fires every 2 seconds), matching ``interval_to_cron``'s output format.
+"""
+
+
+def _ms_to_cron(ms: int) -> str:
+    """
+    Convert a millisecond interval to a cron expression.
+
+    Supported domain (the in-flight tick is the only consumer):
+      - whole-second intervals from 1s to 59s -> ``"* * * * * */<seconds>"``
+      - exactly 60_000 ms (one minute)         -> ``"* * * * *"``
+
+    Raises ``ValueError`` for non-positive, sub-second, fractional-second, or
+    multi-minute intervals.
+    """
+    if ms <= 0:
+        raise ValueError(f"interval must be positive, got {ms}ms")
+    if ms % 1000 != 0:
+        raise ValueError(f"interval must be a whole number of seconds, got {ms}ms")
+
+    seconds = ms // 1000
+    if seconds == 60:
+        return "* * * * *"
+    if 1 <= seconds < 60:
+        return f"* * * * * */{seconds}"
+    raise ValueError(
+        f"_ms_to_cron targets sub-minute intervals; {seconds}s is unsupported "
+        "(use qubx.utils.time.interval_to_cron for >1min schedules)"
+    )

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -1,0 +1,58 @@
+"""
+``AccountState`` — the pure-data account snapshot the ``AccountManager`` owns and mutates.
+
+``AccountState`` holds no behaviour; all transitions go through ``AccountManager`` so the
+state machine stays the single source of truth. It is mutated only on the dispatch thread
+(see ``ACCOUNT_MANAGEMENT_PLAN.md`` — single-writer invariant).
+
+Scope note (Q1): orders are modelled in full (the bug-magnet); positions/balances reuse the
+existing ``qubx.core.basics`` ``Position`` / ``AssetBalance`` and their fill maths, wired in a
+later PR — they are intentionally not duplicated here.
+"""
+
+from dataclasses import dataclass, field
+
+from qubx.core.account_manager.state_machine import OrderState
+from qubx.core.basics import Instrument, OrderSide, OrderType, dt_64
+
+
+@dataclass
+class ManagedOrder:
+    """An order plus the state-machine bookkeeping the AccountManager needs."""
+
+    client_id: str  # cid — stable, framework-generated, never mutated
+    instrument: Instrument
+    side: OrderSide
+    quantity: float
+    price: float | None = None
+    order_type: OrderType = "LIMIT"
+    time_in_force: str = "gtc"
+
+    status: OrderState = OrderState.SUBMITTED
+    venue_id: str | None = None
+    filled_quantity: float = 0.0
+
+    # status captured on entering a PENDING_* state, restored on revert (cancel/update reject)
+    pre_pending_status: OrderState | None = None
+    # number of in-flight status queries issued by the stuck-order sweep
+    retry_count: int = 0
+
+    last_updated_at: dt_64 | None = None
+    created_at: dt_64 | None = None
+
+    # trade ids already applied, for fill dedup
+    fill_trade_ids: set[str] = field(default_factory=set)
+
+
+@dataclass
+class AccountState:
+    """Pure-data container for orders and the indexes the manager maintains."""
+
+    # cid -> order
+    active_orders: dict[str, ManagedOrder] = field(default_factory=dict)
+    # venue_order_id -> cid
+    _venue_id_index: dict[str, str] = field(default_factory=dict)
+    # cids awaiting a venue verdict (SUBMITTED / PENDING_CANCEL / PENDING_UPDATE) — swept for staleness
+    _inflight_index: set[str] = field(default_factory=set)
+    # terminal cid -> time after which it may be evicted (grace window vs late events / snapshots)
+    _pending_evict_index: dict[str, dt_64] = field(default_factory=dict)

--- a/src/qubx/core/account_manager/state_machine.py
+++ b/src/qubx/core/account_manager/state_machine.py
@@ -1,0 +1,138 @@
+"""
+Order state machine for the new account-management design.
+
+This is the bug-magnet of the redesign, kept as a small, pure, I/O-free module so it
+can be tested exhaustively. The transition table is derived from the sequence flows in
+the ``account-management`` excalidraw (submit / cancel / update / stuck-order recovery).
+
+Design notes / judgement calls (no design doc was available; confirm against it):
+  - **Terminalization is venue-authoritative**: a venue can unilaterally move *any* live
+    order to a terminal state (``FILLED``/``CANCELED``/``REJECTED``) in any order — GTD/IOC
+    expiry, liquidation, ADL, admin cancel, late reject after a partial fill, a fill racing
+    a cancel, etc. So ``can_transition`` allows ``<any non-terminal> -> <any terminal>``.
+    The explicit ``TRANSITIONS`` table governs only non-terminal -> non-terminal moves
+    (accept, enter/revert pending, partial fills).
+  - ``PENDING_CANCEL`` and ``PENDING_UPDATE`` may *revert* to a prior live state
+    (the captured ``pre_pending_status``) when the venue rejects the cancel/modify, or
+    race ahead to a fill.
+  - ``STALE`` is a non-terminal quarantine for a ``SUBMITTED`` order the sweep could not
+    confirm after N status queries. We do **not** auto-reject (the order may be live at the
+    venue); instead it waits for an authoritative signal — a late ack/snapshot resurrects it
+    to ``ACCEPTED``, a fill to ``PARTIALLY_FILLED``, and an explicit venue cancel/reject
+    terminalizes it via the rule below.
+  - Terminal states have no outgoing edges (not even to another terminal).
+  - Idempotent no-ops (e.g. re-issuing a cancel on an already ``PENDING_CANCEL`` order)
+    are handled by the caller (AccountManager), not encoded as self-edges here.
+"""
+
+from enum import Enum
+
+
+class OrderState(str, Enum):
+    """Lifecycle states of a managed order."""
+
+    SUBMITTED = "SUBMITTED"  # local order created, sent to venue, no ack yet
+    ACCEPTED = "ACCEPTED"  # venue acknowledged (venue_order_id known)
+    PARTIALLY_FILLED = "PARTIALLY_FILLED"  # at least one fill, remainder live
+    FILLED = "FILLED"  # fully filled (terminal)
+    PENDING_CANCEL = "PENDING_CANCEL"  # cancel requested, awaiting venue verdict
+    PENDING_UPDATE = "PENDING_UPDATE"  # modify requested, awaiting venue verdict
+    STALE = "STALE"  # submitted but never confirmed; quarantined by the sweep (non-terminal)
+    CANCELED = "CANCELED"  # cancel acknowledged (terminal)
+    REJECTED = "REJECTED"  # venue/framework rejected (terminal)
+
+
+TERMINAL_STATES: frozenset[OrderState] = frozenset(
+    {OrderState.FILLED, OrderState.CANCELED, OrderState.REJECTED}
+)
+
+PENDING_STATES: frozenset[OrderState] = frozenset(
+    {OrderState.PENDING_CANCEL, OrderState.PENDING_UPDATE}
+)
+
+
+# Non-terminal -> non-terminal edges only. Transitions to terminal states are governed by
+# the venue-authoritative rule in ``can_transition`` (any live order may be terminalized).
+TRANSITIONS: dict[OrderState, frozenset[OrderState]] = {
+    OrderState.SUBMITTED: frozenset(
+        {
+            OrderState.ACCEPTED,
+            OrderState.PENDING_CANCEL,
+            OrderState.PENDING_UPDATE,
+            OrderState.PARTIALLY_FILLED,
+            OrderState.STALE,  # sweep quarantine: never confirmed after N status queries
+        }
+    ),
+    OrderState.STALE: frozenset(
+        {
+            # resolved by a late authoritative signal
+            OrderState.ACCEPTED,  # late ack / snapshot says live
+            OrderState.PARTIALLY_FILLED,  # late fill
+        }
+    ),
+    OrderState.ACCEPTED: frozenset(
+        {
+            OrderState.PENDING_CANCEL,
+            OrderState.PENDING_UPDATE,
+            OrderState.PARTIALLY_FILLED,
+        }
+    ),
+    OrderState.PARTIALLY_FILLED: frozenset(
+        {
+            OrderState.PARTIALLY_FILLED,
+            OrderState.PENDING_CANCEL,
+            OrderState.PENDING_UPDATE,
+        }
+    ),
+    OrderState.PENDING_CANCEL: frozenset(
+        {
+            # revert targets (pre_pending_status) on cancel-rejected / sweep give-up
+            OrderState.SUBMITTED,
+            OrderState.ACCEPTED,
+            OrderState.PARTIALLY_FILLED,
+        }
+    ),
+    OrderState.PENDING_UPDATE: frozenset(
+        {
+            # confirm or revert (pre_pending_status) on update-rejected / sweep give-up
+            OrderState.SUBMITTED,
+            OrderState.ACCEPTED,
+            OrderState.PARTIALLY_FILLED,
+        }
+    ),
+    OrderState.FILLED: frozenset(),
+    OrderState.CANCELED: frozenset(),
+    OrderState.REJECTED: frozenset(),
+}
+
+
+class IllegalOrderTransition(Exception):
+    """Raised when an order is asked to make a transition the state machine forbids."""
+
+    def __init__(self, frm: OrderState, to: OrderState):
+        self.frm = frm
+        self.to = to
+        super().__init__(f"Illegal order transition: {frm.value} -> {to.value}")
+
+
+def is_terminal(state: OrderState) -> bool:
+    return state in TERMINAL_STATES
+
+
+def is_pending(state: OrderState) -> bool:
+    return state in PENDING_STATES
+
+
+def can_transition(frm: OrderState, to: OrderState) -> bool:
+    if frm in TERMINAL_STATES:
+        return False  # terminal states never transition
+    if to in TERMINAL_STATES:
+        return True  # venue-authoritative terminalization from any live state
+    return to in TRANSITIONS[frm]
+
+
+def transition(frm: OrderState, to: OrderState) -> OrderState:
+    """Validate ``frm -> to`` and return ``to``; raise ``IllegalOrderTransition`` if illegal."""
+    if not can_transition(frm, to):
+        raise IllegalOrderTransition(frm, to)
+    return to

--- a/tests/qubx/core/account_manager_test.py
+++ b/tests/qubx/core/account_manager_test.py
@@ -1,0 +1,877 @@
+"""
+Unit tests for the new-design account-management state machine (Q1).
+
+The state machine is the bug-magnet of the redesign, so it is tested heavily here,
+in-process, with no I/O. Transitions are derived from the sequence flows in the
+`account-management` excalidraw (submit / cancel / update / stuck-order recovery).
+"""
+
+import dataclasses
+
+import numpy as np
+import pytest
+from croniter import croniter
+
+from qubx.core.account_manager.connector import ConnectorCapabilities
+from qubx.core.account_manager.events import (
+    AccountMessage,
+    AccountSnapshotEvent,
+    ChannelMessage,
+    MarketDataMessage,
+    OrderAcceptedEvent,
+    OrderCanceledEvent,
+    OrderCancelRejectedEvent,
+    OrderFilledEvent,
+    OrderRejectedEvent,
+    OrderUpdatedEvent,
+    OrderUpdateRejectedEvent,
+)
+from qubx.core.account_manager.manager import AccountManager
+from qubx.core.account_manager.scheduling import _ms_to_cron
+from qubx.core.account_manager.state import AccountState, ManagedOrder  # noqa: F401
+from qubx.core.account_manager.state_machine import (
+    PENDING_STATES,
+    TERMINAL_STATES,
+    IllegalOrderTransition,
+    OrderState,
+    is_pending,
+    is_terminal,
+    transition,
+)
+from qubx.core.basics import Deal, dt_64
+from qubx.core.lookups import lookup
+
+
+class FakeConnector:
+    """Test double implementing the IConnector protocol; records calls for assertions."""
+
+    def __init__(self, exchange: str = "BINANCE.UM", capabilities: ConnectorCapabilities | None = None):
+        self.exchange = exchange
+        self.capabilities = capabilities or ConnectorCapabilities()
+        self.calls: list[tuple] = []
+
+    def connect(self) -> None:
+        self.calls.append(("connect",))
+
+    def submit_order(self, request) -> None:
+        self.calls.append(("submit_order", request))
+
+    def cancel_order(self, client_order_id: str, venue_order_id: str | None = None) -> None:
+        self.calls.append(("cancel_order", client_order_id, venue_order_id))
+
+    def update_order(
+        self,
+        client_order_id: str,
+        venue_order_id: str | None = None,
+        price: float | None = None,
+        quantity: float | None = None,
+    ) -> None:
+        self.calls.append(("update_order", client_order_id, venue_order_id, price, quantity))
+
+    def request_order_status(self, client_order_id: str, venue_order_id: str | None = None) -> None:
+        self.calls.append(("request_order_status", client_order_id, venue_order_id))
+
+    def request_snapshot(self) -> None:
+        self.calls.append(("request_snapshot",))
+
+
+class MutableClock:
+    """Controllable time provider (nanosecond datetime64) for sweep/age tests."""
+
+    def __init__(self, t0: str = "2026-01-01T00:00:00"):
+        self._t = np.datetime64(t0, "ns")
+
+    def time(self) -> dt_64:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t = self._t + np.timedelta64(int(seconds * 1e9), "ns")
+
+
+class TestTerminalStates:
+    def test_filled_canceled_rejected_are_terminal(self):
+        assert is_terminal(OrderState.FILLED)
+        assert is_terminal(OrderState.CANCELED)
+        assert is_terminal(OrderState.REJECTED)
+
+    def test_live_states_are_not_terminal(self):
+        for s in (
+            OrderState.SUBMITTED,
+            OrderState.ACCEPTED,
+            OrderState.PARTIALLY_FILLED,
+            OrderState.PENDING_CANCEL,
+            OrderState.PENDING_UPDATE,
+        ):
+            assert not is_terminal(s)
+
+    def test_terminal_states_set_matches(self):
+        assert TERMINAL_STATES == {OrderState.FILLED, OrderState.CANCELED, OrderState.REJECTED}
+
+
+class TestPendingStates:
+    def test_pending_cancel_and_update_are_pending(self):
+        assert is_pending(OrderState.PENDING_CANCEL)
+        assert is_pending(OrderState.PENDING_UPDATE)
+        assert PENDING_STATES == {OrderState.PENDING_CANCEL, OrderState.PENDING_UPDATE}
+
+    def test_non_pending_states_are_not_pending(self):
+        assert not is_pending(OrderState.SUBMITTED)
+        assert not is_pending(OrderState.ACCEPTED)
+        assert not is_pending(OrderState.FILLED)
+
+
+LIVE_STATES = [
+    OrderState.SUBMITTED,
+    OrderState.ACCEPTED,
+    OrderState.PARTIALLY_FILLED,
+    OrderState.PENDING_CANCEL,
+    OrderState.PENDING_UPDATE,
+    OrderState.STALE,
+]
+
+LEGAL_TRANSITIONS = [
+    # submit lifecycle
+    (OrderState.SUBMITTED, OrderState.ACCEPTED),
+    (OrderState.SUBMITTED, OrderState.PENDING_CANCEL),
+    (OrderState.SUBMITTED, OrderState.PENDING_UPDATE),  # update an unacked order (symmetry with cancel)
+    (OrderState.SUBMITTED, OrderState.STALE),  # sweep quarantine: never confirmed
+    # stale quarantine -> resolved by a late authoritative signal
+    (OrderState.STALE, OrderState.ACCEPTED),
+    (OrderState.STALE, OrderState.PARTIALLY_FILLED),
+    # accepted lifecycle
+    (OrderState.ACCEPTED, OrderState.PENDING_CANCEL),
+    (OrderState.ACCEPTED, OrderState.PENDING_UPDATE),
+    (OrderState.ACCEPTED, OrderState.PARTIALLY_FILLED),
+    # partial fills
+    (OrderState.PARTIALLY_FILLED, OrderState.PARTIALLY_FILLED),
+    (OrderState.PARTIALLY_FILLED, OrderState.PENDING_CANCEL),
+    (OrderState.PARTIALLY_FILLED, OrderState.PENDING_UPDATE),
+    # pending cancel -> revert (to pre-pending status)
+    (OrderState.PENDING_CANCEL, OrderState.SUBMITTED),
+    (OrderState.PENDING_CANCEL, OrderState.ACCEPTED),
+    (OrderState.PENDING_CANCEL, OrderState.PARTIALLY_FILLED),
+    # pending update -> confirm or revert
+    (OrderState.PENDING_UPDATE, OrderState.ACCEPTED),
+    (OrderState.PENDING_UPDATE, OrderState.PARTIALLY_FILLED),
+    (OrderState.PENDING_UPDATE, OrderState.SUBMITTED),  # revert when update was issued pre-ack
+]
+
+ILLEGAL_TRANSITIONS = [
+    # nothing leaves a terminal state — not even to another terminal
+    (OrderState.FILLED, OrderState.ACCEPTED),
+    (OrderState.CANCELED, OrderState.ACCEPTED),
+    (OrderState.REJECTED, OrderState.SUBMITTED),
+    (OrderState.FILLED, OrderState.CANCELED),
+    (OrderState.CANCELED, OrderState.REJECTED),
+    # cannot un-accept a live order
+    (OrderState.ACCEPTED, OrderState.SUBMITTED),
+]
+
+
+class TestLegalTransitions:
+    def test_allowed(self):
+        for frm, to in LEGAL_TRANSITIONS:
+            assert transition(frm, to) == to, f"{frm.value} -> {to.value} should be legal"
+
+
+class TestVenueAuthoritativeTerminalization:
+    """A venue can unilaterally terminalize any live order, in any order, from any live state."""
+
+    def test_any_live_state_can_reach_any_terminal(self):
+        for s in LIVE_STATES:
+            for t in TERMINAL_STATES:
+                assert transition(s, t) == t, f"{s.value} -> {t.value} should be legal (venue-driven)"
+
+    def test_terminal_states_never_transition(self):
+        for s in TERMINAL_STATES:
+            for t in OrderState:
+                with pytest.raises(IllegalOrderTransition):
+                    transition(s, t)
+
+
+class TestIllegalTransitions:
+    def test_raises(self):
+        for frm, to in ILLEGAL_TRANSITIONS:
+            with pytest.raises(IllegalOrderTransition):
+                transition(frm, to)
+
+    def test_exception_carries_from_and_to(self):
+        with pytest.raises(IllegalOrderTransition) as ei:
+            transition(OrderState.FILLED, OrderState.ACCEPTED)
+        assert ei.value.frm == OrderState.FILLED
+        assert ei.value.to == OrderState.ACCEPTED
+
+
+class TestMsToCron:
+    def test_two_second_tick(self):
+        assert _ms_to_cron(2000) == "* * * * * */2"
+
+    def test_five_second_tick(self):
+        assert _ms_to_cron(5000) == "* * * * * */5"
+
+    def test_one_second_tick(self):
+        assert _ms_to_cron(1000) == "* * * * * */1"
+
+    def test_one_minute_drops_seconds_field(self):
+        assert _ms_to_cron(60000) == "* * * * *"
+
+    def test_output_is_croniter_parseable_with_expected_period(self):
+        for ms in (1000, 2000, 5000, 30000, 60000):
+            expr = _ms_to_cron(ms)
+            it = croniter(expr, 0.0)
+            a, b = it.get_next(float), it.get_next(float)
+            assert (b - a) == ms / 1000.0, f"{expr} period mismatch for {ms}ms"
+
+    def test_non_positive_raises(self):
+        with pytest.raises(ValueError):
+            _ms_to_cron(0)
+        with pytest.raises(ValueError):
+            _ms_to_cron(-1000)
+
+    def test_sub_second_or_fractional_second_raises(self):
+        with pytest.raises(ValueError):
+            _ms_to_cron(500)
+        with pytest.raises(ValueError):
+            _ms_to_cron(2500)
+
+    def test_multi_minute_unsupported_raises(self):
+        # this helper targets the sub-minute in-flight tick; use interval_to_cron above that
+        with pytest.raises(ValueError):
+            _ms_to_cron(120000)
+
+
+def _deal(trade_id: str = "t1", order_id: str = "o1") -> Deal:
+    return Deal(
+        id=trade_id,
+        order_id=order_id,
+        time=np.datetime64("2026-01-01T00:00:00", "ns"),
+        amount=1.0,
+        price=100.0,
+        aggressive=True,
+    )
+
+
+ORDER_EVENTS = [
+    OrderAcceptedEvent(client_id="c1", venue_id="v1"),
+    OrderRejectedEvent(client_id="c1", reason="insufficient margin"),
+    OrderFilledEvent(client_id="c1", fill=_deal()),
+    OrderCanceledEvent(client_id="c1"),
+    OrderCancelRejectedEvent(client_id="c1", reason="order not found"),
+    OrderUpdatedEvent(client_id="c1", venue_id="v1", price=101.0, quantity=2.0),
+    OrderUpdateRejectedEvent(client_id="c1", reason="price out of band"),
+]
+
+
+class TestEventHierarchy:
+    def test_order_events_are_account_messages(self):
+        for ev in ORDER_EVENTS:
+            assert isinstance(ev, AccountMessage)
+            assert isinstance(ev, ChannelMessage)
+
+    def test_snapshot_is_account_message(self):
+        snap = AccountSnapshotEvent(orders=[], positions=[], balances=[])
+        assert isinstance(snap, AccountMessage)
+        assert isinstance(snap, ChannelMessage)
+
+    def test_market_data_is_channel_message_but_not_account_message(self):
+        assert issubclass(MarketDataMessage, ChannelMessage)
+        assert not issubclass(MarketDataMessage, AccountMessage)
+
+    def test_every_order_event_carries_client_id(self):
+        for ev in ORDER_EVENTS:
+            assert ev.client_id == "c1"
+
+    def test_accepted_and_updated_carry_venue_id(self):
+        assert OrderAcceptedEvent(client_id="c1", venue_id="v1").venue_id == "v1"
+        assert OrderUpdatedEvent(client_id="c1", venue_id="v1", price=1.0, quantity=1.0).venue_id == "v1"
+
+    def test_rejection_events_carry_reason(self):
+        assert OrderRejectedEvent(client_id="c1", reason="x").reason == "x"
+        assert OrderCancelRejectedEvent(client_id="c1", reason="y").reason == "y"
+        assert OrderUpdateRejectedEvent(client_id="c1", reason="z").reason == "z"
+
+    def test_fill_event_carries_deal_with_trade_id(self):
+        ev = OrderFilledEvent(client_id="c1", fill=_deal(trade_id="trade-42"))
+        assert ev.fill.id == "trade-42"
+
+    def test_events_are_frozen(self):
+        ev = OrderAcceptedEvent(client_id="c1", venue_id="v1")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ev.client_id = "c2"  # type: ignore[misc]
+
+
+class TestConnectorContract:
+    def test_capabilities_defaults(self):
+        from qubx.core.account_manager.connector import ConnectorCapabilities
+
+        caps = ConnectorCapabilities()
+        assert caps.modify_pattern in ("in_place", "replace")
+        assert isinstance(caps.cancel_by_cloid_supported, bool)
+        assert isinstance(caps.native_snapshot_push, bool)
+        assert isinstance(caps.synthesized_trade_id_supported, bool)
+
+    def test_modify_pattern_replace_is_settable(self):
+        from qubx.core.account_manager.connector import ConnectorCapabilities
+
+        caps = ConnectorCapabilities(modify_pattern="replace", cancel_by_cloid_supported=True)
+        assert caps.modify_pattern == "replace"
+        assert caps.cancel_by_cloid_supported is True
+
+    def test_fake_connector_satisfies_protocol(self):
+        from qubx.core.account_manager.connector import IConnector
+
+        assert isinstance(FakeConnector(), IConnector)
+
+    def test_object_missing_methods_does_not_satisfy_protocol(self):
+        from qubx.core.account_manager.connector import IConnector
+
+        assert not isinstance(object(), IConnector)
+
+
+# --------------------------------------------------------------------------------------
+# AccountState / AccountManager lifecycle
+# --------------------------------------------------------------------------------------
+
+INSTR = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+
+
+def mk_order(cid="c1", qty=1.0, price=100.0, side="BUY", otype="LIMIT") -> "ManagedOrder":
+    return ManagedOrder(
+        client_id=cid,
+        instrument=INSTR,
+        side=side,
+        quantity=qty,
+        price=price,
+        order_type=otype,
+    )
+
+
+def mk_manager(clock=None, connector=None, **kw):
+    clock = clock or MutableClock()
+    conn = connector or FakeConnector(exchange=INSTR.exchange)
+    am = AccountManager(connectors={conn.exchange: conn}, time_provider=clock, **kw)
+    return am, clock, conn
+
+
+def fill(cid="c1", trade_id="t1", amount=1.0, price=100.0) -> OrderFilledEvent:
+    d = Deal(
+        id=trade_id,
+        order_id=cid,
+        time=np.datetime64("2026-01-01T00:00:00", "ns"),
+        amount=amount,
+        price=price,
+        aggressive=True,
+    )
+    return OrderFilledEvent(client_id=cid, fill=d)
+
+
+class TestAddOrder:
+    def test_add_order_registers_in_active_and_inflight(self):
+        am, clock, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        o = am.get_order("c1")
+        assert o is not None
+        assert o.status == OrderState.SUBMITTED
+        assert "c1" in am.state.active_orders
+        assert "c1" in am.state._inflight_index
+        assert o.last_updated_at == clock.time()
+
+    def test_get_unknown_order_returns_none(self):
+        am, _, _ = mk_manager()
+        assert am.get_order("nope") is None
+
+
+class TestAccepted:
+    def test_submitted_to_accepted_sets_and_indexes_venue_id(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        o = am.get_order("c1")
+        assert o.status == OrderState.ACCEPTED
+        assert o.venue_id == "v1"
+        assert am.state._venue_id_index["v1"] == "c1"
+        # accepted is no longer awaiting a venue verdict
+        assert "c1" not in am.state._inflight_index
+
+    def test_accepted_resets_retry_count(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.get_order("c1").retry_count = 3
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        assert am.get_order("c1").retry_count == 0
+
+    def test_accept_for_unknown_order_is_ignored(self):
+        am, _, _ = mk_manager()
+        am.apply(OrderAcceptedEvent(client_id="ghost", venue_id="v9"))  # no raise
+        assert am.get_order("ghost") is None
+
+
+class TestRejected:
+    def test_submitted_to_rejected_is_terminal_and_deindexed(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderRejectedEvent(client_id="c1", reason="insufficient margin"))
+        o = am.get_order("c1")
+        assert o.status == OrderState.REJECTED
+        assert "c1" not in am.state._inflight_index
+        assert "c1" in am.state._pending_evict_index
+
+
+class TestCancel:
+    def test_transition_to_pending_cancel_captures_pre_pending(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        o = am.get_order("c1")
+        assert o.status == OrderState.PENDING_CANCEL
+        assert o.pre_pending_status == OrderState.ACCEPTED
+        assert "c1" in am.state._inflight_index  # awaiting cancel verdict
+
+    def test_cancel_ack_terminalizes_and_clears_pre_pending(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        am.apply(OrderCanceledEvent(client_id="c1"))
+        o = am.get_order("c1")
+        assert o.status == OrderState.CANCELED
+        assert o.pre_pending_status is None
+        assert "c1" not in am.state._inflight_index
+        assert "c1" in am.state._pending_evict_index
+
+    def test_cancel_rejected_reverts_to_pre_pending_status(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        # cancel issued before the order was acknowledged (still SUBMITTED)
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        assert am.get_order("c1").pre_pending_status == OrderState.SUBMITTED
+        am.apply(OrderCancelRejectedEvent(client_id="c1", reason="order not found"))
+        o = am.get_order("c1")
+        assert o.status == OrderState.SUBMITTED
+        assert o.pre_pending_status is None
+        assert "c1" in am.state._inflight_index
+
+
+class TestUpdate:
+    def test_update_confirmed_applies_new_params_and_clears_pre_pending(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", price=100.0, qty=1.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_UPDATE)
+        assert am.get_order("c1").pre_pending_status == OrderState.ACCEPTED
+        am.apply(OrderUpdatedEvent(client_id="c1", venue_id="v1", price=101.0, quantity=2.0))
+        o = am.get_order("c1")
+        assert o.status == OrderState.ACCEPTED
+        assert o.price == 101.0
+        assert o.quantity == 2.0
+        assert o.pre_pending_status is None
+
+    def test_update_reindexes_venue_id_on_replace(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_UPDATE)
+        am.apply(OrderUpdatedEvent(client_id="c1", venue_id="v2", price=101.0, quantity=1.0))
+        o = am.get_order("c1")
+        assert o.venue_id == "v2"
+        assert am.state._venue_id_index.get("v2") == "c1"
+        assert "v1" not in am.state._venue_id_index
+
+    def test_update_rejected_reverts_to_pre_pending_status(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_UPDATE)
+        am.apply(OrderUpdateRejectedEvent(client_id="c1", reason="price out of band"))
+        o = am.get_order("c1")
+        assert o.status == OrderState.ACCEPTED
+        assert o.pre_pending_status is None
+
+
+class TestFills:
+    def test_partial_then_full_fill(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", qty=2.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.apply(fill(cid="c1", trade_id="t1", amount=1.0))
+        o = am.get_order("c1")
+        assert o.status == OrderState.PARTIALLY_FILLED
+        assert o.filled_quantity == 1.0
+        am.apply(fill(cid="c1", trade_id="t2", amount=1.0))
+        o = am.get_order("c1")
+        assert o.status == OrderState.FILLED
+        assert o.filled_quantity == 2.0
+        assert "c1" not in am.state._inflight_index
+        assert "c1" in am.state._pending_evict_index
+
+    def test_duplicate_fill_is_deduped_by_trade_id(self):
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", qty=2.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.apply(fill(cid="c1", trade_id="t1", amount=1.0))
+        am.apply(fill(cid="c1", trade_id="t1", amount=1.0))  # same trade id replayed
+        o = am.get_order("c1")
+        assert o.filled_quantity == 1.0
+        assert o.status == OrderState.PARTIALLY_FILLED
+
+
+class TestStuckOrderSweep:
+    def test_young_inflight_order_is_not_swept(self):
+        am, clock, conn = mk_manager(min_inflight_age_sec=5.0)
+        am.add_order(mk_order(cid="c1"))
+        clock.advance(3.0)  # younger than min age
+        am.on_inflight_tick()
+        assert ("request_order_status", "c1", None) not in conn.calls
+        assert am.get_order("c1").retry_count == 0
+
+    def test_stuck_order_triggers_status_query_and_increments_retry(self):
+        am, clock, conn = mk_manager(min_inflight_age_sec=5.0)
+        am.add_order(mk_order(cid="c1"))
+        clock.advance(6.0)
+        am.on_inflight_tick()
+        assert ("request_order_status", "c1", None) in conn.calls
+        assert am.get_order("c1").retry_count == 1
+
+    def test_status_query_uses_known_venue_id(self):
+        am, clock, conn = mk_manager(min_inflight_age_sec=5.0)
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        # re-enter in-flight via a pending cancel that the venue never answers
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        clock.advance(6.0)
+        am.on_inflight_tick()
+        assert ("request_order_status", "c1", "v1") in conn.calls
+
+    def test_order_quarantined_after_max_retries(self):
+        am, clock, conn = mk_manager(min_inflight_age_sec=5.0, max_inflight_retries=3)
+        am.add_order(mk_order(cid="c1"))
+        clock.advance(6.0)
+        for _ in range(3):  # three status queries
+            am.on_inflight_tick()
+        assert am.get_order("c1").retry_count == 3
+        assert conn.calls.count(("request_order_status", "c1", None)) == 3
+        am.on_inflight_tick()  # fourth tick: give up -> quarantine (not auto-reject)
+        o = am.get_order("c1")
+        assert o.status == OrderState.STALE
+        assert "c1" not in am.state._inflight_index
+
+    def test_venue_ack_during_recovery_resets_and_stops_sweeping(self):
+        am, clock, conn = mk_manager(min_inflight_age_sec=5.0)
+        am.add_order(mk_order(cid="c1"))
+        clock.advance(6.0)
+        am.on_inflight_tick()
+        assert am.get_order("c1").retry_count == 1
+        # status query comes back 'open' -> synthesized OrderAcceptedEvent
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        o = am.get_order("c1")
+        assert o.status == OrderState.ACCEPTED
+        assert o.retry_count == 0
+        assert "c1" not in am.state._inflight_index
+
+
+class TestSnapshotReconcile:
+    def test_adopts_unknown_order_from_snapshot(self):
+        am, _, _ = mk_manager()
+        snap_order = mk_order(cid="c9")
+        snap_order.status = OrderState.ACCEPTED
+        snap_order.venue_id = "v9"
+        am.apply(AccountSnapshotEvent(orders=[snap_order]))
+        o = am.get_order("c9")
+        assert o is not None
+        assert am.state._venue_id_index.get("v9") == "c9"
+
+    def test_grace_window_blocks_resurrecting_evicted_order(self):
+        am, clock, _ = mk_manager(evict_grace_sec=30.0)
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderRejectedEvent(client_id="c1", reason="x"))  # terminal -> evict index
+        clock.advance(60.0)
+        am.evict_terminal()  # past grace: drop the order object, keep the tombstone
+        assert am.get_order("c1") is None
+        assert "c1" in am.state._pending_evict_index
+        # a late snapshot still listing it must not resurrect it
+        stale = mk_order(cid="c1")
+        stale.status = OrderState.ACCEPTED
+        am.apply(AccountSnapshotEvent(orders=[stale]))
+        assert am.get_order("c1") is None
+
+    def test_freshness_keeps_locally_newer_state(self):
+        am, clock, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        clock.advance(10.0)
+        local_ts = am.get_order("c1").last_updated_at
+        # snapshot stamped BEFORE the local update -> stale, must not override
+        stale = mk_order(cid="c1")
+        stale.status = OrderState.CANCELED
+        snap_ts = local_ts - np.timedelta64(5, "s")
+        am.apply(AccountSnapshotEvent(orders=[stale], timestamp=snap_ts))
+        assert am.get_order("c1").status == OrderState.ACCEPTED
+
+
+class TestSimulationAccountManager:
+    def test_base_manager_registers_inflight_tick(self):
+        am, _, _ = mk_manager()
+        assert am.should_register_inflight_tick is True
+
+    def test_base_manager_tick_cron_is_two_seconds(self):
+        am, _, _ = mk_manager()
+        assert am.inflight_tick_cron() == "* * * * * */2"
+
+    def test_simulation_manager_skips_tick_by_default(self):
+        from qubx.core.account_manager.manager import SimulationAccountManager
+
+        sim = SimulationAccountManager(time_provider=MutableClock())
+        assert isinstance(sim, AccountManager)
+        assert sim.should_register_inflight_tick is False
+
+    def test_simulation_manager_tick_is_opt_in(self):
+        from qubx.core.account_manager.manager import SimulationAccountManager
+
+        sim = SimulationAccountManager(time_provider=MutableClock(), register_inflight_tick=True)
+        assert sim.should_register_inflight_tick is True
+
+    def test_simulation_manager_can_still_sweep_when_driven_explicitly(self):
+        # the Q3 stuck-order-recovery test arms the sweep and drives it deterministically
+        from qubx.core.account_manager.manager import SimulationAccountManager
+
+        clock = MutableClock()
+        conn = FakeConnector(exchange=INSTR.exchange)
+        sim = SimulationAccountManager(
+            connectors={conn.exchange: conn},
+            time_provider=clock,
+            register_inflight_tick=True,
+            min_inflight_age_sec=5.0,
+        )
+        sim.add_order(mk_order(cid="c1"))
+        clock.advance(6.0)
+        sim.on_inflight_tick()
+        assert ("request_order_status", "c1", None) in conn.calls
+
+    def test_simulation_manager_shares_lifecycle_behaviour(self):
+        from qubx.core.account_manager.manager import SimulationAccountManager
+
+        sim = SimulationAccountManager(time_provider=MutableClock())
+        sim.add_order(mk_order(cid="c1"))
+        sim.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        assert sim.get_order("c1").status == OrderState.ACCEPTED
+
+
+class TestVenueDrivenOrderings:
+    """Regressions for venue-driven event orderings the original tests never exercised."""
+
+    def test_venue_initiated_cancel_on_accepted(self):  # H3
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.apply(OrderCanceledEvent(client_id="c1"))  # GTD expiry / liquidation / admin cancel
+        o = am.get_order("c1")
+        assert o.status == OrderState.CANCELED
+        assert "c1" not in am.state._inflight_index
+        assert "c1" in am.state._pending_evict_index
+
+    def test_venue_initiated_cancel_on_submitted(self):  # H3
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderCanceledEvent(client_id="c1"))
+        assert am.get_order("c1").status == OrderState.CANCELED
+
+    def test_late_reject_on_partially_filled(self):  # H4
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", qty=2.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.apply(fill(cid="c1", trade_id="t1", amount=1.0))
+        am.apply(OrderRejectedEvent(client_id="c1", reason="late venue reject"))
+        assert am.get_order("c1").status == OrderState.REJECTED
+
+    def test_fill_while_pending_cancel_still_applies(self):  # race fill (non-terminal)
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", qty=2.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        am.apply(fill(cid="c1", trade_id="t1", amount=2.0))
+        assert am.get_order("c1").status == OrderState.FILLED
+
+    def test_fill_after_terminal_is_ignored(self):  # H2
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", qty=2.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        am.apply(OrderCanceledEvent(client_id="c1"))  # terminal
+        am.apply(fill(cid="c1", trade_id="t9", amount=1.0))  # late race fill
+        o = am.get_order("c1")
+        assert o.status == OrderState.CANCELED
+        assert o.filled_quantity == 0.0
+
+    def test_update_on_unacked_submitted_order(self):  # M2
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.transition_order("c1", OrderState.PENDING_UPDATE)
+        assert am.get_order("c1").status == OrderState.PENDING_UPDATE
+        assert am.get_order("c1").pre_pending_status == OrderState.SUBMITTED
+        am.apply(OrderUpdateRejectedEvent(client_id="c1", reason="x"))
+        assert am.get_order("c1").status == OrderState.SUBMITTED
+
+
+class TestStuckPendingGiveUp:
+    def test_stuck_submitted_quarantines_to_stale(self):  # R1: never-acked submit -> STALE, not REJECTED
+        am, clock, _ = mk_manager(min_inflight_age_sec=5.0, max_inflight_retries=2)
+        am.add_order(mk_order(cid="c1"))
+        clock.advance(6.0)
+        for _ in range(3):
+            am.on_inflight_tick()
+        o = am.get_order("c1")
+        assert o.status == OrderState.STALE  # quarantined, not auto-rejected
+        assert "c1" not in am.state._inflight_index  # stops hammering the venue
+        assert "c1" not in am.state._pending_evict_index  # not terminal
+
+    def test_late_ack_resurrects_stale_order(self):  # R1: a slow ack must recover the order
+        am, clock, _ = mk_manager(min_inflight_age_sec=5.0, max_inflight_retries=2)
+        am.add_order(mk_order(cid="c1"))
+        clock.advance(6.0)
+        for _ in range(3):
+            am.on_inflight_tick()
+        assert am.get_order("c1").status == OrderState.STALE
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))  # the ack was just slow
+        assert am.get_order("c1").status == OrderState.ACCEPTED
+
+    def test_stale_order_terminalized_by_explicit_venue_reject(self):  # only explicit reject -> REJECTED
+        am, clock, _ = mk_manager(min_inflight_age_sec=5.0, max_inflight_retries=2)
+        am.add_order(mk_order(cid="c1"))
+        clock.advance(6.0)
+        for _ in range(3):
+            am.on_inflight_tick()
+        am.apply(OrderRejectedEvent(client_id="c1", reason="venue says not found"))
+        assert am.get_order("c1").status == OrderState.REJECTED
+
+    def test_stale_order_resolved_by_late_fill(self):
+        am, clock, _ = mk_manager(min_inflight_age_sec=5.0, max_inflight_retries=2)
+        am.add_order(mk_order(cid="c1", qty=1.0))
+        clock.advance(6.0)
+        for _ in range(3):
+            am.on_inflight_tick()
+        assert am.get_order("c1").status == OrderState.STALE
+        am.apply(fill(cid="c1", trade_id="t1", amount=1.0))
+        assert am.get_order("c1").status == OrderState.FILLED
+
+    def test_stuck_pending_cancel_reverts_not_rejects(self):  # H1
+        am, clock, _ = mk_manager(min_inflight_age_sec=5.0, max_inflight_retries=2)
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        clock.advance(6.0)
+        for _ in range(4):  # exhaust retries then give up
+            am.on_inflight_tick()
+        o = am.get_order("c1")
+        # cancel never acked, but the underlying order is presumed still live -> revert, not reject
+        assert o.status == OrderState.ACCEPTED
+        assert "c1" not in am.state._inflight_index
+
+    def test_open_status_on_pending_cancel_does_not_livelock(self):  # M1
+        am, clock, _ = mk_manager(min_inflight_age_sec=5.0, max_inflight_retries=3)
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        clock.advance(6.0)
+        for _ in range(6):  # each query returns 'open' (synthesized accept) -> must still converge
+            am.on_inflight_tick()
+            am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        assert am.get_order("c1").status == OrderState.ACCEPTED  # converged, not stuck forever
+
+
+class TestRobustnessFixes:
+    def test_add_order_preserves_explicit_epoch_created_at(self):  # L1
+        am, _, _ = mk_manager()
+        o = mk_order(cid="c1")
+        o.created_at = np.datetime64(0, "ns")  # epoch is falsy under `or`
+        am.add_order(o)
+        assert am.get_order("c1").created_at == np.datetime64(0, "ns")
+
+    def test_tombstones_purged_after_ttl(self):  # M3
+        am, clock, _ = mk_manager(evict_grace_sec=30.0, tombstone_ttl_sec=300.0)
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderRejectedEvent(client_id="c1", reason="x"))
+        clock.advance(60.0)
+        am.evict_terminal()
+        assert "c1" in am.state._pending_evict_index  # tombstone retained within ttl
+        clock.advance(400.0)
+        am.evict_terminal()
+        assert "c1" not in am.state._pending_evict_index  # purged after ttl
+
+    def test_apply_does_not_propagate_handler_errors(self):  # M4
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+
+        def boom(ev):
+            raise IllegalOrderTransition(OrderState.FILLED, OrderState.ACCEPTED)
+
+        am._dispatch[OrderAcceptedEvent] = boom
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))  # must not raise
+
+    def test_apply_swallows_non_transition_exceptions(self):  # R2: net must catch any handler error
+        am, _, _ = mk_manager()
+
+        def boom(ev):
+            raise AttributeError("simulated handler bug")
+
+        am._dispatch[OrderAcceptedEvent] = boom
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))  # must not raise
+
+    def test_unknown_event_type_is_ignored(self):  # L5
+        am, _, _ = mk_manager()
+        am.apply(MarketDataMessage())  # not an account event -> ignored, no raise
+
+    def test_stray_update_while_pending_cancel_is_ignored(self):  # L4 + R6
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", price=100.0, qty=1.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.transition_order("c1", OrderState.PENDING_CANCEL)
+        am.apply(OrderUpdatedEvent(client_id="c1", venue_id="v2", price=999.0, quantity=5.0))
+        o = am.get_order("c1")
+        assert o.status == OrderState.PENDING_CANCEL
+        assert o.pre_pending_status == OrderState.ACCEPTED  # cancel's revert state untouched
+        assert o.price == 100.0 and o.quantity == 1.0  # R6: params NOT mutated by stray update
+        assert o.venue_id == "v1"
+
+    def test_update_reducing_qty_to_filled_finalizes(self):  # R7
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1", qty=2.0))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        am.apply(fill(cid="c1", trade_id="t1", amount=1.0))  # filled 1 of 2
+        am.transition_order("c1", OrderState.PENDING_UPDATE)
+        am.apply(OrderUpdatedEvent(client_id="c1", venue_id="v1", quantity=1.0))  # shrink to filled size
+        assert am.get_order("c1").status == OrderState.FILLED
+
+    def test_add_order_overwrite_cleans_stale_venue_index(self):  # R5
+        am, _, _ = mk_manager()
+        am.add_order(mk_order(cid="c1"))
+        am.apply(OrderAcceptedEvent(client_id="c1", venue_id="v1"))
+        assert am.state._venue_id_index.get("v1") == "c1"
+        am.add_order(mk_order(cid="c1"))  # re-submit same cid (new order, no venue id)
+        assert "v1" not in am.state._venue_id_index
+
+    def test_snapshot_adopts_submitted_order_into_inflight(self):  # L2
+        am, _, _ = mk_manager()
+        snap = mk_order(cid="c9")
+        snap.status = OrderState.SUBMITTED
+        am.apply(AccountSnapshotEvent(orders=[snap]))
+        assert "c9" in am.state._inflight_index
+
+    def test_snapshot_with_wrong_shaped_order_is_skipped_not_crash(self):  # R3
+        from qubx.core.basics import Order
+
+        am, _, _ = mk_manager()
+        core_order = Order(
+            id="x",
+            type="LIMIT",
+            instrument=INSTR,
+            time=np.datetime64("2026-01-01", "ns"),
+            quantity=1.0,
+            price=100.0,
+            side="BUY",
+            status="OPEN",
+            time_in_force="gtc",
+            client_id="c1",
+        )
+        am.apply(AccountSnapshotEvent(orders=[core_order]))  # must not raise
+        assert am.get_order("c1") is None  # not adopted (wrong type)


### PR DESCRIPTION
First PR (Q1) of the account-management redesign. **Additive only — no callers yet**, so it doesn't touch existing behaviour. See `ACCOUNT_MANAGEMENT_PLAN.md` (added here) for the full Q1–Q5 rollout.

## What's added
New package `src/qubx/core/account_manager/`:
- **`state_machine.py`** — `OrderState` enum + transition table. Two deliberate policies (flagged for design-doc confirmation): **venue-authoritative terminalization** (a venue may terminalize any live order from any state) and a **`STALE` quarantine** for never-confirmed submits (we never auto-reject on silence).
- **`events.py`** — `ChannelMessage` → `AccountMessage`/`MarketDataMessage` hierarchy + order-lifecycle leaves + `AccountSnapshotEvent`.
- **`state.py` / `manager.py`** — `AccountState` (pure data) + `AccountManager`: apply-dispatch, `pre_pending` capture/revert, fill dedup by trade id, venue-id re-indexing, stuck-order sweep, grace-window eviction + tombstone purge, minimal snapshot reconcile.
- **`connector.py`** — `IConnector` protocol + capability flags.
- **`scheduling.py`** — `_ms_to_cron` for the in-flight tick.
- **`SimulationAccountManager`** — opt-in sweep tick for the backtester.

## Tests
`tests/qubx/core/account_manager_test.py` — **80 unit tests**, ruff clean. Heavy coverage of the state machine plus venue-driven event orderings (external cancels, late rejects, fill/cancel races, stuck-order recovery, STALE resurrection).

## Design decisions needing confirmation
- **Venue-authoritative terminalization** and **STALE quarantine** were derived from the design flows, not a design doc (which wasn't available). Both are documented inline.
- **Deferred:** positions/balances fill maths (reuse existing `Position`/`AssetBalance`); deep snapshot reconcile (divergent status / orders missing from snapshot) — the latter is also the eventual resolver for stranded `STALE` orders.

## Notes
- Opened from a fork (`jaklimoff/Qubx`) — author lacks direct push access to the upstream.
- Draft pending the design-doc cross-check on the two policies above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)