### PR TITLE
fix(account-mgmt): ignore a CANCELED for a venue id the order no longer holds (modify cancel-and-replace)

### DIFF
--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -166,9 +166,27 @@ def _handle_accepted(state: AccountState, event: OrderAcceptedEvent, now: np.dat
     return ApplyResult(order=order, order_change=OrderChange.ACCEPTED)
 
 
+def _is_superseded_oid_cancel(order: Order, event: OrderEvent) -> bool:
+    """True when a CANCELED addresses a venue id the order no longer holds.
+
+    A cancel-and-replace modify (Hyperliquid, and any venue whose ``edit`` is implemented as
+    atomic cancel+recreate) cancels the OLD venue order id but emits its CANCELED carrying the
+    SAME client_order_id as the now-live replacement — which already moved to a NEW venue id.
+    ``_resolve`` matches by client id first, so without this guard that stale CANCELED would
+    cancel the live order. A CANCELED whose venue id differs from the order's current one is for
+    a superseded id and must be ignored. (A cancel with no venue id, or one matching the order's
+    current id, is a real cancel and passes through.)
+    """
+    return (
+        event.venue_order_id is not None
+        and order.venue_order_id is not None
+        and event.venue_order_id != order.venue_order_id
+    )
+
+
 def _handle_canceled(state: AccountState, event: OrderCanceledEvent, now: np.datetime64) -> ApplyResult:
     order = _resolve(state, event)
-    if order is None or order.status.is_terminal:
+    if order is None or order.status.is_terminal or _is_superseded_oid_cancel(order, event):
         return ApplyResult()
     order = reconcile.transition(state, order.client_order_id, OrderStatus.CANCELED, now)
     return ApplyResult(order=order, order_change=OrderChange.CANCELED)

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -130,6 +130,39 @@ def test_cancel_on_terminal_is_noop():
     assert r.order is None
 
 
+def test_cancel_with_matching_venue_id_transitions_to_terminal():
+    # A real cancel (the event's venue id == the order's current id) still cancels.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED, venue_id="B")
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1", venue_order_id="B"), T1)
+    assert r.order is not None and r.order.status is OrderStatus.CANCELED
+
+
+def test_cancel_of_superseded_oid_after_modify_is_ignored():
+    # A cancel-and-replace modify (HL): the modify cancels the OLD oid A but emits its CANCELED
+    # carrying the SAME cloid as the now-live replacement, which already moved to a NEW oid B.
+    # Resolving by cloid would cancel the live order — the reducer must ignore a CANCELED whose
+    # venue id is not the order's current one.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED, venue_id="A")
+    # the modify's WS open(B) lands the order at the new oid (same cloid)
+    apply(state, OrderAcceptedEvent(instrument=None, client_order_id="c1", venue_order_id="B", accepted_at=T0), T1)
+    assert state.get_order("c1").venue_order_id == "B"
+    # the modify's stale CANCELED for the OLD oid A must NOT cancel the live order
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1", venue_order_id="A"), T1)
+    assert r.order is None  # ignored — empty ApplyResult
+    assert state.get_order("c1").status is OrderStatus.ACCEPTED  # the live order survives
+
+
+def test_cancel_without_venue_id_cancels_by_cloid():
+    # A pre-ack cancel (no venue id on the event) still resolves by cloid and cancels — the
+    # superseded-oid guard only fires when the event carries a (differing) venue id.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED, venue_id="A")
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1"), T1)
+    assert r.order is not None and r.order.status is OrderStatus.CANCELED
+
+
 def test_expire_transitions_to_terminal():
     state = _state()
     _order(state, status=OrderStatus.ACCEPTED)


### PR DESCRIPTION
## Problem (found live on Hyperliquid mainnet)

A cancel-and-replace modify cancels the **old** venue order id but emits its `canceled` carrying the **same** client id as the now-live replacement, which has already moved to a **new** oid. Verified against HL mainnet:

```
open      oid=A  cloid=X     ← original resting order
open      oid=B  cloid=X     ← update_order: modify = NEW oid B, SAME cloid
canceled  oid=A  cloid=X     ← the modify canceled the OLD oid A
```

The reducer's `_resolve` matches by `client_order_id` first, so `canceled(oid=A, cloid=X)` resolved to the **live** order (cloid X, now at oid B) and cancelled it. Net effect: **`update_order` left the order `CANCELED` in the AM right after a successful modify** — functionally broken for HL, and latent for any venue whose `edit` is an atomic cancel+recreate that preserves the client id.

## Fix

`_handle_canceled` now ignores a `CANCELED` whose `venue_order_id` differs from the order's **current** one. The replacement's `ACCEPTED(oid=B)` already moved the order to B and dropped A from the venue-id index (`set_venue_id`), so a `canceled(oid=A)` is for a superseded id → no-op.

Precise — it does not regress the other cases:
- **No venue id on the event** (pre-ack cancel) → resolves by cloid, cancels. ✓
- **Venue id matches the order's current id** (a real cancel) → cancels. ✓
- **Differing venue id** (modify's stale old-oid cancel) → ignored. ✓

## Tests
- `test_cancel_of_superseded_oid_after_modify_is_ignored` — the modify scenario; the live order survives.
- `test_cancel_with_matching_venue_id_transitions_to_terminal` — real cancel still works.
- `test_cancel_without_venue_id_cancels_by_cloid` — pre-ack cancel still works.
- Full AM suite green (255).

Surfaced by the Hyperliquid connector's live mainnet validation run.