### PR TITLE
fix(ci): next-version.sh dropped last commit in range (squash feat PRs patch-bumped)

### DIFF
--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -68,7 +68,9 @@ elif [ "$CHANNEL" = "stable" ]; then
         if echo "$msg" | grep -qE '^feat(\(.+\))?:'; then
             HAS_FEAT=true
         fi
-    done < <(git log "${LATEST_STABLE}..HEAD" --pretty=format:"%s" 2>/dev/null)
+        # tformat (not format) terminates every line — format omits the trailing
+        # newline, so `while read` drops the last commit (the whole range for a squash merge).
+    done < <(git log "${LATEST_STABLE}..HEAD" --pretty=tformat:"%s" 2>/dev/null)
 
     if [ "$HAS_BREAKING" = true ]; then
         MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0


### PR DESCRIPTION
## Problem

`scripts/next-version.sh` (stable channel) has **never** honored `feat:`/breaking commits on a squash-merged PR — every release patch-bumps regardless.

The bump-type detection loops:
```bash
while IFS= read -r msg; do … done < <(git log "$LATEST_STABLE..HEAD" --pretty=format:"%s")
```
`--pretty=format:` omits the trailing newline on the **last** line, and bash `while read` does not run the loop body for a final line with no newline. So the **oldest commit in the range is always dropped**. A squash merge is a single commit → it *is* that last line → always dropped → `HAS_FEAT`/`HAS_BREAKING` stay false → patch bump.

## Evidence

- PR #333 (`feat(restorers): …`) released as **v1.11.6** instead of v1.12.0.
- v1.11.3 (from `feat(charting)` #331) and v1.11.4 (from `feat:` #330) were also features that only patch-bumped.

## Fix

`--pretty=format:"%s"` → `--pretty=tformat:"%s"` (tformat terminates every line, incl. the last).

Verified against the live tree (latest stable `v1.11.6`, `origin/main` = the `feat(gathering)` #334 squash commit):

```
old (format):   v1.11.7   # feat dropped → patch
fixed (tformat): v1.12.0  # feat detected → minor
```

Dev channel is unaffected (it doesn't scan commit types).
