### PR TITLE
feat(connector): require instrument on cancel_order/update_order (stateless connectors)

### DIFF
--- a/src/qubx/backtester/connector.py
+++ b/src/qubx/backtester/connector.py
@@ -86,7 +86,13 @@ class SimulatedConnector(ChannelEmitter):
             return
         self._emit_from_report(report)
 
-    def cancel_order(self, *, client_order_id: str | None = None, venue_order_id: str | None = None) -> None:
+    def cancel_order(
+        self,
+        *,
+        instrument: Instrument,
+        client_order_id: str | None = None,
+        venue_order_id: str | None = None,
+    ) -> None:
         # Prefer the venue id (the OME keys orders by it); fall back to the cid before the ack.
         oid = venue_order_id or client_order_id
         if not oid:
@@ -108,6 +114,7 @@ class SimulatedConnector(ChannelEmitter):
     def update_order(
         self,
         *,
+        instrument: Instrument,
         client_order_id: str | None = None,
         venue_order_id: str | None = None,
         price: float | None = None,

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -398,7 +398,13 @@ class CcxtConnector(ChannelEmitter):
     # ------------------------------------------------------------------ #
     # Write side — cancel
     # ------------------------------------------------------------------ #
-    def cancel_order(self, *, client_order_id: str | None = None, venue_order_id: str | None = None) -> None:
+    def cancel_order(
+        self,
+        *,
+        instrument: Instrument,
+        client_order_id: str | None = None,
+        venue_order_id: str | None = None,
+    ) -> None:
         if not client_order_id and not venue_order_id:
             raise InvalidOrderParameters("cancel_order: client_order_id or venue_order_id is required")
         self._spawn(self._cancel_async(client_order_id, venue_order_id))
@@ -560,6 +566,7 @@ class CcxtConnector(ChannelEmitter):
     def update_order(
         self,
         *,
+        instrument: Instrument,
         client_order_id: str | None = None,
         venue_order_id: str | None = None,
         price: float | None = None,

--- a/src/qubx/core/connector.py
+++ b/src/qubx/core/connector.py
@@ -43,11 +43,22 @@ class IConnector(Protocol):
     # id (the only id known before the venue acks). The caller passes whatever it has and the
     # connector picks the id the venue accepts, so the id choice stays in the connector (which
     # knows the venue). Resulting events carry both ids, so the AM routes by either.
-    def cancel_order(self, *, client_order_id: str | None = None, venue_order_id: str | None = None) -> None: ...
+    #
+    # ``instrument`` is supplied by the AM (which holds the Order) so the connector can build the
+    # venue payload (HL asset index, ccxt symbol) without keeping its own per-order cache — the
+    # AccountManager is the single source of order state.
+    def cancel_order(
+        self,
+        *,
+        instrument: Instrument,
+        client_order_id: str | None = None,
+        venue_order_id: str | None = None,
+    ) -> None: ...
 
     def update_order(
         self,
         *,
+        instrument: Instrument,
         client_order_id: str | None = None,
         venue_order_id: str | None = None,
         price: float | None = None,

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -336,6 +336,7 @@ class TradingManager(ITradingManager):
             self._get_connector(order.instrument.exchange).cancel_order(
                 client_order_id=cid,
                 venue_order_id=order.venue_order_id,
+                instrument=order.instrument,
             )
         except Exception as e:
             # A synchronous raise means the cancel never reached the venue. Route the
@@ -397,6 +398,7 @@ class TradingManager(ITradingManager):
             self._get_connector(instrument.exchange).update_order(
                 client_order_id=cid,
                 venue_order_id=order.venue_order_id,
+                instrument=instrument,
                 price=adjusted_price,
                 quantity=abs(amount),
             )

--- a/tests/qubx/backtester/test_simulated_connector.py
+++ b/tests/qubx/backtester/test_simulated_connector.py
@@ -145,7 +145,7 @@ def test_cancel_emits_canceled(setup):
     )
     conn.submit_order(request)
     accepted = _drain(collector)[0]
-    conn.cancel_order(client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
+    conn.cancel_order(instrument=instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderCanceledEvent)
@@ -167,7 +167,7 @@ def test_cancel_by_venue_id_only_emits_canceled(setup):
     )
     conn.submit_order(request)
     accepted = _drain(collector)[0]
-    conn.cancel_order(venue_order_id=accepted.venue_order_id)  # no client_order_id
+    conn.cancel_order(instrument=instr, venue_order_id=accepted.venue_order_id)  # no client_order_id
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderCanceledEvent)
@@ -176,9 +176,9 @@ def test_cancel_by_venue_id_only_emits_canceled(setup):
 
 def test_cancel_without_any_id_raises(setup):
     # At least one id is required — neither given is a caller bug, raised synchronously.
-    conn, _collector, _exchange, _instr, _time = setup
+    conn, _collector, _exchange, instr, _time = setup
     with pytest.raises(ValueError):
-        conn.cancel_order()
+        conn.cancel_order(instrument=instr, )
 
 
 def test_cancel_unknown_order_emits_reject_not_silent(setup):
@@ -186,8 +186,8 @@ def test_cancel_unknown_order_emits_reject_not_silent(setup):
     # NOT die silently — it emits OrderCancelRejectedEvent (the cancel did not succeed),
     # so the AM reverts it out of PENDING_CANCEL instead of being left stuck. It must not
     # raise (rejection boundary) and must not emit a CANCELED.
-    conn, collector, _exchange, _instr, _time = setup
-    conn.cancel_order(client_order_id="qubx-nope", venue_order_id="V-nope")
+    conn, collector, _exchange, instr, _time = setup
+    conn.cancel_order(instrument=instr, client_order_id="qubx-nope", venue_order_id="V-nope")
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderCancelRejectedEvent)
@@ -208,7 +208,7 @@ def test_update_emits_single_updated_event_with_stable_cid(setup):
     )
     conn.submit_order(request)
     accepted = _drain(collector)[0]
-    conn.update_order(
+    conn.update_order(instrument=instr, 
         client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id, price=30500.0, quantity=0.2
     )
     events = _drain(collector)
@@ -233,7 +233,7 @@ def test_update_by_venue_id_only_emits_updated(setup):
     )
     conn.submit_order(request)
     accepted = _drain(collector)[0]
-    conn.update_order(venue_order_id=accepted.venue_order_id, price=30500.0, quantity=0.2)  # no client_order_id
+    conn.update_order(instrument=instr, venue_order_id=accepted.venue_order_id, price=30500.0, quantity=0.2)  # no client_order_id
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderUpdatedEvent)
@@ -263,7 +263,7 @@ def test_update_to_crossing_price_emits_fill(setup):
     assert isinstance(accepted, OrderAcceptedEvent)
 
     # Re-price above the ask (32001) so the modified order crosses and fills immediately.
-    conn.update_order(
+    conn.update_order(instrument=instr, 
         client_order_id=accepted.client_order_id,
         venue_order_id=accepted.venue_order_id,
         price=33000.0,
@@ -300,7 +300,7 @@ def test_update_rejected_replace_emits_update_rejected_then_canceled(setup):
     accepted = _drain(collector)[0]
     assert isinstance(accepted, OrderAcceptedEvent)
 
-    conn.update_order(  # must not raise
+    conn.update_order(instrument=instr,   # must not raise
         client_order_id=accepted.client_order_id,
         venue_order_id=accepted.venue_order_id,
         price=31500.0,  # below ask: the re-placed stop would trigger immediately
@@ -319,7 +319,7 @@ def test_update_rejected_replace_emits_update_rejected_then_canceled(setup):
     # emits OrderCancelRejectedEvent (the cancel did not succeed), not a silent no-op and
     # not a raise. (In the full framework TradingManager short-circuits a terminal order
     # before the connector; this drives the connector directly to exercise the not-found path.)
-    conn.cancel_order(client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
+    conn.cancel_order(instrument=instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
     later = _drain(collector)
     assert [type(e) for e in later] == [OrderCancelRejectedEvent], later
 
@@ -409,7 +409,7 @@ def test_request_order_status_by_venue_id_only_open_emits_accepted(setup):
 
 
 def test_request_order_status_missing_emits_rejected(setup):
-    conn, collector, _exchange, _instr, _time = setup
+    conn, collector, _exchange, instr, _time = setup
     conn.request_order_status(client_order_id="does-not-exist")
     events = _drain(collector)
     assert len(events) == 1
@@ -537,7 +537,7 @@ def test_update_order_preserves_options(setup):
     accepted = _drain(collector)[0]
 
     new_stop_price = 32600.0
-    conn.update_order(
+    conn.update_order(instrument=instr, 
         client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id, price=new_stop_price
     )
     _drain(collector)  # consume the updated event

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
@@ -492,7 +492,7 @@ async def test_cancel_resolves_cached_symbol() -> None:
 
     conn.submit_order(_order_request())
     await _drive(conn)
-    conn.cancel_order(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
+    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
     await _drive(conn)
 
     # Closes the commit-3 gap: cancel_order now awaited WITH the cached ccxt symbol.
@@ -509,7 +509,7 @@ async def test_update_edit_resolves_cached_symbol_and_side() -> None:
 
     conn.submit_order(_order_request())
     await _drive(conn)
-    conn.update_order(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=101.0, quantity=2.0)
+    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=101.0, quantity=2.0)
     await _drive(conn)
 
     kwargs = exchange.edit_order.await_args.kwargs
@@ -532,7 +532,7 @@ async def test_update_cid_only_uses_cloid_edit_variant() -> None:
     conn.submit_order(_order_request())
     await _drive(conn)
     sent.clear()
-    conn.update_order(client_order_id="qubx_BTCUSDT_1", price=101.0, quantity=2.0)
+    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", price=101.0, quantity=2.0)
     await _drive(conn)
 
     exchange.edit_order_with_client_order_id.assert_awaited_once_with(
@@ -552,7 +552,7 @@ async def test_update_cid_only_upgrades_to_cached_venue_id() -> None:
     conn, _sent, _ = _make_connector(exchange=exchange)
     conn._handle_ws_order(_ws_order(status="open"))  # cache learns VENUE123 + symbol
 
-    conn.update_order(client_order_id="qubx_BTCUSDT_1", price=101.0, quantity=2.0)
+    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", price=101.0, quantity=2.0)
     await _drive(conn)
 
     assert exchange.edit_order.await_args.kwargs["id"] == "VENUE123"
@@ -582,7 +582,7 @@ async def test_snapshot_seeds_order_cache() -> None:
     assert conn._venue_to_cid.get("V9") == "recovered-1"
 
     # A cid-only cancel of the snapshot-seen order now resolves venue id + symbol.
-    conn.cancel_order(client_order_id="recovered-1")
+    conn.cancel_order(instrument=_instrument(), client_order_id="recovered-1")
     await _drive(conn)
     exchange.cancel_order.assert_not_called()  # cid-only cancel stays on the cloid path
     exchange.cancel_order_with_client_order_id.assert_awaited_once_with("recovered-1", CCXT_SYMBOL)

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -324,9 +324,9 @@ def test_cancel_raises_when_no_id_given() -> None:
     # to address — a caller bug, raised synchronously.
     conn, _, _ = _make_connector()
     with pytest.raises(InvalidOrderParameters):
-        conn.cancel_order()
+        conn.cancel_order(instrument=_instrument(), )
     with pytest.raises(InvalidOrderParameters):
-        conn.cancel_order(client_order_id="")
+        conn.cancel_order(instrument=_instrument(), client_order_id="")
 
 
 @pytest.mark.parametrize(
@@ -346,7 +346,7 @@ async def test_cancel_by_venue_id_emits_canceled(ids: dict) -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.cancel_order(**ids)
+    conn.cancel_order(instrument=_instrument(), **ids)
     await _drive(conn)
 
     # Order not in cache (never submitted via this connector) -> symbol is None; the
@@ -364,7 +364,7 @@ async def test_cancel_by_cloid_uses_cloid_endpoint() -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.cancel_order(client_order_id="qubx_BTCUSDT_1")
+    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1")
     await _drive(conn)
 
     exchange.cancel_order_with_client_order_id.assert_awaited_once_with("qubx_BTCUSDT_1", None)
@@ -381,7 +381,7 @@ async def test_cancel_venue_reject_emits_cancel_rejected() -> None:
 
     # TradingManager always passes both ids; the reject must route by the REAL cid
     # (not the venue id) so AM can revert the order from PENDING_CANCEL.
-    conn.cancel_order(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
+    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
     await _drive(conn)
 
     assert len(sent) == 1
@@ -399,7 +399,7 @@ async def test_cancel_venue_reject_by_venue_id_only_carries_venue_id() -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.cancel_order(venue_order_id="VENUE123")
+    conn.cancel_order(instrument=_instrument(), venue_order_id="VENUE123")
     await _drive(conn)
 
     assert len(sent) == 1
@@ -418,7 +418,7 @@ async def test_cancel_cloid_network_error_leaves_inflight_no_reject() -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.cancel_order(client_order_id="qubx_BTCUSDT_1")
+    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1")
     await _drive(conn)
 
     assert sent == []
@@ -446,7 +446,7 @@ async def test_update_network_error_leaves_inflight_no_reject() -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=123.0)
+    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=123.0)
     await _drive(conn)
 
     assert sent == []
@@ -462,7 +462,7 @@ async def test_update_direct_edit_emits_updated() -> None:
     exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0, quantity=2.0)
+    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0, quantity=2.0)
     await _drive(conn)
 
     exchange.edit_order.assert_awaited_once()
@@ -481,7 +481,7 @@ async def test_update_edit_venue_reject_emits_update_rejected() -> None:
     exchange.edit_order = AsyncMock(side_effect=ccxt.InvalidOrder("cannot edit"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0)
+    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0)
     await _drive(conn)
 
     assert isinstance(sent[0], OrderUpdateRejectedEvent)
@@ -496,7 +496,7 @@ async def test_update_by_venue_id_only_emits_updated() -> None:
     exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(venue_order_id="VENUE123", price=102.0, quantity=2.0)
+    conn.update_order(instrument=_instrument(), venue_order_id="VENUE123", price=102.0, quantity=2.0)
     await _drive(conn)
 
     exchange.edit_order.assert_awaited_once()
@@ -517,7 +517,7 @@ async def test_update_cancel_recreate_path_rejects_without_touching_live_order()
     exchange.cancel_order = AsyncMock(return_value={"id": "VENUE123"})
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0, quantity=2.0)
+    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0, quantity=2.0)
     await _drive(conn)
 
     exchange.cancel_order.assert_not_awaited()  # live order left untouched
@@ -527,9 +527,9 @@ async def test_update_cancel_recreate_path_rejects_without_touching_live_order()
 def test_update_raises_when_no_id_given() -> None:
     conn, _, _ = _make_connector()
     with pytest.raises(InvalidOrderParameters):
-        conn.update_order(price=1.0)
+        conn.update_order(instrument=_instrument(), price=1.0)
     with pytest.raises(InvalidOrderParameters):
-        conn.update_order(client_order_id="", price=1.0)
+        conn.update_order(instrument=_instrument(), client_order_id="", price=1.0)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -502,7 +502,7 @@ class TestTradingManagerCancelOrder:
             "BINANCE.UM", order.client_order_id, OrderStatus.PENDING_CANCEL
         )
         mock_connector.cancel_order.assert_called_once_with(
-            client_order_id=order.client_order_id, venue_order_id=order.venue_order_id
+            client_order_id=order.client_order_id, venue_order_id=order.venue_order_id, instrument=order.instrument
         )
 
     def test_cancel_terminal_is_idempotent_noop(self, trading_manager, mock_connector, mock_account):
@@ -545,7 +545,7 @@ class TestTradingManagerCancelOrder:
 
         assert trading_manager.cancel_order(order_id="test_order_123") is True
         mock_connector.cancel_order.assert_called_once_with(
-            client_order_id=order.client_order_id, venue_order_id=order.venue_order_id
+            client_order_id=order.client_order_id, venue_order_id=order.venue_order_id, instrument=order.instrument
         )
 
 

--- a/tests/qubx/core/test_order_identifier_routing.py
+++ b/tests/qubx/core/test_order_identifier_routing.py
@@ -68,7 +68,7 @@ def test_cancel_order_routes_client_order_id(trading_manager):
         "BINANCE.UM", "cid_1", OrderStatus.PENDING_CANCEL
     )
     trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_called_once_with(
-        client_order_id="cid_1", venue_order_id="exchange_order_1"
+        client_order_id="cid_1", venue_order_id="exchange_order_1", instrument=order.instrument
     )
 
 
@@ -84,7 +84,7 @@ def test_cancel_order_order_id_falls_back_to_client_id(trading_manager):
     assert ok is True
     trading_manager._account_manager.find_order_by_client_id.assert_called_once_with("qubx_BTCUSDT_1")
     trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_called_once_with(
-        client_order_id="qubx_BTCUSDT_1", venue_order_id=None
+        client_order_id="qubx_BTCUSDT_1", venue_order_id=None, instrument=order.instrument
     )
 
 
@@ -99,7 +99,8 @@ def test_update_order_routes_client_order_id(trading_manager):
         "BINANCE.UM", "cid_1", OrderStatus.PENDING_UPDATE
     )
     trading_manager._exchange_to_connector["BINANCE.UM"].update_order.assert_called_once_with(
-        client_order_id="cid_1", venue_order_id="exchange_order_1", price=123.0, quantity=1.0
+        client_order_id="cid_1", venue_order_id="exchange_order_1", price=123.0, quantity=1.0,
+        instrument=order.instrument,
     )
 
 

--- a/tests/qubx/restarts/test_state_resolvers.py
+++ b/tests/qubx/restarts/test_state_resolvers.py
@@ -507,7 +507,9 @@ class TestStateResolverCloseAll(TestStateResolverBase):
 
         StateResolver.CLOSE_ALL(self.ctx, {}, {}, {})
 
-        connector.cancel_order.assert_called_once_with(client_order_id="qubx_BTCUSDT_1", venue_order_id=None)
+        connector.cancel_order.assert_called_once_with(
+            client_order_id="qubx_BTCUSDT_1", venue_order_id=None, instrument=unacked.instrument
+        )
 
     def test_close_all_ignores_small_positions(self):
         """Test CLOSE_ALL ignores positions smaller than lot_size."""


### PR DESCRIPTION
## Summary

Adds a **required** `instrument` to `IConnector.cancel_order` / `update_order` so a connector can build the venue payload (Hyperliquid asset index, ccxt symbol) **without keeping its own per-order cache**. The `AccountManager` is the single source of order state; it already holds the `Order` when it cancels/updates, so it simply passes the instrument through.

Targets `account-mgmt-redesign`.

## Why

Today two connectors independently re-derive order state the AM already owns:
- the **ccxt** connector keeps "a small order cache the write side consults to fill in the symbol/side/type that cancel/edit require";
- the native **Hyperliquid** connector keeps a `PendingOrderRegistry` (cloid↔oid↔instrument) for the same reason.

That duplication exists only because `cancel_order`/`update_order` don't receive the instrument — note the asymmetry with `request_order_status`, which already does. Passing it closes the gap and lets connectors be **stateless adapters**.

## Change

- `IConnector.cancel_order` / `update_order` gain `instrument: Instrument` as a **required keyword-only** arg (the AM always supplies it — an optional `= None` would force every connector back into defensive None-handling and defeat the purpose).
- `TradingManager` threads `order.instrument` into both connector calls.
- `CcxtConnector` and the simulated backtester `connector.py` accept the new arg. ccxt keeps its existing order cache for now (a follow-up can drop it); the simulated connector ignores it (the OME keys by order id).

## Testing

Full suite green (`just test`: **2023 passed, 5 skipped**). The updated `test_order_identifier_routing` / `trading_test` assertions now verify the framework passes `instrument=order.instrument` to the connector.

## Scope note

`request_order_status` already carried `instrument` (optional) and is left untouched here to keep the diff focused; it can be aligned to required in a follow-up if desired.

## Follow-up (separate repo)

With this merged, the out-of-tree Hyperliquid connector drops `PendingOrderRegistry` entirely and builds cancel/update payloads straight from the passed `(instrument, client_order_id, venue_order_id)` — no per-order state.
