### PR TITLE
fix(core): make ctx.trigger_fit() actually run on_fit

### DIFF
--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -890,6 +890,9 @@ class StrategyContext(IStrategyContext):
     def delay(self, duration: str, method: Callable[["IStrategyContext"], None]) -> str:
         return self._processing_manager.delay(duration, method)
 
+    def trigger_fit(self) -> None:
+        return self._processing_manager.trigger_fit()
+
     # :: IWarmupStateSaver delegation ::
     def set_warmup_positions(self, positions: dict[Instrument, Position]) -> None:
         self._warmup_positions = positions

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -247,8 +247,10 @@ class ProcessingManager(IProcessingManager):
         fit handler on the strategy thread (via delay -> _handle_fit); uses a unique
         delay event id, so the recurring fit schedule is untouched."""
         # short delay defers the fit onto the strategy thread via the scheduler/channel
-        # (any non-zero delay works); a unique delay event id leaves the recurring fit untouched
-        self.delay("1s", lambda c: c._handle_fit(None, "fit", (None, c.time())))
+        # (any non-zero delay works); a unique delay event id leaves the recurring fit untouched.
+        # _handle_fit lives on the ProcessingManager (self), not the context the scheduler
+        # passes into the callback, so bind it from self rather than the callback arg.
+        self.delay("1s", lambda _c: self._handle_fit(None, "fit", (None, self._time_provider.time())))
 
     def configure_stale_data_detection(
         self, enabled: bool, detection_period: str | None = None, check_interval: str | None = None

--- a/tests/qubx/core/context_test.py
+++ b/tests/qubx/core/context_test.py
@@ -122,3 +122,20 @@ class TestStrategyGathererOverride:
         gatherer = strategy.gatherer(mock_ctx)
 
         assert gatherer is None, "Strategy without gatherer override should return None"
+
+
+def test_strategy_context_delegates_trigger_fit():
+    """Regression: ctx.trigger_fit() must reach ProcessingManager.trigger_fit, not
+    silently fall through to the IStrategyContext '...' no-op stub (which left
+    trigger_fit doing nothing — blacklist re-fits and any other on-demand fit
+    were dropped)."""
+    from qubx.core.context import StrategyContext
+
+    # Defined on the facade itself, not inherited from the interface's no-op stub.
+    assert "trigger_fit" in StrategyContext.__dict__
+
+    # And it delegates to the processing manager.
+    ctx = StrategyContext.__new__(StrategyContext)
+    ctx._processing_manager = Mock()
+    ctx.trigger_fit()
+    ctx._processing_manager.trigger_fit.assert_called_once_with()

--- a/tests/qubx/core/mixins/processing_fit_refresh_test.py
+++ b/tests/qubx/core/mixins/processing_fit_refresh_test.py
@@ -1,6 +1,6 @@
 """Tests that ProcessingManager refreshes the instrument-service cache before on_fit."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -98,3 +98,27 @@ def test_invoke_on_fit_marks_fit_called_even_if_refresh_raises(processing_manage
 
     strategy.on_fit.assert_not_called()  # refresh raised before on_fit ran
     assert context._strategy_state.is_on_fit_called is True
+
+
+def test_trigger_fit_schedules_handle_fit_on_manager_not_context(processing_manager):
+    """trigger_fit must schedule a callback that invokes _handle_fit on the
+    ProcessingManager (self), not on the context the scheduler passes in — the
+    context facade has no _handle_fit. Regression for the no-op trigger_fit bug."""
+    pm = processing_manager
+
+    pm.trigger_fit()
+
+    # delay() stored exactly one one-off callback.
+    assert len(pm._custom_scheduled_methods) == 1
+    scheduled = next(iter(pm._custom_scheduled_methods.values()))
+
+    # The scheduler dispatches the callback as method(self._context); that context
+    # exposes no _handle_fit. Using a spec'd mock makes any c._handle_fit access raise.
+    from unittest.mock import MagicMock
+
+    ctx_without_handle_fit = MagicMock(spec=["time"])
+    ctx_without_handle_fit.time.return_value = 0
+
+    with patch.object(pm, "_handle_fit") as mock_handle_fit:
+        scheduled(ctx_without_handle_fit)  # must not raise AttributeError
+        mock_handle_fit.assert_called_once()


### PR DESCRIPTION
## Problem

`ctx.trigger_fit()` was a **silent no-op** for any strategy that called it — it scheduled nothing, ran no `on_fit`, and logged no error.

Surfaced via the instrument-blacklist re-fit flow: when an instrument is blacklisted, the strategy's `on_instrument_service_change` handler calls `ctx.trigger_fit()` to rebalance over the surviving universe. The blacklisted position *was* force-closed (that path is inline in `InstrumentServiceManager.run_cycle`), but the portfolio never re-fit — so freed capital wasn't redeployed until the next scheduled daily fit. Live evidence: `:::::: Instrument blacklist changed (+1 / -0); re-fitting` was logged, but no `on_fit` ran and only the single close order was emitted (no rebalance), with no exception anywhere.

## Root cause (two bugs)

1. **`StrategyContext` never delegated `trigger_fit`.** The `IProcessingManager` delegation block wires `delay`, `schedule`, `emit_signal`, … but not `trigger_fit`, and there's no `__getattr__`. So `ctx.trigger_fit()` resolved to `IStrategyContext.trigger_fit`, whose body is `...` — a concrete no-op (it is **not** `@abstractmethod`, so `StrategyContext` instantiates fine and the call silently does nothing).

2. **The implementation's scheduled callback targeted the wrong object.** `ProcessingManager.trigger_fit` did:
   ```python
   self.delay("1s", lambda c: c._handle_fit(None, "fit", (None, c.time())))
   ```
   The scheduler dispatches custom delayed methods as `method(self._context)`, so `c` is the **context** — but `_handle_fit` lives on the **ProcessingManager**. Once bug #1 is fixed, this would raise `AttributeError` (caught and logged by `_process_custom_event`, but the fit would still never run).

## Fix

1. `context.py` — delegate to the processing manager:
   ```python
   def trigger_fit(self) -> None:
       return self._processing_manager.trigger_fit()
   ```
2. `processing.py` — bind `_handle_fit` from `self` (the manager), not the dispatched context:
   ```python
   self.delay("1s", lambda _c: self._handle_fit(None, "fit", (None, self._time_provider.time())))
   ```

## Tests

- `test_strategy_context_delegates_trigger_fit` — `trigger_fit` is defined on the `StrategyContext` facade (not the interface no-op) and delegates to the processing manager.
- `test_trigger_fit_schedules_handle_fit_on_manager_not_context` — the scheduled callback invokes `_handle_fit` on the manager even when handed a context that has no `_handle_fit` (spec'd mock), guarding bug #2.

Both **fail on the unfixed code** and **pass with the fix**. `tests/qubx/core/mixins/` + `tests/qubx/control/` → 132 passed.

## Impact

General fix — `ctx.trigger_fit()` now works for any caller (control-server `trigger_fit` action, the blacklist re-fit flow, and any strategy using on-demand fits).
