### PR TITLE
fix(core): enforce no open positions in blacklisted instruments

### DIFF
--- a/docs/superpowers/plans/2026-06-18-blacklist-position-enforcement.md
+++ b/docs/superpowers/plans/2026-06-18-blacklist-position-enforcement.md
@@ -1,0 +1,356 @@
+# Blacklist Position Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guarantee a bot never holds an open position in a blacklisted instrument, by force-closing held blacklisted positions on every Apply and every fit, and blocking any order that would open/increase blacklisted exposure.
+
+**Architecture:** Two complementary mechanisms in Qubx core. (#1) `InstrumentServiceManager` gains a full-set force-close helper used by `run_cycle` (Apply) and a new `enforce_at_fit()` (fit-time, callback-free) that replaces `refresh_only()`. (#2) `TradingManager.trade`/`trade_async` gain a reduce-only clamp for blacklisted instruments. Both are no-ops when no instrument service is configured.
+
+**Tech Stack:** Python 3.12, qubx core mixins, pytest. Run tests with `uv run pytest` (env already synced with `--extra connectors`).
+
+**Spec:** `docs/superpowers/specs/2026-06-18-blacklist-position-enforcement-design.md`
+
+**Worktree:** `~/devs/Qubx/.worktrees/blacklist-enforcement`, branch `fix/blacklist-position-enforcement` (off `main`, post-1.9.1). All `cd` paths below are relative to this worktree root.
+
+---
+
+### Task 1: #1 — Full-set force-close in `run_cycle`
+
+Replace the delta-based (`diff.blacklisted_added`) force-close with a sweep over **all** held blacklisted positions, so an already-blacklisted holding (the WLFI case) is closed even when it isn't in the current change delta.
+
+**Files:**
+- Modify: `src/qubx/core/mixins/instrument_service.py` (`run_cycle`, ~lines 36-57; add helper)
+- Test: `tests/qubx/core/instrument_service_manager_test.py`
+
+- [ ] **Step 1: Write the failing regression test** (WLFI: held + blacklisted but NOT in `diff.blacklisted_added`)
+
+Append to `tests/qubx/core/instrument_service_manager_test.py`:
+
+```python
+def test_run_cycle_force_closes_all_held_blacklisted_not_just_delta():
+    # WLFI regression: an already-blacklisted holding (absent from the change delta)
+    # must still be force-closed.
+    ondo, wlfi, btc = MagicMock(), MagicMock(), MagicMock()
+    pos = MagicMock(); pos.quantity = -34767.0
+    btc_pos = MagicMock(); btc_pos.quantity = 1.0
+    svc = MagicMock()
+    # Only ONDO is newly-added this cycle; WLFI was blacklisted earlier.
+    svc.refresh.return_value = InstrumentServiceDiff(blacklisted_added=[ondo], blacklisted_removed=[])
+    svc.is_blacklisted.side_effect = lambda i: i in (ondo, wlfi)
+    m, ctx = _mgr(svc, instruments=[wlfi, btc], positions={wlfi: pos, btc: btc_pos})
+    summary = m.run_cycle()
+    ctx.remove_instruments.assert_called_once_with([wlfi], if_has_position_then="close")
+    assert summary["force_closed"] == 1
+    assert summary["force_closed_instruments"] == [str(wlfi)]
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/qubx/core/instrument_service_manager_test.py::test_run_cycle_force_closes_all_held_blacklisted_not_just_delta -q`
+Expected: FAIL — current code only closes `diff.blacklisted_added` (ONDO, not held) so `remove_instruments` is never called.
+
+- [ ] **Step 3: Add the helper and rewrite `run_cycle` to use it**
+
+In `src/qubx/core/mixins/instrument_service.py`, replace the body of `run_cycle` (the `positions = ...` / `still_held = ...` / `if still_held:` block and the `return {...}`) and add a helper just above `refresh_only`:
+
+```python
+    def _force_close_held_blacklisted(self) -> list[Instrument]:
+        """Force-close every currently-held position whose instrument is blacklisted.
+        Idempotent and full-set (not the change delta), so already-blacklisted holdings
+        are closed too. Reduce-only by construction (closes to 0), so it is allowed by the
+        trade-layer blacklist gate. No-op for the Null service (is_blacklisted is False)."""
+        positions = self._context.get_positions()
+        held = [i for i, p in positions.items() if p.quantity != 0 and self._service.is_blacklisted(i)]
+        if held:
+            self._context.remove_instruments(held, if_has_position_then="close")
+        return held
+```
+
+And `run_cycle` becomes (keep the refresh + callback block unchanged; swap the close block):
+
+```python
+    def run_cycle(self, _ctx: "IStrategyContext | None" = None) -> dict:
+        """Refresh the blacklist, fire change callbacks, then force-close ALL held
+        blacklisted instruments (full set, not just the change delta). Shared by the
+        control action and the startup one-shot. Runs on the strategy thread."""
+        diff = self._service.refresh(self._context.instruments)
+        if diff.blacklisted_added or diff.blacklisted_removed:
+            for cb in self._callbacks:
+                try:
+                    cb(self._context, diff.blacklisted_added, diff.blacklisted_removed)
+                except Exception as e:
+                    logger.error(f"[InstrumentService] :: change callback error: {e}")
+        closed = self._force_close_held_blacklisted()
+        return {
+            "blacklisted_added": len(diff.blacklisted_added),
+            "blacklisted_removed": len(diff.blacklisted_removed),
+            "force_closed": len(closed),
+            "force_closed_instruments": [str(i) for i in closed],
+        }
+```
+
+- [ ] **Step 4: Run the new test + the whole file to verify no regressions**
+
+Run: `uv run pytest tests/qubx/core/instrument_service_manager_test.py -q`
+Expected: PASS. The existing `test_run_cycle_fires_callbacks_before_force_close` still passes (its `svc.is_blacklisted` MagicMock is truthy, so the held `btc` is closed in the same order); `test_run_cycle_no_backstop_when_not_held` and `test_run_cycle_empty_diff_is_noop` pass (empty positions → `held == []`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/mixins/instrument_service.py tests/qubx/core/instrument_service_manager_test.py
+git commit -m "fix(core): force-close all held blacklisted instruments in run_cycle (not just delta)"
+```
+
+---
+
+### Task 2: #1 — `enforce_at_fit()` replaces `refresh_only()`
+
+At fit time the blacklist must not only refresh the cache but also close held blacklisted positions (the orphan case `set_universe` misses). Replace the cache-only `refresh_only()` with `enforce_at_fit()` (refresh + full-set force-close, **no** change callbacks — the fit is already running).
+
+**Files:**
+- Modify: `src/qubx/core/mixins/instrument_service.py` (replace `refresh_only`)
+- Modify: `src/qubx/core/interfaces.py:1364` (`IInstrumentServiceManager.refresh_only` → `enforce_at_fit`)
+- Modify: `src/qubx/core/mixins/processing.py:621` (call site in `__invoke_on_fit`)
+- Test: `tests/qubx/core/instrument_service_manager_test.py`, `tests/qubx/core/mixins/processing_fit_refresh_test.py`
+
+- [ ] **Step 1: Write the failing tests** (mixin behavior + processing call site)
+
+Replace the two `refresh_only` tests in `tests/qubx/core/instrument_service_manager_test.py` (`test_refresh_only_refreshes_cache_without_callbacks_or_force_close` and `test_refresh_only_noop_with_null_service`) with:
+
+```python
+def test_enforce_at_fit_refreshes_and_force_closes_without_callbacks():
+    ondo = MagicMock()
+    pos = MagicMock(); pos.quantity = -891.4
+    svc = MagicMock()
+    svc.refresh.return_value = InstrumentServiceDiff(blacklisted_added=[], blacklisted_removed=[])
+    svc.is_blacklisted.side_effect = lambda i: i is ondo
+    calls = []
+    m, ctx = _mgr(svc, instruments=[ondo], positions={ondo: pos},
+                  callbacks=[lambda c, a, r: calls.append("cb")])
+    assert m.enforce_at_fit() is None
+    svc.refresh.assert_called_once_with([ondo])
+    assert calls == []  # no change callbacks at fit time
+    ctx.remove_instruments.assert_called_once_with([ondo], if_has_position_then="close")
+
+
+def test_enforce_at_fit_noop_with_null_service():
+    m, ctx = _mgr(NullInstrumentService())
+    assert m.enforce_at_fit() is None
+    ctx.remove_instruments.assert_not_called()
+```
+
+In `tests/qubx/core/mixins/processing_fit_refresh_test.py`, rename the mock references in both tests from `refresh_only` to `enforce_at_fit`:
+- `test_invoke_on_fit_refreshes_instrument_service_before_on_fit`: replace every `refresh_only` token with `enforce_at_fit` (the `attach_mock(..., "enforce_at_fit")`, the `assert_called_once_with()`, and the `called.index("enforce_at_fit") < called.index("on_fit")`).
+- `test_invoke_on_fit_marks_fit_called_even_if_refresh_raises`: replace `context._instrument_service_manager.refresh_only.side_effect` with `...enforce_at_fit.side_effect`.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/instrument_service_manager_test.py -k enforce_at_fit tests/qubx/core/mixins/processing_fit_refresh_test.py -q`
+Expected: FAIL — `enforce_at_fit` does not exist yet (AttributeError on the mixin / call site still uses `refresh_only`).
+
+- [ ] **Step 3: Implement `enforce_at_fit`, update interface + call site**
+
+In `src/qubx/core/mixins/instrument_service.py`, replace the entire `refresh_only` method with:
+
+```python
+    def enforce_at_fit(self) -> None:
+        """Fit-time enforcement: refresh the cached blacklist AND force-close any held
+        blacklisted positions, WITHOUT firing change callbacks (the fit is already
+        running; firing re-fit callbacks here would loop). Called immediately before
+        `on_fit` so the rebalance selects over current data and never holds a blacklisted
+        instrument. No-op for the Null service."""
+        self._service.refresh(self._context.instruments)
+        self._force_close_held_blacklisted()
+```
+
+In `src/qubx/core/interfaces.py`, replace the `refresh_only` declaration (the `def refresh_only(self) -> None:` block at ~line 1364 and its docstring) with:
+
+```python
+    def enforce_at_fit(self) -> None:
+        """Fit-time enforcement: refresh the cached blacklist and force-close any held
+        blacklisted positions, without firing change callbacks. No-op for the Null service."""
+        ...
+```
+
+In `src/qubx/core/mixins/processing.py` line 621, change:
+
+```python
+                self._context._instrument_service_manager.refresh_only()
+```
+to:
+```python
+                self._context._instrument_service_manager.enforce_at_fit()
+```
+
+Also update the adjacent comment (lines ~616-618) referencing "refresh the blacklist cache (cache-only...)" to read "refresh the blacklist cache and force-close held blacklisted positions" so the comment matches the new behavior.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/instrument_service_manager_test.py tests/qubx/core/mixins/processing_fit_refresh_test.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Grep to confirm no stale `refresh_only` references remain**
+
+Run: `grep -rn 'refresh_only' src/ tests/`
+Expected: no matches. If any remain, update them to `enforce_at_fit`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/qubx/core/mixins/instrument_service.py src/qubx/core/interfaces.py src/qubx/core/mixins/processing.py tests/qubx/core/instrument_service_manager_test.py tests/qubx/core/mixins/processing_fit_refresh_test.py
+git commit -m "fix(core): enforce blacklist (refresh + force-close) at fit time, replacing refresh_only"
+```
+
+---
+
+### Task 3: #2 — Reduce-only clamp for blacklisted instruments in the trade layer
+
+Block any order that opens or increases exposure on a blacklisted instrument; allow reducing orders; clamp a flip-through-zero to an exact close. Applied at `trade()` and `trade_async()` — the universal order choke.
+
+**Files:**
+- Modify: `src/qubx/core/mixins/trading.py` (add `_blacklist_clamp`; call it in `trade` ~line 95 and `trade_async` ~line 142)
+- Test: `tests/qubx/core/mixins/trading_test.py`
+
+- [ ] **Step 1: Write the failing unit tests for the clamp logic**
+
+First, give the existing `MockStrategyContext` a default `is_blacklisted` (so every existing `trade()` test takes the no-op path once the gate is added). In `tests/qubx/core/mixins/trading_test.py`, add to the `MockStrategyContext` class body:
+
+```python
+    def is_blacklisted(self, instrument):
+        return False
+```
+
+Then append the clamp unit tests (the `trading_manager`, `mock_account`, `strategy_context` fixtures already exist):
+
+```python
+class TestBlacklistReduceOnly:
+    def _pos(self, qty):
+        p = Mock(spec=Position); p.quantity = qty
+        return p
+
+    def test_clamp_blocks_opening_from_flat(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(0.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), -891.4) == 0.0
+
+    def test_clamp_blocks_increasing_short(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(-500.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), -100.0) == 0.0  # -500 -> -600
+
+    def test_clamp_allows_reducing_short(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(-500.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), 200.0) == 200.0  # -500 -> -300
+
+    def test_clamp_flip_through_zero_is_clamped_to_close(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(-500.0)
+        # request would go -500 -> +300 (flip); clamp to exact close (+500)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), 800.0) == 500.0
+
+    def test_clamp_noop_when_not_blacklisted(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: False
+        assert trading_manager._blacklist_clamp(Mock(symbol="BTCUSDT"), -891.4) == -891.4
+        mock_account.get_position.assert_not_called()
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/mixins/trading_test.py::TestBlacklistReduceOnly -q`
+Expected: FAIL — `_blacklist_clamp` does not exist (AttributeError).
+
+- [ ] **Step 3: Implement `_blacklist_clamp` and gate both entry points**
+
+In `src/qubx/core/mixins/trading.py`, add the helper method to `TradingManager` (place it just above `def trade(`):
+
+```python
+    def _blacklist_clamp(self, instrument: Instrument, amount: float) -> float:
+        """Reduce-only for blacklisted instruments: an order may only move the position
+        toward zero, never open or increase exposure. No-op when not blacklisted (always,
+        without an instrument service). Returns the (possibly clamped) amount; 0.0 means
+        'do not send'. A flip through zero is clamped to an exact close."""
+        if not self._context.is_blacklisted(instrument):
+            return amount
+        current = self._account.get_position(instrument).quantity
+        new = current + amount
+        if current == 0 or abs(new) > abs(current):
+            logger.warning(
+                f"[Blacklist] :: blocked order increasing exposure on {instrument.symbol} "
+                f"(current={current}, amount={amount})"
+            )
+            return 0.0
+        if (current > 0) != (new > 0) and new != 0:  # would flip through zero
+            logger.warning(
+                f"[Blacklist] :: clamping {instrument.symbol} order to close "
+                f"(current={current}, requested_new={new})"
+            )
+            return -current
+        return amount
+```
+
+Then at the **first line** of the body of both `trade` (after the signature, before `size_adj = self._adjust_size(...)`) and `trade_async`, insert:
+
+```python
+        amount = self._blacklist_clamp(instrument, amount)
+        if amount == 0.0:
+            return None
+```
+
+(`trade` returns `Order | None`; `trade_async` returns `str | None` — `None` is valid for both.)
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/mixins/trading_test.py::TestBlacklistReduceOnly -q`
+Expected: PASS.
+
+- [ ] **Step 5: Write + run an integration test that `trade()` sends no order when blocked**
+
+Append to `tests/qubx/core/mixins/trading_test.py`:
+
+```python
+def test_trade_sends_no_order_when_blacklisted_and_opening(trading_manager, mock_account, mock_broker, strategy_context):
+    strategy_context.is_blacklisted = lambda inst: True
+    flat = Mock(spec=Position); flat.quantity = 0.0
+    mock_account.get_position.return_value = flat
+    inst = Mock(symbol="ONDOUSDT"); inst.exchange = "BINANCE.UM"
+    assert trading_manager.trade(inst, -891.4) is None
+    mock_broker.send_order.assert_not_called()
+```
+
+Run: `uv run pytest tests/qubx/core/mixins/trading_test.py::test_trade_sends_no_order_when_blacklisted_and_opening -q`
+Expected: PASS (the early `return None` fires before any broker call).
+
+- [ ] **Step 6: Run the whole trading test file for regressions**
+
+Run: `uv run pytest tests/qubx/core/mixins/trading_test.py -q`
+Expected: PASS. Existing `trade()`/`trade_async()` tests take the no-op path via the `MockStrategyContext.is_blacklisted` default added in Step 1. If any test fails with `AttributeError: is_blacklisted`, confirm that default was added to the class.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/qubx/core/mixins/trading.py tests/qubx/core/mixins/trading_test.py
+git commit -m "fix(core): reduce-only trade gate for blacklisted instruments"
+```
+
+---
+
+### Task 4: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the affected suites together**
+
+Run: `uv run pytest tests/qubx/core/ tests/qubx/control/ -q`
+Expected: PASS (all). These cover instrument-service, processing, trading, and control-action behavior.
+
+- [ ] **Step 2: Confirm no `refresh_only` remnants and no broken interface impls**
+
+Run: `grep -rn 'refresh_only' src/ tests/ ; uv run python -c "from qubx.core.context import StrategyContext; print('imports OK')"`
+Expected: no `refresh_only` matches; `imports OK` printed (confirms `IInstrumentServiceManager` is still satisfiable after the interface rename).
+
+- [ ] **Step 3: Final commit if any fixups were needed**
+
+```bash
+git add -A && git commit -m "test: verify blacklist enforcement across instrument-service, processing, trading" || echo "nothing to commit"
+```

--- a/docs/superpowers/specs/2026-06-18-blacklist-position-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-18-blacklist-position-enforcement-design.md
@@ -1,0 +1,125 @@
+# Blacklist Position Enforcement — Design
+
+**Goal:** Guarantee the invariant *"a bot never holds an open position in a blacklisted instrument."* Today the blacklist only filters the selected universe and force-closes the *delta* of newly-added entries on Apply; positions can survive or be re-opened. This adds continuous, idempotent enforcement.
+
+**Status:** Approved (brainstorm 2026-06-18). Targets Qubx, branch `fix/blacklist-position-enforcement` off `main` (post-1.9.1).
+
+---
+
+## Background — two observed failures
+
+Tested on dev by blacklisting `ONDOUSDT` while the bot held shorts; afterwards `ONDOUSDT` (−891.4) and `WLFIUSDT` (−34767) were still open (only `ICPUSDT` was clean).
+
+**Bug A — re-open by a stale signal (ONDO).** `InstrumentServiceManager.run_cycle` force-closes only `diff.blacklisted_added ∩ held` (mixins/instrument_service.py). ONDO *was* newly-added, so it was force-closed (`buy 887.6`). But strategies emit signals asynchronously (factors uses a 1-minute `ctx.delay`), and `__process_signals` (mixins/processing.py:552) does **not** gate on universe membership or blacklist — it processes any signal that has a quote, routing it through trackers → position gathering → `ctx.trade()` (mixins/trading.py:95). A pre-blacklist signal still in the queue re-shorted ONDO *after* the close. Nothing in the signal/deal/order path re-adds the instrument to the universe, so the result is an **orphan position**: held by the account, absent from `_instruments`, unsubscribed — invisible to both `set_universe` and the delta force-close.
+
+**Bug B — already-blacklisted holding never closed (WLFI).** WLFI was blacklisted in an earlier Apply; a redeploy restored its short. The new Apply (adding ONDO) has `diff.blacklisted_added = [ONDO]`, so WLFI is never force-closed. `set_universe` only closes instruments transitioning *out* of the universe (`prev_set − new_set`); a blacklisted instrument already outside the universe with a lingering position is invisible to it.
+
+Common root cause: **enforcement is event-shaped (on-change delta + universe-exit), not invariant-shaped.** And order submission is never gated, so async signals can reopen exposure.
+
+---
+
+## Design — two complementary mechanisms
+
+Neither alone suffices: #1 makes the invariant *true* (closes holdings); #2 keeps it *true* (blocks re-open).
+
+### #1 — Proactive close (full held set, on Apply **and** at fit)
+
+Replace the delta-based force-close with a full-set sweep, and run it at both triggers.
+
+**File:** `src/qubx/core/mixins/instrument_service.py`
+
+Shared helper:
+
+```python
+def _force_close_held_blacklisted(self) -> list[Instrument]:
+    """Close every currently-held position whose instrument is blacklisted (idempotent).
+    Reduce-only by construction (target 0), so it passes the #2 trade gate."""
+    positions = self._context.get_positions()
+    held = [i for i, p in positions.items() if p.quantity != 0 and self._service.is_blacklisted(i)]
+    if held:
+        self._context.remove_instruments(held, if_has_position_then="close")
+    return held
+```
+
+- `run_cycle()` (Apply / `refresh_instrument_service` action): unchanged ordering — refresh → fire change callbacks (re-fit) → **`_force_close_held_blacklisted()`** (was: delta `still_held`). Return dict reports `force_closed` from the full set.
+- New `enforce_at_fit()`: refresh cache → `_force_close_held_blacklisted()`, **no callbacks** (the fit is already running; firing re-fit callbacks here would loop). Replaces the cache-only `refresh_only()` call site.
+
+**File:** `src/qubx/core/mixins/processing.py` — in `__invoke_on_fit` (~line 621), call `self._context._instrument_service_manager.enforce_at_fit()` instead of `refresh_only()`. Sequence becomes: refresh + close blacklisted holdings → `on_fit` (whose `get_universe`/`filter_blacklisted` already exclude blacklisted, so the rebalance covers only survivors).
+
+`refresh_only()` is **replaced by** `enforce_at_fit()`: its only production caller is `__invoke_on_fit`, and its prior assumption that "set_universe handles closing" is the bug being fixed. This requires updating the `IInstrumentServiceManager` interface (interfaces.py:1364, swap `refresh_only` → `enforce_at_fit`) and retargeting its tests (`instrument_service_manager_test.py::test_refresh_only_*`, and `processing_fit_refresh_test.py` which asserts `refresh_only` runs before `on_fit`).
+
+### #2 — Preventive gate (reduce-only clamp at the order choke)
+
+`ctx.trade()` / `ctx.trade_async()` are the single universal choke — position gathering (`gathering/simplest.py:64`) and any manual call funnel through them. Gate there.
+
+**File:** `src/qubx/core/mixins/trading.py`
+
+```python
+def _blacklist_clamp(self, instrument: Instrument, amount: float) -> float:
+    """Reduce-only for blacklisted instruments: an order may only move the position
+    toward zero, never open or increase exposure. No-op when not blacklisted (the
+    common case, and always so without an instrument service). Clamps rather than
+    rejects: the reducing portion is kept; a flip through zero is clamped to an exact
+    close. Returns the (possibly adjusted) amount; 0.0 means 'do not send'."""
+    if not self._context.is_blacklisted(instrument):
+        return amount
+    current = self._account.get_position(instrument).quantity
+    new = current + amount
+    if current == 0 or abs(new) > abs(current):
+        logger.warning(f"[Blacklist] :: blocked order increasing exposure on {instrument.symbol} "
+                       f"(current={current}, amount={amount})")
+        return 0.0
+    if (current > 0) != (new > 0) and new != 0:  # would flip through zero
+        logger.warning(f"[Blacklist] :: clamping {instrument.symbol} order to close "
+                       f"(current={current}, requested new={new})")
+        return -current
+    return amount  # reduces |position| toward zero -> allowed
+```
+
+Both `trade()` and `trade_async()` call it first thing:
+
+```python
+amount = self._blacklist_clamp(instrument, amount)
+if amount == 0.0:
+    return None
+size_adj = self._adjust_size(instrument, amount)
+...
+```
+
+This stops the stale ONDO signal (opens from ~0 → `current == 0` → blocked) while allowing the force-close (a reduction). It also blocks restore-reconciliation re-opens once the cache is warm.
+
+---
+
+## Interaction & data flow
+
+- **Apply:** `run_cycle` → re-fit callbacks → full-set force-close. Survivors rebalanced by the re-fit; all blacklisted holdings closed. #2 prevents any same-tick stale signal from reopening.
+- **Fit (no Apply):** `enforce_at_fit` closes blacklisted holdings before `on_fit`; the rebalance covers survivors only. This is what makes "the blacklist is picked up at the next fit" actually close positions (the poll was removed).
+- **Between events:** #2 guarantees no order can open/increase blacklisted exposure, from any source (async signals, manual `ctx.trade`, restore).
+
+## Edge cases
+
+- **NullInstrumentService:** `is_blacklisted` is always False → #2 is a no-op; `_force_close_held_blacklisted` finds nothing. Zero behavior change for non-blacklist users.
+- **Force-close vs the gate:** closing reduces `|position|` → #2 allows it. No deadlock between #1 and #2.
+- **Flip through zero:** a target that would cross from short to long (or vice-versa) on a blacklisted instrument is clamped to an exact close (`-current`), never to the opposite side.
+- **Startup transient (accepted):** state-restore can re-establish a blacklisted position in the ~1s window before the first blacklist fetch (`start()` → `delay("1s", run_cycle)`). The startup `run_cycle` then force-closes it. Brief, self-healing; not blocked on a warm cache (explicitly out of scope).
+- **Rounding/min-size:** clamp operates on the raw `amount` before `_adjust_size`; if the clamped close is below min size, existing min-size handling applies as today.
+
+## Testing
+
+- **#1 (`instrument_service` tests):**
+  - Held blacklisted instrument **not** in `diff.blacklisted_added` is force-closed by `run_cycle` (WLFI regression).
+  - `enforce_at_fit` refreshes the cache **and** force-closes held blacklisted **without** firing change callbacks (replaces the `refresh_only` tests).
+  - No holdings / NullInstrumentService → no `remove_instruments` call.
+  - `processing_fit_refresh_test.py` updated: assert `enforce_at_fit` runs before `on_fit`.
+- **#2 (`trading` tests, mocked account/context):**
+  - Blacklisted + flat → `trade` returns None, no order sent (ONDO stale-signal regression).
+  - Blacklisted + reducing order → passes through unchanged.
+  - Blacklisted + flip-through-zero → clamped to `-current` (exact close).
+  - Not blacklisted → unchanged (no-op).
+  - Same coverage for `trade_async`.
+
+## Out of scope
+
+- Blocking restore on a warm blacklist cache (the startup transient above).
+- Order-gateway / exchange-side reduce-only flags (this is an in-process guard).
+- Any change to how blacklist entries are authored or distributed (platform side unchanged).

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1342,7 +1342,7 @@ class IUniverseManager:
 
 class IInstrumentServiceManager:
     """Manages the instrument blacklist service: read helpers, refresh/callback/force-close
-    cycle, the cache-only fit refresh, and framework-automatic startup refresh."""
+    cycle, fit-time enforcement, and framework-automatic startup refresh."""
 
     def is_blacklisted(self, instrument: Instrument) -> bool:
         """Return True if the instrument is on the active blacklist."""

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1361,10 +1361,9 @@ class IInstrumentServiceManager:
         newly-blacklisted instruments. Returns a summary dict."""
         ...
 
-    def refresh_only(self) -> None:
-        """Refresh the cached blacklist only — no change callbacks, no force-close.
-        Called before each `on_fit` so universe selection sees current data. No-op for
-        the Null service."""
+    def enforce_at_fit(self) -> None:
+        """Fit-time enforcement: refresh the cached blacklist and force-close any held
+        blacklisted positions, without firing change callbacks. No-op for the Null service."""
         ...
 
     def start(self) -> None:

--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -63,19 +63,19 @@ class InstrumentServiceManager(IInstrumentServiceManager):
             self._context.remove_instruments(held, if_has_position_then="close")
         return held
 
-    def refresh_only(self) -> None:
-        """Refresh the cached blacklist WITHOUT firing change callbacks or force-closing
-        positions. Used as the fit-time safety net: called immediately before `on_fit` so
-        `get_universe` / `ctx.filter_blacklisted` select over current blacklist data, while
-        the actual closing of now-blacklisted positions is handled by the fit's
-        `set_universe` removal path. No-op for the Null service (its `refresh` returns an
-        empty diff and nothing else runs)."""
+    def enforce_at_fit(self) -> None:
+        """Fit-time enforcement: refresh the cached blacklist AND force-close any held
+        blacklisted positions, WITHOUT firing change callbacks (the fit is already
+        running; firing re-fit callbacks here would loop). Called immediately before
+        `on_fit` so the rebalance selects over current data and never holds a blacklisted
+        instrument. No-op for the Null service."""
         self._service.refresh(self._context.instruments)
+        self._force_close_held_blacklisted()
 
     def start(self) -> None:
         """Framework-automatic refresh wiring (non-Null only): a one-shot startup refresh
         dispatched on the strategy thread via the context scheduler. The blacklist is kept
-        current thereafter by the fit-time cache refresh (see `refresh_only`) and by the
+        current thereafter by the fit-time enforcement (see `enforce_at_fit`) and by the
         operator-triggered `refresh_instrument_service` action; there is no periodic poll."""
         if isinstance(self._service, NullInstrumentService):
             return

--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class InstrumentServiceManager(IInstrumentServiceManager):
     """Owns the instrument blacklist service: read helpers, the refresh→callbacks→force-close
-    cycle, the cache-only fit refresh, and the framework-automatic startup refresh. Composed by StrategyContext
+    cycle, fit-time enforcement, and the framework-automatic startup refresh. Composed by StrategyContext
     the same way UniverseManager/ProcessingManager are."""
 
     def __init__(self, context: "IStrategyContext", instrument_service: IInstrumentService):

--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -34,10 +34,9 @@ class InstrumentServiceManager(IInstrumentServiceManager):
         return self._service.matching_instruments(self._context.instruments)
 
     def run_cycle(self, _ctx: "IStrategyContext | None" = None) -> dict:
-        """Refresh the blacklist, fire change callbacks, then force-close any still-held
-        newly-blacklisted instruments. Single shared implementation used by the control action
-        AND the startup one-shot. Runs on the strategy thread. `_ctx` is the
-        scheduler-passed context (unused; the bound `self._context` is the context)."""
+        """Refresh the blacklist, fire change callbacks, then force-close ALL held
+        blacklisted instruments (full set, not just the change delta). Shared by the
+        control action and the startup one-shot. Runs on the strategy thread."""
         diff = self._service.refresh(self._context.instruments)
         if diff.blacklisted_added or diff.blacklisted_removed:
             for cb in self._callbacks:
@@ -45,16 +44,24 @@ class InstrumentServiceManager(IInstrumentServiceManager):
                     cb(self._context, diff.blacklisted_added, diff.blacklisted_removed)
                 except Exception as e:
                     logger.error(f"[InstrumentService] :: change callback error: {e}")
-        positions = self._context.get_positions()
-        still_held = [i for i in diff.blacklisted_added if i in positions and positions[i].quantity != 0]
-        if still_held:
-            self._context.remove_instruments(still_held, if_has_position_then="close")
+        closed = self._force_close_held_blacklisted()
         return {
             "blacklisted_added": len(diff.blacklisted_added),
             "blacklisted_removed": len(diff.blacklisted_removed),
-            "force_closed": len(still_held),
-            "force_closed_instruments": [str(i) for i in still_held],
+            "force_closed": len(closed),
+            "force_closed_instruments": [str(i) for i in closed],
         }
+
+    def _force_close_held_blacklisted(self) -> list[Instrument]:
+        """Force-close every currently-held position whose instrument is blacklisted.
+        Idempotent and full-set (not the change delta), so already-blacklisted holdings
+        are closed too. Reduce-only by construction (closes to 0), so it is allowed by the
+        trade-layer blacklist gate. No-op for the Null service (is_blacklisted is False)."""
+        positions = self._context.get_positions()
+        held = [i for i, p in positions.items() if p.quantity != 0 and self._service.is_blacklisted(i)]
+        if held:
+            self._context.remove_instruments(held, if_has_position_then="close")
+        return held
 
     def refresh_only(self) -> None:
         """Refresh the cached blacklist WITHOUT firing change callbacks or force-closing

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -615,10 +615,12 @@ class ProcessingManager(IProcessingManager):
     def __invoke_on_fit(self) -> None:
         with self._health_monitor("ctx.on_fit"):
             try:
-                # - refresh the blacklist cache (cache-only: no callbacks / no force-close)
-                #   so on_fit's get_universe / filter_blacklisted select over current data.
-                #   No-op for the Null instrument service.
-                self._context._instrument_service_manager.refresh_only()
+                # - enforce the blacklist before fitting: refresh the cache AND force-close
+                #   any held blacklisted positions (no change callbacks), so on_fit's
+                #   get_universe / filter_blacklisted select over current data and no
+                #   blacklisted instrument is held into the rebalance. No-op for the Null
+                #   instrument service.
+                self._context._instrument_service_manager.enforce_at_fit()
                 logger.debug(f"[<y>{self.__class__.__name__}</y>] :: Invoking <g>{self._strategy_name}</g> on_fit")
                 self._strategy.on_fit(self._context)
                 self._subscription_manager.commit()  # apply pending operations

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -92,6 +92,29 @@ class TradingManager(ITradingManager):
         self._client_id_store = ClientIdStore()
         self._exchange_to_broker = {broker.exchange(): broker for broker in brokers}
 
+    def _blacklist_clamp(self, instrument: Instrument, amount: float) -> float:
+        """Reduce-only for blacklisted instruments: an order may only move the position
+        toward zero, never open or increase exposure. No-op when not blacklisted (always,
+        without an instrument service). Returns the (possibly clamped) amount; 0.0 means
+        'do not send'. A flip through zero is clamped to an exact close."""
+        if not self._context.is_blacklisted(instrument):
+            return amount
+        current = self._account.get_position(instrument).quantity
+        new = current + amount
+        if current == 0 or abs(new) > abs(current):
+            logger.warning(
+                f"[Blacklist] :: blocked order increasing exposure on {instrument.symbol} "
+                f"(current={current}, amount={amount})"
+            )
+            return 0.0
+        if (current > 0) != (new > 0) and new != 0:  # would flip through zero
+            logger.warning(
+                f"[Blacklist] :: clamping {instrument.symbol} order to close "
+                f"(current={current}, requested_new={new})"
+            )
+            return -current
+        return amount
+
     def trade(
         self,
         instrument: Instrument,
@@ -101,6 +124,9 @@ class TradingManager(ITradingManager):
         client_id: str | None = None,
         **options,
     ) -> Order | None:
+        amount = self._blacklist_clamp(instrument, amount)
+        if amount == 0.0:
+            return None
         size_adj = self._adjust_size(instrument, amount)
         side = self._get_side(amount)
         type = self._get_order_type(instrument, price, options)
@@ -148,6 +174,9 @@ class TradingManager(ITradingManager):
         client_id: str | None = None,
         **options,
     ) -> str | None:
+        amount = self._blacklist_clamp(instrument, amount)
+        if amount == 0.0:
+            return None
         size_adj = self._adjust_size(instrument, amount)
         side = self._get_side(amount)
         type = self._get_order_type(instrument, price, options)

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -102,13 +102,15 @@ class TradingManager(ITradingManager):
         current = self._account.get_position(instrument).quantity
         new = current + amount
         if current == 0 or abs(new) > abs(current):
-            logger.warning(
+            # Routine, expected enforcement (can recur every bar for a strategy that keeps
+            # signalling a blacklisted instrument) -> debug, not warning, to avoid log spam.
+            logger.debug(
                 f"[Blacklist] :: blocked order increasing exposure on {instrument.symbol} "
                 f"(current={current}, amount={amount})"
             )
             return 0.0
         if (current > 0) != (new > 0) and new != 0:  # would flip through zero
-            logger.warning(
+            logger.debug(
                 f"[Blacklist] :: clamping {instrument.symbol} order to close "
                 f"(current={current}, requested_new={new})"
             )

--- a/src/qubx/gathering/simplest.py
+++ b/src/qubx/gathering/simplest.py
@@ -66,6 +66,14 @@ class SimplePositionGatherer(IPositionGathering):
                 logger.debug(f"  [<y>{self.__class__.__name__}</y>(<g>{instrument}</g>)] :: {e}")
                 return current_position
 
+            if r is None:
+                # No order was placed (e.g. blocked by the blacklist reduce-only trade gate).
+                # The position is unchanged: do not touch entry_order_id or report new_size.
+                logger.debug(
+                    f"  [<y>{self.__class__.__name__}</y>(<g>{instrument}</g>)] :: order not placed; position stays {current_position}"
+                )
+                return current_position
+
             if _is_stop_or_limit:
                 self.entry_order_id = r.id
                 logger.debug(

--- a/tests/qubx/core/account_processor_test.py
+++ b/tests/qubx/core/account_processor_test.py
@@ -147,6 +147,9 @@ class TestAccountProcessorStuff:
 
         mock_context = Mock()
         mock_context.time = DummyTimeProvider().time
+        # No blacklist in these tests: report False so the reduce-only trade gate is a
+        # no-op (a bare Mock would return a truthy is_blacklisted and block opening orders).
+        mock_context.is_blacklisted = Mock(return_value=False)
 
         # Mock the quote method to return a quote with mid_price
         mock_quote = Mock()

--- a/tests/qubx/core/instrument_service_manager_test.py
+++ b/tests/qubx/core/instrument_service_manager_test.py
@@ -95,32 +95,25 @@ def test_set_callbacks_preserves_order():
     assert m._callbacks == [a, b]
 
 
-def test_refresh_only_refreshes_cache_without_callbacks_or_force_close():
-    calls = []
-    btc = MagicMock()
-    pos = MagicMock(); pos.quantity = 1.0
+def test_enforce_at_fit_refreshes_and_force_closes_without_callbacks():
+    ondo = MagicMock()
+    pos = MagicMock(); pos.quantity = -891.4
     svc = MagicMock()
-    svc.refresh.return_value = InstrumentServiceDiff(blacklisted_added=[btc], blacklisted_removed=[])
-    m, ctx = _mgr(
-        svc,
-        instruments=[btc],
-        positions={btc: pos},
-        callbacks=[lambda c, a, r: calls.append("cb")],
-    )
-    result = m.refresh_only()
-    assert result is None
-    svc.refresh.assert_called_once_with([btc])
-    assert calls == []
-    ctx.remove_instruments.assert_not_called()
-    ctx.get_positions.assert_not_called()
+    svc.refresh.return_value = InstrumentServiceDiff(blacklisted_added=[], blacklisted_removed=[])
+    svc.is_blacklisted.side_effect = lambda i: i is ondo
+    calls = []
+    m, ctx = _mgr(svc, instruments=[ondo], positions={ondo: pos},
+                  callbacks=[lambda c, a, r: calls.append("cb")])
+    assert m.enforce_at_fit() is None
+    svc.refresh.assert_called_once_with([ondo])
+    assert calls == []  # no change callbacks at fit time
+    ctx.remove_instruments.assert_called_once_with([ondo], if_has_position_then="close")
 
 
-def test_refresh_only_noop_with_null_service():
+def test_enforce_at_fit_noop_with_null_service():
     m, ctx = _mgr(NullInstrumentService())
-    # Must not raise and must not touch position/removal machinery.
-    assert m.refresh_only() is None
+    assert m.enforce_at_fit() is None
     ctx.remove_instruments.assert_not_called()
-    ctx.get_positions.assert_not_called()
 
 
 def test_run_cycle_force_closes_all_held_blacklisted_not_just_delta():

--- a/tests/qubx/core/instrument_service_manager_test.py
+++ b/tests/qubx/core/instrument_service_manager_test.py
@@ -121,3 +121,20 @@ def test_refresh_only_noop_with_null_service():
     assert m.refresh_only() is None
     ctx.remove_instruments.assert_not_called()
     ctx.get_positions.assert_not_called()
+
+
+def test_run_cycle_force_closes_all_held_blacklisted_not_just_delta():
+    # WLFI regression: an already-blacklisted holding (absent from the change delta)
+    # must still be force-closed.
+    ondo, wlfi, btc = MagicMock(), MagicMock(), MagicMock()
+    pos = MagicMock(); pos.quantity = -34767.0
+    btc_pos = MagicMock(); btc_pos.quantity = 1.0
+    svc = MagicMock()
+    # Only ONDO is newly-added this cycle; WLFI was blacklisted earlier.
+    svc.refresh.return_value = InstrumentServiceDiff(blacklisted_added=[ondo], blacklisted_removed=[])
+    svc.is_blacklisted.side_effect = lambda i: i in (ondo, wlfi)
+    m, ctx = _mgr(svc, instruments=[wlfi, btc], positions={wlfi: pos, btc: btc_pos})
+    summary = m.run_cycle()
+    ctx.remove_instruments.assert_called_once_with([wlfi], if_has_position_then="close")
+    assert summary["force_closed"] == 1
+    assert summary["force_closed_instruments"] == [str(wlfi)]

--- a/tests/qubx/core/mixins/processing_fit_refresh_test.py
+++ b/tests/qubx/core/mixins/processing_fit_refresh_test.py
@@ -74,23 +74,23 @@ def test_invoke_on_fit_refreshes_instrument_service_before_on_fit(processing_man
 
     # Attach both calls to a shared parent mock so their relative order is recorded.
     order = MagicMock()
-    order.attach_mock(context._instrument_service_manager.refresh_only, "refresh_only")
+    order.attach_mock(context._instrument_service_manager.enforce_at_fit, "enforce_at_fit")
     order.attach_mock(strategy.on_fit, "on_fit")
 
     # name-mangled: ProcessingManager.__invoke_on_fit
     processing_manager._ProcessingManager__invoke_on_fit()
 
-    context._instrument_service_manager.refresh_only.assert_called_once_with()
+    context._instrument_service_manager.enforce_at_fit.assert_called_once_with()
     strategy.on_fit.assert_called_once_with(context)
 
     called = [c[0] for c in order.mock_calls]
-    assert called.index("refresh_only") < called.index("on_fit")
+    assert called.index("enforce_at_fit") < called.index("on_fit")
 
 
 def test_invoke_on_fit_marks_fit_called_even_if_refresh_raises(processing_manager):
     context = processing_manager._test_context
     strategy = processing_manager._test_strategy
-    context._instrument_service_manager.refresh_only.side_effect = RuntimeError("boom")
+    context._instrument_service_manager.enforce_at_fit.side_effect = RuntimeError("boom")
 
     # Should not propagate: the on_fit try/except swallows it (refresh shares on_fit's
     # error handling — acceptable per design §5).

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -714,6 +714,24 @@ class TestBlacklistReduceOnly:
         assert trading_manager._blacklist_clamp(Mock(symbol="BTCUSDT"), -891.4) == -891.4
         mock_account.get_position.assert_not_called()
 
+    def test_clamp_blocks_increasing_long(self, trading_manager, mock_account, strategy_context):
+        # long-side mirror of the short-increase block (guards sign handling)
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(500.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), 100.0) == 0.0  # +500 -> +600
+
+    def test_clamp_flip_long_to_short_is_clamped_to_close(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(500.0)
+        # request would go +500 -> -300 (flip); clamp to exact close (-500)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), -800.0) == -500.0
+
+    def test_clamp_allows_exact_close_unchanged(self, trading_manager, mock_account, strategy_context):
+        # an order that lands exactly on zero is a reduce, returned unchanged (not 0.0-blocked)
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(-500.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), 500.0) == 500.0
+
 
 def test_trade_sends_no_order_when_blacklisted_and_opening(trading_manager, mock_account, mock_broker, strategy_context):
     strategy_context.is_blacklisted = lambda inst: True

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -33,6 +33,9 @@ class MockStrategyContext(IStrategyContext):
         else:
             self.emitted_signals.append(signal)
 
+    def is_blacklisted(self, instrument):
+        return False
+
 
 @pytest.fixture
 def time_provider():
@@ -678,3 +681,44 @@ class TestAdjustSizeMinNotional:
         # Selling 5 ADA (reducing position) — below min_notional but should work
         result = notional_trading_manager._adjust_size(ada_instrument, -5.0)
         assert result == 5.0
+
+
+class TestBlacklistReduceOnly:
+    def _pos(self, qty):
+        p = Mock(spec=Position); p.quantity = qty
+        return p
+
+    def test_clamp_blocks_opening_from_flat(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(0.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), -891.4) == 0.0
+
+    def test_clamp_blocks_increasing_short(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(-500.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), -100.0) == 0.0  # -500 -> -600
+
+    def test_clamp_allows_reducing_short(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(-500.0)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), 200.0) == 200.0  # -500 -> -300
+
+    def test_clamp_flip_through_zero_is_clamped_to_close(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: True
+        mock_account.get_position.return_value = self._pos(-500.0)
+        # request would go -500 -> +300 (flip); clamp to exact close (+500)
+        assert trading_manager._blacklist_clamp(Mock(symbol="ONDOUSDT"), 800.0) == 500.0
+
+    def test_clamp_noop_when_not_blacklisted(self, trading_manager, mock_account, strategy_context):
+        strategy_context.is_blacklisted = lambda inst: False
+        assert trading_manager._blacklist_clamp(Mock(symbol="BTCUSDT"), -891.4) == -891.4
+        mock_account.get_position.assert_not_called()
+
+
+def test_trade_sends_no_order_when_blacklisted_and_opening(trading_manager, mock_account, mock_broker, strategy_context):
+    strategy_context.is_blacklisted = lambda inst: True
+    flat = Mock(spec=Position); flat.quantity = 0.0
+    mock_account.get_position.return_value = flat
+    inst = Mock(symbol="ONDOUSDT"); inst.exchange = "BINANCE.UM"
+    assert trading_manager.trade(inst, -891.4) is None
+    mock_broker.send_order.assert_not_called()

--- a/tests/qubx/trackers/trackers_gathering_test.py
+++ b/tests/qubx/trackers/trackers_gathering_test.py
@@ -184,6 +184,22 @@ class TestTrackersAndGatherers:
         assert ctx._n_orders_buy == 2
         assert ctx._n_orders_sell == 1
 
+    def test_gatherer_handles_none_trade_result_without_crash(self):
+        # When ctx.trade returns None (e.g. an order blocked by the blacklist reduce-only
+        # gate), the gatherer must not crash on r.id and must leave the position unchanged.
+        # Uses a LIMIT target (entry_price below the bid) so _is_stop_or_limit is True --
+        # that is the path that dereferenced r.id and crashed before the guard.
+        ctx = DebugStratageyCtx(instrs := [lookup.find_symbol("BINANCE.UM", "BTCUSDT")], 10000)
+        ctx.trade = lambda *a, **k: None  # simulate a blocked/rejected order
+        gathering = SimplePositionGatherer()
+        i = instrs[0]
+        assert i is not None
+        # quote is bid=1000.0/ask=1000.5; entry_price 999.0 <= bid -> limit buy.
+        target = i.target(ctx.time(), 0.1, entry_price=999.0)
+        result = gathering.alter_position_size(ctx, target)  # must not raise AttributeError
+        assert result == 0.0  # position unchanged (no order placed)
+        assert gathering.entry_order_id is None
+
     def test_fixed_risk_sizer(self):
         ctx = DebugStratageyCtx(instrs := [lookup.find_symbol("BINANCE.UM", "BTCUSDT")], 10000)
         i = instrs[0]


### PR DESCRIPTION
## Problem

The instrument blacklist filtered the selected universe but did **not** guarantee the real invariant — *a bot never holds a position in a blacklisted instrument*. Tested on dev by blacklisting `ONDOUSDT` while the bot held shorts; afterwards two blacklisted instruments were still open:

- **WLFI** (`-34767`) — never closed. `run_cycle` only force-closed `diff.blacklisted_added ∩ held`; WLFI was blacklisted in an earlier Apply, so it wasn't in this change's delta, and `set_universe` only closes instruments transitioning *out* of the universe (a blacklisted instrument already outside it with a lingering position is invisible).
- **ONDO** (`-891.4`) — force-closed, then **re-shorted** by a stale signal. Strategies emit signals asynchronously (factors uses a 1-min delay), and order submission was never gated, so a pre-blacklist signal re-opened the position after the close, leaving an orphan position (held, off-universe, unsubscribed).

## Fix — two complementary mechanisms

Neither alone suffices: #1 makes the invariant true (closes holdings); #2 keeps it true (blocks re-open). Both are no-ops without an instrument service (`NullInstrumentService.is_blacklisted` is always `False`), so non-blacklist users — including all backtests — are unaffected.

**#1 Proactive close (full held set, on Apply and at fit).** New `_force_close_held_blacklisted()` closes every held position whose instrument is blacklisted (idempotent, not the delta). Invoked by `run_cycle()` (Apply, with change callbacks) and by a new `enforce_at_fit()` (fit-time, callback-free) that replaces the cache-only `refresh_only()` at the `__invoke_on_fit` call site. The `IInstrumentServiceManager` interface was updated accordingly.

**#2 Preventive gate (reduce-only at the order choke).** New `_blacklist_clamp()` in `TradingManager.trade`/`trade_async`: for a blacklisted instrument an order may only move the position toward zero — opening/increasing is blocked, a flip through zero is clamped to an exact close. The force-close itself is a reduction, so #1 and #2 compose without deadlock.

**Robustness fix (surfaced by #2).** `SimplePositionGatherer.alter_position_size` dereferenced `ctx.trade(...).id` without a `None` guard — a pre-existing latent crash that the new gate makes reachable for a blacklisted limit/stop entry (`None` return). Added an early-return guard (position unchanged) + a regression test that reproduces the exact `'NoneType' object has no attribute 'id'` crash.

## Tests

- `run_cycle` full-set force-close incl. WLFI-not-in-delta regression; `enforce_at_fit` refresh + force-close + no callbacks; Null no-op.
- `_blacklist_clamp`: block-from-flat, block-increasing (long & short), allow-reducing, flip-to-close (both directions), exact-close-unchanged, no-op-not-blacklisted; `trade()` sends no order when blocked.
- Gatherer `None`-result guard regression test.
- `account_processor_test` fixture updated to report `is_blacklisted=False` (a bare Mock returned truthy and would have blocked its opening orders) — legitimate harness fix, not masking.
- Full `tests/qubx/core/ tests/qubx/control/ tests/qubx/trackers/` → **485 passed**.

## Behaviour note

Routine block/clamp events log at `debug` (not `warning`) to avoid per-bar spam for a strategy that keeps signalling a blacklisted name.

Spec + plan: `docs/superpowers/specs/2026-06-18-blacklist-position-enforcement-design.md`, `docs/superpowers/plans/2026-06-18-blacklist-position-enforcement.md`.
