### PR TITLE
feat(connector): pass the Order to cancel/update/request_order_status; drop ccxt order cache (closes #324)

### DIFF
--- a/src/qubx/backtester/connector.py
+++ b/src/qubx/backtester/connector.py
@@ -5,6 +5,7 @@ from qubx.core.basics import (
     CtrlChannel,
     Instrument,
     ITimeProvider,
+    Order,
     OrderRequest,
     OrderStatus,
     Timestamped,
@@ -86,51 +87,33 @@ class SimulatedConnector(ChannelEmitter):
             return
         self._emit_from_report(report)
 
-    def cancel_order(
-        self,
-        *,
-        instrument: Instrument,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-    ) -> None:
+    def cancel_order(self, order: Order) -> None:
         # Prefer the venue id (the OME keys orders by it); fall back to the cid before the ack.
-        oid = venue_order_id or client_order_id
-        if not oid:
-            raise ValueError("cancel_order: client_order_id or venue_order_id is required")
+        oid = order.venue_order_id or order.client_order_id
         try:
             report = self._ome.cancel_order(oid)
         except OrderNotFound:
             self.send(
                 OrderCancelRejectedEvent(
-                    instrument=None,
-                    client_order_id=client_order_id,
-                    venue_order_id=venue_order_id,
+                    instrument=order.instrument,
+                    client_order_id=order.client_order_id,
+                    venue_order_id=order.venue_order_id,
                     reason=f"cancel_order: order not found for {oid}",
                 )
             )
             return
         self._emit_from_report(report)
 
-    def update_order(
-        self,
-        *,
-        instrument: Instrument,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-        price: float | None = None,
-        quantity: float | None = None,
-    ) -> None:
-        oid = venue_order_id or client_order_id
-        if not oid:
-            raise ValueError("update_order: client_order_id or venue_order_id is required")
+    def update_order(self, order: Order, *, price: float | None = None, quantity: float | None = None) -> None:
+        oid = order.venue_order_id or order.client_order_id
         try:
             old = self._ome.cancel_order(oid)
         except OrderNotFound:
             self.send(
                 OrderUpdateRejectedEvent(
-                    instrument=None,
-                    client_order_id=client_order_id or oid,  # cid if known, else the venue id
-                    venue_order_id=venue_order_id,
+                    instrument=order.instrument,
+                    client_order_id=order.client_order_id,
+                    venue_order_id=order.venue_order_id,
                     reason="update_order: order not found",
                 )
             )
@@ -189,34 +172,26 @@ class SimulatedConnector(ChannelEmitter):
         # OrderAcceptedEvent on the already-ACCEPTED order.
         self._emit_exec(new)
 
-    def request_order_status(
-        self,
-        *,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-        instrument: Instrument | None = None,
-    ) -> None:
-        # `instrument` is for live venues that need a symbol on the REST fetch;
-        # the simulated OME resolves orders by id alone.
-        oid = venue_order_id or client_order_id
-        if not oid:
-            raise ValueError("request_order_status: client_order_id or venue_order_id is required")
-        for order in self._ome.get_open_orders().values():
-            if order.venue_order_id == oid or order.client_order_id == oid:
+    def request_order_status(self, order: Order) -> None:
+        # The simulated OME resolves orders by id alone (live venues need the symbol off
+        # the order for the REST fetch).
+        oid = order.venue_order_id or order.client_order_id
+        for resting in self._ome.get_open_orders().values():
+            if resting.venue_order_id == oid or resting.client_order_id == oid:
                 self.send(
                     OrderAcceptedEvent(
-                        instrument=order.instrument,
-                        client_order_id=order.client_order_id,
-                        venue_order_id=order.venue_order_id,
+                        instrument=resting.instrument,
+                        client_order_id=resting.client_order_id,
+                        venue_order_id=resting.venue_order_id,
                         accepted_at=self._time.time(),
                     )
                 )
                 return
         self.send(
             OrderRejectedEvent(
-                instrument=None,
-                client_order_id=client_order_id or oid,  # cid if known, else the venue id
-                venue_order_id=venue_order_id,
+                instrument=order.instrument,
+                client_order_id=order.client_order_id,
+                venue_order_id=order.venue_order_id,
                 reason="reconcile: order not present at venue",
             )
         )

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -4,9 +4,11 @@ This module owns both sides of the IConnector surface:
 
 - WRITE: submit / cancel / update + leverage / margin.
 - READ: the WS account-event subscription (``watch_orders`` → typed lifecycle
-  events), the full-account snapshot fetch, and single-order status reconcile —
-  plus a small order cache the write side consults to fill in the ccxt
-  symbol/side/type that cancel/edit require.
+  events), the full-account snapshot fetch, and single-order status reconcile.
+
+The connector is STATELESS — it keeps no per-order state. cancel / update /
+request_order_status receive the whole ``Order`` from the AccountManager (the single
+source of order state) and read the ccxt symbol / side / type / ids straight off it.
 
 Design contract (see docs/account-management/design.md, "Connectors (IConnector)"
 and its "Rejection boundary" subsection):
@@ -22,10 +24,6 @@ and its "Rejection boundary" subsection):
   error) are CAUGHT and EMITTED as OrderRejected/Cancel/UpdateRejected events on
   the channel — never raised — even when the venue returns them as a synchronous
   REST error.
-- The order cache is connector-local venue-call metadata (symbol/side/type/ids),
-  NOT framework account state. AccountManager owns the authoritative order/
-  position/balance state; the cache only exists so cancel/edit can rebuild the
-  venue payload and so WS updates can resolve the originating client_order_id.
 """
 
 import asyncio
@@ -33,7 +31,6 @@ import math
 import time
 from asyncio.exceptions import CancelledError
 from collections.abc import Coroutine
-from dataclasses import dataclass
 from typing import Any, Literal
 
 import ccxt
@@ -115,26 +112,6 @@ _VENUE_VERDICT_ERRORS: tuple[type[Exception], ...] = (
 # the order is left inflight for AM to reconcile, never terminal-rejected.
 
 
-@dataclass
-class _CachedOrder:
-    """Connector-local venue-call metadata for one order — NOT account state.
-
-    Holds exactly what the venue REST/WS calls need that the framework ids alone
-    don't carry: the ccxt ``symbol`` (cancel/edit require it on most venues), the
-    ``side`` and ``type`` (edit_order requires them), and the venue id once known
-    (so a cloid-keyed cache can still resolve a venue-id cancel). ``status`` is the
-    last ``OrderStatus`` we converted from a WS update, used only to drive the
-    new→ACCEPTED-once transition and terminal eviction.
-    """
-
-    instrument: Instrument
-    ccxt_symbol: str
-    side: str
-    type: str
-    venue_order_id: str | None = None
-    status: OrderStatus | None = None
-
-
 class CcxtConnector(ChannelEmitter):
     """IConnector implementation backed by a CCXT exchange (write side).
 
@@ -178,11 +155,6 @@ class CcxtConnector(ChannelEmitter):
         self.max_cancel_retries = max_cancel_retries
         self.max_ws_retries = max_ws_retries
 
-        # Order cache (read side): client_order_id -> _CachedOrder, plus a
-        # venue_order_id -> client_order_id reverse index. Connector-local venue-call
-        # metadata, not account state (AM owns that).
-        self._orders: dict[str, _CachedOrder] = {}
-        self._venue_to_cid: dict[str, str] = {}
         # Memoized ccxt-symbol -> Instrument resolution shared by the WS loop and the
         # snapshot/order-status converters (ccxt_find_instrument populates it lazily).
         self._symbol_to_instrument: dict[str, Instrument] = {}
@@ -240,56 +212,6 @@ class CcxtConnector(ChannelEmitter):
         return self._loop.submit(coro).result(timeout=timeout)
 
     # ------------------------------------------------------------------ #
-    # Order cache (connector-local venue-call metadata)
-    # ------------------------------------------------------------------ #
-    def _resolve_cached(self, client_order_id: str | None, venue_order_id: str | None) -> _CachedOrder | None:
-        if client_order_id is not None and client_order_id in self._orders:
-            return self._orders[client_order_id]
-        if venue_order_id is not None:
-            cid = self._venue_to_cid.get(venue_order_id)
-            if cid is not None:
-                return self._orders.get(cid)
-        return None
-
-    def _index_venue_id(self, client_order_id: str | None, venue_order_id: str | None) -> None:
-        if client_order_id is None or venue_order_id is None:
-            return
-        cached = self._orders.get(client_order_id)
-        if cached is not None:
-            cached.venue_order_id = venue_order_id
-        self._venue_to_cid[venue_order_id] = client_order_id
-
-    def _cache_from_ws(self, order: Order) -> None:
-        """Insert/update the cache from a WS order update.
-
-        Materializes EXTERNAL orders seen on the venue (so a later cancel/update of a
-        manually-placed order resolves a symbol), refreshes the venue id/status, and
-        evicts on terminal status.
-        """
-        cid = order.client_order_id
-        if cid is None:
-            return
-        cached = self._orders.get(cid)
-        if cached is None:
-            cached = _CachedOrder(
-                instrument=order.instrument,
-                ccxt_symbol=instrument_to_ccxt_symbol(order.instrument),
-                side=order.side.lower(),
-                type=order.type.lower(),
-            )
-            self._orders[cid] = cached
-        if order.venue_order_id is not None:
-            self._index_venue_id(cid, order.venue_order_id)
-        cached.status = order.status
-        if order.status.is_terminal:
-            self._evict(cid)
-
-    def _evict(self, client_order_id: str) -> None:
-        cached = self._orders.pop(client_order_id, None)
-        if cached is not None and cached.venue_order_id is not None:
-            self._venue_to_cid.pop(cached.venue_order_id, None)
-
-    # ------------------------------------------------------------------ #
     # Write side — submit
     # ------------------------------------------------------------------ #
     def submit_order(self, request: OrderRequest) -> None:
@@ -330,18 +252,6 @@ class CcxtConnector(ChannelEmitter):
                 continue
             payload["params"].setdefault(k, v)
 
-        # Cache the order BEFORE the async venue call: a cancel/update issued before
-        # the create round-trips (or before its WS ack) must still be able to resolve
-        # the ccxt symbol/side/type. The venue id is filled in by the REST ack or the
-        # first WS update.
-        if request.client_id is not None:
-            self._orders[request.client_id] = _CachedOrder(
-                instrument=instrument,
-                ccxt_symbol=payload["symbol"],
-                side=payload["side"],
-                type=payload["type"],
-            )
-
         self._spawn(self._submit_async(instrument, request.client_id, payload))
 
     async def _submit_async(self, instrument: Instrument, client_id: str | None, payload: dict[str, Any]) -> None:
@@ -370,8 +280,6 @@ class CcxtConnector(ChannelEmitter):
             return
 
         order = ccxt_convert_order_info(instrument, r, framework_prefix=self.cid_framework_prefix)
-        # Record the venue id on the cache so a subsequent cancel/update can prefer it.
-        self._index_venue_id(order.client_order_id, order.venue_order_id)
         # Immediate ack from the REST response. AM dedups this against the later WS
         # OrderAcceptedEvent (same client_order_id), so emitting both is safe and the
         # strategy gets the faster of the two.
@@ -398,18 +306,14 @@ class CcxtConnector(ChannelEmitter):
     # ------------------------------------------------------------------ #
     # Write side — cancel
     # ------------------------------------------------------------------ #
-    def cancel_order(
-        self,
-        *,
-        instrument: Instrument,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-    ) -> None:
-        if not client_order_id and not venue_order_id:
-            raise InvalidOrderParameters("cancel_order: client_order_id or venue_order_id is required")
-        self._spawn(self._cancel_async(client_order_id, venue_order_id))
+    def cancel_order(self, order: Order) -> None:
+        # Read every venue-call field off the Order SYNCHRONOUSLY — the async path must never
+        # touch the live, AM-mutated object. ``symbol`` is what most venues (e.g. Binance) need.
+        self._spawn(
+            self._cancel_async(order.client_order_id, order.venue_order_id, instrument_to_ccxt_symbol(order.instrument))
+        )
 
-    async def _cancel_async(self, client_order_id: str | None, venue_order_id: str | None) -> None:
+    async def _cancel_async(self, client_order_id: str | None, venue_order_id: str | None, symbol: str) -> None:
         """A successful REST cancel ack emits OrderCanceledEvent immediately; the WS
         read side also emits one and AM dedups. A definitive venue cancel-rejection
         emits OrderCancelRejectedEvent. A transient network failure is an UNKNOWN
@@ -417,7 +321,7 @@ class CcxtConnector(ChannelEmitter):
         AM to reconcile rather than terminal-rejected.
         """
         try:
-            ok, response = await self._cancel_with_retry(client_order_id, venue_order_id)
+            ok, response = await self._cancel_with_retry(client_order_id, venue_order_id, symbol)
         except ccxt.NetworkError as e:
             logger.warning(
                 f"[{self.exchange_name}] Network error cancelling {client_order_id or venue_order_id}: "
@@ -442,7 +346,7 @@ class CcxtConnector(ChannelEmitter):
         )
 
     async def _cancel_with_retry(
-        self, client_order_id: str | None, venue_order_id: str | None
+        self, client_order_id: str | None, venue_order_id: str | None, symbol: str
     ) -> tuple[bool, dict[str, Any] | None]:
         """Cancel with retry/backoff. Prefers venue_order_id; falls back to cloid.
 
@@ -451,14 +355,9 @@ class CcxtConnector(ChannelEmitter):
         ``ccxt.NetworkError`` when the outcome is UNKNOWN (transient connectivity, or
         retries exhausted without a definitive answer) so the caller leaves the order
         inflight rather than terminal-rejecting a cancel that may have landed. Does NOT
-        emit: the caller maps the outcome to an event. The ccxt ``symbol`` (which most
-        venues — e.g. Binance — require) is supplied from the order cache; if the order
-        is unknown (e.g. cancel of an external order we never submitted) we fall back to
-        passing none and let ccxt resolve it from the id alone.
+        emit: the caller maps the outcome to an event. ``symbol`` (which most venues — e.g.
+        Binance — require) comes straight off the order the AM passed.
         """
-        cached = self._resolve_cached(client_order_id, venue_order_id)
-        symbol = cached.ccxt_symbol if cached is not None else None
-
         # cloid-only path: single attempt (Binance rejects cancel-by-cloid without
         # an orderId; retrying is useless).
         if venue_order_id is None:
@@ -563,35 +462,43 @@ class CcxtConnector(ChannelEmitter):
     # ------------------------------------------------------------------ #
     # Write side — update
     # ------------------------------------------------------------------ #
-    def update_order(
-        self,
-        *,
-        instrument: Instrument,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-        price: float | None = None,
-        quantity: float | None = None,
-    ) -> None:
-        if not client_order_id and not venue_order_id:
-            raise InvalidOrderParameters("update_order: client_order_id or venue_order_id is required")
-        self._spawn(self._update_async(client_order_id, venue_order_id, price, quantity))
+    def update_order(self, order: Order, *, price: float | None = None, quantity: float | None = None) -> None:
+        # Read venue-call fields off the Order SYNCHRONOUSLY (see cancel_order); editOrder
+        # needs side/type too, so pass them straight through.
+        self._spawn(
+            self._update_async(
+                order.client_order_id,
+                order.venue_order_id,
+                instrument_to_ccxt_symbol(order.instrument),
+                order.side.lower(),
+                order.type.lower(),
+                price,
+                quantity,
+            )
+        )
 
     async def _update_async(
-        self, client_order_id: str | None, venue_order_id: str | None, price: float | None, quantity: float | None
+        self,
+        client_order_id: str | None,
+        venue_order_id: str | None,
+        symbol: str,
+        side: str,
+        order_type: str,
+        price: float | None,
+        quantity: float | None,
     ) -> None:
         """Direct editOrder where the venue supports it, else cancel+recreate.
 
         The cancel+recreate fallback preserves the original client_order_id so the
         strategy sees a single OrderUpdatedEvent rather than a Canceled+Accepted pair.
         """
-        cached = self._resolve_cached(client_order_id, venue_order_id)
-        # Upgrade a cloid-only update with the cached venue id; without one the edit must
-        # go through ccxt's client-order-id variant (Binance rejects a cloid passed as
+        # The order carries its venue id once the venue acked; before that it is None and the
+        # edit goes through ccxt's client-order-id variant (Binance rejects a cloid passed as
         # orderId with -1102).
-        vid = venue_order_id or (cached.venue_order_id if cached is not None else None)
+        vid = venue_order_id
         try:
             if self._em.exchange.has.get("editOrder", False):
-                r = await self._edit_order_direct(client_order_id, vid, price, quantity, cached)
+                r = await self._edit_order_direct(client_order_id, vid, symbol, side, order_type, price, quantity)
             else:
                 r = await self._update_via_cancel_recreate(client_order_id, venue_order_id, price, quantity)
         except _VENUE_VERDICT_ERRORS as e:
@@ -627,18 +534,14 @@ class CcxtConnector(ChannelEmitter):
         self,
         client_order_id: str | None,
         venue_order_id: str | None,
+        symbol: str,
+        side: str,
+        order_type: str,
         price: float | None,
         quantity: float | None,
-        cached: _CachedOrder | None,
     ) -> dict[str, Any]:
-        # editOrder requires symbol/side/type on most venues (Binance resolves the
-        # market from `symbol`). These come from the order cache; if the order is
-        # unknown we pass the venue-tolerant fallbacks (symbol/side None, type limit)
-        # which works only on venues that can resolve the market from the id alone —
-        # elsewhere ccxt raises ArgumentsRequired, a venue verdict → update-reject.
-        symbol = cached.ccxt_symbol if cached is not None else None
-        order_type = cached.type if cached is not None else "limit"
-        side = cached.side if cached is not None else None
+        # editOrder requires symbol/side/type on most venues (Binance resolves the market from
+        # `symbol`) — all read straight off the order the AM passed.
         amount = abs(quantity) if quantity is not None else None
         if venue_order_id is None:
             # cloid-only (venue ack never seen): ccxt's client-order-id variant sends the
@@ -660,13 +563,13 @@ class CcxtConnector(ChannelEmitter):
     async def _update_via_cancel_recreate(
         self, client_order_id: str | None, venue_order_id: str | None, price: float | None, quantity: float | None
     ) -> dict[str, Any] | None:
-        # Raise BEFORE cancelling: cancel+recreate still needs the ORIGINAL order's full
-        # parameters (quantity/price/tif when the update leaves one unspecified) which the
-        # connector-local cache deliberately does not hold (AM owns that state). Cancelling
-        # first and then raising would leave the order DEAD at the venue while the strategy
-        # is told only "update rejected, order still alive". Until the recreate is wired,
-        # reject without touching the live order. TODO(account-mgmt): wire the recreate.
-        raise ccxt.NotSupported("cancel+recreate update requires the original order parameters")
+        # Raise BEFORE cancelling: cancelling first and then failing to recreate would leave
+        # the order DEAD at the venue while the strategy is told only "update rejected, order
+        # still alive". The AM now passes the whole Order, so wiring a real cancel+recreate
+        # (thread the order's side/type/tif + original price/qty) is straightforward — but it's
+        # deferred to the recreate follow-up. Until then, reject without touching the live order.
+        # TODO(account-mgmt): wire the recreate from the passed Order.
+        raise ccxt.NotSupported("cancel+recreate update is not yet wired for editOrder-less venues")
 
     def _emit_update_rejected(self, client_order_id: str | None, venue_order_id: str | None, error: Exception) -> None:
         logger.warning(f"[{self.exchange_name}] Update for {client_order_id or venue_order_id} rejected: {error}")
@@ -903,39 +806,25 @@ class CcxtConnector(ChannelEmitter):
             logger.warning(f"[{self.exchange_name}] WS order for unknown symbol {raw.get('symbol')}; skipped")
             return
         order = ccxt_convert_order_info(instrument, raw, framework_prefix=self.cid_framework_prefix)
-        # Was this the first venue acknowledgement (no prior ACCEPTED in our cache)?
-        cached = self._orders.get(order.client_order_id) if order.client_order_id is not None else None
-        had_prior_ack = cached is not None and cached.status is not None
-        self._cache_from_ws(order)
-        self._emit_order_events(instrument, order, raw, had_prior_ack)
+        self._emit_order_events(instrument, order, raw)
 
-    def _emit_order_events(
-        self, instrument: Instrument, order: Order, raw: dict[str, Any], had_prior_ack: bool
-    ) -> None:
+    def _emit_order_events(self, instrument: Instrument, order: Order, raw: dict[str, Any]) -> None:
         """Map a converted order's status to the typed lifecycle event(s).
 
-        Fill events carry the new Deal(s) extracted from the execution report; AM
-        dedups by trade_id, so emitting one event per deal is safe even if the venue
-        re-sends. We don't diff against a cached prior status beyond the new→ACCEPTED
-        gate — AM is idempotent on every other transition (late/duplicate events are
-        no-ops there), so the connector stays minimal.
+        Fill events carry the new Deal(s) extracted from the execution report; AM dedups
+        by trade_id, so emitting one event per deal is safe even if the venue re-sends. The
+        connector keeps no per-order state, so it emits ACCEPTED on every venue ack — AM
+        dedups ACCEPTED by client_order_id, so a repeat is a benign no-op and every other
+        transition is idempotent there too.
         """
         status = order.status  # OrderStatus enum (mapped from the ccxt status by utils)
 
         # A fill can be the FIRST event we observe for an order (fast aggressive fills,
         # or a venue that sends no separate "open" report). Synthesize the venue ACCEPTED
         # ack before the fill so the strategy's on_order sees ACCEPTED and the order
-        # lifecycle stays ordered. AM dedups ACCEPTED, so this is safe alongside the REST
-        # immediate-ack. Skipped when the venue id is missing (can't index the order).
-        if (
-            not had_prior_ack
-            and order.venue_order_id is not None
-            and status
-            in (
-                OrderStatus.PARTIALLY_FILLED,
-                OrderStatus.FILLED,
-            )
-        ):
+        # lifecycle stays ordered. AM dedups ACCEPTED. Skipped when the venue id is missing
+        # (can't index the order).
+        if order.venue_order_id is not None and status in (OrderStatus.PARTIALLY_FILLED, OrderStatus.FILLED):
             self.send(
                 OrderAcceptedEvent(
                     instrument=instrument,
@@ -972,29 +861,25 @@ class CcxtConnector(ChannelEmitter):
                 )
             )
             return
-        # ACCEPTED (mapped from new/open, and the safe default for any status the
-        # utils mapper couldn't recognize — it already logged that) → first venue ack
-        # becomes ACCEPTED. A repeat (e.g. the venue re-broadcasting an open order) is
-        # dropped here rather than re-emitting; AM would treat a duplicate ACCEPTED as
-        # benign, but not emitting keeps the channel quiet.
-        if not had_prior_ack:
-            if order.venue_order_id is None:
-                # An ACCEPTED ack with no venue id can't be indexed (AM keys the
-                # venue-id index off it). The venue's open/new report effectively
-                # always carries one, so this is an anomaly worth logging, not a "".
-                logger.warning(
-                    f"[{self.exchange_name}] open WS update for {order.client_order_id} carried no venue id; "
-                    "skipping ACCEPTED emit"
-                )
-                return
-            self.send(
-                OrderAcceptedEvent(
-                    instrument=instrument,
-                    client_order_id=order.client_order_id,
-                    venue_order_id=order.venue_order_id,
-                    accepted_at=order.submitted_at,
-                )
+        # ACCEPTED (mapped from new/open, and the safe default for any status the utils mapper
+        # couldn't recognize — it already logged that). Emitted on every venue ack; AM dedups a
+        # repeat (e.g. the venue re-broadcasting an open order). Skipped only when the venue id
+        # is missing — AM keys the venue-id index off it, and the venue's open/new report
+        # effectively always carries one, so its absence is an anomaly worth logging, not a "".
+        if order.venue_order_id is None:
+            logger.warning(
+                f"[{self.exchange_name}] open WS update for {order.client_order_id} carried no venue id; "
+                "skipping ACCEPTED emit"
             )
+            return
+        self.send(
+            OrderAcceptedEvent(
+                instrument=instrument,
+                client_order_id=order.client_order_id,
+                venue_order_id=order.venue_order_id,
+                accepted_at=order.submitted_at,
+            )
+        )
 
     def _handle_partial_fill_status(self, instrument: Instrument, order: Order, raw: dict[str, Any]) -> None:
         """Emit the PARTIALLY_FILLED fill(s) for a watch_orders report (base / Binance).
@@ -1056,7 +941,11 @@ class CcxtConnector(ChannelEmitter):
         last = len(deals) - 1
         for i, deal in enumerate(deals):
             self._dbg.debug(
-                "emit fill {} amt={} cum={} tid={}", instrument.symbol, deal.amount, order.filled_quantity, deal.trade_id
+                "emit fill {} amt={} cum={} tid={}",
+                instrument.symbol,
+                deal.amount,
+                order.filled_quantity,
+                deal.trade_id,
             )
             # On a full fill the LAST deal closes the order (OrderFilledEvent →
             # terminal); earlier deals are partials. On a partial-fill report every
@@ -1166,30 +1055,24 @@ class CcxtConnector(ChannelEmitter):
     # ------------------------------------------------------------------ #
     # Reconciliation primitives — READ side
     # ------------------------------------------------------------------ #
-    def request_order_status(
-        self,
-        *,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-        instrument: Instrument | None = None,
-    ) -> None:
-        if not client_order_id and not venue_order_id:
-            raise InvalidOrderParameters("request_order_status: client_order_id or venue_order_id is required")
-        self._spawn(self._order_status_async(client_order_id, venue_order_id, instrument))
+    def request_order_status(self, order: Order) -> None:
+        # Read venue-call fields off the Order SYNCHRONOUSLY (see cancel_order). symbol is what
+        # Binance refuses the fetch without.
+        self._spawn(
+            self._order_status_async(
+                order.client_order_id,
+                order.venue_order_id,
+                instrument_to_ccxt_symbol(order.instrument),
+                order.instrument,
+            )
+        )
 
     async def _order_status_async(
-        self, client_order_id: str | None, venue_order_id: str | None, instrument: Instrument | None
+        self, client_order_id: str | None, venue_order_id: str | None, symbol: str, instrument: Instrument
     ) -> None:
-        cached = self._resolve_cached(client_order_id, venue_order_id)
-        # Symbol from the cache, else from the caller's instrument (snapshot-materialized
-        # orders the connector never cached) — Binance refuses a fetch without one.
-        symbol = cached.ccxt_symbol if cached is not None else None
-        if symbol is None and instrument is not None:
-            symbol = instrument_to_ccxt_symbol(instrument)
-        # Prefer the venue id (upgraded from the cache when the caller only has the cloid);
-        # a cloid-only fetch must use ccxt's client-order-id variant — Binance rejects a
-        # cloid passed as orderId with -1102 BadRequest, NOT OrderNotFound.
-        vid = venue_order_id or (cached.venue_order_id if cached is not None else None)
+        # Prefer the venue id; a cloid-only fetch must use ccxt's client-order-id variant —
+        # Binance rejects a cloid passed as orderId with -1102 BadRequest, NOT OrderNotFound.
+        vid = venue_order_id
         lookup_id = vid or client_order_id
         try:
             if vid is not None:
@@ -1198,7 +1081,7 @@ class CcxtConnector(ChannelEmitter):
                 assert client_order_id is not None
                 raw = await self._em.exchange.fetch_order_with_client_order_id(client_order_id, symbol)
         except ccxt.OrderNotFound:
-            self._emit_order_status_not_found(client_order_id, venue_order_id, cached)
+            self._emit_order_status_not_found(client_order_id, venue_order_id, instrument)
             return
         except NetworkError as e:
             logger.warning(f"[{self.exchange_name}] Network error fetching order {lookup_id}: {e}; leaving inflight")
@@ -1213,17 +1096,17 @@ class CcxtConnector(ChannelEmitter):
             logger.error(f"[{self.exchange_name}] error fetching order {lookup_id}: {e}")
             return
         if raw is None or raw.get("id") is None:
-            self._emit_order_status_not_found(client_order_id, venue_order_id, cached)
+            self._emit_order_status_not_found(client_order_id, venue_order_id, instrument)
             return
         self._handle_ws_order(raw)
 
     def _emit_order_status_not_found(
-        self, client_order_id: str | None, venue_order_id: str | None, cached: _CachedOrder | None
+        self, client_order_id: str | None, venue_order_id: str | None, instrument: Instrument
     ) -> None:
         """Emit the reconcile not-found reject, carrying both ids so AM routes by either."""
         self.send(
             OrderRejectedEvent(
-                instrument=cached.instrument if cached is not None else None,
+                instrument=instrument,
                 client_order_id=client_order_id,
                 venue_order_id=venue_order_id,
                 reason="reconcile: order not present at venue",
@@ -1263,10 +1146,6 @@ class CcxtConnector(ChannelEmitter):
                 except CcxtSymbolNotRecognized:
                     continue
                 order = ccxt_convert_order_info(instrument, raw, framework_prefix=self.cid_framework_prefix)
-                # Seed the venue-call cache: a snapshot can be the first (only) place the
-                # connector sees a RECOVERED/EXTERNAL order, and a later cancel/update/
-                # status fetch needs its symbol/side/type/venue id from here.
-                self._cache_from_ws(order)
                 open_orders.append(order)
 
         positions: list[Position] | None = None

--- a/src/qubx/connectors/ccxt/exchanges/_two_stream.py
+++ b/src/qubx/connectors/ccxt/exchanges/_two_stream.py
@@ -73,10 +73,10 @@ class _TwoStreamCcxtConnector(CcxtConnector):
     def _handle_ws_trade(self, raw: dict[str, Any]) -> None:
         """Convert one ``watch_my_trades`` trade to a Deal and emit a ``DealEvent``.
 
-        Resolves the originating client_order_id from the venue id the trade carries
-        (``raw['order']``) via the connector's venue->cid index. The order's status
-        transitions (including the terminal FILLED) are driven by the watch_orders
-        stream, never here — AM books the deal against the order whichever stream
+        The deal is routed by the venue order id the trade carries (``raw['order']``); the
+        connector keeps no state, so AM resolves the originating order (and its cid) from that
+        id. The order's status transitions (including the terminal FILLED) are driven by the
+        watch_orders stream, never here — AM books the deal against the order whichever stream
         delivered first, deduped by trade_id.
         """
         try:
@@ -85,22 +85,11 @@ class _TwoStreamCcxtConnector(CcxtConnector):
             logger.warning(f"[{self.exchange_name}] WS trade for unknown symbol {raw.get('symbol')}; skipped")
             return
         deal = ccxt_convert_deal_info(raw)
-        venue_order_id = raw.get("order")
-        cid = self._venue_to_cid.get(venue_order_id) if venue_order_id is not None else None
-        if cid is None:
-            # The order's open/new report (which seeds the venue->cid index) may not have
-            # arrived yet, the order may already be evicted (terminal status beat the
-            # trade), or this is an external order. Emit routed by venue id — AM resolves
-            # (or materializes) the order from it.
-            logger.debug(
-                f"[{self.exchange_name}] trade {deal.trade_id} for venue id {venue_order_id}: "
-                "no cid in index; emitting deal by venue id"
-            )
         self.send(
             DealEvent(
                 instrument=instrument,
-                client_order_id=cid,  # None when not indexed — AM resolves by venue id
-                venue_order_id=venue_order_id,
+                client_order_id=None,  # AM resolves the order by the venue id
+                venue_order_id=raw.get("order"),
                 deal=deal,
             )
         )

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -261,9 +261,7 @@ class AccountManager(IAccountViewer):
                     if reconcile.terminalize_missing(state, order, now):
                         diff.terminated.append(order)
                 else:
-                    connector.request_order_status(
-                        client_order_id=cid, venue_order_id=order.venue_order_id, instrument=order.instrument
-                    )
+                    connector.request_order_status(order)
                     state.bump_retry(cid)
                     unresolved.append(order)
             except Exception:
@@ -574,11 +572,7 @@ class AccountManager(IAccountViewer):
                         assert self._pm is not None  # ticks only register with a pm
                         self._pm.process_event(reconcile.giveup_event(order, retries))
                     else:
-                        self._connectors[exchange].request_order_status(
-                            client_order_id=cid,
-                            venue_order_id=order.venue_order_id,
-                            instrument=order.instrument,
-                        )
+                        self._connectors[exchange].request_order_status(order)
                         state.bump_retry(cid)
                         order.last_updated_at = now
                 except Exception:

--- a/src/qubx/core/connector.py
+++ b/src/qubx/core/connector.py
@@ -1,6 +1,6 @@
 from typing import Protocol, runtime_checkable
 
-from qubx.core.basics import CtrlChannel, Instrument, OrderRequest, Timestamped
+from qubx.core.basics import CtrlChannel, Instrument, Order, OrderRequest, Timestamped
 from qubx.core.events import ChannelMessage
 
 
@@ -37,44 +37,21 @@ class IConnector(Protocol):
 
     def submit_order(self, request: OrderRequest) -> None: ...
 
-    # cancel/update/request_order_status address an order by EITHER id — client_order_id
-    # and/or venue_order_id of the SAME order. AT LEAST ONE must be given; the connector
-    # prefers venue_order_id when present (the venue's own id) and falls back to the client
-    # id (the only id known before the venue acks). The caller passes whatever it has and the
-    # connector picks the id the venue accepts, so the id choice stays in the connector (which
-    # knows the venue). Resulting events carry both ids, so the AM routes by either.
-    #
-    # ``instrument`` is supplied by the AM (which holds the Order) so the connector can build the
-    # venue payload (HL asset index, ccxt symbol) without keeping its own per-order cache — the
-    # AccountManager is the single source of order state.
-    def cancel_order(
-        self,
-        *,
-        instrument: Instrument,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-    ) -> None: ...
+    # cancel/update/request_order_status take the whole ``Order`` the AccountManager already
+    # holds (it is the single source of order state). The connector reads everything the venue
+    # call needs straight off it — both ids (it prefers ``venue_order_id`` when present, the
+    # venue's own id, and falls back to ``client_order_id``, the only id known before the ack),
+    # the ``instrument`` (HL asset index, ccxt symbol), and ``side``/``type``/``time_in_force``
+    # that an edit-as-cancel-and-replace needs. This keeps every connector a stateless adapter:
+    # no per-order cache. The ``Order`` is READ-ONLY — the connector must extract what it needs
+    # SYNCHRONOUSLY (before scheduling any async venue call) and never mutate it, so the async
+    # path never races the AM mutating the live object. Resulting events carry both ids, so the
+    # AM routes by either.
+    def cancel_order(self, order: Order) -> None: ...
 
-    def update_order(
-        self,
-        *,
-        instrument: Instrument,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-        price: float | None = None,
-        quantity: float | None = None,
-    ) -> None: ...
+    def update_order(self, order: Order, *, price: float | None = None, quantity: float | None = None) -> None: ...
 
-    # ``instrument`` lets the connector resolve the venue symbol for orders it never
-    # cached (snapshot-materialized RECOVERED/EXTERNAL) — most venues (e.g. Binance)
-    # refuse a status fetch without one. The AM always has it; pass it.
-    def request_order_status(
-        self,
-        *,
-        client_order_id: str | None = None,
-        venue_order_id: str | None = None,
-        instrument: Instrument | None = None,
-    ) -> None: ...
+    def request_order_status(self, order: Order) -> None: ...
 
     def request_snapshot(self) -> None: ...
 

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -333,11 +333,7 @@ class TradingManager(ITradingManager):
         )
         self._account_manager.transition_order(order.instrument.exchange, cid, OrderStatus.PENDING_CANCEL)
         try:
-            self._get_connector(order.instrument.exchange).cancel_order(
-                client_order_id=cid,
-                venue_order_id=order.venue_order_id,
-                instrument=order.instrument,
-            )
+            self._get_connector(order.instrument.exchange).cancel_order(order)
         except Exception as e:
             # A synchronous raise means the cancel never reached the venue. Route the
             # synthetic reject through the PM (same path as the reconcile give-up) so the
@@ -395,13 +391,7 @@ class TradingManager(ITradingManager):
         cid = order.client_order_id
         self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
         try:
-            self._get_connector(instrument.exchange).update_order(
-                client_order_id=cid,
-                venue_order_id=order.venue_order_id,
-                instrument=instrument,
-                price=adjusted_price,
-                quantity=abs(amount),
-            )
+            self._get_connector(instrument.exchange).update_order(order, price=adjusted_price, quantity=abs(amount))
         except Exception as e:
             # Same contract as cancel_order: synthetic reject through the PM reverts
             # PENDING_UPDATE via pre_pending, then the original exception re-raises.

--- a/tests/qubx/backtester/test_simulated_connector.py
+++ b/tests/qubx/backtester/test_simulated_connector.py
@@ -7,8 +7,11 @@ from qubx.core.basics import (
     OPTION_AVOID_STOP_ORDER_PRICE_VALIDATION,
     OPTION_FILL_AT_SIGNAL_PRICE,
     ZERO_COSTS,
+    Instrument,
     ITimeProvider,
+    Order,
     OrderRequest,
+    OrderStatus,
 )
 from qubx.core.connector import IConnector
 from qubx.core.events import (
@@ -71,6 +74,34 @@ def _drain(collector: _Collector) -> list:
     events = list(collector.events)
     collector.events.clear()
     return events
+
+
+def _order(
+    instr: Instrument,
+    *,
+    client_order_id: str = "qubx-x",
+    venue_order_id: str | None = None,
+    side: str = "BUY",
+    order_type: str = "LIMIT",
+    quantity: float = 0.1,
+    price: float | None = 31000.0,
+) -> Order:
+    """Build an order to hand to the connector's cancel/update/status calls.
+
+    The SimulatedConnector resolves the real order from the OME by id, so only the
+    ids + instrument matter here (side/type/qty/price are read off the OME's copy).
+    """
+    return Order(
+        client_order_id=client_order_id,
+        type=order_type,  # type: ignore[arg-type]
+        instrument=instr,
+        quantity=quantity,
+        side=side,  # type: ignore[arg-type]
+        time_in_force="gtc",
+        status=OrderStatus.ACCEPTED,
+        venue_order_id=venue_order_id,
+        price=price,
+    )
 
 
 @pytest.fixture
@@ -145,40 +176,11 @@ def test_cancel_emits_canceled(setup):
     )
     conn.submit_order(request)
     accepted = _drain(collector)[0]
-    conn.cancel_order(instrument=instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
+    conn.cancel_order(_order(instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id))
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderCanceledEvent)
     assert events[0].venue_order_id == accepted.venue_order_id
-
-
-def test_cancel_by_venue_id_only_emits_canceled(setup):
-    # A caller that only knows the venue id (e.g. an externally-placed order) must still
-    # be able to cancel — cancel_order accepts either id.
-    conn, collector, _exchange, instr, _time = setup
-    request = OrderRequest(
-        client_id="qubx-3v",
-        instrument=instr,
-        quantity=0.1,
-        price=31000.0,
-        side="BUY",
-        order_type="LIMIT",
-        time_in_force="gtc",
-    )
-    conn.submit_order(request)
-    accepted = _drain(collector)[0]
-    conn.cancel_order(instrument=instr, venue_order_id=accepted.venue_order_id)  # no client_order_id
-    events = _drain(collector)
-    assert len(events) == 1
-    assert isinstance(events[0], OrderCanceledEvent)
-    assert events[0].venue_order_id == accepted.venue_order_id
-
-
-def test_cancel_without_any_id_raises(setup):
-    # At least one id is required — neither given is a caller bug, raised synchronously.
-    conn, _collector, _exchange, instr, _time = setup
-    with pytest.raises(ValueError):
-        conn.cancel_order(instrument=instr, )
 
 
 def test_cancel_unknown_order_emits_reject_not_silent(setup):
@@ -187,7 +189,7 @@ def test_cancel_unknown_order_emits_reject_not_silent(setup):
     # so the AM reverts it out of PENDING_CANCEL instead of being left stuck. It must not
     # raise (rejection boundary) and must not emit a CANCELED.
     conn, collector, _exchange, instr, _time = setup
-    conn.cancel_order(instrument=instr, client_order_id="qubx-nope", venue_order_id="V-nope")
+    conn.cancel_order(_order(instr, client_order_id="qubx-nope", venue_order_id="V-nope"))
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderCancelRejectedEvent)
@@ -208,8 +210,10 @@ def test_update_emits_single_updated_event_with_stable_cid(setup):
     )
     conn.submit_order(request)
     accepted = _drain(collector)[0]
-    conn.update_order(instrument=instr, 
-        client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id, price=30500.0, quantity=0.2
+    conn.update_order(
+        _order(instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id),
+        price=30500.0,
+        quantity=0.2,
     )
     events = _drain(collector)
     assert len(events) == 1
@@ -217,29 +221,6 @@ def test_update_emits_single_updated_event_with_stable_cid(setup):
     assert events[0].client_order_id == "qubx-4"
     assert events[0].new_price == 30500.0
     assert events[0].new_quantity == 0.2
-
-
-def test_update_by_venue_id_only_emits_updated(setup):
-    # update_order by venue id alone resolves the order via the OME and re-emits with both ids.
-    conn, collector, _exchange, instr, _time = setup
-    request = OrderRequest(
-        client_id="qubx-4v",
-        instrument=instr,
-        quantity=0.1,
-        price=31000.0,
-        side="BUY",
-        order_type="LIMIT",
-        time_in_force="gtc",
-    )
-    conn.submit_order(request)
-    accepted = _drain(collector)[0]
-    conn.update_order(instrument=instr, venue_order_id=accepted.venue_order_id, price=30500.0, quantity=0.2)  # no client_order_id
-    events = _drain(collector)
-    assert len(events) == 1
-    assert isinstance(events[0], OrderUpdatedEvent)
-    # cancel+recreate preserves the original client id, recovered from the OME order.
-    assert events[0].client_order_id == "qubx-4v"
-    assert events[0].new_price == 30500.0
 
 
 def test_update_to_crossing_price_emits_fill(setup):
@@ -263,9 +244,8 @@ def test_update_to_crossing_price_emits_fill(setup):
     assert isinstance(accepted, OrderAcceptedEvent)
 
     # Re-price above the ask (32001) so the modified order crosses and fills immediately.
-    conn.update_order(instrument=instr, 
-        client_order_id=accepted.client_order_id,
-        venue_order_id=accepted.venue_order_id,
+    conn.update_order(
+        _order(instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id),
         price=33000.0,
     )
     events = _drain(collector)
@@ -300,9 +280,8 @@ def test_update_rejected_replace_emits_update_rejected_then_canceled(setup):
     accepted = _drain(collector)[0]
     assert isinstance(accepted, OrderAcceptedEvent)
 
-    conn.update_order(instrument=instr,   # must not raise
-        client_order_id=accepted.client_order_id,
-        venue_order_id=accepted.venue_order_id,
+    conn.update_order(  # must not raise
+        _order(instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id),
         price=31500.0,  # below ask: the re-placed stop would trigger immediately
     )
     events = _drain(collector)
@@ -319,7 +298,7 @@ def test_update_rejected_replace_emits_update_rejected_then_canceled(setup):
     # emits OrderCancelRejectedEvent (the cancel did not succeed), not a silent no-op and
     # not a raise. (In the full framework TradingManager short-circuits a terminal order
     # before the connector; this drives the connector directly to exercise the not-found path.)
-    conn.cancel_order(instrument=instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
+    conn.cancel_order(_order(instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id))
     later = _drain(collector)
     assert [type(e) for e in later] == [OrderCancelRejectedEvent], later
 
@@ -381,27 +360,9 @@ def test_request_order_status_open_emits_accepted(setup):
     )
     conn.submit_order(request)
     accepted = _drain(collector)[0]
-    conn.request_order_status(client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
-    events = _drain(collector)
-    assert len(events) == 1
-    assert isinstance(events[0], OrderAcceptedEvent)
-    assert events[0].venue_order_id == accepted.venue_order_id
-
-
-def test_request_order_status_by_venue_id_only_open_emits_accepted(setup):
-    conn, collector, _exchange, instr, _time = setup
-    request = OrderRequest(
-        client_id="qubx-7v",
-        instrument=instr,
-        quantity=0.1,
-        price=31000.0,
-        side="BUY",
-        order_type="LIMIT",
-        time_in_force="gtc",
+    conn.request_order_status(
+        _order(instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id)
     )
-    conn.submit_order(request)
-    accepted = _drain(collector)[0]
-    conn.request_order_status(venue_order_id=accepted.venue_order_id)  # no client_order_id
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderAcceptedEvent)
@@ -410,7 +371,7 @@ def test_request_order_status_by_venue_id_only_open_emits_accepted(setup):
 
 def test_request_order_status_missing_emits_rejected(setup):
     conn, collector, _exchange, instr, _time = setup
-    conn.request_order_status(client_order_id="does-not-exist")
+    conn.request_order_status(_order(instr, client_order_id="does-not-exist"))
     events = _drain(collector)
     assert len(events) == 1
     assert isinstance(events[0], OrderRejectedEvent)
@@ -537,8 +498,9 @@ def test_update_order_preserves_options(setup):
     accepted = _drain(collector)[0]
 
     new_stop_price = 32600.0
-    conn.update_order(instrument=instr, 
-        client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id, price=new_stop_price
+    conn.update_order(
+        _order(instr, client_order_id=accepted.client_order_id, venue_order_id=accepted.venue_order_id),
+        price=new_stop_price,
     )
     _drain(collector)  # consume the updated event
 

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
@@ -21,7 +21,18 @@ from qubx import logger
 from qubx.connectors.ccxt.connector import CcxtConnector
 from qubx.connectors.ccxt.exchanges._two_stream import _TwoStreamCcxtConnector
 from qubx.core.account_manager import SimulatedAccountManager
-from qubx.core.basics import Balance, Instrument, MarketType, OrderOrigin, OrderRequest, OrderStatus, Position
+from qubx.core.basics import (
+    Balance,
+    Instrument,
+    MarketType,
+    Order,
+    OrderOrigin,
+    OrderRequest,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Position,
+)
 from qubx.core.events import (
     AccountSnapshotEvent,
     BalanceUpdateEvent,
@@ -31,7 +42,6 @@ from qubx.core.events import (
     OrderFilledEvent,
     OrderPartiallyFilledEvent,
     OrderRejectedEvent,
-    OrderUpdatedEvent,
     PositionUpdateEvent,
 )
 from qubx.core.series import Quote
@@ -158,6 +168,32 @@ def _order_request(**overrides) -> OrderRequest:
     return OrderRequest(**kw)  # type: ignore[arg-type]
 
 
+def _order(
+    *,
+    client_order_id: str = "qubx_BTCUSDT_1",
+    venue_order_id: str | None = "VENUE123",
+    side: OrderSide = OrderSide.BUY,
+    order_type: OrderType = OrderType.LIMIT,
+    quantity: float = 1.0,
+    price: float | None = 100.0,
+) -> Order:
+    """Build an ACCEPTED order to hand to the connector's request_order_status calls.
+
+    The connector reads symbol/side/type/ids straight off it (it keeps no order cache).
+    """
+    return Order(
+        client_order_id=client_order_id,
+        type=order_type,
+        instrument=_instrument(),
+        quantity=quantity,
+        side=side,
+        time_in_force="gtc",
+        status=OrderStatus.ACCEPTED,
+        venue_order_id=venue_order_id,
+        price=price,
+    )
+
+
 # --------------------------------------------------------------------------- #
 # (a) WS order updates -> typed lifecycle events
 # --------------------------------------------------------------------------- #
@@ -171,11 +207,13 @@ def test_ws_open_emits_accepted() -> None:
     assert ev.venue_order_id == "VENUE123"
 
 
-def test_ws_open_twice_emits_accepted_only_once() -> None:
+def test_ws_open_twice_emits_accepted_each_time() -> None:
+    # The connector keeps no per-order state, so it emits ACCEPTED on every venue ack —
+    # AM dedups ACCEPTED by client_order_id, so a repeat is a benign no-op downstream.
     conn, sent, _ = _make_connector()
     conn._handle_ws_order(_ws_order(status="open"))
     conn._handle_ws_order(_ws_order(status="open"))
-    assert sum(isinstance(e, OrderAcceptedEvent) for e in sent) == 1
+    assert sum(isinstance(e, OrderAcceptedEvent) for e in sent) == 2
 
 
 def test_ws_partial_fill_first_emits_accepted_then_partially_filled() -> None:
@@ -305,27 +343,20 @@ async def test_request_snapshot_failed_leg_left_none() -> None:
 # --------------------------------------------------------------------------- #
 # (c) request_order_status -> lifecycle event / not-found reject
 # --------------------------------------------------------------------------- #
-@pytest.mark.parametrize(
-    "ids",
-    [
-        {"client_order_id": "qubx_BTCUSDT_1", "venue_order_id": "VENUE123"},
-        {"venue_order_id": "VENUE123"},
-    ],
-    ids=["both_ids", "venue_id_only"],
-)
 @pytest.mark.asyncio
-async def test_request_order_status_emits_event(ids: dict) -> None:
-    # Reconcile by both ids or by venue id alone: fetch by venue id and surface the order.
+async def test_request_order_status_emits_event() -> None:
+    # Reconcile of an order carrying a venue id: fetch by venue id (with the symbol read off
+    # the order) and surface the order.
     exchange = Mock()
     exchange.has = {"editOrder": True}
     exchange.fetch_order = AsyncMock(return_value=_ws_order(status="closed", trades=[_ws_trade("TX", amount=1.0)]))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.request_order_status(**ids)
+    conn.request_order_status(_order(venue_order_id="VENUE123"))
     await _drive(conn)
 
-    exchange.fetch_order.assert_awaited_once_with("VENUE123", None)
-    # Reconcile fetch of a filled order with no prior ack: ACCEPTED then the terminal fill.
+    exchange.fetch_order.assert_awaited_once_with("VENUE123", CCXT_SYMBOL)
+    # Reconcile fetch of a filled order: ACCEPTED then the terminal fill.
     assert isinstance(sent[0], OrderAcceptedEvent)
     assert isinstance(sent[1], OrderFilledEvent)
     assert sent[1].fill.trade_id == "TX"
@@ -341,7 +372,7 @@ async def test_request_order_status_filled_without_trades_emits_status_only_fill
     exchange.fetch_order = AsyncMock(return_value=_ws_order(status="closed"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.request_order_status(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
+    conn.request_order_status(_order(venue_order_id="VENUE123"))
     await _drive(conn)
 
     assert isinstance(sent[0], OrderAcceptedEvent)
@@ -358,7 +389,7 @@ async def test_request_order_status_not_found_emits_reject_with_both_ids() -> No
     exchange.fetch_order = AsyncMock(side_effect=ccxt.OrderNotFound("unknown"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.request_order_status(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
+    conn.request_order_status(_order(venue_order_id="VENUE123"))
     await _drive(conn)
 
     assert len(sent) == 1
@@ -376,55 +407,29 @@ async def test_request_order_status_network_error_leaves_inflight() -> None:
     exchange.fetch_order = AsyncMock(side_effect=ccxt.NetworkError("timeout"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.request_order_status(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
+    conn.request_order_status(_order(venue_order_id="VENUE123"))
     await _drive(conn)
 
     assert sent == []
 
 
-def test_request_order_status_raises_when_no_id_given() -> None:
-    conn, _, _ = _make_connector()
-    with pytest.raises(Exception):
-        conn.request_order_status()
-    with pytest.raises(Exception):
-        conn.request_order_status(client_order_id="")
-
-
 @pytest.mark.asyncio
-async def test_request_order_status_cid_only_uncached_uses_cloid_variant_with_instrument() -> None:
-    # R7 lost-ack case: only the cloid is known and the connector never cached the order
-    # (snapshot-materialized RECOVERED order). The fetch must go through ccxt's
-    # client-order-id variant (Binance rejects a cloid passed as orderId with -1102) with
-    # the symbol resolved from the caller-provided instrument.
+async def test_request_order_status_cid_only_uses_cloid_variant() -> None:
+    # R7 lost-ack case: the order has no venue id yet (ack never seen). The fetch must go
+    # through ccxt's client-order-id variant (Binance rejects a cloid passed as orderId with
+    # -1102) with the symbol read off the order's instrument.
     exchange = Mock()
     exchange.has = {"editOrder": True}
     exchange.fetch_order_with_client_order_id = AsyncMock(return_value=_ws_order(status="open"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.request_order_status(client_order_id="qubx_BTCUSDT_1", instrument=_instrument())
+    conn.request_order_status(_order(venue_order_id=None))
     await _drive(conn)
 
     exchange.fetch_order_with_client_order_id.assert_awaited_once_with("qubx_BTCUSDT_1", CCXT_SYMBOL)
     exchange.fetch_order.assert_not_called()
     assert isinstance(sent[0], OrderAcceptedEvent)
     assert sent[0].venue_order_id == "VENUE123"  # venue id recovered from the cloid fetch
-
-
-@pytest.mark.asyncio
-async def test_request_order_status_cid_only_upgrades_to_cached_venue_id() -> None:
-    # When the cache already learned the venue id (WS ack seen), a cid-only request is
-    # upgraded to the plain venue-id fetch — the more reliable path across venues.
-    exchange = Mock()
-    exchange.has = {"editOrder": True}
-    exchange.fetch_order = AsyncMock(return_value=_ws_order(status="open"))
-    conn, sent, _ = _make_connector(exchange=exchange)
-    conn._handle_ws_order(_ws_order(status="open"))  # cache learns VENUE123 + symbol
-    sent.clear()
-
-    conn.request_order_status(client_order_id="qubx_BTCUSDT_1")
-    await _drive(conn)
-
-    exchange.fetch_order.assert_awaited_once_with("VENUE123", CCXT_SYMBOL)
 
 
 @pytest.mark.asyncio
@@ -435,7 +440,7 @@ async def test_request_order_status_cid_only_not_found_emits_reject() -> None:
     exchange.fetch_order_with_client_order_id = AsyncMock(side_effect=ccxt.OrderNotFound("unknown"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.request_order_status(client_order_id="qubx_BTCUSDT_1", instrument=_instrument())
+    conn.request_order_status(_order(venue_order_id=None))
     await _drive(conn)
 
     assert len(sent) == 1
@@ -457,154 +462,13 @@ async def test_request_order_status_venue_refusal_logs_warning_no_event() -> Non
     records: list = []
     sink_id = logger.add(lambda m: records.append(m.record), level="WARNING")
     try:
-        conn.request_order_status(client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
+        conn.request_order_status(_order(venue_order_id="VENUE123"))
         await _drive(conn)
     finally:
         logger.remove(sink_id)
 
     assert sent == []
     assert any("refused by venue" in r["message"] for r in records)
-
-
-# --------------------------------------------------------------------------- #
-# (d) order cache: submit populates it; cancel/update resolve the cached symbol;
-#     terminal WS update evicts it
-# --------------------------------------------------------------------------- #
-@pytest.mark.asyncio
-async def test_submit_populates_cache() -> None:
-    conn, _sent, _ = _make_connector()
-    conn.submit_order(_order_request())
-    await _drive(conn)
-    assert "qubx_BTCUSDT_1" in conn._orders
-    cached = conn._orders["qubx_BTCUSDT_1"]
-    assert cached.ccxt_symbol == CCXT_SYMBOL
-    assert cached.side == "buy"
-    assert cached.type == "limit"
-
-
-@pytest.mark.asyncio
-async def test_cancel_resolves_cached_symbol() -> None:
-    exchange = Mock()
-    exchange.has = {"editOrder": True}
-    exchange.create_order = AsyncMock(return_value={})
-    exchange.cancel_order = AsyncMock(return_value={"id": "VENUE123"})
-    conn, _sent, _ = _make_connector(exchange=exchange)
-
-    conn.submit_order(_order_request())
-    await _drive(conn)
-    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
-    await _drive(conn)
-
-    # Closes the commit-3 gap: cancel_order now awaited WITH the cached ccxt symbol.
-    exchange.cancel_order.assert_awaited_once_with("VENUE123", CCXT_SYMBOL)
-
-
-@pytest.mark.asyncio
-async def test_update_edit_resolves_cached_symbol_and_side() -> None:
-    exchange = Mock()
-    exchange.has = {"editOrder": True}
-    exchange.create_order = AsyncMock(return_value={})
-    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
-    conn, _sent, _ = _make_connector(exchange=exchange)
-
-    conn.submit_order(_order_request())
-    await _drive(conn)
-    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=101.0, quantity=2.0)
-    await _drive(conn)
-
-    kwargs = exchange.edit_order.await_args.kwargs
-    assert kwargs["symbol"] == CCXT_SYMBOL
-    assert kwargs["side"] == "buy"
-    assert kwargs["type"] == "limit"
-
-
-@pytest.mark.asyncio
-async def test_update_cid_only_uses_cloid_edit_variant() -> None:
-    # R7 mirror on the write side: an update before the venue ack (no venue id anywhere)
-    # must go through ccxt's client-order-id edit variant with the cached
-    # symbol/type/side — a cloid passed to edit_order as orderId is Binance -1102.
-    exchange = Mock()
-    exchange.has = {"editOrder": True}
-    exchange.create_order = AsyncMock(return_value={})
-    exchange.edit_order_with_client_order_id = AsyncMock(return_value={"id": "VENUE123"})
-    conn, sent, _ = _make_connector(exchange=exchange)
-
-    conn.submit_order(_order_request())
-    await _drive(conn)
-    sent.clear()
-    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", price=101.0, quantity=2.0)
-    await _drive(conn)
-
-    exchange.edit_order_with_client_order_id.assert_awaited_once_with(
-        "qubx_BTCUSDT_1", CCXT_SYMBOL, "limit", "buy", 2.0, 101.0
-    )
-    exchange.edit_order.assert_not_called()
-    assert isinstance(sent[0], OrderUpdatedEvent)
-    assert sent[0].venue_order_id == "VENUE123"  # venue id recovered from the edit response
-
-
-@pytest.mark.asyncio
-async def test_update_cid_only_upgrades_to_cached_venue_id() -> None:
-    # When the cache already knows the venue id, a cid-only update edits by venue id.
-    exchange = Mock()
-    exchange.has = {"editOrder": True}
-    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
-    conn, _sent, _ = _make_connector(exchange=exchange)
-    conn._handle_ws_order(_ws_order(status="open"))  # cache learns VENUE123 + symbol
-
-    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", price=101.0, quantity=2.0)
-    await _drive(conn)
-
-    assert exchange.edit_order.await_args.kwargs["id"] == "VENUE123"
-    exchange.edit_order_with_client_order_id.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_snapshot_seeds_order_cache() -> None:
-    # R7 third leg: a snapshot can be the only place the connector sees a RECOVERED/
-    # EXTERNAL order — it must seed the venue-call cache so later cancel/update/status
-    # calls resolve the symbol and venue id instead of dying on ArgumentsRequired.
-    exchange = Mock()
-    exchange.has = {"editOrder": True}
-    exchange.fetch_open_orders = AsyncMock(return_value=[_ws_order(status="open", cid="recovered-1", venue_id="V9")])
-    exchange.fetch_positions = AsyncMock(return_value=[])
-    exchange.fetch_balance = AsyncMock(return_value={"total": {}, "used": {}})
-    exchange.markets = {}
-    exchange.cancel_order = AsyncMock(return_value={"id": "V9"})
-    exchange.cancel_order_with_client_order_id = AsyncMock(return_value={"id": "V9"})
-    conn, _sent, _ = _make_connector(exchange=exchange)
-
-    conn.request_snapshot()
-    await _drive(conn)
-
-    assert "recovered-1" in conn._orders
-    assert conn._orders["recovered-1"].ccxt_symbol == CCXT_SYMBOL
-    assert conn._venue_to_cid.get("V9") == "recovered-1"
-
-    # A cid-only cancel of the snapshot-seen order now resolves venue id + symbol.
-    conn.cancel_order(instrument=_instrument(), client_order_id="recovered-1")
-    await _drive(conn)
-    exchange.cancel_order.assert_not_called()  # cid-only cancel stays on the cloid path
-    exchange.cancel_order_with_client_order_id.assert_awaited_once_with("recovered-1", CCXT_SYMBOL)
-
-
-def test_terminal_ws_update_evicts_cache() -> None:
-    conn, _sent, _ = _make_connector()
-    # First an open update populates the cache + venue index.
-    conn._handle_ws_order(_ws_order(status="open"))
-    assert "qubx_BTCUSDT_1" in conn._orders
-    assert conn._venue_to_cid.get("VENUE123") == "qubx_BTCUSDT_1"
-    # A terminal update evicts both.
-    conn._handle_ws_order(_ws_order(status="canceled"))
-    assert "qubx_BTCUSDT_1" not in conn._orders
-    assert "VENUE123" not in conn._venue_to_cid
-
-
-def test_ws_external_order_materialized_in_cache() -> None:
-    conn, _sent, _ = _make_connector()
-    conn._handle_ws_order(_ws_order(status="open", cid="manual-123", venue_id="V_EXT"))
-    assert "manual-123" in conn._orders
-    assert conn._orders["manual-123"].ccxt_symbol == CCXT_SYMBOL
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -13,7 +13,16 @@ import ccxt
 import pytest
 
 from qubx.connectors.ccxt.connector import CcxtConnector
-from qubx.core.basics import CtrlChannel, Instrument, MarketType, OrderRequest
+from qubx.core.basics import (
+    CtrlChannel,
+    Instrument,
+    MarketType,
+    Order,
+    OrderRequest,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+)
 from qubx.core.connector import IConnector
 from qubx.core.events import (
     OrderAcceptedEvent,
@@ -118,6 +127,32 @@ def _order_request(**overrides) -> OrderRequest:
     )
     kw.update(overrides)
     return OrderRequest(**kw)  # type: ignore[arg-type]
+
+
+def _order(
+    *,
+    client_order_id: str = "qubx_BTCUSDT_1",
+    venue_order_id: str | None = None,
+    side: OrderSide = OrderSide.BUY,
+    order_type: OrderType = OrderType.LIMIT,
+    quantity: float = 1.0,
+    price: float | None = 100.0,
+) -> Order:
+    """Build an ACCEPTED order to hand to the connector's cancel/update/status calls.
+
+    The connector reads symbol/side/type/ids straight off it (it keeps no order cache).
+    """
+    return Order(
+        client_order_id=client_order_id,
+        type=order_type,
+        instrument=_instrument(),
+        quantity=quantity,
+        side=side,
+        time_in_force="gtc",
+        status=OrderStatus.ACCEPTED,
+        venue_order_id=venue_order_id,
+        price=price,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -319,55 +354,35 @@ async def test_submit_no_id_emits_nothing() -> None:
 # --------------------------------------------------------------------------- #
 # (5) cancel_order
 # --------------------------------------------------------------------------- #
-def test_cancel_raises_when_no_id_given() -> None:
-    # cancel_order accepts EITHER id; with neither (or only an empty cid) there is nothing
-    # to address — a caller bug, raised synchronously.
-    conn, _, _ = _make_connector()
-    with pytest.raises(InvalidOrderParameters):
-        conn.cancel_order(instrument=_instrument(), )
-    with pytest.raises(InvalidOrderParameters):
-        conn.cancel_order(instrument=_instrument(), client_order_id="")
-
-
-@pytest.mark.parametrize(
-    "ids",
-    [
-        {"venue_order_id": "VENUE123"},
-        {"client_order_id": "qubx_BTCUSDT_1", "venue_order_id": "VENUE123"},
-    ],
-    ids=["venue_id_only", "both_ids"],
-)
 @pytest.mark.asyncio
-async def test_cancel_by_venue_id_emits_canceled(ids: dict) -> None:
-    # With a venue id (alone, or alongside the cid) the venue-id endpoint is used — a caller
-    # that only knows the venue id must still be able to cancel.
+async def test_cancel_by_venue_id_emits_canceled() -> None:
+    # An order carrying a venue id cancels through the venue-id endpoint, with the ccxt
+    # symbol the connector reads straight off the order's instrument (no cache).
     exchange = Mock()
     exchange.cancel_order = AsyncMock(return_value={"id": "VENUE123", "clientOrderId": "qubx_BTCUSDT_1"})
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.cancel_order(instrument=_instrument(), **ids)
+    conn.cancel_order(_order(venue_order_id="VENUE123"))
     await _drive(conn)
 
-    # Order not in cache (never submitted via this connector) -> symbol is None; the
-    # read-side cache fills the symbol in for orders this connector submitted (see the
-    # reads test suite). ccxt resolves the market from the id alone in that case.
-    exchange.cancel_order.assert_awaited_once_with("VENUE123", None)
+    exchange.cancel_order.assert_awaited_once_with("VENUE123", "BTC/USDT:USDT")
     assert isinstance(sent[0], OrderCanceledEvent)
     assert sent[0].venue_order_id == "VENUE123"
 
 
 @pytest.mark.asyncio
 async def test_cancel_by_cloid_uses_cloid_endpoint() -> None:
+    # No venue id yet (ack not seen) -> cloid endpoint, symbol from the order's instrument.
     exchange = Mock()
     exchange.cancel_order_with_client_order_id = AsyncMock(return_value={"id": "VENUE123"})
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1")
+    conn.cancel_order(_order(venue_order_id=None))
     await _drive(conn)
 
-    exchange.cancel_order_with_client_order_id.assert_awaited_once_with("qubx_BTCUSDT_1", None)
+    exchange.cancel_order_with_client_order_id.assert_awaited_once_with("qubx_BTCUSDT_1", "BTC/USDT:USDT")
     assert isinstance(sent[0], OrderCanceledEvent)
 
 
@@ -379,33 +394,15 @@ async def test_cancel_venue_reject_emits_cancel_rejected() -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    # TradingManager always passes both ids; the reject must route by the REAL cid
-    # (not the venue id) so AM can revert the order from PENDING_CANCEL.
-    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123")
+    # The reject carries both ids (the order always has its cid) so AM can revert the order
+    # from PENDING_CANCEL by either.
+    conn.cancel_order(_order(venue_order_id="VENUE123"))
     await _drive(conn)
 
     assert len(sent) == 1
     assert isinstance(sent[0], OrderCancelRejectedEvent)
     assert sent[0].client_order_id == "qubx_BTCUSDT_1"
     assert sent[0].venue_order_id == "VENUE123"  # both ids carried so AM routes by either
-
-
-@pytest.mark.asyncio
-async def test_cancel_venue_reject_by_venue_id_only_carries_venue_id() -> None:
-    # Venue-id-only cancel that the venue refuses: the reject must still carry the venue id
-    # so AM resolves the order by it; the unknown cid stays None (no stand-in).
-    exchange = Mock()
-    exchange.cancel_order = AsyncMock(side_effect=ccxt.OperationRejected("Order already filled"))
-    exchange.has = {"editOrder": True}
-    conn, sent, _ = _make_connector(exchange=exchange)
-
-    conn.cancel_order(instrument=_instrument(), venue_order_id="VENUE123")
-    await _drive(conn)
-
-    assert len(sent) == 1
-    assert isinstance(sent[0], OrderCancelRejectedEvent)
-    assert sent[0].venue_order_id == "VENUE123"
-    assert sent[0].client_order_id is None  # cid unknown -> venue-only addressing
 
 
 @pytest.mark.asyncio
@@ -418,7 +415,7 @@ async def test_cancel_cloid_network_error_leaves_inflight_no_reject() -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.cancel_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1")
+    conn.cancel_order(_order(venue_order_id=None))
     await _drive(conn)
 
     assert sent == []
@@ -446,7 +443,7 @@ async def test_update_network_error_leaves_inflight_no_reject() -> None:
     exchange.has = {"editOrder": True}
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=123.0)
+    conn.update_order(_order(venue_order_id="VENUE123"), price=123.0)
     await _drive(conn)
 
     assert sent == []
@@ -462,10 +459,13 @@ async def test_update_direct_edit_emits_updated() -> None:
     exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0, quantity=2.0)
+    conn.update_order(_order(venue_order_id="VENUE123"), price=102.0, quantity=2.0)
     await _drive(conn)
 
-    exchange.edit_order.assert_awaited_once()
+    # symbol/side/type come straight off the order — the venue-id edit endpoint gets them all.
+    exchange.edit_order.assert_awaited_once_with(
+        id="VENUE123", symbol="BTC/USDT:USDT", type="limit", side="buy", amount=2.0, price=102.0, params={}
+    )
     ev = sent[0]
     assert isinstance(ev, OrderUpdatedEvent)
     assert ev.client_order_id == "qubx_BTCUSDT_1"
@@ -475,13 +475,30 @@ async def test_update_direct_edit_emits_updated() -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_by_cloid_uses_cloid_edit_endpoint() -> None:
+    # No venue id yet -> ccxt's client-order-id edit variant, with symbol/side/type off the order.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.edit_order_with_client_order_id = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.update_order(_order(venue_order_id=None), price=102.0, quantity=2.0)
+    await _drive(conn)
+
+    exchange.edit_order_with_client_order_id.assert_awaited_once_with(
+        "qubx_BTCUSDT_1", "BTC/USDT:USDT", "limit", "buy", 2.0, 102.0
+    )
+    assert isinstance(sent[0], OrderUpdatedEvent)
+
+
+@pytest.mark.asyncio
 async def test_update_edit_venue_reject_emits_update_rejected() -> None:
     exchange = Mock()
     exchange.has = {"editOrder": True}
     exchange.edit_order = AsyncMock(side_effect=ccxt.InvalidOrder("cannot edit"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0)
+    conn.update_order(_order(venue_order_id="VENUE123"), price=102.0)
     await _drive(conn)
 
     assert isinstance(sent[0], OrderUpdateRejectedEvent)
@@ -489,47 +506,20 @@ async def test_update_edit_venue_reject_emits_update_rejected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_by_venue_id_only_emits_updated() -> None:
-    # update_order by venue id alone (no client_order_id): editOrder path, venue id addresses the event.
-    exchange = Mock()
-    exchange.has = {"editOrder": True}
-    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
-    conn, sent, _ = _make_connector(exchange=exchange)
-
-    conn.update_order(instrument=_instrument(), venue_order_id="VENUE123", price=102.0, quantity=2.0)
-    await _drive(conn)
-
-    exchange.edit_order.assert_awaited_once()
-    ev = sent[0]
-    assert isinstance(ev, OrderUpdatedEvent)
-    assert ev.venue_order_id == "VENUE123"
-    assert ev.client_order_id is None  # cid unknown -> venue-only addressing
-    assert ev.new_price == 102.0
-
-
-@pytest.mark.asyncio
 async def test_update_cancel_recreate_path_rejects_without_touching_live_order() -> None:
-    # Exchange without editOrder support -> cancel+recreate path. The recreate can't be
-    # built yet (no original params held), so it must reject WITHOUT cancelling: cancelling
-    # first would leave the order dead at the venue while telling the strategy "still alive".
+    # Exchange without editOrder support -> cancel+recreate path, not yet wired, so it must
+    # reject WITHOUT cancelling: cancelling first would leave the order dead at the venue
+    # while telling the strategy "still alive".
     exchange = Mock()
     exchange.has = {"editOrder": False}
     exchange.cancel_order = AsyncMock(return_value={"id": "VENUE123"})
     conn, sent, _ = _make_connector(exchange=exchange)
 
-    conn.update_order(instrument=_instrument(), client_order_id="qubx_BTCUSDT_1", venue_order_id="VENUE123", price=102.0, quantity=2.0)
+    conn.update_order(_order(venue_order_id="VENUE123"), price=102.0, quantity=2.0)
     await _drive(conn)
 
     exchange.cancel_order.assert_not_awaited()  # live order left untouched
     assert isinstance(sent[0], OrderUpdateRejectedEvent)
-
-
-def test_update_raises_when_no_id_given() -> None:
-    conn, _, _ = _make_connector()
-    with pytest.raises(InvalidOrderParameters):
-        conn.update_order(instrument=_instrument(), price=1.0)
-    with pytest.raises(InvalidOrderParameters):
-        conn.update_order(instrument=_instrument(), client_order_id="", price=1.0)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
@@ -139,9 +139,10 @@ def test_okx_partial_status_emits_status_only_event() -> None:
     raw = _ws_order(status="open")
     raw["info"] = {"status": "PARTIALLY_FILLED"}
     conn._handle_ws_order(raw)
-    assert len(sent) == 1
-    ev = sent[0]
-    assert isinstance(ev, OrderPartiallyFilledEvent)
+    # The stateless connector synthesizes ACCEPTED ahead of the fill (AM dedups it); the
+    # fill itself is the status-only PartiallyFilled.
+    assert [type(e) for e in sent] == [OrderAcceptedEvent, OrderPartiallyFilledEvent]
+    ev = sent[-1]
     assert ev.client_order_id == "qubxBTCUSDT1"
     assert ev.venue_order_id == "VENUE123"
     assert ev.fill is None
@@ -149,7 +150,6 @@ def test_okx_partial_status_emits_status_only_event() -> None:
 
 def test_okx_watch_my_trades_emits_deal_event() -> None:
     conn, sent, _ = _make_connector(OkxCcxtConnector)
-    # Seed the venue->cid index via the open order so the trade resolves its cid.
     conn._handle_ws_order(_ws_order(status="open"))
     sent.clear()
 
@@ -157,7 +157,7 @@ def test_okx_watch_my_trades_emits_deal_event() -> None:
     assert len(sent) == 1
     ev = sent[0]
     assert isinstance(ev, DealEvent)
-    assert ev.client_order_id == "qubxBTCUSDT1"
+    assert ev.client_order_id is None  # stateless connector: the deal routes by venue id
     assert ev.venue_order_id == "VENUE123"
     assert ev.deal.trade_id == "T1"
     assert ev.deal.amount == 0.5
@@ -170,13 +170,13 @@ def test_okx_filled_status_emits_status_only_filled() -> None:
     sent.clear()
 
     # watch_orders reports the order FILLED (no trade) -> plain terminal status, no
-    # stitching: the deal already rode the trade stream as a DealEvent.
+    # stitching: the deal already rode the trade stream as a DealEvent. (The stateless
+    # connector also synthesizes ACCEPTED ahead of the terminal status; AM dedups it.)
     conn._handle_ws_order(_ws_order(status="closed"))
-    assert len(sent) == 1
-    ev = sent[0]
-    assert isinstance(ev, OrderFilledEvent)
-    assert ev.client_order_id == "qubxBTCUSDT1"
-    assert ev.fill is None
+    fills = [e for e in sent if isinstance(e, OrderFilledEvent)]
+    assert len(fills) == 1
+    assert fills[0].client_order_id == "qubxBTCUSDT1"
+    assert fills[0].fill is None
 
 
 def test_okx_filled_status_without_prior_trade_still_emits() -> None:
@@ -186,16 +186,15 @@ def test_okx_filled_status_without_prior_trade_still_emits() -> None:
     conn._handle_ws_order(_ws_order(status="open"))
     sent.clear()
     conn._handle_ws_order(_ws_order(status="closed"))
-    assert len(sent) == 1
-    ev = sent[0]
-    assert isinstance(ev, OrderFilledEvent)
-    assert ev.fill is None
+    fills = [e for e in sent if isinstance(e, OrderFilledEvent)]
+    assert len(fills) == 1
+    assert fills[0].fill is None
 
 
-def test_okx_trade_after_terminal_eviction_emits_deal_by_venue_id() -> None:
-    # The FILLED status evicts the connector's order cache; a trade landing after that
-    # can't resolve its cid but still rides as a DealEvent addressed by venue id — AM
-    # resolves it through its own venue-id index.
+def test_okx_trade_after_terminal_emits_deal_by_venue_id() -> None:
+    # A trade landing after the FILLED status can't be tied to a cid by the stateless
+    # connector (it keeps no venue->cid index), but still rides as a DealEvent addressed
+    # by venue id — AM resolves it through its own venue-id index.
     conn, sent, _ = _make_connector(OkxCcxtConnector)
     conn._handle_ws_order(_ws_order(status="open"))
     conn._handle_ws_order(_ws_order(status="closed"))

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -501,9 +501,7 @@ class TestTradingManagerCancelOrder:
         mock_account.transition_order.assert_called_once_with(
             "BINANCE.UM", order.client_order_id, OrderStatus.PENDING_CANCEL
         )
-        mock_connector.cancel_order.assert_called_once_with(
-            client_order_id=order.client_order_id, venue_order_id=order.venue_order_id, instrument=order.instrument
-        )
+        mock_connector.cancel_order.assert_called_once_with(order)
 
     def test_cancel_terminal_is_idempotent_noop(self, trading_manager, mock_connector, mock_account):
         """Cancelling a terminal order is a no-op that still reports success."""
@@ -544,9 +542,7 @@ class TestTradingManagerCancelOrder:
         mock_account.find_order_by_id.return_value = order
 
         assert trading_manager.cancel_order(order_id="test_order_123") is True
-        mock_connector.cancel_order.assert_called_once_with(
-            client_order_id=order.client_order_id, venue_order_id=order.venue_order_id, instrument=order.instrument
-        )
+        mock_connector.cancel_order.assert_called_once_with(order)
 
 
 class _AccountRoutingContext(MockStrategyContext):

--- a/tests/qubx/core/test_account_manager_snapshot.py
+++ b/tests/qubx/core/test_account_manager_snapshot.py
@@ -124,9 +124,7 @@ def test_missing_order_past_grace_requests_status_fetch_not_terminalized():
 
     order = state.get_order("cid-1")
     assert order.status is OrderStatus.SUBMITTED  # untouched until the venue answers
-    am._connectors["binance"].request_order_status.assert_called_once_with(
-        client_order_id="cid-1", venue_order_id="V1", instrument=inst
-    )
+    am._connectors["binance"].request_order_status.assert_called_once_with(order)
     assert state.get_retry("cid-1") == 1
     assert result.reconcile_diff is not None
     assert result.reconcile_diff.missing == [order]
@@ -239,9 +237,7 @@ def test_open_orders_empty_list_engages_missing_handling():
 
     fresh = state.get_order("cid-fresh")
     assert fresh.status is OrderStatus.ACCEPTED  # fetch rescue, not terminalized
-    am._connectors["binance"].request_order_status.assert_called_once_with(
-        client_order_id="cid-fresh", venue_order_id="VF", instrument=inst
-    )
+    am._connectors["binance"].request_order_status.assert_called_once_with(fresh)
     assert state.get_retry("cid-fresh") == 1
     spent = state.get_order("cid-spent")
     assert spent.status is OrderStatus.REJECTED  # budget gone -> give-up

--- a/tests/qubx/core/test_account_manager_ticks.py
+++ b/tests/qubx/core/test_account_manager_ticks.py
@@ -63,11 +63,7 @@ def test_inflight_tick_requests_status_and_bumps_retry():
     am._states["binance"].add_order(_mk_order("cid-1", OrderStatus.SUBMITTED, "V1"))
     am._time.adv(6_000)
     am._on_inflight_tick(None)
-    conn.request_order_status.assert_called_once_with(
-        client_order_id="cid-1",
-        venue_order_id="V1",
-        instrument=None,
-    )
+    conn.request_order_status.assert_called_once_with(am._states["binance"].get_order("cid-1"))
     assert am._states["binance"].get_retry("cid-1") == 1
 
 
@@ -167,7 +163,7 @@ def test_retry_budget_resets_on_status_change():
     am._time.adv(6_000)
     am._on_inflight_tick(None)
     # fresh budget: the sweep polls the venue instead of giving up and reverting
-    conn.request_order_status.assert_called_once_with(client_order_id="cid-1", venue_order_id="V1", instrument=None)
+    conn.request_order_status.assert_called_once_with(state.get_order("cid-1"))
     assert state.get_order("cid-1").status is OrderStatus.PENDING_CANCEL
     assert state.get_retry("cid-1") == 1
 
@@ -328,6 +324,6 @@ def test_inflight_sweep_isolates_raising_callback():
     am._on_inflight_tick(None)  # must not raise
 
     # order B still processed despite A's callback raising
-    conn.request_order_status.assert_any_call(client_order_id="cid-b", venue_order_id="VB", instrument=None)
+    conn.request_order_status.assert_any_call(b)
     # A reverted out of PENDING_CANCEL to its captured pre-pending status
     assert state.get_order("cid-a").status is OrderStatus.ACCEPTED

--- a/tests/qubx/core/test_order_identifier_routing.py
+++ b/tests/qubx/core/test_order_identifier_routing.py
@@ -67,9 +67,7 @@ def test_cancel_order_routes_client_order_id(trading_manager):
     trading_manager._account_manager.transition_order.assert_called_once_with(
         "BINANCE.UM", "cid_1", OrderStatus.PENDING_CANCEL
     )
-    trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_called_once_with(
-        client_order_id="cid_1", venue_order_id="exchange_order_1", instrument=order.instrument
-    )
+    trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_called_once_with(order)
 
 
 def test_cancel_order_order_id_falls_back_to_client_id(trading_manager):
@@ -83,9 +81,7 @@ def test_cancel_order_order_id_falls_back_to_client_id(trading_manager):
 
     assert ok is True
     trading_manager._account_manager.find_order_by_client_id.assert_called_once_with("qubx_BTCUSDT_1")
-    trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_called_once_with(
-        client_order_id="qubx_BTCUSDT_1", venue_order_id=None, instrument=order.instrument
-    )
+    trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_called_once_with(order)
 
 
 def test_update_order_routes_client_order_id(trading_manager):
@@ -99,8 +95,7 @@ def test_update_order_routes_client_order_id(trading_manager):
         "BINANCE.UM", "cid_1", OrderStatus.PENDING_UPDATE
     )
     trading_manager._exchange_to_connector["BINANCE.UM"].update_order.assert_called_once_with(
-        client_order_id="cid_1", venue_order_id="exchange_order_1", price=123.0, quantity=1.0,
-        instrument=order.instrument,
+        order, price=123.0, quantity=1.0
     )
 
 

--- a/tests/qubx/restarts/test_state_resolvers.py
+++ b/tests/qubx/restarts/test_state_resolvers.py
@@ -507,9 +507,7 @@ class TestStateResolverCloseAll(TestStateResolverBase):
 
         StateResolver.CLOSE_ALL(self.ctx, {}, {}, {})
 
-        connector.cancel_order.assert_called_once_with(
-            client_order_id="qubx_BTCUSDT_1", venue_order_id=None, instrument=unacked.instrument
-        )
+        connector.cancel_order.assert_called_once_with(unacked)
 
     def test_close_all_ignores_small_positions(self):
         """Test CLOSE_ALL ignores positions smaller than lot_size."""


### PR DESCRIPTION
## What

Supersedes #323's `instrument` kwarg with the **Order-based IConnector contract**, making every connector a fully **stateless adapter**.

`IConnector` now takes the whole `Order` the AccountManager already holds (the single source of order state):

```python
def cancel_order(self, order: Order) -> None: ...
def update_order(self, order: Order, *, price=None, quantity=None) -> None: ...
def request_order_status(self, order: Order) -> None: ...
```

The connector reads everything the venue call needs straight off the `Order` — both ids (prefers `venue_order_id`, falls back to `client_order_id`), the `instrument` (ccxt symbol / HL asset index), and `side`/`type`/`time_in_force` (which an edit-as-cancel-and-replace needs). The `Order` is **read-only**: the connector extracts what it needs **synchronously** before scheduling any async venue call, so the async path never races the AM mutating the live object.

## Why

- `#323`'s `instrument` kwarg was a partial step — it's insufficient for `update` (no side/tif). The `Order` carries everything.
- Two connectors were re-deriving this state: ccxt kept a `_CachedOrder` cache; the native Hyperliquid connector kept a `PendingOrderRegistry`. Passing the `Order` removes the duplication at the source.

## Changes

- **Core contract** (`core/connector.py`): `IConnector` Protocol takes `order`.
- **Call sites**: `TradingManager.cancel_order`/`update_order` and the AccountManager inflight/reconcile sweeps pass the resolved `Order`.
- **ccxt connector**: cancel/update/status derive `symbol`/`side`/`type` from the order; **removed the order cache** (`_CachedOrder`, `_orders`, `_venue_to_cid`, `_resolve_cached`, `_cache_from_ws`, `_evict`, submit-time population, snapshot seed) and the `had_prior_ack` gate — ACCEPTED is now emitted on every venue ack and the AM dedups it.
- **Two-stream (OKX/Bitfinex)**: the trade handler routes deals by venue id alone (the AM resolves the originating order).
- **Backtester `SimulatedConnector`**: reads ids/instrument off the order (OME keys by id).

## Net

`15 files changed, +357 / −761` — a net **−404 lines**, most of it the deleted cache + its tests.

## Tests

Full unit suite green (`2004 passed, 5 skipped`). ccxt write/read/exchange suites, backtester connector, order-id routing, trading mixin, AM ticks/snapshot, and state-resolver tests all updated to the Order-based contract; obsolete cache + "no-id" tests removed.

## Follow-up

Update the native Hyperliquid connector's `cancel_order`/`update_order` to the `order`-based signatures (its `update_order` was stubbed precisely because it needed side/tif — this unblocks it).

Closes #324.