### PR TITLE
feat(instrument-service): drop per-minute poll, refresh blacklist at fit

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1361,8 +1361,14 @@ class IInstrumentServiceManager:
         newly-blacklisted instruments. Returns a summary dict."""
         ...
 
+    def refresh_only(self) -> None:
+        """Refresh the cached blacklist only — no change callbacks, no force-close.
+        Called before each `on_fit` so universe selection sees current data. No-op for
+        the Null service."""
+        ...
+
     def start(self) -> None:
-        """Wire framework-automatic startup refresh and periodic TTL poll (non-Null only)."""
+        """Wire framework-automatic startup refresh (non-Null only). No periodic poll."""
         ...
 
     def set_callbacks(self, callbacks: list) -> None:

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1342,7 +1342,7 @@ class IUniverseManager:
 
 class IInstrumentServiceManager:
     """Manages the instrument blacklist service: read helpers, refresh/callback/force-close
-    cycle, and framework-automatic startup + TTL-poll scheduling."""
+    cycle, the cache-only fit refresh, and framework-automatic startup refresh."""
 
     def is_blacklisted(self, instrument: Instrument) -> bool:
         """Return True if the instrument is on the active blacklist."""

--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -56,6 +56,15 @@ class InstrumentServiceManager(IInstrumentServiceManager):
             "force_closed_instruments": [str(i) for i in still_held],
         }
 
+    def refresh_only(self) -> None:
+        """Refresh the cached blacklist WITHOUT firing change callbacks or force-closing
+        positions. Used as the fit-time safety net: called immediately before `on_fit` so
+        `get_universe` / `ctx.filter_blacklisted` select over current blacklist data, while
+        the actual closing of now-blacklisted positions is handled by the fit's
+        `set_universe` removal path. No-op for the Null service (its `refresh` returns an
+        empty diff and nothing else runs)."""
+        self._service.refresh(self._context.instruments)
+
     def start(self) -> None:
         """Framework-automatic refresh wiring (non-Null only): a one-shot startup refresh
         dispatched on the strategy thread via the context scheduler. The blacklist is kept

--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -57,9 +57,10 @@ class InstrumentServiceManager(IInstrumentServiceManager):
         }
 
     def start(self) -> None:
-        """Framework-automatic refresh wiring (non-Null only): one-shot startup refresh +
-        per-minute TTL poll, both dispatched on the strategy thread via the context scheduler."""
+        """Framework-automatic refresh wiring (non-Null only): a one-shot startup refresh
+        dispatched on the strategy thread via the context scheduler. The blacklist is kept
+        current thereafter by the fit-time cache refresh (see `refresh_only`) and by the
+        operator-triggered `refresh_instrument_service` action; there is no periodic poll."""
         if isinstance(self._service, NullInstrumentService):
             return
         self._context.delay("1s", self.run_cycle)
-        self._context.schedule("* * * * *", self.run_cycle)

--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class InstrumentServiceManager(IInstrumentServiceManager):
     """Owns the instrument blacklist service: read helpers, the refresh→callbacks→force-close
-    cycle, and the framework-automatic startup + TTL-poll scheduling. Composed by StrategyContext
+    cycle, the cache-only fit refresh, and the framework-automatic startup refresh. Composed by StrategyContext
     the same way UniverseManager/ProcessingManager are."""
 
     def __init__(self, context: "IStrategyContext", instrument_service: IInstrumentService):
@@ -36,7 +36,7 @@ class InstrumentServiceManager(IInstrumentServiceManager):
     def run_cycle(self, _ctx: "IStrategyContext | None" = None) -> dict:
         """Refresh the blacklist, fire change callbacks, then force-close any still-held
         newly-blacklisted instruments. Single shared implementation used by the control action
-        AND the startup/TTL-poll schedules. Runs on the strategy thread. `_ctx` is the
+        AND the startup one-shot. Runs on the strategy thread. `_ctx` is the
         scheduler-passed context (unused; the bound `self._context` is the context)."""
         diff = self._service.refresh(self._context.instruments)
         if diff.blacklisted_added or diff.blacklisted_removed:

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -613,6 +613,10 @@ class ProcessingManager(IProcessingManager):
     def __invoke_on_fit(self) -> None:
         with self._health_monitor("ctx.on_fit"):
             try:
+                # - refresh the blacklist cache (cache-only: no callbacks / no force-close)
+                #   so on_fit's get_universe / filter_blacklisted select over current data.
+                #   No-op for the Null instrument service.
+                self._context._instrument_service_manager.refresh_only()
                 logger.debug(f"[<y>{self.__class__.__name__}</y>] :: Invoking <g>{self._strategy_name}</g> on_fit")
                 self._strategy.on_fit(self._context)
                 self._subscription_manager.commit()  # apply pending operations

--- a/tests/qubx/core/instrument_service_manager_test.py
+++ b/tests/qubx/core/instrument_service_manager_test.py
@@ -72,12 +72,12 @@ def test_run_cycle_accepts_scheduler_ctx_arg():
     assert result["blacklisted_added"] == 0
 
 
-def test_start_registers_startup_and_poll_when_non_null():
+def test_start_registers_startup_oneshot_but_not_poll_when_non_null():
     svc = MagicMock(spec=HttpInstrumentService)
     m, ctx = _mgr(svc)
     m.start()
     ctx.delay.assert_called_once_with("1s", m.run_cycle)
-    ctx.schedule.assert_called_once_with("* * * * *", m.run_cycle)
+    ctx.schedule.assert_not_called()
 
 
 def test_start_noop_with_null_service():

--- a/tests/qubx/core/instrument_service_manager_test.py
+++ b/tests/qubx/core/instrument_service_manager_test.py
@@ -93,3 +93,31 @@ def test_set_callbacks_preserves_order():
     b = lambda c, ad, rm: None
     m.set_callbacks([a, b])
     assert m._callbacks == [a, b]
+
+
+def test_refresh_only_refreshes_cache_without_callbacks_or_force_close():
+    calls = []
+    btc = MagicMock()
+    pos = MagicMock(); pos.quantity = 1.0
+    svc = MagicMock()
+    svc.refresh.return_value = InstrumentServiceDiff(blacklisted_added=[btc], blacklisted_removed=[])
+    m, ctx = _mgr(
+        svc,
+        instruments=[btc],
+        positions={btc: pos},
+        callbacks=[lambda c, a, r: calls.append("cb")],
+    )
+    result = m.refresh_only()
+    assert result is None
+    svc.refresh.assert_called_once_with([btc])
+    assert calls == []
+    ctx.remove_instruments.assert_not_called()
+    ctx.get_positions.assert_not_called()
+
+
+def test_refresh_only_noop_with_null_service():
+    m, ctx = _mgr(NullInstrumentService())
+    # Must not raise and must not touch position/removal machinery.
+    assert m.refresh_only() is None
+    ctx.remove_instruments.assert_not_called()
+    ctx.get_positions.assert_not_called()

--- a/tests/qubx/core/mixins/processing_fit_refresh_test.py
+++ b/tests/qubx/core/mixins/processing_fit_refresh_test.py
@@ -1,0 +1,100 @@
+"""Tests that ProcessingManager refreshes the instrument-service cache before on_fit."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from qubx.core.mixins.processing import ProcessingManager
+
+
+@pytest.fixture
+def processing_manager():
+    """ProcessingManager with fully mocked dependencies (mirrors the harness in
+    processing_pending_signals_test.py)."""
+    context = MagicMock()
+    context.is_simulation = True
+    context.instruments = []
+    context._strategy_state = MagicMock()
+    context._strategy_state.is_on_fit_called = False
+
+    strategy = MagicMock()
+    strategy.__class__.__name__ = "TestStrategy"
+
+    logging = MagicMock()
+
+    cache = MagicMock()
+    cache.default_timeframe = "1h"
+
+    market_data = MagicMock()
+    market_data.get_market_data_cache.return_value = cache
+
+    subscription_manager = MagicMock()
+    subscription_manager.get_base_subscription.return_value = "quote"
+
+    time_provider = MagicMock()
+
+    account = MagicMock()
+    position_tracker = MagicMock()
+    position_tracker.process_signals.return_value = []
+    position_gathering = MagicMock()
+    universe_manager = MagicMock()
+    universe_manager.is_trading_allowed.return_value = True
+    scheduler = MagicMock()
+
+    health_monitor = MagicMock()
+    health_monitor.return_value.__enter__ = MagicMock(return_value=None)
+    health_monitor.return_value.__exit__ = MagicMock(return_value=False)
+
+    delisting_detector = MagicMock()
+
+    pm = ProcessingManager(
+        context=context,
+        strategy=strategy,
+        logging=logging,
+        market_data=market_data,
+        subscription_manager=subscription_manager,
+        time_provider=time_provider,
+        account=account,
+        position_tracker=position_tracker,
+        position_gathering=position_gathering,
+        universe_manager=universe_manager,
+        scheduler=scheduler,
+        is_simulation=True,
+        health_monitor=health_monitor,
+        delisting_detector=delisting_detector,
+    )
+    pm._test_context = context
+    pm._test_strategy = strategy
+    return pm
+
+
+def test_invoke_on_fit_refreshes_instrument_service_before_on_fit(processing_manager):
+    context = processing_manager._test_context
+    strategy = processing_manager._test_strategy
+
+    # Attach both calls to a shared parent mock so their relative order is recorded.
+    order = MagicMock()
+    order.attach_mock(context._instrument_service_manager.refresh_only, "refresh_only")
+    order.attach_mock(strategy.on_fit, "on_fit")
+
+    # name-mangled: ProcessingManager.__invoke_on_fit
+    processing_manager._ProcessingManager__invoke_on_fit()
+
+    context._instrument_service_manager.refresh_only.assert_called_once_with()
+    strategy.on_fit.assert_called_once_with(context)
+
+    called = [c[0] for c in order.mock_calls]
+    assert called.index("refresh_only") < called.index("on_fit")
+
+
+def test_invoke_on_fit_marks_fit_called_even_if_refresh_raises(processing_manager):
+    context = processing_manager._test_context
+    strategy = processing_manager._test_strategy
+    context._instrument_service_manager.refresh_only.side_effect = RuntimeError("boom")
+
+    # Should not propagate: the on_fit try/except swallows it (refresh shares on_fit's
+    # error handling — acceptable per design §5).
+    processing_manager._ProcessingManager__invoke_on_fit()
+
+    strategy.on_fit.assert_not_called()  # refresh raised before on_fit ran
+    assert context._strategy_state.is_on_fit_called is True


### PR DESCRIPTION
## Blacklist: drop the per-minute poll, refresh at fit

Completes the blacklist propagation redesign (the platform/operator half shipped in xlydian-platform#235). The blacklist stays the single source of truth; this changes *how bots converge on it*.

### Changes
- **Drop the per-minute TTL poll** from `InstrumentServiceManager.start()` — it caused force-closes at unpredictable minutes and constant per-bot request churn. The startup one-shot is kept.
- **`refresh_only()`** — a new cache-only refresh (`self._service.refresh(...)`, diff discarded; **no callbacks, no force-close**), invoked in `ProcessingManager.__invoke_on_fit` right before `on_fit`. So at each fit the strategy selects/`set_universe`s over the current blacklist, and now-blacklisted positions close via the normal `set_universe` removal path (no double force-close).
- The operator **`refresh_instrument_service` action** (the Apply path) is **unchanged** — it still runs the full `run_cycle` (refresh → callbacks → force-close) for immediate effect.

### Triggers, before → after
`startup + push + 60s poll` → **`startup + push + fit`**. A missed Apply now converges at the bot's next fit instead of within 60s.

### Safety
- `refresh_only` is side-effect-free (verified) — no callbacks, no `remove_instruments`.
- **Backtests/local unaffected:** `NullInstrumentService.refresh` returns an empty diff, so `refresh_only` is a no-op on every fit; `start()` schedules nothing for Null.
- A `refresh_only` error cannot wedge the fit loop (`__invoke_on_fit`'s `finally` still sets `is_on_fit_called`); and `HttpInstrumentService._fetch` already swallows network errors and preserves the cache, so it essentially never raises.

### Tests
118 passed across the instrument-service + processing + control suites, incl. poll-not-registered, refresh-before-`on_fit` ordering, side-effect-free, Null no-op, and refresh-raises-doesn't-wedge-fit. Final code-quality review: APPROVE.

Design: xlydian-platform `docs/superpowers/specs/2026-06-17-blacklist-apply-and-fit-refresh-design.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
