### PR TITLE
feat(gathering): add suspend/resume/is_suspended to IPositionGathering

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1535,6 +1535,20 @@ class IPositionGathering:
         """
         pass
 
+    def suspend(self, ctx: IStrategyContext) -> None:
+        """Suspend the gatherer — stop reconciling/re-quoting and drop pending targets.
+        Used by an operator kill-switch (panic). Default no-op."""
+        ...
+
+    def resume(self, ctx: IStrategyContext) -> None:
+        """Resume a previously suspended gatherer. Default no-op."""
+        ...
+
+    @property
+    def is_suspended(self) -> bool:
+        """True when the gatherer is suspended (not reconciling). Default False."""
+        return False
+
 
 class IPositionSizer:
     """Interface for calculating target positions from signals."""

--- a/tests/qubx/core/test_position_gathering_suspend.py
+++ b/tests/qubx/core/test_position_gathering_suspend.py
@@ -1,0 +1,16 @@
+from unittest.mock import Mock
+
+from qubx.core.interfaces import IPositionGathering
+
+
+def test_default_gatherer_is_not_suspended():
+    g = IPositionGathering()
+    assert g.is_suspended is False
+
+
+def test_default_suspend_resume_are_noops():
+    g = IPositionGathering()
+    ctx = Mock()
+    g.suspend(ctx)  # must not raise
+    g.resume(ctx)  # must not raise
+    assert g.is_suspended is False


### PR DESCRIPTION
## What

Adds three default **no-op** members to the `IPositionGathering` base class:

- `suspend(self, ctx) -> None` — default no-op
- `resume(self, ctx) -> None` — default no-op
- `is_suspended` — property, default `False`

## Why

First of a three-repo change (qubx → quantkit → frab) that fixes a live funding-arb incident where a `panic` action could not flatten positions because the maker-taker execution layer has no way to be halted. These interface hooks let a concrete gatherer (quantkit `MakerTakerGatherer`) implement an operator kill-switch: stop reconciling/re-quoting and drop pending targets. `SimplePositionGatherer` and any other gatherer inherit the harmless no-ops.

Purely additive — matches the existing default-no-op style of sibling methods (`on_order`, `on_position_change`, `restore_from_target_positions`). No existing behavior changes.

## Test

`tests/qubx/core/test_position_gathering_suspend.py` — asserts `is_suspended` defaults to `False` and `suspend`/`resume` are callable no-ops. 2 passed.
