### PR TITLE
fix(core): re-fit on blacklist removal of an off-universe instrument

### DIFF
--- a/src/qubx/core/instrument_service.py
+++ b/src/qubx/core/instrument_service.py
@@ -39,10 +39,18 @@ class BlacklistEntry:
 
 @dataclass
 class InstrumentServiceDiff:
-    """Difference between two blacklist evaluations over a known instrument set."""
+    """Difference between two blacklist evaluations over a known instrument set.
+
+    `blacklisted_added`/`blacklisted_removed` are scoped to the known universe (used to
+    force-close held positions). `entries_changed` reflects whether the raw blacklist
+    *entry set* changed at all — it flips even for edits to instruments outside the current
+    universe (e.g. un-blacklisting an instrument that was already evicted), which the
+    universe-scoped lists cannot detect. The manager uses it to decide whether to fire the
+    re-fit callbacks."""
 
     blacklisted_added: list[Instrument] = field(default_factory=list)
     blacklisted_removed: list[Instrument] = field(default_factory=list)
+    entries_changed: bool = False
 
 
 class IInstrumentService:
@@ -133,7 +141,12 @@ class HttpInstrumentService(IInstrumentService):
         now_matched = {i for i in known_instruments if self._any_match(new_entries, i)}
         added = [i for i in known_instruments if i in now_matched and i not in prev_matched]
         removed = [i for i in known_instruments if i in prev_matched and i not in now_matched]
-        return InstrumentServiceDiff(blacklisted_added=added, blacklisted_removed=removed)
+        # entries_changed flips for ANY blacklist edit, including instruments outside the
+        # known universe (BlacklistEntry is a frozen dataclass, so it is set-comparable).
+        entries_changed = set(prev_entries) != set(new_entries)
+        return InstrumentServiceDiff(
+            blacklisted_added=added, blacklisted_removed=removed, entries_changed=entries_changed
+        )
 
     @staticmethod
     def _any_match(entries: list[BlacklistEntry], instrument: Instrument) -> bool:

--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -38,7 +38,10 @@ class InstrumentServiceManager(IInstrumentServiceManager):
         blacklisted instruments (full set, not just the change delta). Shared by the
         control action and the startup one-shot. Runs on the strategy thread."""
         diff = self._service.refresh(self._context.instruments)
-        if diff.blacklisted_added or diff.blacklisted_removed:
+        # Fire on ANY blacklist edit (entries_changed), not just universe-scoped add/remove:
+        # un-blacklisting an instrument that was already evicted from the universe produces
+        # no add/remove but must still re-fit so the strategy can re-select it.
+        if diff.entries_changed or diff.blacklisted_added or diff.blacklisted_removed:
             for cb in self._callbacks:
                 try:
                     cb(self._context, diff.blacklisted_added, diff.blacklisted_removed)

--- a/tests/qubx/core/instrument_service_manager_test.py
+++ b/tests/qubx/core/instrument_service_manager_test.py
@@ -63,6 +63,22 @@ def test_run_cycle_empty_diff_is_noop():
     assert summary == {"blacklisted_added": 0, "blacklisted_removed": 0, "force_closed": 0, "force_closed_instruments": []}
 
 
+def test_run_cycle_fires_callbacks_on_entries_change_with_empty_universe_diff():
+    # Removing an off-universe blacklist entry yields no added/removed (the instrument is no
+    # longer in the universe) but entries_changed is True -> the re-fit callback must fire so
+    # the strategy re-selects and can bring the un-blacklisted instrument back.
+    calls = []
+    svc = MagicMock()
+    svc.refresh.return_value = InstrumentServiceDiff(
+        blacklisted_added=[], blacklisted_removed=[], entries_changed=True
+    )
+    svc.is_blacklisted.return_value = False
+    m, ctx = _mgr(svc, positions={}, callbacks=[lambda c, a, r: calls.append((list(a), list(r)))])
+    m.run_cycle()
+    assert calls == [([], [])]
+    ctx.remove_instruments.assert_not_called()
+
+
 def test_run_cycle_accepts_scheduler_ctx_arg():
     # the scheduler dispatches scheduled methods as method(ctx); run_cycle must accept it
     svc = MagicMock()

--- a/tests/qubx/core/instrument_service_test.py
+++ b/tests/qubx/core/instrument_service_test.py
@@ -81,6 +81,7 @@ class TestNullInstrumentService:
         assert isinstance(diff, InstrumentServiceDiff)
         assert diff.blacklisted_added == []
         assert diff.blacklisted_removed == []
+        assert diff.entries_changed is False
 
     def test_is_blacklisted_always_false(self):
         assert NullInstrumentService().is_blacklisted(BTC_SWAP) is False
@@ -164,7 +165,30 @@ class TestHttpInstrumentService:
         diff = svc.refresh([BTC_SWAP, ETH_SPOT])
         assert diff.blacklisted_added == []
         assert diff.blacklisted_removed == []
+        assert diff.entries_changed is False  # cache preserved -> no change
         assert svc.is_blacklisted(BTC_SWAP) is True
+
+    def test_refresh_reports_entries_changed_for_off_universe_edit(self):
+        # An entry for an instrument NOT in the known universe produces no universe diff,
+        # but entries_changed must still flip so the manager can re-fit on add AND remove.
+        client = MagicMock()
+        svc = HttpInstrumentService(base_url="http://svc", exchanges=["BINANCE.UM"], client=client)
+        universe = [ETH_SPOT]  # does not contain BTC
+        client.get.return_value = _resp(
+            {"entries": [{"exchange": "BINANCE.UM", "market_type": None, "asset": "BTC", "symbol": None}]}
+        )
+        d_add = svc.refresh(universe)
+        assert d_add.blacklisted_added == [] and d_add.blacklisted_removed == []
+        assert d_add.entries_changed is True
+        # remove the off-universe entry: still no universe diff, but entries changed
+        client.get.return_value = _resp({"entries": []})
+        d_remove = svc.refresh(universe)
+        assert d_remove.blacklisted_added == [] and d_remove.blacklisted_removed == []
+        assert d_remove.entries_changed is True
+        # a repeat refresh with identical entries is not a change
+        client.get.return_value = _resp({"entries": []})
+        d_same = svc.refresh(universe)
+        assert d_same.entries_changed is False
 
 
 from qubx.core.instrument_service import create_instrument_service


### PR DESCRIPTION
## Problem

After the blacklist-position-enforcement change, **removing** an instrument from the blacklist and clicking Apply did **not** trigger a re-fit, so the instrument never returned to the bot's universe until the next scheduled daily fit.

Verified on dev: `refresh_instrument_service` ran `ok`, but no change callback / `trigger_fit` fired.

## Root cause

`InstrumentServiceManager.run_cycle` fired the re-fit callbacks only when the **universe-scoped** diff (`blacklisted_added` / `blacklisted_removed`) was non-empty. Those lists are computed over `ctx.instruments` (the current universe). But blacklisting an instrument **force-closes it and evicts it from the universe** — so when it's later *removed* from the blacklist, it's no longer in `ctx.instruments` to be compared:

```python
prev_matched = {i for i in known_instruments if any_match(prev_entries, i)}   # excludes the evicted instrument
now_matched  = {i for i in known_instruments if any_match(new_entries, i)}
removed = [...]   # empty
```

Empty diff → no callback → no `trigger_fit`. Adds work (the instrument is still in the universe at that point); removes are invisible.

## Fix

Add `InstrumentServiceDiff.entries_changed`: whether the **raw blacklist entry set** changed at all, detectable even for instruments outside the current universe (`BlacklistEntry` is a frozen dataclass, so `set(prev) != set(new)`). `run_cycle` now fires callbacks when `entries_changed` **or** the existing add/remove signal:

```python
if diff.entries_changed or diff.blacklisted_added or diff.blacklisted_removed:
    for cb in self._callbacks: ...
```

Any blacklist edit now triggers a re-fit; the re-fit's `get_universe` re-selects from the full candidate set, so an un-blacklisted instrument can come back. The force-close path (`_force_close_held_blacklisted`, full-set) is unchanged. Keeping the `or added/removed` makes the change backward-compatible (existing callers/tests that build a diff with only `added` still fire).

## Tests

- `refresh()` reports `entries_changed=True` for an add **and** a remove of an instrument **not** in the known universe (no universe diff), and `False` on a no-op repeat / network error / Null service.
- `run_cycle` fires the callback when `entries_changed` is set even with empty add/remove.
- Full `tests/qubx/core/ tests/qubx/control/` → **472 passed**.
