### PR TITLE
fix(core): warm blacklist cache synchronously at startup

### DIFF
--- a/src/qubx/core/mixins/instrument_service.py
+++ b/src/qubx/core/mixins/instrument_service.py
@@ -76,10 +76,19 @@ class InstrumentServiceManager(IInstrumentServiceManager):
         self._force_close_held_blacklisted()
 
     def start(self) -> None:
-        """Framework-automatic refresh wiring (non-Null only): a one-shot startup refresh
-        dispatched on the strategy thread via the context scheduler. The blacklist is kept
-        current thereafter by the fit-time enforcement (see `enforce_at_fit`) and by the
+        """Framework-automatic refresh wiring (non-Null only). Runs in the context's
+        __post_init__, before the universe is set and state is restored.
+
+        Two steps: (1) warm the blacklist cache SYNCHRONOUSLY now, so universe selection
+        (the `set_universe` blacklist filter) and the reduce-only trade gate are
+        blacklist-aware from t=0 -- otherwise state-restore can re-establish a blacklisted
+        position before the first async refresh. Best-effort: on a network error the cache
+        stays empty and fit-time enforcement still applies. (2) schedule a one-shot
+        force-close pass on the strategy thread once it is running, to close any blacklisted
+        holding the restore established before the cache was warm. The blacklist is kept
+        current thereafter by the fit-time enforcement (see `enforce_at_fit`) and the
         operator-triggered `refresh_instrument_service` action; there is no periodic poll."""
         if isinstance(self._service, NullInstrumentService):
             return
+        self._service.refresh(self._context.instruments)
         self._context.delay("1s", self.run_cycle)

--- a/tests/qubx/core/instrument_service_manager_test.py
+++ b/tests/qubx/core/instrument_service_manager_test.py
@@ -103,6 +103,20 @@ def test_start_noop_with_null_service():
     ctx.schedule.assert_not_called()
 
 
+def test_start_warms_cache_synchronously():
+    # The blacklist cache must be populated synchronously at startup (start() runs in
+    # context __post_init__, before the universe is set and state is restored) so universe
+    # selection and the reduce-only trade gate are blacklist-aware from t=0 -- not only via
+    # the delayed one-shot run_cycle, which fires after restore could re-open a blacklisted
+    # position.
+    svc = MagicMock(spec=HttpInstrumentService)
+    inst = MagicMock()
+    m, ctx = _mgr(svc, instruments=[inst])
+    m.start()
+    svc.refresh.assert_called_once_with([inst])  # synchronous cache warm-up
+    ctx.delay.assert_called_once_with("1s", m.run_cycle)  # one-shot force-close still scheduled
+
+
 def test_set_callbacks_preserves_order():
     m, ctx = _mgr(MagicMock())
     a = lambda c, ad, rm: None


### PR DESCRIPTION
## Problem

On a bot **restart**, the blacklist wasn't enforced from t=0: state-restore could briefly re-establish (or hold) a position in a now-blacklisted instrument before the blacklist was loaded, and the bot only force-closed it ~1s later. A brief, self-healing, but visible transient — flagged as "accepted / out-of-scope" in the original enforcement spec; this closes it.

## Root cause

`InstrumentServiceManager.start()` runs in the context's `__post_init__` — *before* the live `start()` does `set_universe(self._initial_instruments)` (which includes restored open-position instruments) and before the restore reconciliation trades. But `start()` only scheduled a **delayed** one-shot refresh:

```python
self._context.delay("1s", self.run_cycle)
```

So during the initial `set_universe` and reconciliation the blacklist cache was still empty: `set_universe`'s `_filter_blacklisted` was a no-op, the reduce-only trade gate (`is_blacklisted` → `False`) couldn't block re-opens, and the blacklisted instrument was only force-closed when the delayed `run_cycle` fired ~1s later.

## Fix

Warm the cache **synchronously** in `start()`, before returning (i.e. before `set_universe`/restore run):

```python
self._service.refresh(self._context.instruments)   # synchronous warm-up
self._context.delay("1s", self.run_cycle)           # one-shot force-close of anything restored before warm-up
```

Now the cache is populated from t=0, so universe selection filters blacklisted instruments and the reduce-only gate is armed immediately — restore can't re-open a blacklisted position. The delayed `run_cycle` is retained to force-close any holding that already existed in the restored snapshot. Best-effort: `refresh()` swallows network errors (keeps cache empty), and fit-time `enforce_at_fit` remains the backstop, so a slow/unreachable control-api can't break startup.

## Tests

- New `test_start_warms_cache_synchronously`: `start()` calls `service.refresh(instruments)` synchronously **and** still schedules the one-shot `run_cycle`.
- Existing start tests unchanged (delayed one-shot still scheduled; Null service still a no-op — returns before any refresh).
- Full `tests/qubx/core/ tests/qubx/control/` → **473 passed**.
