### PR TITLE
fix(restorers): scope Postgres state restore to the previous run

### DIFF
--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -1060,7 +1060,11 @@ class ProcessingManager(IProcessingManager):
         if not self._is_ready():
             return
 
-        # Restore tracker state from signals
+        # Restore tracker state from signals.
+        # NB: unlike targets below, signals are NOT re-persisted on restart, so a run that
+        # hasn't re-emitted yet restores no signals (state restore is run-scoped). Harmless
+        # while restore_position_from_signals is a no-op; a tracker that implements it should
+        # mirror the save_targets chain-hop with save_signals here, NOT widen restore across runs.
         all_signals = []
         for instrument, signals in restored_state.instrument_to_signal_positions.items():
             all_signals.extend(signals)

--- a/src/qubx/restorers/balance.py
+++ b/src/qubx/restorers/balance.py
@@ -16,7 +16,7 @@ from pymongo import MongoClient
 from qubx import logger
 from qubx.core.basics import Balance
 from qubx.restorers.interfaces import IBalanceRestorer
-from qubx.restorers.utils import find_latest_run_folder
+from qubx.restorers.utils import find_latest_run_folder, latest_run_id
 
 
 class CsvBalanceRestorer(IBalanceRestorer):
@@ -221,10 +221,12 @@ class PostgresBalanceRestorer(IBalanceRestorer):
         strategy_name: str,
         connection: Connection,
         table_name: str = "qubx_logs_balance",
+        run_id: str | None = None,
     ):
         self.strategy_name = strategy_name
         self.connection = connection
         self.table_name = table_name
+        self.run_id = run_id
 
     def restore_balances(self) -> list[Balance]:
         try:
@@ -232,21 +234,11 @@ class PostgresBalanceRestorer(IBalanceRestorer):
             lookup_range = now - timedelta(days=7)
 
             with self.connection.cursor() as cur:
-                # Find latest run_id
-                cur.execute(
-                    sql.SQL(
-                        "SELECT run_id FROM {table} WHERE strategy_name = %s AND timestamp >= %s "
-                        "ORDER BY timestamp DESC LIMIT 1"
-                    ).format(table=sql.Identifier(self.table_name)),
-                    (self.strategy_name, lookup_range),
-                )
-                row = cur.fetchone()
-                if not row:
+                latest_run = self.run_id or latest_run_id(cur, self.table_name, self.strategy_name, lookup_range)
+                if latest_run is None:
                     logger.warning("No balance logs found in PostgreSQL for given filters.")
                     return []
-
-                latest_run_id = row[0]
-                logger.info(f"Restoring balances from PostgreSQL for run_id: {latest_run_id}")
+                logger.info(f"Restoring balances from PostgreSQL for run_id: {latest_run}")
 
                 # Get latest balance per (exchange, currency)
                 cur.execute(
@@ -257,7 +249,7 @@ class PostgresBalanceRestorer(IBalanceRestorer):
                         "WHERE strategy_name = %s AND run_id = %s AND timestamp >= %s "
                         "ORDER BY exchange, currency, timestamp DESC"
                     ).format(table=sql.Identifier(self.table_name)),
-                    (self.strategy_name, latest_run_id, lookup_range),
+                    (self.strategy_name, latest_run, lookup_range),
                 )
 
                 balances: list[Balance] = []

--- a/src/qubx/restorers/balance.py
+++ b/src/qubx/restorers/balance.py
@@ -16,7 +16,7 @@ from pymongo import MongoClient
 from qubx import logger
 from qubx.core.basics import Balance
 from qubx.restorers.interfaces import IBalanceRestorer
-from qubx.restorers.utils import find_latest_run_folder, latest_run_id
+from qubx.restorers.utils import find_latest_run_folder, latest_run_id, mongo_latest_run_id
 
 
 class CsvBalanceRestorer(IBalanceRestorer):
@@ -139,11 +139,13 @@ class MongoDBBalanceRestorer(IBalanceRestorer):
         mongo_client: MongoClient,
         db_name: str = "default_logs_db",
         collection_name: str = "qubx_logs",
+        run_id: str | None = None,
     ):
         self.mongo_client = mongo_client
         self.db_name = db_name
         self.collection_name = collection_name
         self.strategy_name = strategy_name
+        self.run_id = run_id
 
         self.collection = self.mongo_client[db_name][collection_name]
 
@@ -164,21 +166,15 @@ class MongoDBBalanceRestorer(IBalanceRestorer):
                 "timestamp": {"$gte": lookup_range},
             }
 
-            latest_run_doc = (
-                self.collection.find(base_match, {"run_id": 1, "timestamp": 1}).sort("timestamp", -1).limit(1)
-            )
-
-            latest_run = next(latest_run_doc, None)
-            if not latest_run:
+            run_id = self.run_id or mongo_latest_run_id(self.collection, base_match)
+            if run_id is None:
                 logger.warning("No balance logs found for given filters.")
                 return []
 
-            latest_run_id = latest_run["run_id"]
-
-            logger.info(f"Restoring balances from MongoDB for run_id: {latest_run_id}")
+            logger.info(f"Restoring balances from MongoDB for run_id: {run_id}")
 
             pipeline = [
-                {"$match": {**base_match, "run_id": latest_run_id}},
+                {"$match": {**base_match, "run_id": run_id}},
                 {"$sort": {"timestamp": -1}},
                 {"$group": {"_id": {"exchange": "$exchange", "currency": "$currency"}, "doc": {"$first": "$$ROOT"}}},
             ]

--- a/src/qubx/restorers/position.py
+++ b/src/qubx/restorers/position.py
@@ -19,7 +19,7 @@ from qubx.core.basics import Instrument, Position
 from qubx.core.lookups import lookup
 from qubx.core.utils import recognize_time
 from qubx.restorers.interfaces import IPositionRestorer
-from qubx.restorers.utils import find_latest_run_folder
+from qubx.restorers.utils import find_latest_run_folder, latest_run_id
 
 
 class CsvPositionRestorer(IPositionRestorer):
@@ -264,10 +264,12 @@ class PostgresPositionRestorer(IPositionRestorer):
         strategy_name: str,
         connection: Connection,
         table_name: str = "qubx_logs_positions",
+        run_id: str | None = None,
     ):
         self.strategy_name = strategy_name
         self.connection = connection
         self.table_name = table_name
+        self.run_id = run_id
 
     def restore_positions(self) -> dict[Instrument, Position]:
         try:
@@ -275,21 +277,11 @@ class PostgresPositionRestorer(IPositionRestorer):
             lookup_range = now - timedelta(days=7)
 
             with self.connection.cursor() as cur:
-                # Find latest run_id
-                cur.execute(
-                    sql.SQL(
-                        "SELECT run_id FROM {table} WHERE strategy_name = %s AND timestamp >= %s "
-                        "ORDER BY timestamp DESC LIMIT 1"
-                    ).format(table=sql.Identifier(self.table_name)),
-                    (self.strategy_name, lookup_range),
-                )
-                row = cur.fetchone()
-                if not row:
+                latest_run = self.run_id or latest_run_id(cur, self.table_name, self.strategy_name, lookup_range)
+                if latest_run is None:
                     logger.warning("No position logs found in PostgreSQL for given filters.")
                     return {}
-
-                latest_run_id = row[0]
-                logger.info(f"Restoring positions from PostgreSQL for run_id: {latest_run_id}")
+                logger.info(f"Restoring positions from PostgreSQL for run_id: {latest_run}")
 
                 # Get latest position per instrument
                 cur.execute(
@@ -301,7 +293,7 @@ class PostgresPositionRestorer(IPositionRestorer):
                         "WHERE strategy_name = %s AND run_id = %s AND timestamp >= %s "
                         "ORDER BY symbol, exchange, market_type, timestamp DESC"
                     ).format(table=sql.Identifier(self.table_name)),
-                    (self.strategy_name, latest_run_id, lookup_range),
+                    (self.strategy_name, latest_run, lookup_range),
                 )
 
                 positions: dict[Instrument, Position] = {}

--- a/src/qubx/restorers/position.py
+++ b/src/qubx/restorers/position.py
@@ -19,7 +19,7 @@ from qubx.core.basics import Instrument, Position
 from qubx.core.lookups import lookup
 from qubx.core.utils import recognize_time
 from qubx.restorers.interfaces import IPositionRestorer
-from qubx.restorers.utils import find_latest_run_folder, latest_run_id
+from qubx.restorers.utils import find_latest_run_folder, latest_run_id, mongo_latest_run_id
 
 
 class CsvPositionRestorer(IPositionRestorer):
@@ -157,11 +157,13 @@ class MongoDBPositionRestorer(IPositionRestorer):
         mongo_client: MongoClient,
         db_name: str = "default_logs_db",
         collection_name: str = "qubx_logs",
+        run_id: str | None = None,
     ):
         self.mongo_client = mongo_client
         self.db_name = db_name
         self.collection_name = collection_name
         self.strategy_name = strategy_name
+        self.run_id = run_id
 
         self.collection = self.mongo_client[db_name][collection_name]
 
@@ -182,21 +184,15 @@ class MongoDBPositionRestorer(IPositionRestorer):
                 "timestamp": {"$gte": lookup_range},
             }
 
-            latest_run_doc = (
-                self.collection.find(base_match, {"run_id": 1, "timestamp": 1}).sort("timestamp", -1).limit(1)
-            )
-
-            latest_run = next(latest_run_doc, None)
-            if not latest_run:
+            run_id = self.run_id or mongo_latest_run_id(self.collection, base_match)
+            if run_id is None:
                 logger.warning("No position logs found for given filters.")
                 return {}
 
-            latest_run_id = latest_run["run_id"]
-
-            logger.info(f"Restoring positions from MongoDB for run_id: {latest_run_id}")
+            logger.info(f"Restoring positions from MongoDB for run_id: {run_id}")
 
             pipeline = [
-                {"$match": {**base_match, "run_id": latest_run_id}},
+                {"$match": {**base_match, "run_id": run_id}},
                 {"$sort": {"timestamp": -1}},
                 {
                     "$group": {

--- a/src/qubx/restorers/signal.py
+++ b/src/qubx/restorers/signal.py
@@ -7,7 +7,7 @@ for restoring signals from various sources.
 
 import ast
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -20,7 +20,7 @@ from qubx.core.basics import Instrument, Signal, TargetPosition
 from qubx.core.lookups import lookup
 from qubx.core.utils import recognize_time
 from qubx.restorers.interfaces import ISignalRestorer
-from qubx.restorers.utils import find_latest_run_folder
+from qubx.restorers.utils import find_latest_run_folder, latest_run_id
 
 
 def _parse_options_cell(value) -> dict:
@@ -421,12 +421,14 @@ class PostgresSignalRestorer(ISignalRestorer):
         signals_table_name: str = "qubx_logs_signals",
         targets_table_name: str = "qubx_logs_targets",
         max_restored_records: int = 20,
+        run_id: str | None = None,
     ):
         self.strategy_name = strategy_name
         self.connection = connection
         self.signals_table_name = signals_table_name
         self.targets_table_name = targets_table_name
         self.max_restored_records = max_restored_records
+        self.run_id = run_id
 
     def restore_signals(self) -> dict[Instrument, list[Signal]]:
         logger.info(f"Restoring latest {self.max_restored_records} signals per symbol from PostgreSQL")
@@ -507,16 +509,20 @@ class PostgresSignalRestorer(ISignalRestorer):
 
     def _load_data(self, table_name: str) -> list[dict] | None:
         try:
-            query = sql.SQL(
-                "SELECT * FROM ("
-                "  SELECT *, ROW_NUMBER() OVER ("
-                "    PARTITION BY symbol, exchange, market_type ORDER BY timestamp DESC"
-                "  ) AS rn FROM {table} WHERE strategy_name = %s"
-                ") sub WHERE rn <= %s ORDER BY symbol, exchange, market_type, timestamp DESC"
-            ).format(table=sql.Identifier(table_name))
-
+            since = datetime.now(timezone.utc) - timedelta(days=7)
             with self.connection.cursor() as cur:
-                cur.execute(query, (self.strategy_name, self.max_restored_records))
+                run_id = self.run_id or latest_run_id(cur, table_name, self.strategy_name, since)
+                if run_id is None:
+                    return None
+                query = sql.SQL(
+                    "SELECT * FROM ("
+                    "  SELECT *, ROW_NUMBER() OVER ("
+                    "    PARTITION BY symbol, exchange, market_type ORDER BY timestamp DESC"
+                    "  ) AS rn FROM {table} "
+                    "  WHERE strategy_name = %s AND run_id = %s AND timestamp >= %s"
+                    ") sub WHERE rn <= %s ORDER BY symbol, exchange, market_type, timestamp DESC"
+                ).format(table=sql.Identifier(table_name))
+                cur.execute(query, (self.strategy_name, run_id, since, self.max_restored_records))
                 columns = [desc.name for desc in cur.description]
                 return [dict(zip(columns, row)) for row in cur.fetchall()]
         except Exception as e:

--- a/src/qubx/restorers/signal.py
+++ b/src/qubx/restorers/signal.py
@@ -20,7 +20,7 @@ from qubx.core.basics import Instrument, Signal, TargetPosition
 from qubx.core.lookups import lookup
 from qubx.core.utils import recognize_time
 from qubx.restorers.interfaces import ISignalRestorer
-from qubx.restorers.utils import find_latest_run_folder, latest_run_id
+from qubx.restorers.utils import find_latest_run_folder, latest_run_id, mongo_latest_run_id
 
 
 def _parse_options_cell(value) -> dict:
@@ -283,12 +283,14 @@ class MongoDBSignalRestorer(ISignalRestorer):
         db_name: str = "default_logs_db",
         collection_name: str = "qubx_logs",
         max_restored_records: int = 20,
+        run_id: str | None = None,
     ):
         self.mongo_client = mongo_client
         self.db_name = db_name
         self.collection_name = collection_name
         self.strategy_name = strategy_name
         self.max_restored_records = max_restored_records
+        self.run_id = run_id
         self.collection = self.mongo_client[db_name][collection_name]
 
     def restore_signals(self) -> dict[Instrument, list[Signal]]:
@@ -381,10 +383,18 @@ class MongoDBSignalRestorer(ISignalRestorer):
 
     def _load_data_from_mongo(self, log_type: str) -> CommandCursor | None:
         try:
-            logger.info(f"Restoring latest {self.max_restored_records} signals per symbol from MongoDB")
+            since = datetime.utcnow() - timedelta(days=7)
+            base_match = {
+                "log_type": log_type,
+                "strategy_name": self.strategy_name,
+                "timestamp": {"$gte": since},
+            }
+            run_id = self.run_id or mongo_latest_run_id(self.collection, base_match)
+            if run_id is None:
+                return None
 
             pipeline = [
-                {"$match": {"log_type": log_type, "strategy_name": self.strategy_name}},
+                {"$match": {**base_match, "run_id": run_id}},
                 {"$sort": {"timestamp": -1}},
                 {
                     "$group": {

--- a/src/qubx/restorers/state.py
+++ b/src/qubx/restorers/state.py
@@ -6,6 +6,7 @@ from various sources.
 """
 
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import numpy as np
@@ -19,7 +20,7 @@ from qubx.restorers.balance import CsvBalanceRestorer, MongoDBBalanceRestorer, P
 from qubx.restorers.interfaces import IStateRestorer
 from qubx.restorers.position import CsvPositionRestorer, MongoDBPositionRestorer, PostgresPositionRestorer
 from qubx.restorers.signal import CsvSignalRestorer, MongoDBSignalRestorer, PostgresSignalRestorer
-from qubx.restorers.utils import find_latest_run_folder
+from qubx.restorers.utils import canonical_run_id, find_latest_run_folder
 
 
 class CsvStateRestorer(IStateRestorer):
@@ -259,21 +260,34 @@ class PostgresStateRestorer(IStateRestorer):
 
             logger.info(f"Restoring state from PostgreSQL (prefix: {self.table_prefix})")
 
+            since = datetime.now(timezone.utc) - timedelta(days=7)
+            state_tables = [
+                f"{self.table_prefix}_{suffix}"
+                for suffix in ("positions", "signals", "targets", "balance")
+                if f"{self.table_prefix}_{suffix}" in existing_tables
+            ]
+            with conn.cursor() as cur:
+                run_id = canonical_run_id(cur, state_tables, self.strategy_name, since)
+            logger.info(f"Restoring state from PostgreSQL for canonical run_id: {run_id}")
+
             position_restorer = PostgresPositionRestorer(
                 strategy_name=self.strategy_name,
                 connection=conn,
                 table_name=f"{self.table_prefix}_positions",
+                run_id=run_id,
             )
             signal_restorer = PostgresSignalRestorer(
                 strategy_name=self.strategy_name,
                 connection=conn,
                 signals_table_name=f"{self.table_prefix}_signals",
                 targets_table_name=f"{self.table_prefix}_targets",
+                run_id=run_id,
             )
             balance_restorer = PostgresBalanceRestorer(
                 strategy_name=self.strategy_name,
                 connection=conn,
                 table_name=f"{self.table_prefix}_balance",
+                run_id=run_id,
             )
 
             positions = position_restorer.restore_positions()

--- a/src/qubx/restorers/state.py
+++ b/src/qubx/restorers/state.py
@@ -20,7 +20,7 @@ from qubx.restorers.balance import CsvBalanceRestorer, MongoDBBalanceRestorer, P
 from qubx.restorers.interfaces import IStateRestorer
 from qubx.restorers.position import CsvPositionRestorer, MongoDBPositionRestorer, PostgresPositionRestorer
 from qubx.restorers.signal import CsvSignalRestorer, MongoDBSignalRestorer, PostgresSignalRestorer
-from qubx.restorers.utils import canonical_run_id, find_latest_run_folder
+from qubx.restorers.utils import canonical_run_id, find_latest_run_folder, mongo_canonical_run_id
 
 
 class CsvStateRestorer(IStateRestorer):
@@ -196,6 +196,27 @@ class MongoDBStateRestorer(IStateRestorer):
             )
 
         logger.info(f"Restoring state from MongoDB {self.db_name}")
+
+        since = datetime.utcnow() - timedelta(days=7)
+        sources = [
+            (
+                restorer.collection,
+                {"log_type": suffix, "strategy_name": self.strategy_name, "timestamp": {"$gte": since}},
+            )
+            for suffix, restorer in (
+                ("positions", self.position_restorer),
+                ("signals", self.signal_restorer),
+                ("targets", self.targets_restorer),
+                ("balance", self.balance_restorer),
+            )
+            if f"{self.collection_name_prefix}_{suffix}" in mongo_collections
+        ]
+        run_id = mongo_canonical_run_id(sources)
+        logger.info(f"Restoring state from MongoDB for canonical run_id: {run_id}")
+        self.position_restorer.run_id = run_id
+        self.signal_restorer.run_id = run_id
+        self.targets_restorer.run_id = run_id
+        self.balance_restorer.run_id = run_id
 
         positions = self.position_restorer.restore_positions()
         signals = self.signal_restorer.restore_signals()

--- a/src/qubx/restorers/utils.py
+++ b/src/qubx/restorers/utils.py
@@ -77,3 +77,28 @@ def canonical_run_id(cur, tables: list[str], strategy_name: str, since) -> str |
     cur.execute(query, params)
     row = cur.fetchone()
     return row[0] if row else None
+
+
+def mongo_latest_run_id(collection, match: dict) -> str | None:
+    """Return the most recent run_id in *collection* matching *match* (which must
+    already carry strategy_name/log_type and any lookback bound). None if no docs."""
+    doc = next(
+        collection.find(match, {"run_id": 1, "timestamp": 1}).sort("timestamp", -1).limit(1),
+        None,
+    )
+    return doc["run_id"] if doc else None
+
+
+def mongo_canonical_run_id(sources: list[tuple]) -> str | None:
+    """Return the run_id of the most recent doc across all *sources* (the previous
+    run), shared across log types. Each source is a ``(collection, match)`` pair.
+    None if no source has a matching doc."""
+    best_ts, best_run = None, None
+    for collection, match in sources:
+        doc = next(
+            collection.find(match, {"run_id": 1, "timestamp": 1}).sort("timestamp", -1).limit(1),
+            None,
+        )
+        if doc is not None and (best_ts is None or doc["timestamp"] > best_ts):
+            best_ts, best_run = doc["timestamp"], doc["run_id"]
+    return best_run

--- a/src/qubx/restorers/utils.py
+++ b/src/qubx/restorers/utils.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Optional
 
+from psycopg import sql
+
 
 def find_latest_run_folder(base_dir: str | Path) -> Optional[Path]:
     """
@@ -40,3 +42,38 @@ def find_latest_run_folder(base_dir: str | Path) -> Optional[Path]:
     latest_run = sorted(run_folders, key=lambda x: x.name, reverse=True)[0]
 
     return latest_run
+
+
+def latest_run_id(cur, table: str, strategy_name: str, since) -> str | None:
+    """Return the most recent run_id for *strategy_name* in *table*, within the
+    *since* lower bound. None if the table has no matching rows."""
+    cur.execute(
+        sql.SQL(
+            "SELECT run_id FROM {table} WHERE strategy_name = %s AND timestamp >= %s "
+            "ORDER BY timestamp DESC LIMIT 1"
+        ).format(table=sql.Identifier(table)),
+        (strategy_name, since),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def canonical_run_id(cur, tables: list[str], strategy_name: str, since) -> str | None:
+    """Return the run_id of the most recent row across all *tables* (the previous
+    run), within the *since* lower bound. None if no tables or no matching rows."""
+    if not tables:
+        return None
+    parts, params = [], []
+    for table in tables:
+        parts.append(
+            sql.SQL(
+                "SELECT run_id, timestamp FROM {table} WHERE strategy_name = %s AND timestamp >= %s"
+            ).format(table=sql.Identifier(table))
+        )
+        params.extend([strategy_name, since])
+    query = sql.SQL("SELECT run_id FROM ({union}) u ORDER BY timestamp DESC LIMIT 1").format(
+        union=sql.SQL(" UNION ALL ").join(parts)
+    )
+    cur.execute(query, params)
+    row = cur.fetchone()
+    return row[0] if row else None

--- a/tests/qubx/restorers/test_restorers.py
+++ b/tests/qubx/restorers/test_restorers.py
@@ -41,6 +41,7 @@ from qubx.restorers.interfaces import (
 from qubx.restorers.position import CsvPositionRestorer, MongoDBPositionRestorer
 from qubx.restorers.signal import CsvSignalRestorer, MongoDBSignalRestorer
 from qubx.restorers.state import CsvStateRestorer, MongoDBStateRestorer
+from qubx.restorers.utils import mongo_canonical_run_id, mongo_latest_run_id
 
 
 # Mock instruments for testing
@@ -936,3 +937,177 @@ class TestMongoDBStateRestorer:
             assert btc_position is not None
             assert btc_position.position_avg_price > 0
             assert btc_position.quantity > 0
+
+
+class TestMongoRunScoping:
+    """Run-scoping for the MongoDB restorers: restore only the previous run's state,
+    so a de-universed instrument's stale doc from an older run is never resurrected."""
+
+    _strategy_name = "test_strategy"
+
+    @staticmethod
+    def _pos_doc(run_id, symbol, ts, strategy="test_strategy"):
+        return {
+            "timestamp": ts, "symbol": symbol, "exchange": "BINANCE.UM", "market_type": "SWAP",
+            "quantity": 1, "realized_pnl_quoted": 0, "avg_position_price": 100.0,
+            "run_id": run_id, "strategy_name": strategy, "log_type": "positions",
+        }
+
+    @staticmethod
+    def _sig_doc(run_id, symbol, ts, strategy="test_strategy"):
+        return {
+            "timestamp": ts, "symbol": symbol, "exchange": "BINANCE.UM", "market_type": "SWAP",
+            "signal": 1, "reference_price": 90000, "run_id": run_id,
+            "strategy_name": strategy, "log_type": "signals",
+        }
+
+    @staticmethod
+    def _bal_doc(run_id, currency, ts, strategy="test_strategy"):
+        return {
+            "timestamp": ts, "exchange": "BINANCE.UM", "currency": currency,
+            "total": 1000.0, "locked": 0.0, "run_id": run_id,
+            "strategy_name": strategy, "log_type": "balance",
+        }
+
+    # ---- utils helpers ----
+
+    def test_mongo_latest_run_id_picks_most_recent(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        now = datetime.now()
+        col.insert_one(self._pos_doc("run-old", "ETHUSDT", now - timedelta(hours=3)))
+        col.insert_one(self._pos_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        match = {"log_type": "positions", "strategy_name": self._strategy_name}
+        assert mongo_latest_run_id(col, match) == "run-new"
+
+    def test_mongo_latest_run_id_none_when_empty(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        match = {"log_type": "positions", "strategy_name": self._strategy_name}
+        assert mongo_latest_run_id(col, match) is None
+
+    def test_mongo_canonical_run_id_across_collections(self):
+        client = mongomock.MongoClient()
+        db = client["default_logs_db"]
+        now = datetime.now()
+        db["qubx_logs_positions"].insert_one(self._pos_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        db["qubx_logs_targets"].insert_one(
+            {**self._pos_doc("run-old", "ETHUSDT", now - timedelta(hours=5)), "log_type": "targets"}
+        )
+        sources = [
+            (db["qubx_logs_positions"], {"log_type": "positions", "strategy_name": self._strategy_name}),
+            (db["qubx_logs_targets"], {"log_type": "targets", "strategy_name": self._strategy_name}),
+        ]
+        assert mongo_canonical_run_id(sources) == "run-new"
+
+    def test_mongo_canonical_run_id_none_when_no_sources(self):
+        assert mongo_canonical_run_id([]) is None
+
+    # ---- position restorer ----
+
+    def test_position_scopes_to_latest_run(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        now = datetime.now()
+        col.insert_one(self._pos_doc("run-old", "ETHUSDT", now - timedelta(hours=3)))
+        col.insert_one(self._pos_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        restorer = MongoDBPositionRestorer(strategy_name=self._strategy_name, mongo_client=client)
+        result = restorer.restore_positions()
+        assert {i.symbol for i in result} == {"BTCUSDT"}
+
+    def test_position_uses_injected_run_id(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        now = datetime.now()
+        col.insert_one(self._pos_doc("run-old", "ETHUSDT", now - timedelta(hours=3)))
+        col.insert_one(self._pos_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        restorer = MongoDBPositionRestorer(strategy_name=self._strategy_name, mongo_client=client, run_id="run-old")
+        result = restorer.restore_positions()
+        assert {i.symbol for i in result} == {"ETHUSDT"}
+
+    # ---- signal restorer (the core bug) ----
+
+    def test_signal_scopes_to_latest_run(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        now = datetime.now()
+        col.insert_one(self._sig_doc("run-old", "ETHUSDT", now - timedelta(hours=3)))
+        col.insert_one(self._sig_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        restorer = MongoDBSignalRestorer(strategy_name=self._strategy_name, mongo_client=client)
+        result = restorer.restore_signals()
+        assert {i.symbol for i in result} == {"BTCUSDT"}
+
+    def test_signal_uses_injected_run_id(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        now = datetime.now()
+        col.insert_one(self._sig_doc("run-old", "ETHUSDT", now - timedelta(hours=3)))
+        col.insert_one(self._sig_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        restorer = MongoDBSignalRestorer(strategy_name=self._strategy_name, mongo_client=client, run_id="run-old")
+        result = restorer.restore_signals()
+        assert {i.symbol for i in result} == {"ETHUSDT"}
+
+    def test_signal_empty_when_no_run(self):
+        client = mongomock.MongoClient()
+        restorer = MongoDBSignalRestorer(strategy_name=self._strategy_name, mongo_client=client)
+        assert restorer.restore_signals() == {}
+
+    # ---- balance restorer ----
+
+    def test_balance_scopes_to_latest_run(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        now = datetime.now()
+        col.insert_one(self._bal_doc("run-old", "BTC", now - timedelta(hours=3)))
+        col.insert_one(self._bal_doc("run-new", "USDT", now - timedelta(hours=1)))
+        restorer = MongoDBBalanceRestorer(strategy_name=self._strategy_name, mongo_client=client)
+        result = restorer.restore_balances()
+        assert {b.currency for b in result} == {"USDT"}
+
+    def test_balance_uses_injected_run_id(self):
+        client = mongomock.MongoClient()
+        col = client["default_logs_db"]["qubx_logs"]
+        now = datetime.now()
+        col.insert_one(self._bal_doc("run-old", "BTC", now - timedelta(hours=3)))
+        col.insert_one(self._bal_doc("run-new", "USDT", now - timedelta(hours=1)))
+        restorer = MongoDBBalanceRestorer(strategy_name=self._strategy_name, mongo_client=client, run_id="run-old")
+        result = restorer.restore_balances()
+        assert {b.currency for b in result} == {"BTC"}
+
+    # ---- state restorer: one shared canonical run (Option B) ----
+
+    def test_state_flat_previous_run_restores_no_targets(self):
+        """Canonical run (from positions) that logged no targets restores no targets,
+        never an older run's — the flat-previous-run guarantee."""
+        client = mongomock.MongoClient()
+        db = client["default_logs_db"]
+        now = datetime.now()
+        db["qubx_logs_positions"].insert_one(self._pos_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        db["qubx_logs_balance"].insert_one(self._bal_doc("run-new", "USDT", now - timedelta(hours=1)))
+        db["qubx_logs_targets"].insert_one(
+            {
+                "timestamp": now - timedelta(hours=5), "symbol": "ETHUSDT", "exchange": "BINANCE.UM",
+                "market_type": "SWAP", "target_position": 1, "entry_price": 90000,
+                "run_id": "run-old", "strategy_name": self._strategy_name, "log_type": "targets",
+            }
+        )
+        with patch("qubx.restorers.state.MongoClient", return_value=client):
+            restorer = MongoDBStateRestorer(strategy_name=self._strategy_name)
+            state = restorer.restore_state()
+        assert {i.symbol for i in state.positions} == {"BTCUSDT"}
+        assert state.instrument_to_target_positions == {}
+
+    def test_state_injects_canonical_run_into_sub_restorers(self):
+        client = mongomock.MongoClient()
+        db = client["default_logs_db"]
+        now = datetime.now()
+        db["qubx_logs_positions"].insert_one(self._pos_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        db["qubx_logs_signals"].insert_one(self._sig_doc("run-new", "BTCUSDT", now - timedelta(hours=1)))
+        db["qubx_logs_balance"].insert_one(self._bal_doc("run-new", "USDT", now - timedelta(hours=1)))
+        with patch("qubx.restorers.state.MongoClient", return_value=client):
+            restorer = MongoDBStateRestorer(strategy_name=self._strategy_name)
+            restorer.restore_state()
+            assert restorer.position_restorer.run_id == "run-new"
+            assert restorer.signal_restorer.run_id == "run-new"
+            assert restorer.targets_restorer.run_id == "run-new"
+            assert restorer.balance_restorer.run_id == "run-new"

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -470,26 +470,32 @@ class TestPostgresStateRestorer:
         conn.close.assert_called_once()
 
     @patch("qubx.restorers.state.psycopg")
-    def test_flat_previous_run_restores_no_targets(self, mock_psycopg, mock_lookup):
-        """Canonical run (from positions) that logged no targets → targets empty,
-        never an older run's targets."""
+    @patch("qubx.restorers.state.PostgresBalanceRestorer")
+    @patch("qubx.restorers.state.PostgresSignalRestorer")
+    @patch("qubx.restorers.state.PostgresPositionRestorer")
+    def test_injects_canonical_run_into_all_sub_restorers(
+        self, mock_pos, mock_sig, mock_bal, mock_psycopg
+    ):
+        """Task 4 wiring: one canonical run_id is computed and injected into
+        every sub-restorer, so positions/signals/targets/balance share a run."""
         conn, cursor = _make_mock_connection()
         mock_psycopg.connect.return_value = conn
-
-        # Tables exist (positions, signals, balance, targets).
-        cursor.fetchone.return_value = ("run-latest",)  # canonical + any per-table lookups
-        # existing-tables probe + all data queries return empty; only run resolution matters here.
         cursor.fetchall.return_value = [
             ("qubx_logs_positions",), ("qubx_logs_signals",),
             ("qubx_logs_balance",), ("qubx_logs_targets",),
         ]
-        cursor.description = []
+        cursor.fetchone.return_value = ("run-latest",)  # canonical_run_id result
+        mock_pos.return_value.restore_positions.return_value = {}
+        mock_sig.return_value.restore_signals.return_value = {}
+        mock_sig.return_value.restore_targets.return_value = {}
+        mock_bal.return_value.restore_balances.return_value = []
 
         restorer = PostgresStateRestorer(strategy_name="test_strategy")
-        state = restorer.restore_state()
+        restorer.restore_state()
 
-        assert isinstance(state, RestoredState)
-        assert state.instrument_to_target_positions == {}
+        assert mock_pos.call_args.kwargs["run_id"] == "run-latest"
+        assert mock_sig.call_args.kwargs["run_id"] == "run-latest"
+        assert mock_bal.call_args.kwargs["run_id"] == "run-latest"
 
 
 # --- Logger tests ---

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -25,6 +25,7 @@ from qubx.restorers.interfaces import (
 from qubx.restorers.position import PostgresPositionRestorer
 from qubx.restorers.signal import PostgresSignalRestorer
 from qubx.restorers.state import PostgresStateRestorer
+from qubx.restorers.utils import latest_run_id, canonical_run_id
 
 # --- Helpers ---
 
@@ -84,6 +85,38 @@ def _make_mock_connection():
     conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
     conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     return conn, cursor
+
+
+# --- Run ID helper tests ---
+
+class TestRunIdHelpers:
+    def test_latest_run_id_returns_run(self):
+        _, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = ("run-123",)
+        assert latest_run_id(cursor, "qubx_logs_targets", "s", "2026-01-01") == "run-123"
+        assert cursor.execute.called
+
+    def test_latest_run_id_none_when_empty(self):
+        _, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = None
+        assert latest_run_id(cursor, "qubx_logs_targets", "s", "2026-01-01") is None
+
+    def test_canonical_run_id_returns_run(self):
+        _, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = ("run-abc",)
+        got = canonical_run_id(cursor, ["qubx_logs_positions", "qubx_logs_targets"], "s", "2026-01-01")
+        assert got == "run-abc"
+        assert cursor.execute.called
+
+    def test_canonical_run_id_none_when_no_tables(self):
+        _, cursor = _make_mock_connection()
+        assert canonical_run_id(cursor, [], "s", "2026-01-01") is None
+        assert not cursor.execute.called
+
+    def test_canonical_run_id_none_when_empty(self):
+        _, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = None
+        assert canonical_run_id(cursor, ["qubx_logs_targets"], "s", "2026-01-01") is None
 
 
 # --- Protocol tests ---

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -25,7 +25,7 @@ from qubx.restorers.interfaces import (
 from qubx.restorers.position import PostgresPositionRestorer
 from qubx.restorers.signal import PostgresSignalRestorer
 from qubx.restorers.state import PostgresStateRestorer
-from qubx.restorers.utils import latest_run_id, canonical_run_id
+from qubx.restorers.utils import canonical_run_id, latest_run_id
 
 # --- Helpers ---
 

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -469,6 +469,28 @@ class TestPostgresStateRestorer:
 
         conn.close.assert_called_once()
 
+    @patch("qubx.restorers.state.psycopg")
+    def test_flat_previous_run_restores_no_targets(self, mock_psycopg, mock_lookup):
+        """Canonical run (from positions) that logged no targets → targets empty,
+        never an older run's targets."""
+        conn, cursor = _make_mock_connection()
+        mock_psycopg.connect.return_value = conn
+
+        # Tables exist (positions, signals, balance, targets).
+        cursor.fetchone.return_value = ("run-latest",)  # canonical + any per-table lookups
+        # existing-tables probe + all data queries return empty; only run resolution matters here.
+        cursor.fetchall.return_value = [
+            ("qubx_logs_positions",), ("qubx_logs_signals",),
+            ("qubx_logs_balance",), ("qubx_logs_targets",),
+        ]
+        cursor.description = []
+
+        restorer = PostgresStateRestorer(strategy_name="test_strategy")
+        state = restorer.restore_state()
+
+        assert isinstance(state, RestoredState)
+        assert state.instrument_to_target_positions == {}
+
 
 # --- Logger tests ---
 

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -184,6 +184,22 @@ class TestPostgresPositionRestorer:
 class TestPostgresSignalRestorer:
     _strategy_name = "test_strategy"
 
+    def _target_columns_and_row(self):
+        col_names = [
+            "id", "run_id", "account_id", "strategy_name", "created_at",
+            "timestamp", "symbol", "exchange", "market_type",
+            "target_position", "entry_price", "stop_price", "take_price", "options", "rn",
+        ]
+        description = [MagicMock() for _ in col_names]
+        for desc, name in zip(description, col_names):
+            desc.name = name
+        row = (
+            1, "run-B", "acc", "test_strategy", "2026-07-10",
+            datetime(2026, 7, 10, tzinfo=timezone.utc), "BTCUSDT", "BINANCE.UM", "SWAP",
+            0.5, 100.0, None, None, None, 1,
+        )
+        return description, [row]
+
     def test_with_no_data(self):
         conn, cursor = _make_mock_connection()
         cursor.fetchall.return_value = []
@@ -210,6 +226,7 @@ class TestPostgresSignalRestorer:
         for desc, name in zip(cursor.description, col_names):
             desc.name = name
 
+        cursor.fetchone.return_value = ("run-123",)
         cursor.fetchall.return_value = [
             (1, "run-123", "acc", "test_strategy", ts,
              ts, "BTCUSDT", "BINANCE.UM", "SWAP",
@@ -239,6 +256,7 @@ class TestPostgresSignalRestorer:
         for desc, name in zip(cursor.description, col_names):
             desc.name = name
 
+        cursor.fetchone.return_value = ("run-123",)
         cursor.fetchall.return_value = [
             (1, "run-123", "acc", "test_strategy", ts,
              ts, "BTCUSDT", "BINANCE.UM", "SWAP",
@@ -253,6 +271,41 @@ class TestPostgresSignalRestorer:
         btc_targets = next(t for i, t in result.items() if i.symbol == "BTCUSDT")
         assert len(btc_targets) == 1
         assert btc_targets[0].target_position_size == 0.5
+
+    def test_targets_use_injected_run_id_without_fallback_query(self, mock_lookup):
+        conn, cursor = _make_mock_connection()
+        description, rows = self._target_columns_and_row()
+        cursor.description = description
+        cursor.fetchall.return_value = rows
+        restorer = PostgresSignalRestorer(
+            strategy_name="test_strategy", connection=conn, run_id="run-B"
+        )
+        result = restorer.restore_targets()
+        assert len(result) == 1  # BTC target restored
+        # Injected run_id → no separate latest-run lookup.
+        assert not cursor.fetchone.called
+        # The data query is filtered by the injected run_id.
+        params = cursor.execute.call_args[0][1]
+        assert "run-B" in params
+
+    def test_targets_fall_back_to_own_latest_run(self, mock_lookup):
+        conn, cursor = _make_mock_connection()
+        description, rows = self._target_columns_and_row()
+        cursor.description = description
+        cursor.fetchone.return_value = ("run-A",)  # latest_run_id fallback
+        cursor.fetchall.return_value = rows
+        restorer = PostgresSignalRestorer(strategy_name="test_strategy", connection=conn)
+        result = restorer.restore_targets()
+        assert len(result) == 1
+        assert cursor.fetchone.called  # resolved its own latest run
+        params = cursor.execute.call_args[0][1]
+        assert "run-A" in params
+
+    def test_targets_empty_when_no_run(self, mock_lookup):
+        conn, cursor = _make_mock_connection()
+        cursor.fetchone.return_value = None  # no run in window
+        restorer = PostgresSignalRestorer(strategy_name="test_strategy", connection=conn)
+        assert restorer.restore_targets() == {}
 
 
 # --- Balance restorer tests ---

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -178,6 +178,21 @@ class TestPostgresPositionRestorer:
         assert btc_pos.quantity == 1.5
         assert btc_pos.position_avg_price == 90000.0
 
+    def test_uses_injected_run_id(self, mock_lookup):
+        conn, cursor = _make_mock_connection()
+        cursor.fetchall.return_value = [
+            ("BTCUSDT", "BINANCE.UM", "SWAP", 1.0, 100.0, 0.0, 101.0, 0.0, 0.0,
+             datetime(2026, 7, 10, tzinfo=timezone.utc)),
+        ]
+        restorer = PostgresPositionRestorer(
+            strategy_name="test_strategy", connection=conn, run_id="run-B"
+        )
+        result = restorer.restore_positions()
+        assert len(result) == 1
+        assert not cursor.fetchone.called  # injected → no latest-run lookup
+        params = cursor.execute.call_args[0][1]
+        assert "run-B" in params
+
 
 # --- Signal restorer tests ---
 
@@ -339,6 +354,18 @@ class TestPostgresBalanceRestorer:
         assert result[0].locked == 1000.0
         assert result[0].free == 9000.0
         assert result[0].exchange == "BINANCE.UM"
+
+    def test_uses_injected_run_id(self):
+        conn, cursor = _make_mock_connection()
+        cursor.fetchall.return_value = [("BINANCE.UM", "USDT", 1000.0, 0.0)]
+        restorer = PostgresBalanceRestorer(
+            strategy_name="test_strategy", connection=conn, run_id="run-B"
+        )
+        result = restorer.restore_balances()
+        assert len(result) == 1
+        assert not cursor.fetchone.called
+        params = cursor.execute.call_args[0][1]
+        assert "run-B" in params
 
 
 # --- State restorer tests ---


### PR DESCRIPTION
## Problem

On restart, the state restorers rebuilt strategy state from the **latest row per instrument across all history**, with **no `run_id` filter** in the signal/target restorers (Postgres *and* MongoDB). State from arbitrarily old runs leaked into the restore: a delisted / de-universed group (e.g. `TSTUSDC` removed from HyperLiquid) whose only target rows came from an old run got restored on **every** restart, producing a one-legged group that wedged the downstream maker-taker reconciler (`group 'TST' must have exactly 2 legs`).

The position and balance restorers *did* resolve a latest `run_id` — but each independently, in its own table/collection — and the signal/target restorer didn't scope at all.

## Fix (Option B — one shared canonical run)

Scope restore to a **single canonical `run_id` — the previous run — shared across positions, signals, targets, and balance.** A run that logged positions but emitted no targets restores *no* targets, never an older run's. This closes the gap where per-table latest-run resolution could restore positions and targets from different runs.

### Postgres
- **`restorers/utils.py`** — shared helpers `latest_run_id(cur, table, strategy_name, since)` and `canonical_run_id(cur, tables, strategy_name, since)` (single UNION-ALL, most-recent run wins). The duplicated inline latest-run SQL in the position/balance restorers is replaced by these — net reduction in duplicated SQL.
- **`PostgresSignalRestorer`** — the core bug fix: optional `run_id`; `_load_data` adds `AND run_id = %s` to the `ROW_NUMBER()` inner `WHERE`. Latest-N-per-instrument is preserved **within** the resolved run.
- **`PostgresPositionRestorer` / `PostgresBalanceRestorer`** — optional `run_id`; resolve `self.run_id or latest_run_id(...)` via the shared helper.
- **`PostgresStateRestorer.restore_state`** — computes one `canonical_run_id` across the existing state tables and injects it into all three sub-restorers.

### MongoDB (same design, parity)
- **`restorers/utils.py`** — `mongo_latest_run_id(collection, match)` and `mongo_canonical_run_id(sources)` (the Mongo analogues; resolve via `find(...).sort("timestamp", -1).limit(1)`).
- **`MongoDBSignalRestorer`** — the same core bug fix: optional `run_id`; `_load_data_from_mongo` builds a `base_match` (7-day bound), resolves `self.run_id or mongo_latest_run_id(...)`, and adds `run_id` to the aggregation `$match`.
- **`MongoDBPositionRestorer` / `MongoDBBalanceRestorer`** — optional `run_id`; replace their inline latest-run `find` with the helper.
- **`MongoDBStateRestorer.restore_state`** — computes one `mongo_canonical_run_id` across the existing per-type collections and injects it into all four sub-restorer instances.

## Design decisions

- **Backward compatible.** Sub-restorers take an optional `run_id`: injected → filter to it (the shared-run path); omitted → fall back to their own table/collection's latest run (standalone use, existing tests) — which also makes standalone signal/target restore run-scoped for the first time.
- **7-day lookback** applied consistently, so a bot down longer than the window restores nothing rather than resurrecting very stale state. Postgres uses tz-aware `datetime.now(timezone.utc)`; MongoDB uses naive `datetime.utcnow()` to match the naive-UTC timestamps its logger writes.
- **`targets` is included in the canonical-resolution set** even though it's not in `required_suffixes`, so a targets-only run still counts.
- **Signals are intentionally not re-persisted on restart** (unlike targets, which chain-hop via `save_targets`). A code comment in `processing._restore_tracker_and_gatherer_state` documents this: restore is run-scoped, and a tracker that ever implements `restore_position_from_signals` (currently a no-op everywhere) should mirror the `save_targets` chain-hop with `save_signals` rather than widen restore across runs.

## Tests

- `tests/qubx/test_postgres.py` (mocked-cursor): signal/target run-scoping (injected `run_id` lands in params and skips fallback; fallback still resolves own latest; no-run → empty); position/balance injected run; state `test_injects_canonical_run_into_all_sub_restorers` (spies on sub-restorer construction — **verified RED against pre-fix `state.py`**).
- `tests/qubx/restorers/test_restorers.py` (`TestMongoRunScoping`, 13 mongomock tests): helper resolution; each Mongo restorer scopes to the latest run and honors an injected run; the signal test excludes a de-universed instrument's older-run doc (**would fail against the pre-fix unfiltered query**); state flat-previous-run → empty targets; canonical run injected into all four sub-restorers.

Full restorer suite green; the one `test_postgres.py::test_factory_registration` failure is a pre-existing `ccxt` `ModuleNotFoundError` in an unrelated logger test — predates this branch.

## Follow-ups (optional, not blocking)

- Minor observability: `MongoDBSignalRestorer` could log the resolved `run_id` (position/balance/state already do).
- Minor: the two `mongo_*_run_id` helpers share a `find().sort().limit(1)` snippet that could be factored.

Spec + plan: `docs/superpowers/specs/2026-07-10-restorer-run-scoping-design.md`, `docs/superpowers/plans/2026-07-10-restorer-run-scoping.md`.