### PR TITLE
feat: delisting resilience (skip gone markets in warmup, settle phantom positions)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-delisting-resilience.md
+++ b/docs/superpowers/plans/2026-06-16-delisting-resilience.md
@@ -547,14 +547,18 @@ Add these methods to `UniverseManager` (place them right after `_has_position`, 
 
 - [ ] **Step 5: Wire `_drop_gone` into `set_universe`**
 
-In `src/qubx/core/mixins/universe.py`, in `set_universe`, right after the
-existing delisting filter (line 78), add the gone filter:
+In `src/qubx/core/mixins/universe.py`, in `set_universe`, replace the existing
+delisting filter (line 78) so `_drop_gone` runs **BEFORE** `filter_delistings`.
+Order matters: `filter_delistings` strips anything with `delist_date <= now +
+check_days` (incl. past dates), so running it first would remove a gone
+instrument that also carries a `delist_date` before `_drop_gone` could settle
+its held position. Settle state B first, then filter state A:
 
 ```python
-        # Filter out instruments with upcoming delist dates (state A: close via trade)
-        instruments = self._delisting_detector.filter_delistings(instruments)
-        # Filter out instruments whose market is already gone (state B: settle in place)
+        # Settle & exclude instruments whose market is already gone (state B) FIRST
         instruments = self._drop_gone(instruments)
+        # Then filter scheduled/upcoming delistings (state A: still listed → close via trade)
+        instruments = self._delisting_detector.filter_delistings(instruments)
 ```
 
 - [ ] **Step 6: Branch `__do_remove_instruments` to settle gone instruments**

--- a/docs/superpowers/plans/2026-06-16-delisting-resilience.md
+++ b/docs/superpowers/plans/2026-06-16-delisting-resilience.md
@@ -1,0 +1,823 @@
+# Delisting Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a delisted-and-gone instrument (market removed from the exchange) from crashing warmup or lingering as a phantom position, while leaving scheduled (future) delistings on the existing close-via-trade path untouched.
+
+**Architecture:** A connector-agnostic `IDataProvider.is_instrument_listed` capability (ccxt reads `exchange.markets`) is surfaced through `IMarketManager.is_instrument_listed`. The `UniverseManager` uses it to detect "market gone" (state B), exclude such instruments from the universe, and settle held positions **in place** (quantity → 0, realized PnL kept) without trading. A ccxt warmup guard skips unlisted instruments so startup never crashes. Future/scheduled delistings (state A) keep flowing through the existing `DelistingDetector`/close-via-trade path, unchanged.
+
+**Tech Stack:** Python 3.12, pytest + pytest-mock, ccxt, qubx core (`UniverseManager`, `IAccountProcessor`, `Position`, `IDataProvider`, `IMarketManager`).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-delisting-resilience-design.md`
+
+**Run a single test:** `uv run pytest <path>::<test> -v`
+**Run the unit suite:** `just test` (i.e. `uv run pytest -m "not integration and not e2e" --ignore=debug -v -n auto`)
+
+---
+
+### Task 1: `Position.flatten()` — zero quantity without losing history
+
+Settle a position in place: zero quantity and derived market values/margins, but
+keep `r_pnl`, average price, commissions, and funding history. Distinct from the
+existing `Position.reset()` which also wipes `r_pnl`.
+
+**Files:**
+- Modify: `src/qubx/core/basics.py` (class `Position`, near `reset()` at `:800`)
+- Test: `tests/qubx/core/basics_test.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/qubx/core/basics_test.py`:
+
+```python
+def test_position_flatten_zeroes_quantity_but_keeps_realized(mocker):
+    from qubx.core.basics import Instrument, Position
+
+    instr = mocker.Mock(spec=Instrument)
+    instr.lot_size = 0.001
+    pos = Position(instr, quantity=10.0, pos_average_price=100.0, r_pnl=42.0)
+    pos.market_value = 1000.0
+    pos.market_value_funds = 1000.0
+    pos.initial_margin = 250.0
+    pos.maint_margin = 125.0
+
+    pos.flatten()
+
+    assert pos.quantity == 0.0
+    assert pos.market_value == 0.0
+    assert pos.market_value_funds == 0.0
+    assert pos.initial_margin == 0.0
+    assert pos.maint_margin == 0.0
+    assert pos.pnl == 42.0            # unrealized is 0 at qty 0 → pnl == r_pnl
+    assert pos.r_pnl == 42.0          # realized preserved
+    assert pos.position_avg_price == 100.0   # entry preserved
+    assert pos.is_open() is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/core/basics_test.py::test_position_flatten_zeroes_quantity_but_keeps_realized -v`
+Expected: FAIL with `AttributeError: 'Position' object has no attribute 'flatten'`
+
+- [ ] **Step 3: Implement `flatten()`**
+
+In `src/qubx/core/basics.py`, add this method to `Position` immediately after `reset()` (after line ~812, before `reset_by_position`):
+
+```python
+    def flatten(self) -> None:
+        """
+        Mark the position flat WITHOUT trading: zero quantity and the derived
+        market values / margins, while KEEPING realized PnL, average price,
+        commissions and funding history.
+
+        For an instrument whose market has been delisted/removed from the
+        exchange (already cash-settled) we cannot place a closing order, so we
+        reconcile the in-memory position to flat. Unlike reset(), this preserves
+        r_pnl so the record stays identical to a normally-closed position.
+        """
+        self.quantity = 0.0
+        self.market_value = 0.0
+        self.market_value_funds = 0.0
+        self.initial_margin = 0.0
+        self.maint_margin = 0.0
+        self.pnl = self.r_pnl  # unrealized PnL is zero at zero quantity
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/qubx/core/basics_test.py::test_position_flatten_zeroes_quantity_but_keeps_realized -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/basics.py tests/qubx/core/basics_test.py
+git commit -m "feat(core): add Position.flatten() to zero quantity without losing realized PnL"
+```
+
+---
+
+### Task 2: `IDataProvider.is_instrument_listed` + ccxt implementation
+
+Connector-agnostic capability: "does this instrument currently exist on the
+exchange?" Base default `True` (unknown ⇒ assume listed, never wrongly drop).
+ccxt reads `exchange.markets`, fail-open when markets are empty/unloaded.
+
+**Files:**
+- Modify: `src/qubx/core/interfaces.py` (class `IDataProvider`, after `get_quote` ~`:906`)
+- Modify: `src/qubx/connectors/ccxt/data.py` (class `CcxtDataProvider`; import at `:7`)
+- Test: `tests/qubx/connectors/ccxt/test_data_provider.py`
+
+- [ ] **Step 1: Add the base interface method**
+
+In `src/qubx/core/interfaces.py`, inside `class IDataProvider`, add after the `get_quote` method (around line 910):
+
+```python
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        """
+        Whether the instrument currently exists / is tradeable on the exchange.
+
+        Default is True: callers must never drop an instrument just because a
+        provider cannot determine listing status (fail-open). Connectors that
+        can answer authoritatively (e.g. ccxt via exchange.markets) override this.
+        """
+        return True
+```
+
+- [ ] **Step 2: Write the failing ccxt test**
+
+Append to `tests/qubx/connectors/ccxt/test_data_provider.py` (uses the existing
+`data_provider` and `btc_instrument` fixtures in that file):
+
+```python
+class TestIsInstrumentListed:
+    def test_listed_when_symbol_in_markets(self, data_provider, btc_instrument):
+        from qubx.connectors.ccxt.utils import instrument_to_ccxt_symbol
+
+        sym = instrument_to_ccxt_symbol(btc_instrument)
+        data_provider._exchange_manager.exchange.markets = {sym: {"id": "x"}}
+        assert data_provider.is_instrument_listed(btc_instrument) is True
+
+    def test_not_listed_when_symbol_absent(self, data_provider, btc_instrument):
+        data_provider._exchange_manager.exchange.markets = {"OTHER/USDT:USDT": {}}
+        assert data_provider.is_instrument_listed(btc_instrument) is False
+
+    def test_fail_open_when_markets_empty(self, data_provider, btc_instrument):
+        data_provider._exchange_manager.exchange.markets = {}
+        assert data_provider.is_instrument_listed(btc_instrument) is True
+
+    def test_fail_open_when_markets_none(self, data_provider, btc_instrument):
+        data_provider._exchange_manager.exchange.markets = None
+        assert data_provider.is_instrument_listed(btc_instrument) is True
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_data_provider.py::TestIsInstrumentListed -v`
+Expected: FAIL — base returns `True` for the `absent` case (assertion error: expected False).
+
+- [ ] **Step 4: Implement in `CcxtDataProvider`**
+
+In `src/qubx/connectors/ccxt/data.py`, extend the import at line 7:
+
+```python
+from qubx.connectors.ccxt.utils import ccxt_convert_timeframe_to_exchange_format, instrument_to_ccxt_symbol
+```
+
+Then add this method to `CcxtDataProvider` (place it next to the other public
+methods, e.g. right after `__init__` ends / before `subscribe`):
+
+```python
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        markets = getattr(self._exchange_manager.exchange, "markets", None)
+        if not markets:  # None or empty ⇒ not loaded / can't tell ⇒ fail-open
+            return True
+        return instrument_to_ccxt_symbol(instrument) in markets
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_data_provider.py::TestIsInstrumentListed -v`
+Expected: PASS (all 4)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/qubx/core/interfaces.py src/qubx/connectors/ccxt/data.py tests/qubx/connectors/ccxt/test_data_provider.py
+git commit -m "feat(data): add IDataProvider.is_instrument_listed (ccxt reads exchange.markets, fail-open)"
+```
+
+---
+
+### Task 3: `IMarketManager.is_instrument_listed` — resolve provider by exchange
+
+Surface the capability at the market-manager level so the `UniverseManager`
+(which already depends on `IMarketManager`) can ask without reaching into
+per-exchange data providers. Fail-open when no provider is found.
+
+**Files:**
+- Modify: `src/qubx/core/interfaces.py` (class `IMarketManager` ~`:971`)
+- Modify: `src/qubx/core/mixins/market.py` (class `MarketManager`, near `_get_data_provider` `:486`)
+- Test: `tests/qubx/core/mixins/market_manager_listing_test.py` (new)
+
+- [ ] **Step 1: Add the interface method**
+
+In `src/qubx/core/interfaces.py`, inside `class IMarketManager`, add:
+
+```python
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        """Whether the instrument is currently listed on its exchange.
+        Fail-open: True when no data provider can answer."""
+        ...
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/qubx/core/mixins/market_manager_listing_test.py`:
+
+```python
+import pytest
+from pytest_mock import MockerFixture
+
+from qubx.core.basics import Instrument
+from qubx.core.mixins.market import MarketManager
+
+
+def _instr(mocker: MockerFixture, exchange: str = "BINANCE.UM"):
+    i = mocker.Mock(spec=Instrument)
+    i.exchange = exchange
+    i.symbol = "TONUSDT"
+    return i
+
+
+def _market_manager_with(provider):
+    mm = MarketManager.__new__(MarketManager)  # bypass heavy __init__
+    mm._exchange_to_data_provider = {} if provider is None else {"BINANCE.UM": provider}
+    return mm
+
+
+def test_listed_delegates_to_provider_true(mocker: MockerFixture):
+    dp = mocker.Mock()
+    dp.is_instrument_listed.return_value = True
+    mm = _market_manager_with(dp)
+    assert mm.is_instrument_listed(_instr(mocker)) is True
+
+
+def test_not_listed_delegates_to_provider_false(mocker: MockerFixture):
+    dp = mocker.Mock()
+    dp.is_instrument_listed.return_value = False
+    mm = _market_manager_with(dp)
+    assert mm.is_instrument_listed(_instr(mocker)) is False
+
+
+def test_fail_open_when_no_provider(mocker: MockerFixture):
+    mm = _market_manager_with(None)
+    assert mm.is_instrument_listed(_instr(mocker)) is True
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/core/mixins/market_manager_listing_test.py -v`
+Expected: FAIL with `AttributeError: 'MarketManager' object has no attribute 'is_instrument_listed'`
+
+- [ ] **Step 4: Implement in `MarketManager`**
+
+In `src/qubx/core/mixins/market.py`, add immediately after `_get_data_provider` (after line 491):
+
+```python
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        try:
+            dp = self._get_data_provider(instrument.exchange)
+        except ValueError:
+            return True  # no provider ⇒ can't tell ⇒ fail-open
+        return dp.is_instrument_listed(instrument)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/qubx/core/mixins/market_manager_listing_test.py -v`
+Expected: PASS (3)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/qubx/core/interfaces.py src/qubx/core/mixins/market.py tests/qubx/core/mixins/market_manager_listing_test.py
+git commit -m "feat(market): add IMarketManager.is_instrument_listed resolving provider by exchange"
+```
+
+---
+
+### Task 4: `IAccountProcessor.settle_position` — flatten in place, no trade
+
+Public way to settle a held position without trading, for a market the exchange
+already removed/cash-settled. Implemented on both account processors.
+
+**Files:**
+- Modify: `src/qubx/core/interfaces.py` (class `IAccountProcessor` ~`:1450`, near `attach_positions` `:1583`)
+- Modify: `src/qubx/core/account.py` (`BasicAccountProcessor` `:27`, `CompositeAccountProcessor` `:615`)
+- Test: `tests/qubx/core/account_processor_test.py`
+
+- [ ] **Step 1: Add the interface method**
+
+In `src/qubx/core/interfaces.py`, inside `class IAccountProcessor`, add near `attach_positions`:
+
+```python
+    def settle_position(self, instrument: Instrument) -> None:
+        """Flatten a held position in place (no trade) for a delisted/removed
+        market the exchange has already cash-settled. Realized PnL is kept."""
+        ...
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/qubx/core/account_processor_test.py`:
+
+```python
+def test_settle_position_flattens_without_trade(mocker):
+    from qubx.core.account import BasicAccountProcessor
+    from qubx.core.basics import Instrument, Position
+
+    acc = BasicAccountProcessor(
+        account_id="t",
+        time_provider=mocker.Mock(),
+        base_currency="USDT",
+        health_monitor=mocker.Mock(),
+        exchange="OKX.F",
+    )
+    instr = mocker.Mock(spec=Instrument)
+    instr.lot_size = 0.001
+    pos = Position(instr, quantity=3175.0, pos_average_price=1.69, r_pnl=-7.0)
+    acc.attach_positions(pos)
+
+    acc.settle_position(instr)
+
+    settled = acc.get_positions()[instr]
+    assert settled.quantity == 0.0
+    assert settled.r_pnl == -7.0          # realized kept
+    assert settled.is_open() is False
+
+
+def test_settle_position_noop_when_not_held(mocker):
+    from qubx.core.account import BasicAccountProcessor
+    from qubx.core.basics import Instrument
+
+    acc = BasicAccountProcessor(
+        account_id="t",
+        time_provider=mocker.Mock(),
+        base_currency="USDT",
+        health_monitor=mocker.Mock(),
+        exchange="OKX.F",
+    )
+    instr = mocker.Mock(spec=Instrument)
+    acc.settle_position(instr)  # must not raise
+    assert instr not in acc.get_positions()
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/core/account_processor_test.py::test_settle_position_flattens_without_trade tests/qubx/core/account_processor_test.py::test_settle_position_noop_when_not_held -v`
+Expected: FAIL with `AttributeError: 'BasicAccountProcessor' object has no attribute 'settle_position'`
+
+- [ ] **Step 4: Implement on both processors**
+
+In `src/qubx/core/account.py`, add to `BasicAccountProcessor` (e.g. right after `attach_positions`, after line ~264):
+
+```python
+    def settle_position(self, instrument: Instrument) -> None:
+        pos = self._positions.get(instrument)
+        if pos is not None:
+            pos.flatten()
+```
+
+And add to `CompositeAccountProcessor` (mirror its `get_positions` dispatch style, near line 742):
+
+```python
+    def settle_position(self, instrument: Instrument) -> None:
+        exch = self._get_exchange(instrument=instrument)
+        self._account_processors[exch].settle_position(instrument)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/qubx/core/account_processor_test.py::test_settle_position_flattens_without_trade tests/qubx/core/account_processor_test.py::test_settle_position_noop_when_not_held -v`
+Expected: PASS (2)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/qubx/core/interfaces.py src/qubx/core/account.py tests/qubx/core/account_processor_test.py
+git commit -m "feat(account): add settle_position to flatten a delisted position without trading"
+```
+
+---
+
+### Task 5: `UniverseManager` — detect "gone", exclude, and settle in place
+
+The orchestration: `_is_market_gone` (live-listing authoritative; past
+`delist_date` as fallback, future `delist_date` is NOT gone), `_drop_gone`
+(exclude + settle held + alert), `_settle_if_held` (settle only when
+live-confirmed gone), `_notify_gone`. Wire `_drop_gone` into `set_universe`
+alongside the existing `filter_delistings`, and branch `__do_remove_instruments`
+to settle (not trade) gone instruments.
+
+**Files:**
+- Modify: `src/qubx/core/mixins/universe.py` (imports `:1`; `set_universe` `:78`; `__do_remove_instruments` close loop `:180-195`; add new methods)
+- Test: `tests/qubx/core/universe_manager_test.py`
+
+- [ ] **Step 1: Extend the test fixture with a market-manager listing default**
+
+In `tests/qubx/core/universe_manager_test.py`, the `mock_dependencies` fixture
+sets `market_data_manager` as a bare `Mock`. Add a default so listing is
+"listed" unless a test overrides it. Edit the `market_data_manager` setup block
+(after line 18) to add:
+
+```python
+    market_data_manager.is_instrument_listed.return_value = True
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/qubx/core/universe_manager_test.py`:
+
+```python
+def _gone_instr(mocker, symbol="TONUSDT"):
+    i = mocker.Mock(spec=Instrument, symbol=symbol)
+    i.exchange = "OKX.F"
+    i.delist_date = None
+    i.min_size = 0.001
+    return i
+
+
+def test_set_universe_excludes_gone_instrument(universe_manager, mock_dependencies, mocker):
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+    live = mocker.Mock(spec=Instrument, symbol="BTCUSDT")
+    live.exchange = "OKX.F"
+    live.delist_date = None
+    live.min_size = 0.001
+    gone = _gone_instr(mocker)
+
+    def listed(instr):
+        return instr is not gone
+
+    mock_dependencies["market_data_manager"].is_instrument_listed.side_effect = listed
+    # no positions held
+    mock_dependencies["account"].positions = {}
+
+    universe_manager.set_universe([live, gone])
+
+    assert set(universe_manager.instruments) == {live}
+    assert gone not in universe_manager.instruments
+
+
+def test_gone_held_position_is_settled_not_traded(universe_manager, mock_dependencies, mocker):
+    gone = _gone_instr(mocker)
+    pos = mocker.Mock()
+    pos.quantity = 3175.0
+    mock_dependencies["account"].positions = {gone: pos}
+    mock_dependencies["market_data_manager"].is_instrument_listed.side_effect = lambda i: i is not gone
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    universe_manager.set_universe([gone])
+
+    mock_dependencies["account"].settle_position.assert_called_once_with(gone)
+    mock_dependencies["position_gathering"].alter_positions.assert_not_called()
+
+
+def test_future_delist_but_listed_is_not_gone(universe_manager, mock_dependencies, mocker):
+    import pandas as pd
+
+    instr = _gone_instr(mocker, symbol="SOLUSDT")
+    instr.delist_date = pd.Timestamp("2999-01-01")  # far future
+    mock_dependencies["market_data_manager"].is_instrument_listed.return_value = True
+    mock_dependencies["account"].positions = {}
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    universe_manager.set_universe([instr])
+
+    assert instr in universe_manager.instruments
+    mock_dependencies["account"].settle_position.assert_not_called()
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/universe_manager_test.py -k "gone or future_delist" -v`
+Expected: FAIL — `test_set_universe_excludes_gone_instrument` keeps `gone` in the universe (no `_drop_gone` yet).
+
+- [ ] **Step 4: Add imports and the new methods**
+
+In `src/qubx/core/mixins/universe.py`, extend the imports. Change line 1 and add `to_timestamp`:
+
+```python
+from qubx import logger
+from qubx.core.basics import DataType, Instrument
+from qubx.utils.time import to_timestamp
+```
+
+(Keep the existing `from qubx.core.detectors import DelistingDetector` and the `from qubx.core.interfaces import (...)` block.)
+
+Add these methods to `UniverseManager` (place them right after `_has_position`, after line 63):
+
+```python
+    def _is_market_gone(self, instrument: Instrument) -> bool:
+        """State B only: the market no longer exists / is untradeable.
+        A future delist_date (state A) is NOT gone."""
+        if not self._mkt_manager.is_instrument_listed(instrument):
+            return True  # authoritative live signal
+        d = instrument.delist_date
+        if d is None:
+            return False
+        return to_timestamp(d).replace(tzinfo=None) <= to_timestamp(self._time_provider.time())
+
+    def _settle_if_held(self, instrument: Instrument) -> None:
+        if not self._has_position(instrument):
+            return
+        if not self._mkt_manager.is_instrument_listed(instrument):
+            # live-confirmed gone: cannot trade out, exchange already settled
+            self._trading_manager.cancel_orders(instrument)
+            self._account.settle_position(instrument)
+            logger.warning(f"[UniverseManager] Settled delisted position {instrument.symbol} (market gone)")
+        else:
+            # flagged by past delist_date metadata only, but still listed (settlement
+            # overlap) — leave it for the close-via-trade path / manual review
+            logger.warning(
+                f"[UniverseManager] {instrument.symbol} flagged delisted by metadata but still listed; "
+                "leaving position for close-via-trade / manual review"
+            )
+
+    def _notify_gone(self, instruments: list[Instrument]) -> None:
+        symbols = ", ".join(sorted(i.symbol for i in instruments))
+        logger.warning(f"[UniverseManager] Dropping delisted (gone) instruments: {symbols}")
+        notifier = getattr(self._context, "notifier", None)
+        if notifier is not None and not self._context.is_simulation:
+            notifier.notify_message(
+                f"[{self._context.strategy_name}] Dropped delisted (gone) instruments: {symbols}",
+                metadata={"event": "delisted_gone", "instruments": symbols},
+            )
+
+    def _drop_gone(self, instruments: list[Instrument]) -> list[Instrument]:
+        gone = [i for i in instruments if self._is_market_gone(i)]
+        if not gone:
+            return instruments
+        for i in gone:
+            self._settle_if_held(i)
+        self._notify_gone(gone)
+        gone_set = set(gone)
+        return [i for i in instruments if i not in gone_set]
+```
+
+- [ ] **Step 5: Wire `_drop_gone` into `set_universe`**
+
+In `src/qubx/core/mixins/universe.py`, in `set_universe`, right after the
+existing delisting filter (line 78), add the gone filter:
+
+```python
+        # Filter out instruments with upcoming delist dates (state A: close via trade)
+        instruments = self._delisting_detector.filter_delistings(instruments)
+        # Filter out instruments whose market is already gone (state B: settle in place)
+        instruments = self._drop_gone(instruments)
+```
+
+- [ ] **Step 6: Branch `__do_remove_instruments` to settle gone instruments**
+
+In `src/qubx/core/mixins/universe.py`, in `__do_remove_instruments`, change the
+close loop (lines ~180-195) so a gone instrument is settled instead of traded:
+
+```python
+        # - close all open positions
+        exit_targets = []
+        for instr in instruments:
+            if self._has_position(instr):
+                if not self._mkt_manager.is_instrument_listed(instr):
+                    # market gone — cannot trade; settle in place
+                    self._account.settle_position(instr)
+                    logger.warning(f"[UniverseManager] Settled delisted position {instr.symbol} on removal")
+                    continue
+
+                # - create exit target
+                exit_targets.append(instr.target(self._context, 0))
+
+                self._removal_in_progress.add(instr)
+
+                # - emit service signals for instruments that are being removed
+                self._context.emit_signal(
+                    instr.service_signal(self._context, 0, group="Universe", comment="Universe change")
+                )
+
+        # - alter positions
+        self._position_gathering.alter_positions(self._context, exit_targets)
+```
+
+- [ ] **Step 7: Run the new tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/universe_manager_test.py -k "gone or future_delist" -v`
+Expected: PASS (3)
+
+- [ ] **Step 8: Run the full universe-manager suite (no regressions)**
+
+Run: `uv run pytest tests/qubx/core/universe_manager_test.py -v`
+Expected: PASS (existing tests still green; `filter_delistings` and `is_instrument_listed` mocks default to no-op/listed)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/qubx/core/mixins/universe.py tests/qubx/core/universe_manager_test.py
+git commit -m "feat(universe): detect gone markets, exclude from universe, settle held positions in place"
+```
+
+---
+
+### Task 6: ccxt warmup guard — skip unlisted, never abort the batch
+
+The startup crash fix: `OhlcDataHandler.warmup()` must skip instruments whose
+market is gone and tolerate a per-instrument fetch failure, so one delisted
+instrument can't abort `asyncio.gather`.
+
+**Files:**
+- Modify: `src/qubx/connectors/ccxt/handlers/ohlc.py` (`warmup`, loop at `:96`)
+- Test: `tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py`:
+
+```python
+import asyncio
+
+import pytest
+from pytest_mock import MockerFixture
+
+from qubx.connectors.ccxt.handlers.ohlc import OhlcDataHandler
+from qubx.core.basics import Instrument
+
+
+def _handler(mocker: MockerFixture, listed_map, fetch_side_effect):
+    data_provider = mocker.Mock()
+    data_provider.is_instrument_listed.side_effect = lambda i: listed_map[i]
+    data_provider._get_exch_timeframe.return_value = "1d"
+    data_provider._time_msec_nbars_back.return_value = 0
+
+    exchange = mocker.Mock()
+    exchange.fetch_ohlcv = mocker.AsyncMock(side_effect=fetch_side_effect)
+    exchange_manager = mocker.Mock()
+    exchange_manager.exchange = exchange
+
+    return OhlcDataHandler(data_provider=data_provider, exchange_manager=exchange_manager, exchange_id="okx"), exchange
+
+
+def _instr(mocker, symbol):
+    i = mocker.Mock(spec=Instrument)
+    i.symbol = symbol
+    return i
+
+
+def test_warmup_skips_unlisted_instrument(mocker: MockerFixture):
+    listed = _instr(mocker, "BTCUSDT")
+    gone = _instr(mocker, "TONUSDT")
+    channel = mocker.Mock()
+
+    # one bar then stop, for any listed instrument
+    async def fetch(symbol, timeframe, since, limit):
+        return [[0, 1.0, 2.0, 0.5, 1.5, 100.0]]
+
+    handler, exchange = _handler(mocker, {listed: True, gone: False}, fetch)
+    # patch the bar/quote converters to avoid needing real Instrument internals
+    mocker.patch.object(handler, "_convert_ohlcv_to_bar", side_effect=lambda oh: oh)
+    mocker.patch.object(handler, "_convert_ohlcv_to_quote", return_value=object())
+
+    asyncio.run(handler.warmup({listed, gone}, channel, warmup_period="1d", timeframe="1d"))
+
+    # gone instrument is never fetched; its ccxt symbol is never requested
+    called_instruments = {c.kwargs.get("symbol") if c.kwargs else None for c in exchange.fetch_ohlcv.call_args_list}
+    # at least the listed instrument was fetched and gone was skipped (fewer than 2 distinct)
+    assert exchange.fetch_ohlcv.await_count >= 1
+
+
+def test_warmup_continues_when_one_instrument_raises(mocker: MockerFixture):
+    a = _instr(mocker, "AAAUSDT")
+    b = _instr(mocker, "BBBUSDT")
+    channel = mocker.Mock()
+
+    from ccxt import BadSymbol
+
+    async def fetch(symbol, timeframe, since, limit):
+        # first instrument raises, second returns data
+        if fetch.calls == 0:
+            fetch.calls += 1
+            raise BadSymbol("okx does not have market symbol AAA/USDT:USDT")
+        return [[0, 1.0, 2.0, 0.5, 1.5, 100.0]]
+
+    fetch.calls = 0
+    handler, exchange = _handler(mocker, {a: True, b: True}, fetch)
+    mocker.patch.object(handler, "_convert_ohlcv_to_bar", side_effect=lambda oh: oh)
+    mocker.patch.object(handler, "_convert_ohlcv_to_quote", return_value=object())
+
+    # must NOT raise even though one instrument failed
+    asyncio.run(handler.warmup({a, b}, channel, warmup_period="1d", timeframe="1d"))
+    assert exchange.fetch_ohlcv.await_count >= 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py -v`
+Expected: FAIL — `test_warmup_continues_when_one_instrument_raises` propagates `BadSymbol` (no guard yet).
+
+- [ ] **Step 3: Add the guard in `warmup()`**
+
+In `src/qubx/connectors/ccxt/handlers/ohlc.py`, wrap the per-instrument body of
+the `for instrument in instruments:` loop (starts ~line 96). Replace the loop
+body so it begins with a listed-check and wraps the fetch/send in try/except:
+
+```python
+        for instrument in instruments:
+            if not self._data_provider.is_instrument_listed(instrument):
+                logger.warning(
+                    f"<yellow>{self._exchange_id}</yellow> {instrument} is not listed on the exchange "
+                    "(delisted/removed); skipping warmup"
+                )
+                continue
+
+            try:
+                start_since = self._data_provider._time_msec_nbars_back(timeframe, nbarsback)
+                ccxt_symbol = instrument_to_ccxt_symbol(instrument)
+
+                # Paginate: exchanges may return fewer bars than requested per call
+                ohlcv_map: dict[int, list] = {}
+                while len(ohlcv_map) < nbarsback:
+                    batch = await self._exchange_manager.exchange.fetch_ohlcv(
+                        ccxt_symbol, exch_timeframe, since=start_since,
+                        limit=min(nbarsback - len(ohlcv_map), self.MAX_BARS_PER_REQUEST_FOR_PROVIDER) + 1,
+                    )
+                    if not batch:
+                        break
+                    prev_count = len(ohlcv_map)
+                    for bar in batch:
+                        ohlcv_map[bar[0]] = bar
+                    if len(ohlcv_map) == prev_count:
+                        break
+                    start_since = batch[-1][0] + _tf_msec
+
+                ohlcv = list(ohlcv_map.values())
+                logger.debug(f"<yellow>{self._exchange_id}</yellow> {instrument}: loaded {len(ohlcv)} {timeframe} bars")
+
+                channel.send(
+                    (
+                        instrument,
+                        DataType.OHLC[timeframe],
+                        [self._convert_ohlcv_to_bar(oh) for oh in ohlcv],
+                        True,  # historical data
+                    )
+                )
+
+                if len(ohlcv) > 0:
+                    # Send a quote update to the context at the end of warmup
+                    channel.send((instrument, DataType.QUOTE, self._convert_ohlcv_to_quote(ohlcv, instrument), False))
+            except Exception as e:
+                logger.warning(
+                    f"<yellow>{self._exchange_id}</yellow> warmup failed for {instrument} "
+                    f"({type(e).__name__}: {e}); skipping"
+                )
+                continue
+```
+
+(Keep the lines above the loop — `nbarsback`, `exch_timeframe`, `_tf_msec` — as they are.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py -v`
+Expected: PASS (2)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/connectors/ccxt/handlers/ohlc.py tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py
+git commit -m "fix(ccxt): warmup skips unlisted instruments and tolerates per-instrument failures"
+```
+
+---
+
+### Task 7: Full suite + lint
+
+- [ ] **Step 1: Run the unit suite**
+
+Run: `just test`
+Expected: all pass (no regressions). If `pytest-xdist` OOMs locally, use `uv run pytest -m "not integration and not e2e" --ignore=debug -n 2 -q`.
+
+- [ ] **Step 2: Lint / format**
+
+Run: `just style-check` (or `uv run ruff check src tests` and `uv run ruff format --check src tests`)
+Expected: clean. Fix any line-length (120) issues introduced.
+
+- [ ] **Step 3: Commit any lint fixes**
+
+```bash
+git add -A
+git commit -m "chore: lint delisting resilience changes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 connector capability → Task 2. ✅
+- §2 `_is_market_gone`/`_drop_gone`/`_settle_if_held`/`_notify_gone` + `set_universe` wiring + `__do_remove_instruments` gone-branch → Task 5; `IMarketManager` resolution → Task 3. ✅
+- §3 `Position.flatten` + `IAccountProcessor.settle_position`, live-confirmed forget guard → Tasks 1, 4, 5 (`_settle_if_held`). ✅
+- §4 ccxt warmup guard → Task 6. ✅
+- Fail-open (markets empty/no provider) → Tasks 2, 3 tests. ✅
+- State A never settled (future delist still listed) → Task 5 `test_future_delist_but_listed_is_not_gone`. ✅
+- Backtest unaffected → base `is_instrument_listed` returns True (Task 2); simulator inherits base. (No explicit sim test task — acceptable; covered by existing simulation suite in Task 7.)
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code. The `...`
+in interface stubs (Tasks 2–4) are intentional Python interface bodies matching
+the existing `IDataProvider`/`IAccountProcessor` style.
+
+**Type/signature consistency:** `is_instrument_listed(instrument) -> bool` used
+identically on `IDataProvider` (Task 2), `IMarketManager`/`MarketManager`
+(Task 3), and called as `self._mkt_manager.is_instrument_listed(...)` (Task 5).
+`settle_position(instrument) -> None` consistent across interface + both
+processors (Task 4) and called in Task 5. `Position.flatten()` defined Task 1,
+used by `settle_position` Task 4.
+
+**Out of scope (deliberate):** runner-side restored-state pre-filter (spec shows
+unnecessary), state-A behavior changes, global kill-switch, optional partial-load
+hardening.

--- a/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
@@ -224,6 +224,26 @@ so logs, metrics, and reporting are unaffected. Capital stays correct because
 the live account-balance sync is authoritative (the settled value is already in
 the quote-currency balance) and a qty-0 position contributes zero market value.
 
+### 3b. Eager markets load before the first `set_universe`
+
+`_is_market_gone` is only authoritative if the connector's market list is
+loaded. The ccxt provider loads `exchange.markets` lazily (on first
+subscription), and in **paper mode** there is no live account processor to
+eager-load them — so at `ctx.start()` → `set_universe` the markets are empty,
+`is_instrument_listed` fail-opens to `True`, and a delisted held position is
+NOT settled (it slips into the live subscription and only fails there). This was
+found via a local restart reproduction; unit tests missed it because they mock
+`is_instrument_listed`.
+
+Fix: add a lifecycle `IDataProvider.start()` (base no-op; pairs with the
+existing `close()`). The ccxt impl synchronously loads markets
+(`self._loop.submit(exchange.load_markets()).result()`, wrapped so a transient
+failure logs and continues — fail-open preserved). `StrategyContext.start()`
+calls `data_provider.start()` for every provider **before** the initial
+`set_universe` (mirroring the existing `close()` shutdown loop). With markets
+loaded, `_drop_gone` settles the delisted position in place at startup and
+excludes it before any subscription.
+
 ### 4. Connector-side warmup guard (the actual crash fix)
 
 The warmup crash happens in the runner's warmup pass, **before** the live

--- a/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
@@ -46,33 +46,34 @@ instrument is still physically tradeable; a position on it is real and
 legitimate. The correct exit is a **trade to flat**, which the existing
 `DelistingDetector` + `set_universe` removal + the 23:30 scheduled check already
 perform (remove from universe, `alter_positions` → close via order). This path
-is **unchanged** by this design, and such a position is **never forgotten** —
-forgetting it would silently discard a real, still-tradeable holding.
+is **unchanged** by this design, and such a position is **never settled by us** —
+zeroing it would silently discard a real, still-tradeable holding.
 
 **B. Delisting *already happened* (market gone from the exchange).** You
 physically cannot hold a tradeable position anymore — the exchange has
-cash-settled it and there is no market to trade against. Only here is "forget"
-(`drop_position`, no trade) correct, because a closing order is impossible. This
-is the TON case and the new behavior in this design.
+cash-settled it and there is no market to trade against. Only here is
+settle-in-place (`settle_position` — zero quantity, no trade) correct, because a
+closing order is impossible. This is the TON case and the new behavior here.
 
 | State | Market listed? | `delist_date` | Position action |
 |---|---|---|---|
 | Scheduled delist | yes | future | existing path: remove from universe, **close via trade** |
-| Settlement overlap | yes | past | prefer close via trade; **don't forget** (alert if stuck) |
-| Gone | **no** | any / past | skip warmup/subscribe, **forget** (`drop_position`) |
+| Settlement overlap | yes | past | prefer close via trade; **don't settle** (alert if stuck) |
+| Gone | **no** | any / past | skip warmup/subscribe, **settle in place** (`settle_position`) |
 
 The authoritative signal for state B is the **live market-listing absence**
 (`is_instrument_listed() == False`). A past `delist_date` is only a cheap
 first-pass hint to skip warmup/subscription; it never, on its own, authorizes
-the destructive forget (see §3).
+the destructive settle (see §3).
 
 ## Goals
 
 - A delisted instrument must never abort warmup or block startup.
 - An instrument the exchange no longer lists must never be subscribed, warmed
   up, or kept as a tradeable position.
-- A held position on a delisted (already cash-settled) instrument is forgotten
-  and reconciled to exchange truth, with an operator alert.
+- A held position on a delisted (already cash-settled) instrument is settled in
+  place (quantity 0, record retained) and reconciled to exchange truth, with an
+  operator alert.
 - Detection is connector-agnostic at the Qubx core level; connectors supply
   only the raw "is this listed?" fact.
 - Backtests are completely unaffected.
@@ -85,7 +86,7 @@ the destructive forget (see §3).
 - Retroactive cleanup of historical logs or PnL re-derivation (we trust the
   live account-balance sync).
 - A global config kill-switch — rejected as over-engineering; fail-open plus a
-  live-confirmed forget (§3) cover the false-positive risk.
+  live-confirmed settle (§3) cover the false-positive risk.
 
 ## Design
 
@@ -135,13 +136,13 @@ def _is_market_gone(self, instrument: Instrument) -> bool:
     d = instrument.delist_date
     return d is not None and to_timestamp(d) <= self._time_provider.time()
 
-# Excludes gone instruments and forgets held positions on them (§3 guard).
+# Excludes gone instruments and settles held positions on them (§3 guard).
 # Returns the KEPT (still-tradeable) instruments. Runs IN ADDITION to the
 # existing filter_delistings (state A), not instead of it.
 def _drop_gone(self, instruments: list[Instrument]) -> list[Instrument]:
     gone = [i for i in instruments if self._is_market_gone(i)]
     for i in gone:
-        self._forget_if_held(i)        # see §3 (live-confirmed forget only)
+        self._settle_if_held(i)        # see §3 (live-confirmed settle only)
     if gone:
         self._notify_gone(gone)
     gone_set = set(gone)
@@ -154,51 +155,67 @@ def _drop_gone(self, instruments: list[Instrument]) -> list[Instrument]:
   `self._delisting_detector.filter_delistings(...)` (`core/mixins/universe.py:78`),
   before `__do_add_instruments`/subscribe (`:90`, `:215`). `filter_delistings`
   keeps handling state A (remove → close via trade); `_drop_gone` handles state
-  B (exclude → forget). One placement covers startup (`ctx.start()` →
+  B (exclude → settle). One placement covers startup (`ctx.start()` →
   `set_universe`) and every mid-run universe change.
-- A held gone instrument is forgotten by `_drop_gone` even when it was never in
-  the prior universe (the restored-position startup case), since `_forget_if_held`
+- A held gone instrument is settled by `_drop_gone` even when it was never in
+  the prior universe (the restored-position startup case), since `_settle_if_held`
   acts on the held position directly, not on `prev_set` membership.
 - **Removal path also branches on "gone":** `__do_remove_instruments`
   (`core/mixins/universe.py:159`) currently closes positions via
-  `alter_positions` → trade. Add a guard: if `_is_market_gone(instr)`, forget
-  (`drop_position`) instead of trading — so the scheduled 23:30 delisting check
-  and any other removal can never attempt a trade on a vanished market.
+  `alter_positions` → trade. Add a guard: if `_is_market_gone(instr)`, settle in
+  place (§3) instead of trading — so the scheduled 23:30 delisting check and any
+  other removal can never attempt a trade on a vanished market.
 
 The existing `DelistingDetector` is **unchanged** — no `is_delisting` predicate
 is added; state B never routes through it.
 
-### 3. Forget path — `IAccountProcessor.drop_position`
+### 3. Settle-in-place — `IAccountProcessor.settle_position`
 
-No public way exists to drop a position without trading; the normal removal
-path (`UniverseManager.__do_remove_instruments` → `alter_positions` → trade to
-flat) is impossible on a gone market. Add:
+The normal removal path (`UniverseManager.__do_remove_instruments` →
+`alter_positions` → trade to flat) is impossible on a gone market, and there's
+no public way to flatten a position without trading. Rather than delete the
+position record (which would lose realized PnL, average price, funding history),
+we **zero the quantity in place** so the record — and a normally-closed position
+— look identical (`is_open()` is `abs(quantity) >= lot_size`, so qty 0 ⇒ closed).
 
 ```python
-def drop_position(self, instrument: Instrument) -> None:
-    """Remove an instrument's position from tracking WITHOUT trading.
-    For delisted/settled markets the exchange already cash-settled it."""
+# core/basics.py — Position
+def flatten(self) -> None:
+    """Mark the position flat WITHOUT trading: zero quantity and the derived
+    market values; keep r_pnl, average price, cumulative funding, etc.
+    Distinct from reset(), which also wipes r_pnl."""
+    self.quantity = 0.0
+    self.market_value = 0.0
+    self.market_value_funds = 0.0
+    self.pnl = self.r_pnl            # unrealized is 0 at qty 0
+
+# core/interfaces.py — IAccountProcessor
+def settle_position(self, instrument: Instrument) -> None:
+    """Flatten a held position in place (no trade) for a delisted/settled
+    market the exchange has already cash-settled."""
 ```
 
-`_forget_if_held(instrument)`:
+`_settle_if_held(instrument)`:
 - if no open position → just ensure it's unsubscribed / out of the universe;
-- if a position is held → **forget only on a live-confirmed gone market.**
-  Concretely, `drop_position` is allowed only when the per-exchange data
+- if a position is held → **settle only on a live-confirmed gone market.**
+  Concretely, `settle_position` is allowed only when the per-exchange data
   provider exists and reports the instrument **absent from a loaded, non-empty
   market list** (`is_instrument_listed() == False` with markets loaded). In any
   other case — a past `delist_date` but the market still lists it (settlement
   overlap, where a reduce-only close may still be possible), no live signal
-  available, or markets empty/unloaded (fail-open) — we **do not forget**; we
+  available, or markets empty/unloaded (fail-open) — we **do not settle**; we
   **emit a "needs manual review" alert** and leave the position for the existing
-  close-via-trade path or an operator. We never forget a position whose
+  close-via-trade path or an operator. We never flatten a position whose
   delisting has not actually happened.
   - *Optional hardening (not required for v1):* protect against a *partial*
     market load by comparing the current market count against the connector's
-    last-known-good count and skipping the forget on a large unexpected drop.
+    last-known-good count and skipping the settle on a large unexpected drop.
 
-Capital stays correct because the live account-balance sync is authoritative
-(the settled value is already reflected in the quote-currency balance); we only
-discard the stale phantom.
+The settled position stays visible in `get_positions()` with qty 0 and its
+realized PnL / entry / funding intact — identical to a normally-closed position,
+so logs, metrics, and reporting are unaffected. Capital stays correct because
+the live account-balance sync is authoritative (the settled value is already in
+the quote-currency balance) and a qty-0 position contributes zero market value.
 
 ### 4. Connector-side warmup guard (the actual crash fix)
 
@@ -221,7 +238,7 @@ Other connectors mirror the same skip in their own warmup handlers.
 - **State A (scheduled delist, still listed)** → existing `filter_delistings` +
   removal path: remove from universe, **close via trade**. Unchanged.
 - **State B (market gone) + phantom-position lifecycle** → `UniverseManager`
-  (§2–3): exclude + forget (live-confirmed).
+  (§2–3): exclude + settle in place (live-confirmed).
 - **No runner changes, no new component, no callables, no global toggle.**
 
 ### Fail-safe & alerting
@@ -230,8 +247,8 @@ Other connectors mirror the same skip in their own warmup handlers.
   (`is_instrument_listed` returns base `True`, or markets failed to load),
   nothing is treated as gone. A market-load hiccup must never nuke the universe.
 - **Forget only on a live-confirmed gone market (§3):** the only destructive
-  step (forgetting a held position) requires the live listing signal; metadata
-  alone, settlement overlap, or no signal ⇒ no forget, manual-review alert.
+  step (settling a held position to qty 0) requires the live listing signal;
+  metadata alone, settlement overlap, or no signal ⇒ no settle, manual-review alert.
 - **Alert:** on any gone-drop,
   `ctx.notifier.notify_message("[<bot>] Dropped delisted (gone) instruments: TONUSDT (...)", metadata=...)`
   plus a WARN log; on a guarded skip, a "needs manual review" alert. Silent
@@ -278,15 +295,15 @@ subscription without a restored-state pre-filter.
 4. `_drop_gone` runs at the top: `_is_market_gone(TON)` is true because the live
    data provider reports TON absent from `exchange.markets` (the `delist_date`
    you added is corroborating but not required, and is not what authorizes the
-   forget). `_forget_if_held(TON)`: market is live-confirmed gone and markets are
-   loaded/non-empty → `drop_position` + unsubscribe. Notifier alert: "Dropped
-   delisted (gone) instruments: TONUSDT".
+   settle). `_settle_if_held(TON)`: market is live-confirmed gone and markets are
+   loaded/non-empty → `settle_position` (qty 0, r_pnl kept) + unsubscribe.
+   Notifier alert: "Dropped delisted (gone) instruments: TONUSDT".
 5. TON is absent from `to_add` → never subscribed. The bot starts with the
    remaining live positions; capital reflects the OKX-settled balance.
 
 Contrast — a *scheduled* (state A) delist, e.g. TON still listed with a
 `delist_date` 2 days out: `_is_market_gone` is **false** (still listed), so TON
-is never forgotten. The existing `filter_delistings`/removal path closes it via
+is never settled by us. The existing `filter_delistings`/removal path closes it via
 a normal trade when its window arrives.
 
 ## Testing
@@ -296,34 +313,36 @@ a normal trade when its window arrives.
     not gone even with a past `delist_date`; not-listed ⇒ gone); no data
     provider ⇒ fall back to metadata, where a **past** `delist_date` ⇒ gone but
     a **future** `delist_date` ⇒ not gone; fail-open (markets empty) ⇒ not gone.
-  - **State A is never forgotten:** an instrument still listed with a future
+  - **State A is never settled:** an instrument still listed with a future
     `delist_date` is not gone and routes through the existing close-via-trade
-    path, not `drop_position`.
+    path, not `settle_position`.
   - ccxt `is_instrument_listed` against a stubbed `exchange.markets`
     (present / absent / empty-fail-open).
-  - `drop_position` removes the position without emitting a trade.
-  - `_forget_if_held` guard: live-confirmed gone ⇒ forget; past `delist_date`
-    but still listed (settlement overlap) ⇒ no forget, "needs review" alert;
-    no data provider / empty markets ⇒ no forget, alert.
-  - `__do_remove_instruments` gone-branch: removing a gone instrument forgets
-    (no trade); removing a still-listed one trades to flat as before.
+  - `Position.flatten` zeroes quantity and market values but preserves `r_pnl`
+    / average price (vs `reset()` which wipes `r_pnl`); `settle_position` calls
+    it without emitting a trade; `is_open()` is false afterward.
+  - `_settle_if_held` guard: live-confirmed gone ⇒ settle; past `delist_date`
+    but still listed (settlement overlap) ⇒ no settle, "needs review" alert;
+    no data provider / empty markets ⇒ no settle, alert.
+  - `__do_remove_instruments` gone-branch: removing a gone instrument settles
+    in place (no trade); removing a still-listed one trades to flat as before.
 - **Integration**
   - Warmup with one gone instrument in the set → completes, warms the rest,
     logs the skip, no crash (direct regression for the TON incident).
   - Restart with a restored gone position → instrument excluded, position
-    forgotten, alert emitted, bot starts; instrument never subscribed.
+    settled (qty 0, record kept), alert emitted, bot starts; never subscribed.
   - Restart with a still-listed instrument carrying a future `delist_date` →
-    position retained and closed via the existing trade path; not forgotten.
+    position retained and closed via the existing trade path; not settled by us.
 - **Backtest guard**
   - A sim run still warms/trades everything (`is_instrument_listed` no-ops).
 
 ## Scope
 
 **In:** `IDataProvider.is_instrument_listed` (+ ccxt impl), `UniverseManager`
-state-B handling (`_is_market_gone`, `_drop_gone`, `_forget_if_held`,
+state-B handling (`_is_market_gone`, `_drop_gone`, `_settle_if_held`,
 `_data_provider_for`, `_notify_gone`, and the `__do_remove_instruments`
-gone-branch), `IAccountProcessor.drop_position`, ccxt warmup guard, alerting,
-tests.
+gone-branch), `Position.flatten` + `IAccountProcessor.settle_position`, ccxt
+warmup guard, alerting, tests.
 
 **Out:** state-A / future-delist handling (existing `DelistingDetector` +
 close-via-trade path, unchanged), broker-side listing checks, restored-state
@@ -337,5 +356,5 @@ historical-log cleanup.
    the version bump).
 3. Bump factors' qubx pin to the new version; rebuild the strategy release.
 4. Update the `okx.factors` bot to the new release version and restart — TON is
-   skipped in warmup and forgotten at start; the bot comes up clean without a
+   skipped in warmup and settled at start; the bot comes up clean without a
    manual state reset.

--- a/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
@@ -151,10 +151,17 @@ def _drop_gone(self, instruments: list[Instrument]) -> list[Instrument]:
 
 - `_data_provider_for(instrument)` resolves the per-exchange `IDataProvider`
   the manager already has access to via the context (`ctx._data_providers`).
-- `set_universe` calls `_drop_gone(...)` at the **top**, alongside the existing
+- `set_universe` calls `_drop_gone(...)` at the **top, BEFORE** the existing
   `self._delisting_detector.filter_delistings(...)` (`core/mixins/universe.py:78`),
-  before `__do_add_instruments`/subscribe (`:90`, `:215`). `filter_delistings`
-  keeps handling state A (remove → close via trade); `_drop_gone` handles state
+  before `__do_add_instruments`/subscribe (`:90`, `:215`). **Order matters:**
+  `filter_delistings` removes anything with `delist_date <= now + check_days`
+  (including already-past dates), so if it ran first it would strip a gone
+  instrument that *also* carries a `delist_date` before `_drop_gone` could settle
+  its held position (and on the empty-`prev_set` startup path the removal branch
+  wouldn't fire either) — leaving the phantom un-settled. Running `_drop_gone`
+  first settles the live-gone held position regardless of any `delist_date`.
+  `filter_delistings` keeps handling state A (remove → close via trade);
+  `_drop_gone` handles state
   B (exclude → settle). One placement covers startup (`ctx.start()` →
   `set_universe`) and every mid-run universe change.
 - A held gone instrument is settled by `_drop_gone` even when it was never in

--- a/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
@@ -1,0 +1,270 @@
+# Delisting resilience: don't crash or hold phantom positions on delisted instruments
+
+**Date:** 2026-06-16
+**Status:** Design approved, pending spec review
+**Repo:** Qubx
+**Branch:** `feat/delisting-resilience`
+
+## Problem
+
+A live `okx.factors` bot crash-looped on restart and could not start. The
+warmup OHLC fetch raised:
+
+```
+ccxt.base.errors.BadSymbol: okx does not have market symbol TON/USDT:USDT
+```
+
+OKX had delisted the `TON-USDT-SWAP` perpetual (confirmed: the OKX public API
+returns `code 51001 "Instrument ID ... doesn't exist"` and lists no TON swap at
+all). The bot still held an open TON position. On restart:
+
+1. `ctx.start()` force-adds every open position to the initial instrument set
+   (`core/context.py:378-380`), so the held-but-delisted TON instrument is
+   included in warmup.
+2. `OhlcDataHandler.warmup()` (`connectors/ccxt/handlers/ohlc.py:80-126`) loops
+   over instruments calling `fetch_ohlcv` with **no per-instrument error
+   handling**, and `execute_all_warmups` does `asyncio.gather(...)` then
+   re-raises (`connectors/ccxt/warmup_service.py:111-116`). So one delisted
+   instrument aborts the entire warmup and the bot never starts.
+
+Two distinct failures: (a) warmup is not resilient to a missing market, and
+(b) the framework keeps a phantom position on an instrument that no longer
+trades, with no path to reconcile it (the normal removal path trades to flat,
+which is impossible on a gone market).
+
+The existing `DelistingDetector` (`core/detectors/delisting.py`) only handles a
+**future** `delist_date` within a look-ahead window. It does not cover
+"the market is already gone," and nothing consults the live exchange.
+
+## Goals
+
+- A delisted instrument must never abort warmup or block startup.
+- An instrument the exchange no longer lists must never be subscribed, warmed
+  up, or kept as a tradeable position.
+- A held position on a delisted (already cash-settled) instrument is forgotten
+  and reconciled to exchange truth, with an operator alert.
+- Detection is connector-agnostic at the Qubx core level; connectors supply
+  only the raw "is this listed?" fact.
+- Backtests are completely unaffected.
+
+## Non-goals
+
+- Future-delist handling — the existing `DelistingDetector` stays as-is for
+  scheduled delistings.
+- Broker-side listing checks (data side covers the crash and subscriptions).
+- Retroactive cleanup of historical logs or PnL re-derivation (we trust the
+  live account-balance sync).
+- A global config kill-switch (see "Decisions" — rejected as over-engineering;
+  fail-open + a conservative forget guard cover the risk).
+
+## Design
+
+Three layers; detection is expressed through a connector-agnostic interface and
+orchestrated by the `UniverseManager`, with each connector supplying only the
+raw listing fact.
+
+### 1. Connector capability — `IDataProvider.is_instrument_listed`
+
+```python
+class IDataProvider:
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        """True if the instrument currently exists on the exchange.
+        Base default: True (unknown ⇒ assume listed; never wrongly drop)."""
+        return True
+```
+
+- **ccxt** (`CcxtDataProvider`, `connectors/ccxt/data.py`): return `True` if
+  `self._exchange_manager.exchange.markets` is empty/not loaded (fail-open
+  against a load hiccup); otherwise
+  `instrument_to_ccxt_symbol(instrument) in exchange.markets`.
+- **Simulator / backtester:** inherits the base → always `True` → backtests
+  unaffected.
+- Lives on `IDataProvider` only. Brokers are out of scope (YAGNI).
+
+### 2. Detection + reconciliation on `UniverseManager`
+
+Two-tier, **ordered metadata → live** (metadata is cheap/offline; the live
+check needs the connector). No standalone component, no callables threaded
+through signatures — the manager reaches its own dependencies.
+
+```python
+def _is_delisted(self, instrument: Instrument) -> bool:
+    # tier 1: delist_date metadata (from the InstrumentsLookup), via the
+    #         existing detector — reuses its date math, no reimplementation
+    if self._delisting_detector.is_delisting(instrument):
+        return True
+    # tier 2: live market listing, via the per-exchange data provider
+    dp = self._data_provider_for(instrument)
+    return dp is not None and not dp.is_instrument_listed(instrument)
+
+# mirrors the existing filter_delistings idiom: returns the KEPT (tradeable)
+# instruments and handles drops (forget + alert) internally
+def _drop_delisted(self, instruments: list[Instrument]) -> list[Instrument]:
+    delisted = [i for i in instruments if self._is_delisted(i)]
+    for i in delisted:
+        self._forget_if_held(i)        # see §3 (with conservative guard)
+    if delisted:
+        self._notify_delisted(delisted)
+    kept = set(delisted)
+    return [i for i in instruments if i not in kept]
+```
+
+- Add `DelistingDetector.is_delisting(instrument) -> bool` — the
+  single-instrument form of its existing batch `detect_delistings` logic — so
+  tier 1 reuses the detector rather than duplicating the date comparison.
+- `_data_provider_for(instrument)` resolves the per-exchange `IDataProvider`
+  the manager already has access to via the context (`ctx._data_providers`).
+- `set_universe` calls `_drop_delisted(...)` exactly where it currently calls
+  `self._delisting_detector.filter_delistings(...)` (`core/mixins/universe.py:78`),
+  at the **top**, before `__do_add_instruments`/subscribe (`:90`, `:215`). This
+  single placement covers startup (`ctx.start()` → `set_universe`) and every
+  mid-run universe change.
+
+### 3. Forget path — `IAccountProcessor.drop_position`
+
+No public way exists to drop a position without trading; the normal removal
+path (`UniverseManager.__do_remove_instruments` → `alter_positions` → trade to
+flat) is impossible on a gone market. Add:
+
+```python
+def drop_position(self, instrument: Instrument) -> None:
+    """Remove an instrument's position from tracking WITHOUT trading.
+    For delisted/settled markets the exchange already cash-settled it."""
+```
+
+`_forget_if_held(instrument)`:
+- if no open position → just ensure it's unsubscribed / out of the universe;
+- if a position is held → **conservative guard**: only `drop_position` when we
+  have *positive* delisting evidence, namely either (a) an explicit `delist_date`
+  (tier 1), or (b) the instrument is absent from a **loaded, non-empty** market
+  list (tier 2). The empty/unloaded case is already excluded by fail-open in
+  `is_instrument_listed` (§ below), so a wholesale `load_markets` failure can
+  never trigger a forget. When the guard is not satisfied we **skip the forget
+  and emit a "needs manual review" alert** instead of discarding a position.
+  - *Optional hardening (not required for v1):* protect against a *partial*
+    market load by comparing the current market count against the connector's
+    last-known-good count and skipping the forget on a large unexpected drop.
+
+Capital stays correct because the live account-balance sync is authoritative
+(the settled value is already reflected in the quote-currency balance); we only
+discard the stale phantom.
+
+### 4. Connector-side warmup guard (the actual crash fix)
+
+The warmup crash happens in the runner's warmup pass, **before** the live
+`UniverseManager` exists, so the manager cannot prevent it. The fix is local
+and connector-appropriate: in `OhlcDataHandler.warmup()`
+(`connectors/ccxt/handlers/ohlc.py`), per instrument:
+
+- skip when `not self._data_provider.is_instrument_listed(instrument)`
+  (log a warning, continue);
+- wrap the fetch in `try/except` catching `BadSymbol`/`NotSupported` (and
+  generally per-instrument failures) → log + continue, so no single instrument
+  can abort `asyncio.gather`.
+
+Other connectors mirror the same skip in their own warmup handlers.
+
+### Responsibilities split
+
+- **Warmup robustness** → connector guard (§4).
+- **Universe + phantom-position lifecycle** → `UniverseManager` (§2–3),
+  two-tier metadata→live detection.
+- **No runner changes, no new component, no callables, no global toggle.**
+
+### Fail-safe & alerting
+
+- **Fail-open everywhere:** if a connector can't produce a confident listed-set
+  (`is_instrument_listed` returns base `True`, or markets failed to load),
+  nothing is dropped. A market-load hiccup must never nuke the universe.
+- **Conservative forget (§3):** the only destructive step (forgetting a held
+  position) is additionally gated on the market list looking healthy.
+- **Alert:** on any drop,
+  `ctx.notifier.notify_message("[<bot>] Dropped delisted instruments: TONUSDT (...)", metadata=...)`
+  plus a WARN log. Silent drops are not acceptable for a prod trading bot.
+
+## Why no restored-state pre-filter is needed (verified)
+
+`set_universe` is not the only subscription path, so this was checked directly:
+
+1. **Universe path** (`set_universe`): the delisting filter runs at the top
+   (`core/mixins/universe.py:78`) before subscribe (`:90`/`:215`); a dropped
+   instrument never reaches `to_add` → never subscribed.
+2. **Account poller path** (`connectors/ccxt/account.py`): `_update_subscriptions`
+   (`:312`) subscribes `_required_instruments`, which is populated **only from
+   exchange-reported state** — `_update_balance` (`:367`) and `_update_positions`
+   (`:379`). It is *not* populated by `attach_positions` (restore just fills the
+   `_positions` dict). For a genuinely delisted instrument the exchange no
+   longer reports it, so it never enters `_required_instruments`.
+
+Restored positions (`QUBX_RESTORE`) flow into `ctx.start()` →
+`_initial_instruments` (`core/context.py:378-380`) → `set_universe` (path 1,
+filtered) and do **not** feed the account's `_required_instruments`. So the
+restored phantom is filtered before subscription on the path that handles it,
+and the account path never sees it because the exchange doesn't report it.
+
+Residual case — metadata says delisted but the exchange *still* lists it (e.g. a
+near-future `delist_date` during settlement overlap): the account poller could
+briefly subscribe it, but (a) it isn't actually gone yet so a brief
+subscription is harmless, (b) `set_universe` removal unsubscribes it, and (c) the
+**live** OHLC watch handler already has per-instrument try/except
+(`connectors/ccxt/handlers/ohlc.py:197+`). Only *warmup* lacked the guard, which
+§4 fixes.
+
+Conclusion: §2 (filter at top of `set_universe`) + §4 (warmup guard) cover
+subscription without a restored-state pre-filter.
+
+## Behavior walkthrough (the TON restart scenario)
+
+1. Bot restarts with a held TON position; OKX no longer lists TON.
+2. **Warmup**: §4 guard skips TON (not in `exchange.markets`), warms the other
+   instruments, logs a warning, completes — no crash.
+3. **Live start**: `ctx.start()` builds `_initial_instruments` including the
+   restored TON position → `set_universe(...)`.
+4. `_drop_delisted` runs at the top: tier 1 sees the `delist_date` you added
+   (or, even without it, tier 2 sees TON missing from `exchange.markets`) → TON
+   is delisted. `_forget_if_held(TON)`: market list is healthy → `drop_position`
+   + unsubscribe. Notifier alert: "Dropped delisted instruments: TONUSDT".
+5. TON is absent from `to_add` → never subscribed. The bot starts with the
+   remaining live positions; capital reflects the OKX-settled balance.
+
+## Testing
+
+- **Unit**
+  - `DelistingDetector.is_delisting` (past, within-window, future-beyond-window,
+    no `delist_date`).
+  - `UniverseManager._is_delisted` ordering: metadata hit short-circuits before
+    the data-provider call; metadata miss falls through to the listing check;
+    no data provider ⇒ fail-open (not delisted).
+  - ccxt `is_instrument_listed` against a stubbed `exchange.markets`
+    (present / absent / empty-fail-open).
+  - `drop_position` removes the position without emitting a trade.
+  - `_forget_if_held` conservative guard: empty/too-small market list ⇒ no
+    forget, "needs review" alert instead.
+- **Integration**
+  - Warmup with one delisted instrument in the set → completes, warms the rest,
+    logs the skip, no crash (direct regression for the TON incident).
+  - Restart with a restored delisted position → instrument dropped, position
+    forgotten, alert emitted, bot starts; instrument never subscribed.
+- **Backtest guard**
+  - A sim run still warms/trades everything (`is_instrument_listed` no-ops).
+
+## Scope
+
+**In:** `IDataProvider.is_instrument_listed` (+ ccxt impl), `UniverseManager`
+detection/reconciliation (`_is_delisted`, `_drop_delisted`, `_forget_if_held`,
+`_data_provider_for`, `_notify_delisted`), `DelistingDetector.is_delisting`,
+`IAccountProcessor.drop_position`, ccxt warmup guard, alerting, tests.
+
+**Out:** future-delist handling (unchanged), broker-side listing checks,
+restored-state pre-filter (shown unnecessary), global kill-switch toggle, PnL
+re-derivation, historical-log cleanup.
+
+## Rollout
+
+1. Implement + test on `feat/delisting-resilience`; PR to Qubx `dev`.
+2. Push to `dev` → CI publishes a new qubx version (conventional commits drive
+   the version bump).
+3. Bump factors' qubx pin to the new version; rebuild the strategy release.
+4. Update the `okx.factors` bot to the new release version and restart — TON is
+   skipped in warmup and forgotten at start; the bot comes up clean without a
+   manual state reset.

--- a/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-16-delisting-resilience-design.md
@@ -36,6 +36,36 @@ The existing `DelistingDetector` (`core/detectors/delisting.py`) only handles a
 **future** `delist_date` within a look-ahead window. It does not cover
 "the market is already gone," and nothing consults the live exchange.
 
+## Conceptual model: two distinct states (do not conflate)
+
+The decision of what to do with a held position keys on **tradeability — is the
+market physically there right now? — not on `delist_date`.**
+
+**A. Delisting *scheduled* (future `delist_date`, market still listed).** The
+instrument is still physically tradeable; a position on it is real and
+legitimate. The correct exit is a **trade to flat**, which the existing
+`DelistingDetector` + `set_universe` removal + the 23:30 scheduled check already
+perform (remove from universe, `alter_positions` → close via order). This path
+is **unchanged** by this design, and such a position is **never forgotten** —
+forgetting it would silently discard a real, still-tradeable holding.
+
+**B. Delisting *already happened* (market gone from the exchange).** You
+physically cannot hold a tradeable position anymore — the exchange has
+cash-settled it and there is no market to trade against. Only here is "forget"
+(`drop_position`, no trade) correct, because a closing order is impossible. This
+is the TON case and the new behavior in this design.
+
+| State | Market listed? | `delist_date` | Position action |
+|---|---|---|---|
+| Scheduled delist | yes | future | existing path: remove from universe, **close via trade** |
+| Settlement overlap | yes | past | prefer close via trade; **don't forget** (alert if stuck) |
+| Gone | **no** | any / past | skip warmup/subscribe, **forget** (`drop_position`) |
+
+The authoritative signal for state B is the **live market-listing absence**
+(`is_instrument_listed() == False`). A past `delist_date` is only a cheap
+first-pass hint to skip warmup/subscription; it never, on its own, authorizes
+the destructive forget (see §3).
+
 ## Goals
 
 - A delisted instrument must never abort warmup or block startup.
@@ -54,8 +84,8 @@ The existing `DelistingDetector` (`core/detectors/delisting.py`) only handles a
 - Broker-side listing checks (data side covers the crash and subscriptions).
 - Retroactive cleanup of historical logs or PnL re-derivation (we trust the
   live account-balance sync).
-- A global config kill-switch (see "Decisions" — rejected as over-engineering;
-  fail-open + a conservative forget guard cover the risk).
+- A global config kill-switch — rejected as over-engineering; fail-open plus a
+  live-confirmed forget (§3) cover the false-positive risk.
 
 ## Design
 
@@ -81,44 +111,62 @@ class IDataProvider:
   unaffected.
 - Lives on `IDataProvider` only. Brokers are out of scope (YAGNI).
 
-### 2. Detection + reconciliation on `UniverseManager`
+### 2. "Market gone" detection + reconciliation on `UniverseManager`
 
-Two-tier, **ordered metadata → live** (metadata is cheap/offline; the live
-check needs the connector). No standalone component, no callables threaded
-through signatures — the manager reaches its own dependencies.
+This handles **only state B (market gone)**. State A (future/scheduled
+delisting) is left entirely to the existing `filter_delistings` path, which
+still runs and still closes positions via trade.
+
+The authoritative "gone" signal is the **live market-listing absence**. A
+**past** `delist_date` is a cheap offline hint usable for *exclusion* (skip
+warmup/subscription), but a **future** `delist_date` is explicitly *not* gone.
+No standalone component, no callables threaded through signatures — the manager
+reaches its own dependencies.
 
 ```python
-def _is_delisted(self, instrument: Instrument) -> bool:
-    # tier 1: delist_date metadata (from the InstrumentsLookup), via the
-    #         existing detector — reuses its date math, no reimplementation
-    if self._delisting_detector.is_delisting(instrument):
-        return True
-    # tier 2: live market listing, via the per-exchange data provider
+def _is_market_gone(self, instrument: Instrument) -> bool:
+    """State B only: the market no longer exists / is untradeable.
+    A future delist_date (state A) is NOT gone."""
     dp = self._data_provider_for(instrument)
-    return dp is not None and not dp.is_instrument_listed(instrument)
+    if dp is not None:
+        return not dp.is_instrument_listed(instrument)   # authoritative
+    # No live signal (e.g. connector can't tell): fall back to metadata,
+    # but ONLY a past delist_date counts as gone — never a future one.
+    d = instrument.delist_date
+    return d is not None and to_timestamp(d) <= self._time_provider.time()
 
-# mirrors the existing filter_delistings idiom: returns the KEPT (tradeable)
-# instruments and handles drops (forget + alert) internally
-def _drop_delisted(self, instruments: list[Instrument]) -> list[Instrument]:
-    delisted = [i for i in instruments if self._is_delisted(i)]
-    for i in delisted:
-        self._forget_if_held(i)        # see §3 (with conservative guard)
-    if delisted:
-        self._notify_delisted(delisted)
-    kept = set(delisted)
-    return [i for i in instruments if i not in kept]
+# Excludes gone instruments and forgets held positions on them (§3 guard).
+# Returns the KEPT (still-tradeable) instruments. Runs IN ADDITION to the
+# existing filter_delistings (state A), not instead of it.
+def _drop_gone(self, instruments: list[Instrument]) -> list[Instrument]:
+    gone = [i for i in instruments if self._is_market_gone(i)]
+    for i in gone:
+        self._forget_if_held(i)        # see §3 (live-confirmed forget only)
+    if gone:
+        self._notify_gone(gone)
+    gone_set = set(gone)
+    return [i for i in instruments if i not in gone_set]
 ```
 
-- Add `DelistingDetector.is_delisting(instrument) -> bool` — the
-  single-instrument form of its existing batch `detect_delistings` logic — so
-  tier 1 reuses the detector rather than duplicating the date comparison.
 - `_data_provider_for(instrument)` resolves the per-exchange `IDataProvider`
   the manager already has access to via the context (`ctx._data_providers`).
-- `set_universe` calls `_drop_delisted(...)` exactly where it currently calls
+- `set_universe` calls `_drop_gone(...)` at the **top**, alongside the existing
   `self._delisting_detector.filter_delistings(...)` (`core/mixins/universe.py:78`),
-  at the **top**, before `__do_add_instruments`/subscribe (`:90`, `:215`). This
-  single placement covers startup (`ctx.start()` → `set_universe`) and every
-  mid-run universe change.
+  before `__do_add_instruments`/subscribe (`:90`, `:215`). `filter_delistings`
+  keeps handling state A (remove → close via trade); `_drop_gone` handles state
+  B (exclude → forget). One placement covers startup (`ctx.start()` →
+  `set_universe`) and every mid-run universe change.
+- A held gone instrument is forgotten by `_drop_gone` even when it was never in
+  the prior universe (the restored-position startup case), since `_forget_if_held`
+  acts on the held position directly, not on `prev_set` membership.
+- **Removal path also branches on "gone":** `__do_remove_instruments`
+  (`core/mixins/universe.py:159`) currently closes positions via
+  `alter_positions` → trade. Add a guard: if `_is_market_gone(instr)`, forget
+  (`drop_position`) instead of trading — so the scheduled 23:30 delisting check
+  and any other removal can never attempt a trade on a vanished market.
+
+The existing `DelistingDetector` is **unchanged** — no `is_delisting` predicate
+is added; state B never routes through it.
 
 ### 3. Forget path — `IAccountProcessor.drop_position`
 
@@ -134,13 +182,16 @@ def drop_position(self, instrument: Instrument) -> None:
 
 `_forget_if_held(instrument)`:
 - if no open position → just ensure it's unsubscribed / out of the universe;
-- if a position is held → **conservative guard**: only `drop_position` when we
-  have *positive* delisting evidence, namely either (a) an explicit `delist_date`
-  (tier 1), or (b) the instrument is absent from a **loaded, non-empty** market
-  list (tier 2). The empty/unloaded case is already excluded by fail-open in
-  `is_instrument_listed` (§ below), so a wholesale `load_markets` failure can
-  never trigger a forget. When the guard is not satisfied we **skip the forget
-  and emit a "needs manual review" alert** instead of discarding a position.
+- if a position is held → **forget only on a live-confirmed gone market.**
+  Concretely, `drop_position` is allowed only when the per-exchange data
+  provider exists and reports the instrument **absent from a loaded, non-empty
+  market list** (`is_instrument_listed() == False` with markets loaded). In any
+  other case — a past `delist_date` but the market still lists it (settlement
+  overlap, where a reduce-only close may still be possible), no live signal
+  available, or markets empty/unloaded (fail-open) — we **do not forget**; we
+  **emit a "needs manual review" alert** and leave the position for the existing
+  close-via-trade path or an operator. We never forget a position whose
+  delisting has not actually happened.
   - *Optional hardening (not required for v1):* protect against a *partial*
     market load by comparing the current market count against the connector's
     last-known-good count and skipping the forget on a large unexpected drop.
@@ -167,20 +218,24 @@ Other connectors mirror the same skip in their own warmup handlers.
 ### Responsibilities split
 
 - **Warmup robustness** → connector guard (§4).
-- **Universe + phantom-position lifecycle** → `UniverseManager` (§2–3),
-  two-tier metadata→live detection.
+- **State A (scheduled delist, still listed)** → existing `filter_delistings` +
+  removal path: remove from universe, **close via trade**. Unchanged.
+- **State B (market gone) + phantom-position lifecycle** → `UniverseManager`
+  (§2–3): exclude + forget (live-confirmed).
 - **No runner changes, no new component, no callables, no global toggle.**
 
 ### Fail-safe & alerting
 
 - **Fail-open everywhere:** if a connector can't produce a confident listed-set
   (`is_instrument_listed` returns base `True`, or markets failed to load),
-  nothing is dropped. A market-load hiccup must never nuke the universe.
-- **Conservative forget (§3):** the only destructive step (forgetting a held
-  position) is additionally gated on the market list looking healthy.
-- **Alert:** on any drop,
-  `ctx.notifier.notify_message("[<bot>] Dropped delisted instruments: TONUSDT (...)", metadata=...)`
-  plus a WARN log. Silent drops are not acceptable for a prod trading bot.
+  nothing is treated as gone. A market-load hiccup must never nuke the universe.
+- **Forget only on a live-confirmed gone market (§3):** the only destructive
+  step (forgetting a held position) requires the live listing signal; metadata
+  alone, settlement overlap, or no signal ⇒ no forget, manual-review alert.
+- **Alert:** on any gone-drop,
+  `ctx.notifier.notify_message("[<bot>] Dropped delisted (gone) instruments: TONUSDT (...)", metadata=...)`
+  plus a WARN log; on a guarded skip, a "needs manual review" alert. Silent
+  drops are not acceptable for a prod trading bot.
 
 ## Why no restored-state pre-filter is needed (verified)
 
@@ -220,44 +275,60 @@ subscription without a restored-state pre-filter.
    instruments, logs a warning, completes — no crash.
 3. **Live start**: `ctx.start()` builds `_initial_instruments` including the
    restored TON position → `set_universe(...)`.
-4. `_drop_delisted` runs at the top: tier 1 sees the `delist_date` you added
-   (or, even without it, tier 2 sees TON missing from `exchange.markets`) → TON
-   is delisted. `_forget_if_held(TON)`: market list is healthy → `drop_position`
-   + unsubscribe. Notifier alert: "Dropped delisted instruments: TONUSDT".
+4. `_drop_gone` runs at the top: `_is_market_gone(TON)` is true because the live
+   data provider reports TON absent from `exchange.markets` (the `delist_date`
+   you added is corroborating but not required, and is not what authorizes the
+   forget). `_forget_if_held(TON)`: market is live-confirmed gone and markets are
+   loaded/non-empty → `drop_position` + unsubscribe. Notifier alert: "Dropped
+   delisted (gone) instruments: TONUSDT".
 5. TON is absent from `to_add` → never subscribed. The bot starts with the
    remaining live positions; capital reflects the OKX-settled balance.
+
+Contrast — a *scheduled* (state A) delist, e.g. TON still listed with a
+`delist_date` 2 days out: `_is_market_gone` is **false** (still listed), so TON
+is never forgotten. The existing `filter_delistings`/removal path closes it via
+a normal trade when its window arrives.
 
 ## Testing
 
 - **Unit**
-  - `DelistingDetector.is_delisting` (past, within-window, future-beyond-window,
-    no `delist_date`).
-  - `UniverseManager._is_delisted` ordering: metadata hit short-circuits before
-    the data-provider call; metadata miss falls through to the listing check;
-    no data provider ⇒ fail-open (not delisted).
+  - `UniverseManager._is_market_gone`: live signal authoritative (listed ⇒
+    not gone even with a past `delist_date`; not-listed ⇒ gone); no data
+    provider ⇒ fall back to metadata, where a **past** `delist_date` ⇒ gone but
+    a **future** `delist_date` ⇒ not gone; fail-open (markets empty) ⇒ not gone.
+  - **State A is never forgotten:** an instrument still listed with a future
+    `delist_date` is not gone and routes through the existing close-via-trade
+    path, not `drop_position`.
   - ccxt `is_instrument_listed` against a stubbed `exchange.markets`
     (present / absent / empty-fail-open).
   - `drop_position` removes the position without emitting a trade.
-  - `_forget_if_held` conservative guard: empty/too-small market list ⇒ no
-    forget, "needs review" alert instead.
+  - `_forget_if_held` guard: live-confirmed gone ⇒ forget; past `delist_date`
+    but still listed (settlement overlap) ⇒ no forget, "needs review" alert;
+    no data provider / empty markets ⇒ no forget, alert.
+  - `__do_remove_instruments` gone-branch: removing a gone instrument forgets
+    (no trade); removing a still-listed one trades to flat as before.
 - **Integration**
-  - Warmup with one delisted instrument in the set → completes, warms the rest,
+  - Warmup with one gone instrument in the set → completes, warms the rest,
     logs the skip, no crash (direct regression for the TON incident).
-  - Restart with a restored delisted position → instrument dropped, position
+  - Restart with a restored gone position → instrument excluded, position
     forgotten, alert emitted, bot starts; instrument never subscribed.
+  - Restart with a still-listed instrument carrying a future `delist_date` →
+    position retained and closed via the existing trade path; not forgotten.
 - **Backtest guard**
   - A sim run still warms/trades everything (`is_instrument_listed` no-ops).
 
 ## Scope
 
 **In:** `IDataProvider.is_instrument_listed` (+ ccxt impl), `UniverseManager`
-detection/reconciliation (`_is_delisted`, `_drop_delisted`, `_forget_if_held`,
-`_data_provider_for`, `_notify_delisted`), `DelistingDetector.is_delisting`,
-`IAccountProcessor.drop_position`, ccxt warmup guard, alerting, tests.
+state-B handling (`_is_market_gone`, `_drop_gone`, `_forget_if_held`,
+`_data_provider_for`, `_notify_gone`, and the `__do_remove_instruments`
+gone-branch), `IAccountProcessor.drop_position`, ccxt warmup guard, alerting,
+tests.
 
-**Out:** future-delist handling (unchanged), broker-side listing checks,
-restored-state pre-filter (shown unnecessary), global kill-switch toggle, PnL
-re-derivation, historical-log cleanup.
+**Out:** state-A / future-delist handling (existing `DelistingDetector` +
+close-via-trade path, unchanged), broker-side listing checks, restored-state
+pre-filter (shown unnecessary), global kill-switch toggle, PnL re-derivation,
+historical-log cleanup.
 
 ## Rollout
 

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 # CCXT exceptions are now handled in ConnectionManager
 from qubx import logger
-from qubx.connectors.ccxt.utils import ccxt_convert_timeframe_to_exchange_format
+from qubx.connectors.ccxt.utils import ccxt_convert_timeframe_to_exchange_format, instrument_to_ccxt_symbol
 from qubx.connectors.registry import data_provider
 from qubx.core.basics import CtrlChannel, DataType, Instrument, ITimeProvider
 from qubx.core.interfaces import IDataProvider, IHealthMonitor
@@ -120,6 +120,12 @@ class CcxtDataProvider(IDataProvider):
             bool: True if any stream is enabled (indicating active connection), False otherwise
         """
         return any(self._connection_manager._is_stream_enabled.values())
+
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        markets = getattr(self._exchange_manager.exchange, "markets", None)
+        if not markets:  # None or empty => not loaded / can't tell => fail-open
+            return True
+        return instrument_to_ccxt_symbol(instrument) in markets
 
     def subscribe(
         self,

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -228,6 +228,22 @@ class CcxtDataProvider(IDataProvider):
 
         return self._loop.submit(_get_historical()).result(60)
 
+    def start(self):
+        # Eagerly load markets so is_instrument_listed() is authoritative before the
+        # initial set_universe (in paper mode no account processor loads them). ccxt
+        # caches markets, so this is idempotent with the account processor's load.
+        try:
+            self._loop.submit(self._exchange_manager.exchange.load_markets()).result()
+            logger.info(
+                f"<yellow>{self._exchange_id}</yellow> Markets loaded "
+                f"({len(self._exchange_manager.exchange.markets or {})})"
+            )
+        except Exception as e:
+            logger.warning(
+                f"<yellow>{self._exchange_id}</yellow> Failed to eagerly load markets: {e} "
+                "(continuing, listing checks will fail-open)"
+            )
+
     def close(self):
         """Properly close all connections and clean up resources."""
         try:

--- a/src/qubx/connectors/ccxt/handlers/ohlc.py
+++ b/src/qubx/connectors/ccxt/handlers/ohlc.py
@@ -94,42 +94,56 @@ class OhlcDataHandler(BaseDataTypeHandler):
         _tf_msec = to_timedelta(timeframe).value // 1_000_000
 
         for instrument in instruments:
-            start_since = self._data_provider._time_msec_nbars_back(timeframe, nbarsback)
-            ccxt_symbol = instrument_to_ccxt_symbol(instrument)
-
-            # Paginate: exchanges may return fewer bars than requested per call
-            ohlcv_map: dict[int, list] = {}
-            while len(ohlcv_map) < nbarsback:
-                batch = await self._exchange_manager.exchange.fetch_ohlcv(
-                    ccxt_symbol, exch_timeframe, since=start_since,
-                    limit=min(nbarsback - len(ohlcv_map), self.MAX_BARS_PER_REQUEST_FOR_PROVIDER) + 1,
+            if not self._data_provider.is_instrument_listed(instrument):
+                logger.warning(
+                    f"<yellow>{self._exchange_id}</yellow> {instrument} is not listed on the exchange "
+                    "(delisted/removed); skipping warmup"
                 )
-                if not batch:
-                    break
-                prev_count = len(ohlcv_map)
-                for bar in batch:
-                    ohlcv_map[bar[0]] = bar
-                if len(ohlcv_map) == prev_count:
-                    break
-                start_since = batch[-1][0] + _tf_msec
+                continue
 
-            ohlcv = list(ohlcv_map.values())
-            logger.debug(f"<yellow>{self._exchange_id}</yellow> {instrument}: loaded {len(ohlcv)} {timeframe} bars")
+            try:
+                start_since = self._data_provider._time_msec_nbars_back(timeframe, nbarsback)
+                ccxt_symbol = instrument_to_ccxt_symbol(instrument)
 
-            channel.send(
-                (
-                    instrument,
-                    DataType.OHLC[timeframe],
-                    [self._convert_ohlcv_to_bar(oh) for oh in ohlcv],
-                    True,  # historical data
+                # Paginate: exchanges may return fewer bars than requested per call
+                ohlcv_map: dict[int, list] = {}
+                while len(ohlcv_map) < nbarsback:
+                    batch = await self._exchange_manager.exchange.fetch_ohlcv(
+                        ccxt_symbol, exch_timeframe, since=start_since,
+                        limit=min(nbarsback - len(ohlcv_map), self.MAX_BARS_PER_REQUEST_FOR_PROVIDER) + 1,
+                    )
+                    if not batch:
+                        break
+                    prev_count = len(ohlcv_map)
+                    for bar in batch:
+                        ohlcv_map[bar[0]] = bar
+                    if len(ohlcv_map) == prev_count:
+                        break
+                    start_since = batch[-1][0] + _tf_msec
+
+                ohlcv = list(ohlcv_map.values())
+                logger.debug(f"<yellow>{self._exchange_id}</yellow> {instrument}: loaded {len(ohlcv)} {timeframe} bars")
+
+                channel.send(
+                    (
+                        instrument,
+                        DataType.OHLC[timeframe],
+                        [self._convert_ohlcv_to_bar(oh) for oh in ohlcv],
+                        True,  # historical data
+                    )
                 )
-            )
 
-            if len(ohlcv) > 0:
-                # Send a quote update to the context at the end of warmup
-                channel.send((instrument, DataType.QUOTE, self._convert_ohlcv_to_quote(ohlcv, instrument), False))
+                if len(ohlcv) > 0:
+                    # Send a quote update to the context at the end of warmup
+                    channel.send((instrument, DataType.QUOTE, self._convert_ohlcv_to_quote(ohlcv, instrument), False))
 
-            self._update_quote(instrument, ohlcv)
+                self._update_quote(instrument, ohlcv)
+            except Exception as e:
+                logger.warning(
+                    f"<yellow>{self._exchange_id}</yellow> warmup failed for {instrument} "
+                    f"({type(e).__name__}: {e}); skipping"
+                )
+                continue
 
     async def get_historical_ohlc(self, instrument: Instrument, timeframe: str, nbarsback: int) -> list[Bar]:
         """

--- a/src/qubx/connectors/ccxt/handlers/ohlc.py
+++ b/src/qubx/connectors/ccxt/handlers/ohlc.py
@@ -138,7 +138,7 @@ class OhlcDataHandler(BaseDataTypeHandler):
                     channel.send((instrument, DataType.QUOTE, self._convert_ohlcv_to_quote(ohlcv, instrument), False))
 
                 self._update_quote(instrument, ohlcv)
-            except Exception as e:
+            except BadSymbol as e:
                 logger.warning(
                     f"<yellow>{self._exchange_id}</yellow> warmup failed for {instrument} "
                     f"({type(e).__name__}: {e}); skipping"

--- a/src/qubx/connectors/ccxt/handlers/ohlc.py
+++ b/src/qubx/connectors/ccxt/handlers/ohlc.py
@@ -138,6 +138,9 @@ class OhlcDataHandler(BaseDataTypeHandler):
                     channel.send((instrument, DataType.QUOTE, self._convert_ohlcv_to_quote(ohlcv, instrument), False))
 
                 self._update_quote(instrument, ohlcv)
+            # Skip (don't re-raise) so one delisted/missing symbol can't abort the whole
+            # warmup batch. NOTE: this intentionally differs from the live-subscription
+            # path, which re-raises BadSymbol to let ConnectionManager drop the instrument.
             except BadSymbol as e:
                 logger.warning(
                     f"<yellow>{self._exchange_id}</yellow> warmup failed for {instrument} "

--- a/src/qubx/core/account.py
+++ b/src/qubx/core/account.py
@@ -263,6 +263,11 @@ class BasicAccountProcessor(IAccountProcessor):
                 self._positions[p.instrument].reset_by_position(p)
         return self
 
+    def settle_position(self, instrument: Instrument) -> None:
+        pos = self._positions.get(instrument)
+        if pos is not None:
+            pos.flatten()
+
     def merge_restored_accounting(self, restored_state: RestoredState | None) -> None:
         """
         Merge accounting fields (commissions, r_pnl, cumulative_funding) from restored state.
@@ -751,6 +756,10 @@ class CompositeAccountProcessor(IAccountProcessor):
             exch_positions = processor.get_positions(exch_name)
             all_positions.update(exch_positions)
         return all_positions
+
+    def settle_position(self, instrument: Instrument) -> None:
+        exch = self._get_exchange(instrument=instrument)
+        self._account_processors[exch].settle_position(instrument)
 
     def get_position(self, instrument: Instrument) -> Position:
         exch = self._get_exchange(instrument=instrument)

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -823,6 +823,24 @@ class Position:
         self.__pos_incr_qty = 0
         self._qty_multiplier = self.instrument.quantity_multiplier
 
+    def flatten(self) -> None:
+        """
+        Mark the position flat WITHOUT trading: zero quantity and the derived
+        market values / margins, while KEEPING realized PnL, average price,
+        commissions and funding history.
+
+        For an instrument whose market has been delisted/removed from the
+        exchange (already cash-settled) we cannot place a closing order, so we
+        reconcile the in-memory position to flat. Unlike reset(), this preserves
+        r_pnl so the record stays identical to a normally-closed position.
+        """
+        self.quantity = 0.0
+        self.market_value = 0.0
+        self.market_value_funds = 0.0
+        self.initial_margin = 0.0
+        self.maint_margin = 0.0
+        self.pnl = self.r_pnl  # unrealized PnL is zero at zero quantity
+
     def reset_by_position(self, pos: "Position") -> None:
         self.quantity = pos.quantity
         self.pnl = pos.pnl

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -840,6 +840,7 @@ class Position:
         self.initial_margin = 0.0
         self.maint_margin = 0.0
         self.pnl = self.r_pnl  # unrealized PnL is zero at zero quantity
+        self.__pos_incr_qty = 0
 
     def reset_by_position(self, pos: "Position") -> None:
         self.quantity = pos.quantity

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -394,6 +394,10 @@ class StrategyContext(IStrategyContext):
             except Exception as e:
                 logger.error(f"[StrategyContext] :: Failed to notify strategy start: {e}")
 
+        # - ensure data providers are initialized (e.g. markets loaded) before set_universe
+        for data_provider in self._data_providers:
+            data_provider.start()
+
         # - update universe with initial instruments after the strategy is initialized
         self.set_universe(self._initial_instruments, skip_callback=True)
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -926,6 +926,17 @@ class IDataProvider:
         """
         ...
 
+    def start(self):
+        """
+        Start the data provider and ensure it is ready for use (e.g. load
+        exchange markets) before the strategy universe is first set.
+
+        Default is a no-op. Connectors that need eager initialization
+        (e.g. ccxt loading markets so is_instrument_listed is authoritative)
+        override this.
+        """
+        ...
+
     def close(self):
         """
         Close the data provider.

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -909,6 +909,16 @@ class IDataProvider:
         """
         ...
 
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        """
+        Whether the instrument currently exists / is tradeable on the exchange.
+
+        Default is True: callers must never drop an instrument just because a
+        provider cannot determine listing status (fail-open). Connectors that
+        can answer authoritatively (e.g. ccxt via exchange.markets) override this.
+        """
+        return True
+
     @property
     def is_simulation(self) -> bool:
         """

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1606,6 +1606,11 @@ class IAccountProcessor(IAccountViewer):
         """
         ...
 
+    def settle_position(self, instrument: Instrument) -> None:
+        """Flatten a held position in place (no trade) for a delisted/removed
+        market the exchange has already cash-settled. Realized PnL is kept."""
+        ...
+
     def add_active_orders(self, orders: dict[str, Order]) -> None:
         """Add active orders to the account.
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1092,6 +1092,11 @@ class IMarketManager(ITimeProvider):
 
     def get_market_data_cache(self) -> IMarketDataCache: ...
 
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        """Whether the instrument is currently listed on its exchange.
+        Fail-open: True when no data provider can answer."""
+        ...
+
 
 class ITradingManager:
     """Manages order operations."""

--- a/src/qubx/core/mixins/market.py
+++ b/src/qubx/core/mixins/market.py
@@ -489,3 +489,10 @@ class MarketManager(IMarketManager):
         if exchange in EXCHANGE_MAPPINGS and EXCHANGE_MAPPINGS[exchange] in self._exchange_to_data_provider:
             return self._exchange_to_data_provider[EXCHANGE_MAPPINGS[exchange]]
         raise ValueError(f"Data provider for exchange {exchange} not found")
+
+    def is_instrument_listed(self, instrument: Instrument) -> bool:
+        try:
+            dp = self._get_data_provider(instrument.exchange)
+        except ValueError:
+            return True  # no provider => can't tell => fail-open
+        return dp.is_instrument_listed(instrument)

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -1,3 +1,4 @@
+from qubx import logger
 from qubx.core.basics import DataType, Instrument
 from qubx.core.detectors import DelistingDetector
 from qubx.core.interfaces import (
@@ -13,6 +14,7 @@ from qubx.core.interfaces import (
     RemovalPolicy,
 )
 from qubx.core.loggers import StrategyLogging
+from qubx.utils.time import to_timestamp
 
 
 class UniverseManager(IUniverseManager):
@@ -62,6 +64,58 @@ class UniverseManager(IUniverseManager):
             and abs(self._account.positions[instrument].quantity) > instrument.min_size
         )
 
+    def _is_market_gone(self, instrument: Instrument) -> bool:
+        """State B only: the market no longer exists / is untradeable.
+        A future delist_date (state A) is NOT gone."""
+        if not self._mkt_manager.is_instrument_listed(instrument):
+            return True  # authoritative live signal
+        d = instrument.delist_date
+        if d is None:
+            return False
+        try:
+            delist_ts = to_timestamp(d).replace(tzinfo=None)
+            now_ts = to_timestamp(self._time_provider.time())
+        except (TypeError, ValueError):
+            # - unparseable delist_date: fail-open, treat as not gone
+            return False
+        return delist_ts <= now_ts
+
+    def _settle_if_held(self, instrument: Instrument) -> None:
+        if not self._has_position(instrument):
+            return
+        if not self._mkt_manager.is_instrument_listed(instrument):
+            # live-confirmed gone: cannot trade out, exchange already settled
+            self._trading_manager.cancel_orders(instrument)
+            self._account.settle_position(instrument)
+            logger.warning(f"[UniverseManager] Settled delisted position {instrument.symbol} (market gone)")
+        else:
+            # flagged by past delist_date metadata only, but still listed (settlement
+            # overlap) -- leave it for the close-via-trade path / manual review
+            logger.warning(
+                f"[UniverseManager] {instrument.symbol} flagged delisted by metadata but still listed; "
+                "leaving position for close-via-trade / manual review"
+            )
+
+    def _notify_gone(self, instruments: list[Instrument]) -> None:
+        symbols = ", ".join(sorted(i.symbol for i in instruments))
+        logger.warning(f"[UniverseManager] Dropping delisted (gone) instruments: {symbols}")
+        notifier = getattr(self._context, "notifier", None)
+        if notifier is not None and not self._context.is_simulation:
+            notifier.notify_message(
+                f"[{self._context.strategy_name}] Dropped delisted (gone) instruments: {symbols}",
+                metadata={"event": "delisted_gone", "instruments": symbols},
+            )
+
+    def _drop_gone(self, instruments: list[Instrument]) -> list[Instrument]:
+        gone = [i for i in instruments if self._is_market_gone(i)]
+        if not gone:
+            return instruments
+        for i in gone:
+            self._settle_if_held(i)
+        self._notify_gone(gone)
+        gone_set = set(gone)
+        return [i for i in instruments if i not in gone_set]
+
     def set_universe(
         self,
         instruments: list[Instrument],
@@ -76,6 +130,9 @@ class UniverseManager(IUniverseManager):
 
         # Filter out instruments with upcoming delist dates
         instruments = self._delisting_detector.filter_delistings(instruments)
+
+        # Filter out instruments whose market is already gone (state B: settle in place)
+        instruments = self._drop_gone(instruments)
 
         new_set = set(instruments)
         prev_set = self._instruments.copy()
@@ -181,6 +238,12 @@ class UniverseManager(IUniverseManager):
         exit_targets = []
         for instr in instruments:
             if self._has_position(instr):
+                if not self._mkt_manager.is_instrument_listed(instr):
+                    # market gone -- cannot trade; settle in place
+                    self._account.settle_position(instr)
+                    logger.warning(f"[UniverseManager] Settled delisted position {instr.symbol} on removal")
+                    continue
+
                 # - create exit target
                 exit_targets.append(instr.target(self._context, 0))
 

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -128,11 +128,14 @@ class UniverseManager(IUniverseManager):
             "wait_for_change",
         ), "Invalid if_has_position_then policy"
 
-        # Filter out instruments with upcoming delist dates
-        instruments = self._delisting_detector.filter_delistings(instruments)
-
-        # Filter out instruments whose market is already gone (state B: settle in place)
+        # Settle & exclude instruments whose market is already gone (state B) FIRST,
+        # so a gone instrument that also carries a delist_date is settled in place
+        # before the delisting filter (state A) would otherwise strip it from the list.
         instruments = self._drop_gone(instruments)
+
+        # Then filter out instruments with upcoming/scheduled delist dates (state A:
+        # still listed -> closed via trade through the normal removal path).
+        instruments = self._delisting_detector.filter_delistings(instruments)
 
         new_set = set(instruments)
         prev_set = self._instruments.copy()

--- a/tests/qubx/connectors/ccxt/test_data_provider.py
+++ b/tests/qubx/connectors/ccxt/test_data_provider.py
@@ -1,7 +1,7 @@
 """Simple unit tests for CcxtDataProvider focusing on core functionality."""
 
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 
@@ -191,6 +191,33 @@ class TestBasicFunctionality:
         with patch.object(data_provider._data_type_handler_factory, "get_handler", return_value=mock_wrong_handler):
             with pytest.raises(ValueError, match="Expected OhlcDataHandler"):
                 data_provider.get_ohlc(btc_instrument, "1m", 10)
+
+    def test_start_loads_markets(self, data_provider):
+        """start() should eagerly load markets via the async loop."""
+        data_provider._exchange_manager.exchange.load_markets = Mock(return_value="markets_coro")
+        data_provider._exchange_manager.exchange.markets = {"BTC/USDT:USDT": {}}
+
+        # - _loop is a property; patch it so submit(...).result() is fully mocked
+        mock_loop = Mock()
+        with patch.object(type(data_provider), "_loop", new_callable=PropertyMock, return_value=mock_loop):
+            data_provider.start()
+
+        # - load_markets coroutine must have been created and submitted to the loop
+        data_provider._exchange_manager.exchange.load_markets.assert_called_once()
+        mock_loop.submit.assert_called_once_with("markets_coro")
+        mock_loop.submit.return_value.result.assert_called_once()
+
+    def test_start_swallows_load_markets_error(self, data_provider):
+        """start() must not raise if markets load fails (listing checks fail-open)."""
+        mock_loop = Mock()
+        mock_loop.submit.return_value.result.side_effect = Exception("boom")
+        data_provider._exchange_manager.exchange.load_markets = Mock(return_value="markets_coro")
+
+        with patch.object(type(data_provider), "_loop", new_callable=PropertyMock, return_value=mock_loop):
+            # - should not raise
+            data_provider.start()
+
+        mock_loop.submit.return_value.result.assert_called_once()
 
     def test_close_calls_exchange_close(self, data_provider):
         """Test that close method calls exchange close."""

--- a/tests/qubx/connectors/ccxt/test_data_provider.py
+++ b/tests/qubx/connectors/ccxt/test_data_provider.py
@@ -341,3 +341,24 @@ class TestDelegation:
         with patch.object(data_provider._warmup_service, "execute_warmup") as mock_warmup:
             data_provider.warmup(warmups)
             mock_warmup.assert_called_once_with(warmups)
+
+
+class TestIsInstrumentListed:
+    def test_listed_when_symbol_in_markets(self, data_provider, btc_instrument):
+        from qubx.connectors.ccxt.utils import instrument_to_ccxt_symbol
+
+        sym = instrument_to_ccxt_symbol(btc_instrument)
+        data_provider._exchange_manager.exchange.markets = {sym: {"id": "x"}}
+        assert data_provider.is_instrument_listed(btc_instrument) is True
+
+    def test_not_listed_when_symbol_absent(self, data_provider, btc_instrument):
+        data_provider._exchange_manager.exchange.markets = {"OTHER/USDT:USDT": {}}
+        assert data_provider.is_instrument_listed(btc_instrument) is False
+
+    def test_fail_open_when_markets_empty(self, data_provider, btc_instrument):
+        data_provider._exchange_manager.exchange.markets = {}
+        assert data_provider.is_instrument_listed(btc_instrument) is True
+
+    def test_fail_open_when_markets_none(self, data_provider, btc_instrument):
+        data_provider._exchange_manager.exchange.markets = None
+        assert data_provider.is_instrument_listed(btc_instrument) is True

--- a/tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py
+++ b/tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py
@@ -46,8 +46,8 @@ def test_warmup_skips_unlisted_instrument(mocker: MockerFixture):
     mocker.patch.object(handler, "_convert_ohlcv_to_quote", return_value=object())
 
     asyncio.run(handler.warmup({listed, gone}, channel, warmup_period="1d", timeframe="1d"))
-    # at least the listed instrument was fetched; gone was skipped (no crash)
-    assert exchange.fetch_ohlcv.await_count >= 1
+    # exactly one fetch: the listed instrument was fetched, gone was skipped (not fetched)
+    assert exchange.fetch_ohlcv.await_count == 1
 
 
 def test_warmup_continues_when_one_instrument_raises(mocker: MockerFixture):

--- a/tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py
+++ b/tests/qubx/connectors/ccxt/test_ohlc_warmup_guard.py
@@ -1,0 +1,73 @@
+import asyncio
+
+from pytest_mock import MockerFixture
+
+from qubx.connectors.ccxt.handlers.ohlc import OhlcDataHandler
+from qubx.core.basics import Instrument
+
+
+def _handler(mocker: MockerFixture, listed_map, fetch_side_effect):
+    data_provider = mocker.Mock()
+    data_provider.is_instrument_listed.side_effect = lambda i: listed_map[i]
+    data_provider._get_exch_timeframe.return_value = "1d"
+    data_provider._time_msec_nbars_back.return_value = 0
+    # - real warmup calls _update_quote -> _last_quotes[instrument] = ...; needs a real dict
+    data_provider._last_quotes = {}
+
+    exchange = mocker.Mock()
+    exchange.fetch_ohlcv = mocker.AsyncMock(side_effect=fetch_side_effect)
+    exchange_manager = mocker.Mock()
+    exchange_manager.exchange = exchange
+
+    return OhlcDataHandler(data_provider=data_provider, exchange_manager=exchange_manager, exchange_id="okx"), exchange
+
+
+def _instr(mocker, symbol):
+    i = mocker.Mock(spec=Instrument)
+    i.symbol = symbol
+    # - attributes needed by instrument_to_ccxt_symbol (called inside warmup)
+    i.base = symbol.replace("USDT", "")
+    i.quote = "USDT"
+    i.settle = "USDT"
+    i.is_futures.return_value = False
+    return i
+
+
+def test_warmup_skips_unlisted_instrument(mocker: MockerFixture):
+    listed = _instr(mocker, "BTCUSDT")
+    gone = _instr(mocker, "TONUSDT")
+    channel = mocker.Mock()
+
+    async def fetch(symbol, timeframe, since, limit):
+        return [[0, 1.0, 2.0, 0.5, 1.5, 100.0]]
+
+    handler, exchange = _handler(mocker, {listed: True, gone: False}, fetch)
+    mocker.patch.object(handler, "_convert_ohlcv_to_bar", side_effect=lambda oh: oh)
+    mocker.patch.object(handler, "_convert_ohlcv_to_quote", return_value=object())
+
+    asyncio.run(handler.warmup({listed, gone}, channel, warmup_period="1d", timeframe="1d"))
+    # at least the listed instrument was fetched; gone was skipped (no crash)
+    assert exchange.fetch_ohlcv.await_count >= 1
+
+
+def test_warmup_continues_when_one_instrument_raises(mocker: MockerFixture):
+    a = _instr(mocker, "AAAUSDT")
+    b = _instr(mocker, "BBBUSDT")
+    channel = mocker.Mock()
+
+    from ccxt import BadSymbol
+
+    async def fetch(symbol, timeframe, since, limit):
+        if fetch.calls == 0:
+            fetch.calls += 1
+            raise BadSymbol("okx does not have market symbol AAA/USDT:USDT")
+        return [[0, 1.0, 2.0, 0.5, 1.5, 100.0]]
+
+    fetch.calls = 0
+    handler, exchange = _handler(mocker, {a: True, b: True}, fetch)
+    mocker.patch.object(handler, "_convert_ohlcv_to_bar", side_effect=lambda oh: oh)
+    mocker.patch.object(handler, "_convert_ohlcv_to_quote", return_value=object())
+
+    # must NOT raise even though one instrument failed
+    asyncio.run(handler.warmup({a, b}, channel, warmup_period="1d", timeframe="1d"))
+    assert exchange.fetch_ohlcv.await_count >= 2

--- a/tests/qubx/core/account_processor_test.py
+++ b/tests/qubx/core/account_processor_test.py
@@ -617,7 +617,7 @@ def test_settle_position_flattens_without_trade(mocker):
 
     settled = acc.get_positions()[instr]
     assert settled.quantity == 0.0
-    assert settled.r_pnl == -7.0          # realized kept
+    assert settled.r_pnl == -7.0  # realized kept
     assert settled.is_open() is False
 
 

--- a/tests/qubx/core/account_processor_test.py
+++ b/tests/qubx/core/account_processor_test.py
@@ -595,3 +595,43 @@ class TestProcessFundingPaymentDedup:
 
         # Post-prune size should be << total bookings; tolerate up to threshold+window.
         assert len(account._applied_funding_buckets) <= 1024
+
+
+def test_settle_position_flattens_without_trade(mocker):
+    from qubx.core.account import BasicAccountProcessor
+    from qubx.core.basics import Instrument, Position
+
+    acc = BasicAccountProcessor(
+        account_id="t",
+        time_provider=mocker.Mock(),
+        base_currency="USDT",
+        health_monitor=mocker.Mock(),
+        exchange="OKX.F",
+    )
+    instr = mocker.Mock(spec=Instrument)
+    instr.lot_size = 0.001
+    pos = Position(instr, quantity=3175.0, pos_average_price=1.69, r_pnl=-7.0)
+    acc.attach_positions(pos)
+
+    acc.settle_position(instr)
+
+    settled = acc.get_positions()[instr]
+    assert settled.quantity == 0.0
+    assert settled.r_pnl == -7.0          # realized kept
+    assert settled.is_open() is False
+
+
+def test_settle_position_noop_when_not_held(mocker):
+    from qubx.core.account import BasicAccountProcessor
+    from qubx.core.basics import Instrument
+
+    acc = BasicAccountProcessor(
+        account_id="t",
+        time_provider=mocker.Mock(),
+        base_currency="USDT",
+        health_monitor=mocker.Mock(),
+        exchange="OKX.F",
+    )
+    instr = mocker.Mock(spec=Instrument)
+    acc.settle_position(instr)  # must not raise
+    assert instr not in acc.get_positions()

--- a/tests/qubx/core/basics_test.py
+++ b/tests/qubx/core/basics_test.py
@@ -214,7 +214,7 @@ def test_position_flatten_zeroes_quantity_but_keeps_realized(mocker):
     assert pos.market_value_funds == 0.0
     assert pos.initial_margin == 0.0
     assert pos.maint_margin == 0.0
-    assert pos.pnl == 42.0            # unrealized is 0 at qty 0 -> pnl == r_pnl
-    assert pos.r_pnl == 42.0          # realized preserved
-    assert pos.position_avg_price == 100.0   # entry preserved
+    assert pos.pnl == 42.0  # unrealized is 0 at qty 0 -> pnl == r_pnl
+    assert pos.r_pnl == 42.0  # realized preserved
+    assert pos.position_avg_price == 100.0  # entry preserved
     assert pos.is_open() is False

--- a/tests/qubx/core/basics_test.py
+++ b/tests/qubx/core/basics_test.py
@@ -194,3 +194,27 @@ class TestBasics:
         assert 355 * 5 == pos2.get_amount_released_funds_after_closing(10)
         assert 355 * 1 == pos2.get_amount_released_funds_after_closing(-4)
         assert 355 * 5 == pos2.get_amount_released_funds_after_closing()
+
+
+def test_position_flatten_zeroes_quantity_but_keeps_realized(mocker):
+    from qubx.core.basics import Instrument, Position
+
+    instr = mocker.Mock(spec=Instrument)
+    instr.lot_size = 0.001
+    pos = Position(instr, quantity=10.0, pos_average_price=100.0, r_pnl=42.0)
+    pos.market_value = 1000.0
+    pos.market_value_funds = 1000.0
+    pos.initial_margin = 250.0
+    pos.maint_margin = 125.0
+
+    pos.flatten()
+
+    assert pos.quantity == 0.0
+    assert pos.market_value == 0.0
+    assert pos.market_value_funds == 0.0
+    assert pos.initial_margin == 0.0
+    assert pos.maint_margin == 0.0
+    assert pos.pnl == 42.0            # unrealized is 0 at qty 0 -> pnl == r_pnl
+    assert pos.r_pnl == 42.0          # realized preserved
+    assert pos.position_avg_price == 100.0   # entry preserved
+    assert pos.is_open() is False

--- a/tests/qubx/core/mixins/market_manager_listing_test.py
+++ b/tests/qubx/core/mixins/market_manager_listing_test.py
@@ -1,0 +1,36 @@
+from pytest_mock import MockerFixture
+
+from qubx.core.basics import Instrument
+from qubx.core.mixins.market import MarketManager
+
+
+def _instr(mocker: MockerFixture, exchange: str = "BINANCE.UM"):
+    i = mocker.Mock(spec=Instrument)
+    i.exchange = exchange
+    i.symbol = "TONUSDT"
+    return i
+
+
+def _market_manager_with(provider):
+    mm = MarketManager.__new__(MarketManager)  # bypass heavy __init__
+    mm._exchange_to_data_provider = {} if provider is None else {"BINANCE.UM": provider}
+    return mm
+
+
+def test_listed_delegates_to_provider_true(mocker: MockerFixture):
+    dp = mocker.Mock()
+    dp.is_instrument_listed.return_value = True
+    mm = _market_manager_with(dp)
+    assert mm.is_instrument_listed(_instr(mocker)) is True
+
+
+def test_not_listed_delegates_to_provider_false(mocker: MockerFixture):
+    dp = mocker.Mock()
+    dp.is_instrument_listed.return_value = False
+    mm = _market_manager_with(dp)
+    assert mm.is_instrument_listed(_instr(mocker)) is False
+
+
+def test_fail_open_when_no_provider(mocker: MockerFixture):
+    mm = _market_manager_with(None)
+    assert mm.is_instrument_listed(_instr(mocker)) is True

--- a/tests/qubx/core/universe_manager_test.py
+++ b/tests/qubx/core/universe_manager_test.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
@@ -15,7 +16,12 @@ def mock_dependencies(mocker: MockerFixture):
     # - market_data_manager mock exposes IMarketDataCache via get_market_data_cache()
     cache = mocker.Mock()
     market_data_manager = mocker.Mock()
+    market_data_manager.is_instrument_listed.return_value = True
     market_data_manager.get_market_data_cache.return_value = cache
+
+    # - provide a real "now" so _is_market_gone can compare against delist_date
+    time_provider = mocker.Mock()
+    time_provider.time.return_value = np.datetime64("2026-06-16T00:00:00", "ns")
 
     return {
         "context": mocker.Mock(),
@@ -25,7 +31,7 @@ def mock_dependencies(mocker: MockerFixture):
         "logging": mocker.Mock(),
         "subscription_manager": mocker.Mock(),
         "trading_manager": mocker.Mock(),
-        "time_provider": mocker.Mock(),
+        "time_provider": time_provider,
         "account": mocker.Mock(),
         "position_gathering": mocker.Mock(),
         "delisting_detector": delisting_detector,
@@ -97,7 +103,7 @@ def test_set_universe_with_skip_callback(universe_manager, mock_dependencies, mo
 def test_set_universe_with_position_close(universe_manager, mock_dependencies, mocker: MockerFixture):
     ctx = mock_dependencies["context"]
 
-    sol = (mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0),)
+    sol = mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0)
     universe_manager.set_universe(
         [
             btc := mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0),
@@ -242,3 +248,60 @@ def test_set_universe_keeps_non_delisting_instruments(universe_manager, mock_dep
     # All instruments should be in the universe
     assert set(universe_manager.instruments) == set(instruments)
     mock_dependencies["delisting_detector"].filter_delistings.assert_called_once()
+
+
+def _gone_instr(mocker, symbol="TONUSDT"):
+    i = mocker.Mock(spec=Instrument, symbol=symbol)
+    i.exchange = "OKX.F"
+    i.delist_date = None
+    i.min_size = 0.001
+    return i
+
+
+def test_set_universe_excludes_gone_instrument(universe_manager, mock_dependencies, mocker):
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+    live = mocker.Mock(spec=Instrument, symbol="BTCUSDT")
+    live.exchange = "OKX.F"
+    live.delist_date = None
+    live.min_size = 0.001
+    gone = _gone_instr(mocker)
+
+    def listed(instr):
+        return instr is not gone
+
+    mock_dependencies["market_data_manager"].is_instrument_listed.side_effect = listed
+    mock_dependencies["account"].positions = {}
+
+    universe_manager.set_universe([live, gone])
+
+    assert set(universe_manager.instruments) == {live}
+    assert gone not in universe_manager.instruments
+
+
+def test_gone_held_position_is_settled_not_traded(universe_manager, mock_dependencies, mocker):
+    gone = _gone_instr(mocker)
+    pos = mocker.Mock()
+    pos.quantity = 3175.0
+    mock_dependencies["account"].positions = {gone: pos}
+    mock_dependencies["market_data_manager"].is_instrument_listed.side_effect = lambda i: i is not gone
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    universe_manager.set_universe([gone])
+
+    mock_dependencies["account"].settle_position.assert_called_once_with(gone)
+    mock_dependencies["position_gathering"].alter_positions.assert_not_called()
+
+
+def test_future_delist_but_listed_is_not_gone(universe_manager, mock_dependencies, mocker):
+    import pandas as pd
+
+    instr = _gone_instr(mocker, symbol="SOLUSDT")
+    instr.delist_date = pd.Timestamp("2999-01-01")  # far future
+    mock_dependencies["market_data_manager"].is_instrument_listed.return_value = True
+    mock_dependencies["account"].positions = {}
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    universe_manager.set_universe([instr])
+
+    assert instr in universe_manager.instruments
+    mock_dependencies["account"].settle_position.assert_not_called()

--- a/tests/qubx/core/universe_manager_test.py
+++ b/tests/qubx/core/universe_manager_test.py
@@ -325,3 +325,30 @@ def test_future_delist_but_listed_is_not_gone(universe_manager, mock_dependencie
 
     assert instr in universe_manager.instruments
     mock_dependencies["account"].settle_position.assert_not_called()
+
+
+def test_gone_held_with_delist_date_settled_before_filter_delistings(universe_manager, mock_dependencies, mocker):
+    """A gone instrument that ALSO has a (past) delist_date must still be settled:
+    _drop_gone must run before filter_delistings, else the delisting filter strips it
+    first and the held position is never settled."""
+    import pandas as pd
+
+    gone = _gone_instr(mocker)
+    gone.delist_date = pd.Timestamp("2020-01-01")  # already past
+    pos = mocker.Mock()
+    pos.quantity = 3175.0
+    mock_dependencies["account"].positions = {gone: pos}
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    # live listing: gone is not listed (authoritative "gone" signal)
+    mock_dependencies["market_data_manager"].is_instrument_listed.side_effect = lambda i: i is not gone
+    # simulate the REAL DelistingDetector: it strips instruments whose delist_date is set
+    mock_dependencies["delisting_detector"].filter_delistings.side_effect = (
+        lambda instruments: [i for i in instruments if i.delist_date is None]
+    )
+
+    universe_manager.set_universe([gone])
+
+    # _drop_gone ran first and settled the gone, still-held instrument
+    mock_dependencies["account"].settle_position.assert_called_once_with(gone)
+    assert gone not in universe_manager.instruments

--- a/tests/qubx/core/universe_manager_test.py
+++ b/tests/qubx/core/universe_manager_test.py
@@ -292,6 +292,26 @@ def test_gone_held_position_is_settled_not_traded(universe_manager, mock_depende
     mock_dependencies["position_gathering"].alter_positions.assert_not_called()
 
 
+def test_remove_instruments_settles_gone_held_position(universe_manager, mock_dependencies, mocker):
+    # - gone instrument with a held position, already in the universe (prev_set)
+    gone = _gone_instr(mocker)
+    pos = mocker.Mock()
+    pos.quantity = 3175.0
+    universe_manager._instruments = {gone}
+    mock_dependencies["account"].positions = {gone: pos}
+    mock_dependencies["market_data_manager"].is_instrument_listed.side_effect = lambda i: i is not gone
+
+    # - this is the path the scheduled delisting check uses (NOT set_universe)
+    universe_manager.remove_instruments([gone])
+
+    # - gone-branch: settle in place, do NOT trade an exit target
+    mock_dependencies["account"].settle_position.assert_called_once_with(gone)
+    mock_dependencies["position_gathering"].alter_positions.assert_called_once_with(
+        mock_dependencies["context"], []
+    )
+    assert gone not in universe_manager.instruments
+
+
 def test_future_delist_but_listed_is_not_gone(universe_manager, mock_dependencies, mocker):
     import pandas as pd
 


### PR DESCRIPTION
## Summary

Makes the framework resilient to instruments whose market has been **removed/delisted from the exchange** ("market gone"), so a held-but-delisted instrument can neither crash startup warmup nor linger as a phantom position. Scheduled/future delistings (still-listed) are untouched and keep flowing through the existing close-via-trade path.

Motivated by a prod incident: an `okx.factors` bot crash-looped on restart because OKX had delisted the TON perp, and `OhlcDataHandler.warmup()` raised `ccxt.BadSymbol: okx does not have market symbol TON/USDT:USDT`, aborting the whole warmup.

### What changed
- **`IDataProvider.is_instrument_listed(instrument)`** — connector-agnostic capability; base returns `True` (fail-open). ccxt reads `exchange.markets` (fail-open when markets unloaded/empty). Simulator inherits base ⇒ backtests unaffected.
- **`IMarketManager.is_instrument_listed`** — resolves the per-exchange provider, fail-open when none.
- **`UniverseManager`** — `_is_market_gone` (live-listing authoritative; a *future* `delist_date` is **not** gone), `_drop_gone` (exclude from universe + settle held positions + notifier alert), `_settle_if_held` (settle only when live-confirmed gone; metadata-only/settlement-overlap ⇒ leave for close-via-trade + manual-review alert). Wired into `set_universe` alongside the existing `filter_delistings`; plus a gone-branch in `__do_remove_instruments` (settle instead of trade) so the scheduled delisting check never tries to trade a vanished market.
- **`IAccountProcessor.settle_position` + `Position.flatten()`** — flatten a held position in place (quantity → 0) **without trading**, preserving `r_pnl`/avg price/commissions/funding. A settled phantom is indistinguishable from a normally-closed position; capital stays correct via the authoritative balance sync.
- **ccxt `OhlcDataHandler.warmup()`** — skips unlisted instruments and wraps each fetch in `except BadSymbol` so one delisted symbol can't abort the batch (transient errors still propagate to the retry path; the intentional divergence from the live-subscription `raise BadSymbol` is documented in-code).

### Design / plan
- Spec: `docs/superpowers/specs/2026-06-16-delisting-resilience-design.md`
- Plan: `docs/superpowers/plans/2026-06-16-delisting-resilience.md`

## Test Plan
- [ ] `Position.flatten()` zeroes quantity/market values/margins, keeps `r_pnl`/avg price; `is_open()` False.
- [ ] ccxt `is_instrument_listed`: present→True, absent→False, empty/None markets→True (fail-open).
- [ ] `IMarketManager.is_instrument_listed`: delegate True/False; no provider→True.
- [ ] `settle_position` flattens without a trade; no-op when not held.
- [ ] `UniverseManager`: gone instrument excluded from universe; held gone position settled (not traded); **future delist + still listed is NOT gone/settled**; removal-path gone-branch settles in place.
- [ ] ccxt warmup: unlisted skipped (exactly one fetch for the listed one); a `BadSymbol` on one instrument doesn't abort the batch.
- [ ] Full unit suite: `just test` → 1435 passed / 5 skipped; ccxt tests via `uv run --extra connectors pytest tests/qubx/connectors/ccxt/...`.

> Note: 5 pre-existing `tests/qubx/connectors/ccxt/test_ohlc_pagination.py` event-loop-isolation failures reproduce on the pristine merge-base and are unrelated to this branch (recommend a separate fix migrating that file off `asyncio.get_event_loop()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
