### PR TITLE
feat(universe): settle gone held positions out of universe + force-settle action

### DIFF
--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -125,7 +125,13 @@ class CcxtDataProvider(IDataProvider):
         markets = getattr(self._exchange_manager.exchange, "markets", None)
         if not markets:  # None or empty => not loaded / can't tell => fail-open
             return True
-        return instrument_to_ccxt_symbol(instrument) in markets
+        market = markets.get(instrument_to_ccxt_symbol(instrument))
+        if market is None:
+            return False
+        # A present-but-inactive market (e.g. Binance SETTLING / active=False during a
+        # delisting) is not tradeable -> treat as not listed so the gone-settle path can
+        # flatten held positions. Missing/None active fails open (treated as listed).
+        return market.get("active") is not False
 
     def subscribe(
         self,

--- a/src/qubx/control/builtin.py
+++ b/src/qubx/control/builtin.py
@@ -106,6 +106,15 @@ def _remove_instruments(ctx: IStrategyContext, symbols: list[str], exchange: str
     )
 
 
+def _settle_position(ctx: IStrategyContext, symbol: str, exchange: str | None = None, **kwargs) -> ActionResult:
+    instr = _resolve(ctx, symbol, exchange)
+    if instr is None:
+        return ActionResult(status="error", error=f"Unknown symbol: {symbol}")
+
+    ctx.settle_position(instr)
+    return ActionResult(status="ok", data={"settled": str(instr)})
+
+
 def _set_universe(ctx: IStrategyContext, symbols: list[str], exchange: str | None = None, if_has_position: str = "close", **kwargs) -> ActionResult:
     instruments = []
     errors = []
@@ -680,6 +689,19 @@ BUILTIN_ACTIONS: dict[str, tuple[ActionDef, Callable]] = {
             ],
         ),
         _remove_instruments,
+    ),
+    "settle_position": (
+        ActionDef(
+            name="settle_position",
+            description="Force-settle a held position in place (flatten to zero without trading). Operator override for an untradeable/stuck position, e.g. a delisted market with no live quote.",
+            category="universe",
+            dangerous=True,
+            params=[
+                ActionParam(name="symbol", type="string", description="Trading instrument symbol to force-settle"),
+                _EXCHANGE_PARAM,
+            ],
+        ),
+        _settle_position,
     ),
     "set_universe": (
         ActionDef(

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -791,6 +791,9 @@ class StrategyContext(IStrategyContext):
     def remove_instruments(self, instruments: list[Instrument], if_has_position_then: RemovalPolicy = "close"):
         return self._universe_manager.remove_instruments(instruments, if_has_position_then)
 
+    def settle_position(self, instrument: Instrument) -> None:
+        return self._universe_manager.settle_position(instrument)
+
     @property
     def instruments(self):
         return self._universe_manager.instruments

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1319,6 +1319,14 @@ class IUniverseManager:
         """
         ...
 
+    def settle_position(self, instrument: Instrument) -> None:
+        """Force-settle a held position in place: cancel resting orders and flatten the
+        position to zero via the account WITHOUT trading, regardless of whether the market is
+        still listed. Operator override for an untradeable/stuck position (e.g. a delisted
+        market with no live quote) that the normal close-via-trade path can never flatten.
+        """
+        ...
+
     @property
     def instruments(self) -> list[Instrument]:
         """

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -120,6 +120,30 @@ class UniverseManager(IUniverseManager):
         gone_set = set(gone)
         return [i for i in instruments if i not in gone_set]
 
+    def _settle_gone_holdings(self, handled: set[Instrument]) -> None:
+        """Settle held positions whose market is gone, regardless of universe membership.
+
+        Complements `_drop_gone`, which only sweeps universe *candidates*: a held position
+        that is out of the universe -- blacklisted, dropped, or orphaned -- is invisible to
+        the candidate sweep, so without this it could never be settled once its market
+        disappears from the exchange.
+
+        `handled` are the candidate instruments already processed by `_drop_gone` this pass;
+        they are skipped to avoid settling the same position twice."""
+        for instrument in list(self._account.positions):
+            if instrument in handled:
+                continue
+            if self._is_market_gone(instrument):
+                self._settle_if_held(instrument)
+
+    def settle_position(self, instrument: Instrument) -> None:
+        """Operator override: flatten a held position in place without trading, regardless of
+        whether the market is still listed. For an untradeable/stuck position (e.g. a delisted
+        market with no live quote) where the normal close-via-trade path can never fill."""
+        self._trading_manager.cancel_orders(instrument)
+        self._account.settle_position(instrument)
+        logger.warning(f"[UniverseManager] Force-settled position {instrument.symbol} (operator override)")
+
     def _filter_blacklisted(self, instruments: list[Instrument]) -> list[Instrument]:
         kept = [i for i in instruments if not self._instrument_service.is_blacklisted(i)]
         dropped = [i for i in instruments if i not in set(kept)]
@@ -143,7 +167,12 @@ class UniverseManager(IUniverseManager):
         # Settle & exclude instruments whose market is already gone (state B) FIRST,
         # so a gone instrument that also carries a delist_date is settled in place
         # before the delisting filter (state A) would otherwise strip it from the list.
+        candidate_set = set(instruments)
         instruments = self._drop_gone(instruments)
+
+        # Also settle any held position whose market is gone but which is absent from the
+        # candidate list above (blacklisted / dropped / orphaned) -- _drop_gone can't see it.
+        self._settle_gone_holdings(candidate_set)
 
         # Then filter out instruments with upcoming/scheduled delist dates (state A:
         # still listed -> closed via trade through the normal removal path).

--- a/tests/qubx/connectors/ccxt/test_data_provider.py
+++ b/tests/qubx/connectors/ccxt/test_data_provider.py
@@ -389,3 +389,22 @@ class TestIsInstrumentListed:
     def test_fail_open_when_markets_none(self, data_provider, btc_instrument):
         data_provider._exchange_manager.exchange.markets = None
         assert data_provider.is_instrument_listed(btc_instrument) is True
+
+    def test_not_listed_when_market_inactive(self, data_provider, btc_instrument):
+        """A present-but-inactive market (e.g. Binance SETTLING / active=False during a
+        delisting) is not tradeable -> treat as not listed so the gone-settle path can
+        flatten held positions without trying to trade out of a dead market."""
+        from qubx.connectors.ccxt.utils import instrument_to_ccxt_symbol
+
+        sym = instrument_to_ccxt_symbol(btc_instrument)
+        data_provider._exchange_manager.exchange.markets = {sym: {"id": "x", "active": False}}
+        assert data_provider.is_instrument_listed(btc_instrument) is False
+
+    def test_listed_when_market_active_unset(self, data_provider, btc_instrument):
+        """Missing/None active flag fails open (treated as listed) -- only an explicit
+        active=False marks the market untradeable."""
+        from qubx.connectors.ccxt.utils import instrument_to_ccxt_symbol
+
+        sym = instrument_to_ccxt_symbol(btc_instrument)
+        data_provider._exchange_manager.exchange.markets = {sym: {"id": "x", "active": None}}
+        assert data_provider.is_instrument_listed(btc_instrument) is True

--- a/tests/qubx/control/test_builtin.py
+++ b/tests/qubx/control/test_builtin.py
@@ -253,14 +253,14 @@ class TestBuiltinRegistry:
         dangerous = {
             "trade", "set_target_position", "set_target_leverage", "close_position",
             "close_positions", "emit_signal", "remove_instruments", "set_universe",
-            "trigger_fit",
+            "settle_position", "trigger_fit",
         }
         for name in dangerous:
             action_def, _ = BUILTIN_ACTIONS[name]
             assert action_def.dangerous is True, f"{name} should be dangerous"
 
     def test_expected_action_count(self):
-        assert len(BUILTIN_ACTIONS) == 27
+        assert len(BUILTIN_ACTIONS) == 28
 
 
 from qubx.control.builtin import _refresh_instrument_service
@@ -295,3 +295,25 @@ def test_refresh_action_errors_when_service_missing():
     result = _refresh_instrument_service(ctx)
     assert result.status == "error"
     ctx._run_instrument_service_cycle.assert_not_called()
+
+
+def test_settle_position_action_force_flattens_without_trading():
+    ctx = _make_mock_ctx()
+    action_def, handler = BUILTIN_ACTIONS["settle_position"]
+    assert action_def.dangerous is True
+    instr1 = ctx.instruments[0]  # query_instrument("BTCUSDT") -> instr1
+
+    result = handler(ctx, symbol="BTCUSDT")
+
+    assert result.status == "ok"
+    assert "BTCUSDT" in str(result.data)
+    ctx.settle_position.assert_called_once_with(instr1)
+    ctx.close_position.assert_not_called()  # settled in place, never traded
+
+
+def test_settle_position_action_errors_on_unknown_symbol():
+    ctx = _make_mock_ctx()
+    _, handler = BUILTIN_ACTIONS["settle_position"]
+    result = handler(ctx, symbol="NOPEUSDT")
+    assert result.status == "error"
+    ctx.settle_position.assert_not_called()

--- a/tests/qubx/core/universe_manager_test.py
+++ b/tests/qubx/core/universe_manager_test.py
@@ -27,6 +27,11 @@ def mock_dependencies(mocker: MockerFixture):
 
     instrument_service = NullInstrumentService()
 
+    # - account.positions is a dict in production (IAccountProcessor); default it so the
+    #   gone-holdings sweep can iterate it. Tests that need holdings override this.
+    account = mocker.Mock()
+    account.positions = {}
+
     return {
         "context": mocker.Mock(),
         "strategy": mocker.Mock(),
@@ -36,7 +41,7 @@ def mock_dependencies(mocker: MockerFixture):
         "subscription_manager": mocker.Mock(),
         "trading_manager": mocker.Mock(),
         "time_provider": time_provider,
-        "account": mocker.Mock(),
+        "account": account,
         "position_gathering": mocker.Mock(),
         "delisting_detector": delisting_detector,
         "instrument_service": instrument_service,
@@ -432,4 +437,45 @@ def test_add_instruments_excludes_gone_and_settles(universe_manager, mock_depend
     assert live in universe_manager.instruments
     assert gone not in universe_manager.instruments
     mock_dependencies["account"].settle_position.assert_called_once_with(gone)
+    mock_dependencies["position_gathering"].alter_positions.assert_not_called()
+
+
+def test_set_universe_settles_gone_held_position_out_of_universe(universe_manager, mock_dependencies, mocker):
+    """A held position whose market is gone must be settled even when the instrument is NOT
+    in the new universe (e.g. blacklisted/dropped/orphaned). The candidate-only _drop_gone
+    never sees it, so a dedicated held-position sweep is required."""
+    live = mocker.Mock(spec=Instrument, symbol="BTCUSDT")
+    live.exchange = "BINANCE.UM"
+    live.delist_date = None
+    live.min_size = 0.001
+    gone = _gone_instr(mocker)  # TONUSDT, delisted (is_instrument_listed -> False)
+
+    mock_dependencies["market_data_manager"].is_instrument_listed.side_effect = lambda i: i is not gone
+    held = mocker.Mock()
+    held.quantity = 2358.0
+    mock_dependencies["account"].positions = {live: mocker.Mock(quantity=1.0), gone: held}
+
+    # gone is held but excluded from the new universe (as if blacklisted)
+    universe_manager.set_universe([live])
+
+    mock_dependencies["trading_manager"].cancel_orders.assert_any_call(gone)
+    mock_dependencies["account"].settle_position.assert_called_once_with(gone)
+
+
+def test_settle_position_force_flattens_without_trading_even_if_listed(
+    universe_manager, mock_dependencies, mocker
+):
+    """Operator override: settle_position cancels resting orders and flattens the position via
+    the account (no trade), regardless of whether the market is still listed -- for an
+    untradeable/stuck position where no fillable market exists."""
+    instr = mocker.Mock(spec=Instrument, symbol="TONUSDT")
+    instr.min_size = 0.001
+    # still listed, yet we want to force-settle anyway (operator override)
+    mock_dependencies["market_data_manager"].is_instrument_listed.return_value = True
+    mock_dependencies["account"].positions = {instr: mocker.Mock(quantity=2358.0)}
+
+    universe_manager.settle_position(instr)
+
+    mock_dependencies["trading_manager"].cancel_orders.assert_called_once_with(instr)
+    mock_dependencies["account"].settle_position.assert_called_once_with(instr)
     mock_dependencies["position_gathering"].alter_positions.assert_not_called()


### PR DESCRIPTION
Closes #319.

## Problem
A held position in a delisted market gets permanently stuck when it's also out of the universe (blacklisted/dropped). The blacklist force-close needs a live quote (delisted ⇒ none), and the gone-settle (`account.settle_position`, no trade) only swept universe **candidates** — so a blacklisted/orphaned holding was invisible to it. And `is_instrument_listed` only checked **presence** in ccxt `load_markets`, so a `SETTLING`/`active=False` market still counted as "listed". Hit in prod on `binance-factors` with `TONUSDT`.

## Changes
1. **Held-position settle sweep** — `UniverseManager._settle_gone_holdings()` sweeps `account.positions` in `set_universe` and settles any *held* position whose market is gone (`is_instrument_listed == False`), regardless of universe membership. Skips candidates already handled by `_drop_gone`.
2. **Operator force-settle action** — new `settle_position` control action (single symbol, `dangerous`) → `UniverseManager.settle_position()` → cancel resting orders + flatten via the account, **unconditional** (no trade, ignores listed-status). Exposed through `IUniverseManager` → `IStrategyContext`. The deterministic escape-hatch for a still-listed-but-untradeable position.
3. **Active-flag listing check** — `is_instrument_listed` (ccxt connector) now returns `False` for a present-but-inactive market (e.g. Binance `SETTLING` / `active=False` during a delisting), instead of only checking presence in `load_markets`. This lets the gone-settle path fire **during** settlement rather than waiting for full removal. Missing/`None` active fails open (still treated as listed). Exchange-authoritative — not a stale-quote heuristic.

## Testing
TDD (each test watched fail first). 6 new tests + adjusted action-count/dangerous-set tests. Green across `universe_manager`, `control/builtin`, `ccxt/test_data_provider` (listing), `market_manager_listing`, `instrument_service_manager`, `delisting_detector`, and backtest `set_universe` suites.

## Notes
- The auto-sweep fires on `set_universe` (every fit / startup / blacklist-driven re-fit), **not** `add_instruments` — can extend if wanted.
- With change 3, a mid-delisting symbol (e.g. TON — currently `status=SETTLING`, `active=False` on Binance, empty orderbook) is caught by the auto-sweep once the bot's ccxt markets reflect `active=False`; the manual `settle_position` action remains available for an immediate clear.