### PR TITLE
feat(core): position episodes — per-open P&L/funding/commission baselines

### DIFF
--- a/docs/specs/2026-07-21-position-episodes-design.md
+++ b/docs/specs/2026-07-21-position-episodes-design.md
@@ -1,0 +1,94 @@
+# Position Episodes — Design
+
+- **Date:** 2026-07-21
+- **Status:** Draft (pending approval)
+- **Repo:** `Qubx` (core). Downstream consumer: `frab` (separate PR — pair-level `*_current` P&L from leg episodes; retires its tick-sampled baseline map).
+- **Branch:** `feat/position-episodes` (off `main`)
+
+## Goal
+
+`Position` accumulators (`r_pnl`, `commissions`, `cumulative_funding`) are **lifetime** values — they survive closes and restarts by design. Strategies and dashboards, however, routinely need P&L **scoped to the currently open position**: "what has this position earned since it was opened", including its own entry costs.
+
+Today the only way to get that is strategy-side baseline sampling (frab stamps baselines on a 5 s scheduler tick, up to 5 s *after* the opening fills — so entry commissions, the crossed spread, and any funding settle inside the window leak into the baseline). This can never be exact.
+
+Fix it where the truth lives: the `Position` itself tracks **episodes** — the span from one flat→open transition to the next return to flat — by stamping baselines synchronously in the deal-processing path.
+
+## Concept
+
+An **episode** starts when a flat position becomes non-flat and ends when it returns to flat. "Flat" is qubx's existing canonical predicate — `abs(quantity) < instrument.lot_size` — the same test used by `is_open()` and by `update_position`'s full-close snap (which zeroes quantity and avg price exactly). No new epsilon is introduced; sub-lot dust is already flat everywhere in qubx, and a full close lands on exact `0.0`. This satisfies the "episode ends at exact zero" decision without inventing a second flatness definition.
+
+Episodes are a **view over the lifetime accumulators** — none of the existing fields change meaning.
+
+## New `Position` state (4 fields)
+
+```python
+episode_start_time: dt_64 = NaT      # stamp of the opening deal
+r_pnl_at_open: float = 0.0
+commissions_at_open: float = 0.0
+cumulative_funding_at_open: float = 0.0
+```
+
+Defaults make legacy state degrade gracefully: with zero baselines, episode accessors equal the lifetime values — exactly today's behavior.
+
+## New accessors
+
+```python
+def episode_pnl(self) -> float:          # total P&L of the current episode:
+    return self.pnl - self.r_pnl_at_open #   realized-since-open + unrealized + funding
+                                         #   (pnl == r_pnl at the stamp instant, position flat)
+def episode_funding(self) -> float:
+    return self.cumulative_funding - self.cumulative_funding_at_open
+
+def episode_commissions(self) -> float:
+    return self.commissions - self.commissions_at_open
+
+def episode_price_pnl(self) -> float:    # excludes funding (mirrors get_total_price_pnl)
+    return self.episode_pnl() - self.episode_funding()
+
+def episode_net_pnl(self) -> float:      # the "honest" number: costs included
+    return self.episode_pnl() - self.episode_commissions()
+```
+
+`pnl`'s existing convention (includes funding via `r_pnl`, excludes commissions) carries over unchanged; `episode_net_pnl` is the all-in figure. A fresh entry honestly starts at ≈ −(entry fees + crossed spread) — intended.
+
+## Stamping semantics (single mutation path: `Position.update_position`)
+
+`update_position` already decomposes every deal into `qty_closing` / `qty_opening` and is the sole size-mutation path for both live and simulation — episodes work in backtests for free.
+
+1. **Flat → open** (`not self.is_open()` before the deal, non-flat after): stamp all four fields from the **pre-deal** accumulator values (plus the deal timestamp) — the opening deal's own fee and any crossed spread land *inside* the episode.
+2. **Partial close / add** (no flat crossing): no stamping. Realized P&L from trims accrues inside the episode; `position_avg_price` adjusts on adds as today.
+3. **Full close** (existing snap to exact zero): no stamping; the episode's final values remain readable via the accessors until the next open (useful for "last episode" reporting).
+4. **Sign flip through zero in one deal** (`qty_closing` and `qty_opening` both non-zero with direction change): the closing portion's `deal_pnl` and a **pro-rata share of the deal fee** (by `|qty_closing| : |qty_opening|`) belong to the *old* episode; the new baselines are stamped after applying those and before the opening portion.
+5. **`realize_only=True`** (stale-deal recovery — books P&L/fee without size change): never stamps; deltas flow into the current episode's lifetime accumulators, which is the correct recovery semantic.
+6. **`reconcile_size`** (authoritative venue snapshot): if it takes a flat position to non-flat (first-connect recovery of a pre-existing position), stamp an episode at the current accumulator values — "episode starts now", the honest lower bound when the true opening was never observed.
+7. **`apply_funding_payment`**: unchanged. Settles booked while flat land *before* the next baseline stamp and are thus attributed to the closed episode (correct). A late settle arriving after a re-open is attributed to the new episode — known, accepted, documented (rare: requires close + settle-lag + reopen inside one funding interval).
+8. **`flatten()`** (delisted-market reconcile): ends the episode by the flat predicate; accumulators preserved as today.
+9. **`reset()`**: clears the four fields (as it clears everything). **`reset_by_position`**: copies them.
+
+## Persistence & restore
+
+Episode fields ride the same channel as `cumulative_funding`:
+
+- **`core/loggers.py`** position record: add `episode_start_time`, `realized_pnl_at_open_quoted`, `commissions_at_open_quoted`, `funding_at_open_quoted` alongside the existing `realized_pnl_quoted` / `commissions_quoted` / `funding_pnl_quoted`.
+- **`restorers/position.py`** — all three `IPositionRestorer` implementations (Csv, MongoDB, Postgres) read them back. **Migration:** rows written by an older qubx lack the fields → restorer stamps episode-at-restore (current accumulators, `episode_start_time = restore time`) — identical to today's behavior, self-heals when the position next turns over.
+
+## What downstream gets (context, not in this PR)
+
+frab: `funding_pnl_current = Σ leg.episode_funding()`, `net_pnl_current = Σ leg.episode_net_pnl()`; pair entry time = earliest leg `episode_start_time`; the persisted `frab_entries` baseline map dies (entry_time optionally retained for the pair-level notion). Dashboard flips its P&L columns to the `_current` values.
+
+## Non-goals
+
+- No changes to lifetime accumulator semantics, `AccountState`, or margin math.
+- No multi-episode history on the object (one current episode; history is the position log's job).
+- No pair/portfolio aggregation in core (strategy concern).
+- No epsilon-flat configuration.
+
+## Testing
+
+- **Unit (`Position`)**: open-from-flat stamps pre-deal values (entry fee inside episode); partial trim/add keeps baselines; full close preserves final episode values; reopen re-stamps; sign-flip splits deal_pnl and pro-rates fee between episodes; funding settle while flat attributed to old episode; `realize_only` doesn't stamp; `reconcile_size` flat→open stamps at-now; `reset`/`reset_by_position`/`flatten` behaviors; legacy zero-baseline degradation.
+- **Restorer round-trip**: log → restore reproduces episode fields; legacy rows (fields absent) stamp episode-at-restore.
+- **Simulation integration**: a scripted backtest (open → funding → trim → close → reopen) asserts episode accessors at each step.
+
+## Rollout
+
+Additive, non-breaking. Qubx PR to `main` → CI releases a stable version to PyPI → frab repins in its own PR (already sequenced) → xrelease → user-controlled bot restart. No coordination hazard: until frab consumes the accessors, nothing reads them.

--- a/docs/specs/2026-07-21-position-episodes-impl.md
+++ b/docs/specs/2026-07-21-position-episodes-impl.md
@@ -1,0 +1,140 @@
+# Position Episodes — Implementation Spec
+
+- **Date:** 2026-07-21
+- **Status:** Draft (design approved: [2026-07-21-position-episodes-design.md](2026-07-21-position-episodes-design.md))
+- **Branch:** `feat/position-episodes` off `main`
+- **Touched files:** `src/qubx/core/basics.py`, `src/qubx/core/loggers.py`, `src/qubx/core/account_manager/state.py`, `src/qubx/restorers/position.py`, new `tests/qubx/core/test_position_episodes.py`
+
+## 1. `Position` (basics.py)
+
+### 1.1 New state (class attrs, near the funding block at ~line 931)
+
+```python
+# episode tracking — baselines stamped at the last flat→open transition
+episode_start_time: dt_64 = np.datetime64("NaT")
+r_pnl_at_open: float = 0.0
+commissions_at_open: float = 0.0
+cumulative_funding_at_open: float = 0.0
+```
+
+Zero defaults = legacy degradation (episode accessors equal lifetime values).
+
+### 1.2 `__init__` (line ~939)
+
+Add optional kwargs after the existing accumulators:
+
+```python
+episode_start_time: dt_64 | None = None,
+r_pnl_at_open: float | None = None,
+commissions_at_open: float | None = None,
+cumulative_funding_at_open: float | None = None,
+```
+
+After the existing accumulator assignment and the `quantity != 0` block:
+- If all four kwargs provided → assign verbatim (restorer round-trip path).
+- Else if the position is constructed **open** (`quantity != 0.0`) → stamp episode-at-init: baselines = the supplied lifetime accumulators, `episode_start_time = episode_start_time or NaT` (restorers pass restore time; NaT means "opening never observed"). A flat construction leaves the zero defaults.
+
+### 1.3 Accessors (next to `get_realized_price_pnl`, ~line 1221)
+
+Exactly the five methods from the design doc: `episode_pnl`, `episode_funding`, `episode_commissions`, `episode_price_pnl`, `episode_net_pnl`. One-line docstrings; `episode_pnl = self.pnl - self.r_pnl_at_open`.
+
+### 1.4 `update_position` ordering refactor (line ~1071)
+
+Current order: compute `qty_closing`/`qty_opening` → deal_pnl → (realize_only early-return) → size/avg mutation → `r_pnl += deal_pnl` (once, line 1135) → `update_market_price` → `commissions += fee` (once, line 1141). Restructure the accumulator application so stamping can sit between the closing and opening halves:
+
+```python
+was_open = self.is_open()                       # BEFORE any mutation
+...existing qty_closing / qty_opening / deal_pnl computation...
+...realize_only early-return UNCHANGED (never stamps)...
+
+# fee attribution: pro-rata by quantity when a deal both closes and opens
+#   (sign flip); otherwise the whole fee goes to the single side.
+abs_c, abs_o = abs(qty_closing), abs(qty_opening)
+fee_closing = fee_amount * abs_c / (abs_c + abs_o) if (abs_c and abs_o) else (fee_amount if abs_c and not abs_o else 0.0)
+fee_opening = fee_amount - fee_closing
+
+...existing closing-half size/avg mutation...
+self.r_pnl += deal_pnl / conversion_rate        # closing realization → OLD episode
+self.commissions += fee_closing / conversion_rate
+
+opens_episode = (not was_open and not np.isclose(qty_opening, 0.0)) \
+                or (abs_c and abs_o)            # flip always re-stamps
+if opens_episode:
+    self.episode_start_time = <deal timestamp as dt_64>   # same normalization as update_market_price
+    self.r_pnl_at_open = self.r_pnl
+    self.commissions_at_open = self.commissions
+    self.cumulative_funding_at_open = self.cumulative_funding
+
+...existing opening-half avg-price mutation...
+self.quantity = position; self.position_avg_price_funds = ...
+self.commissions += fee_opening / conversion_rate
+self.update_market_price(...)
+```
+
+Return value `(deal_pnl, comms)` must remain the total fee in funds currency (`(fee_closing + fee_opening) / conversion_rate`) — callers (`AccountState`, sim accounting) treat it as the whole deal's commission; verify against every call site of `update_position`/`change_position_by`/`update_position_by_deal` before changing anything about the return.
+
+Notes:
+- Sub-lot-dust reopen (`was_open` False but `quantity != 0`, same sign): no `qty_closing`, plain stamp-then-open — dust's residual value rides into the new episode via avg-price averaging, which is the existing behavior; only the *baselines* are new.
+- Pure close (`qty_opening ≈ 0`): no stamp; whole fee = `fee_closing` → old episode.
+- `update_market_price` call stays last, as today.
+
+### 1.5 Lifecycle methods
+
+- `reset()` (~line 961): clear the four fields (NaT / 0.0).
+- `reset_by_position` (~line 1008): copy the four fields.
+- `flatten()` (~line 989): **no change** — comment noting the episode ends via the flat predicate and final values stay readable.
+- `reconcile_size` (~line 1032): add keyword-only `timestamp: dt_64 | None = None`. If the position was flat (`not is_open()` pre-call) and the reconciled quantity is open → stamp episode from current accumulators with `episode_start_time = timestamp if timestamp is not None else self.last_update_time`. Caller update in `account_manager/state.py:423`: pass the venue snapshot's timestamp (whatever field the surrounding reconcile code already uses for staleness ordering — read the local code, don't guess the field name).
+- `apply_funding_payment`: no change.
+
+## 2. Position log record (loggers.py)
+
+Both position-record emit sites (~line 112 and ~line 152 — the per-position record and the batch/portfolio variant; locate by the existing `funding_pnl_quoted` key) gain:
+
+```python
+"episode_start_time": <ISO or None if NaT>,
+"realized_pnl_at_open_quoted": position.r_pnl_at_open,
+"commissions_at_open_quoted": position.commissions_at_open,
+"funding_at_open_quoted": position.cumulative_funding_at_open,
+```
+
+Match the surrounding None/NaN handling style exactly (see how `last_funding_time`-adjacent fields serialize, if any; otherwise mirror `funding_pnl_quoted`).
+
+## 3. Restorers (restorers/position.py)
+
+All three (`CsvPositionRestorer`, `MongoDBPositionRestorer`, `PostgresPositionRestorer`): read the four fields from the record with `.get(..., None)` and pass them to `Position(...)`. When absent (legacy rows) pass `None` for the baselines and the **restore time** as `episode_start_time` — `__init__`'s episode-at-init path then stamps baselines from the restored accumulators. When present, round-trip verbatim. Postgres: check whether the position log table schema is column-typed or JSONB — if columns, the write side (postgres logger under `src/qubx/loggers/postgres.py`) and any DDL/migration for the log table must gain the four columns too; investigate before editing.
+
+## 4. Tests (`tests/qubx/core/test_position_episodes.py`, new)
+
+Model fixtures on the existing `basics_test.py` / `test_position_funding.py` style. Cases (one test each, names matching):
+
+1. `test_open_from_flat_stamps_pre_deal` — entry fee lands inside episode; `episode_net_pnl ≈ -fee` right after open.
+2. `test_partial_trim_and_add_keep_baselines`.
+3. `test_full_close_preserves_final_episode` — accessors still report the closed episode.
+4. `test_reopen_restamps`.
+5. `test_sign_flip_splits_pnl_and_fee` — closing pnl + pro-rata fee in old episode; new episode starts at ≈ −fee_opening.
+6. `test_funding_while_flat_attributed_to_old_episode` — settle after close, then reopen: new `episode_funding() == 0`.
+7. `test_realize_only_never_stamps`.
+8. `test_reconcile_size_flat_to_open_stamps_at_now`.
+9. `test_reset_clears_reset_by_position_copies_flatten_keeps`.
+10. `test_legacy_zero_baselines_degrade_to_lifetime`.
+11. `test_constructor_open_position_stamps_episode_at_init` (with and without explicit episode kwargs).
+12. Restorer round-trip: extend the existing restorer tests (find them under `tests/`) — new fields round-trip; legacy record (fields absent) → episode-at-restore.
+13. Simulation integration: scripted mini-backtest (open → funding settle → trim → close → reopen) asserting accessor values at each step — follow the existing sim-test harness patterns (look at how `test_position_funding.py` drives deals/settles).
+
+## 5. Gates
+
+- `uv run pytest tests/qubx/core -q` plus the full suite the repo's CI runs (`just test` if defined, else `uv run pytest`), and the repo linter (`just style-check` / ruff per config). Cython build untouched — no rebuild concerns.
+- Grep-verify: every constructor call of `Position(` in src/ still type-checks with the new optional kwargs (they're keyword-optional — no call-site churn expected).
+
+## 6. Subagent plan
+
+| Stage | Agent | Model | Scope |
+|---|---|---|---|
+| Implement | 1 | opus | Everything above in one pass — the change is small but tightly coupled (ordering refactor + persistence + tests); splitting it invites seam bugs |
+| Adversarial review | 1 | opus | Refute correctness of: fee pro-rata vs return-value contract, stamping order vs `realize_only`, dust/flip edges, restorer legacy path, no behavioral change to lifetime accumulators (diff every existing test expectation) |
+
+Main loop: commit, run full gates, author the PR to `dev`.
+
+## 7. Rollout
+
+PR → `main` → CI releases a stable wheel to PyPI automatically. frab repin + consumption is the already-sequenced separate PR (do not start it until the new qubx version exists — per ecosystem rule, wait for CI to finish before pinning downstream).

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -420,7 +420,9 @@ class AccountState:
                 f"[{self.exchange}] reconcile: position <y>{snapshot.instrument}</y> from snapshot -> "
                 f"size {existing.quantity}->{snapshot.quantity} avg {existing.position_avg_price}->{snapshot.position_avg_price}"
             )
-            existing.reconcile_size(snapshot.quantity, snapshot.position_avg_price)
+            existing.reconcile_size(
+                snapshot.quantity, snapshot.position_avg_price, timestamp=snapshot.last_update_time
+            )
 
         # external margins first, so the mark refresh below skips recalculating them
         if snapshot._maint_margin_external:

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -20,6 +20,21 @@ from qubx.utils.time import to_timedelta
 dt_64 = np.datetime64
 td_64 = np.timedelta64
 
+
+def _as_dt64_or_nat(value: Any) -> "dt_64":
+    """Normalize an arbitrary timestamp-like value (str / int / datetime / datetime64 / None) to a
+    nanosecond ``datetime64``. ``None`` and unparseable / NaT-like values become ``NaT``."""
+    if value is None:
+        return np.datetime64("NaT")
+    if isinstance(value, np.datetime64):
+        return value if not np.isnat(value) else np.datetime64("NaT")
+    try:
+        ts = pd.Timestamp(value)
+    except (ValueError, TypeError):
+        return np.datetime64("NaT")
+    return np.datetime64("NaT") if pd.isna(ts) else ts.asm8
+
+
 OPTION_FILL_AT_SIGNAL_PRICE = "fill_at_signal_price"
 OPTION_SIGNAL_PRICE = "signal_price"
 OPTION_SKIP_PRICE_CROSS_CONTROL = "skip_price_cross_control"
@@ -932,6 +947,15 @@ class Position:
     cumulative_funding: float = 0.0  # cumulative funding paid (negative) or received (positive)
     last_funding_time: dt_64 = np.datetime64("NaT")  # last funding payment time
 
+    # episode tracking - baselines stamped at the last flat->open transition.
+    # An episode is the span from one flat->open transition to the next return to flat.
+    # These are a view over the lifetime accumulators (r_pnl / commissions / cumulative_funding):
+    # with zero baselines the episode accessors equal the lifetime values (legacy degradation).
+    episode_start_time: dt_64 = np.datetime64("NaT")  # stamp of the opening deal
+    r_pnl_at_open: float = 0.0
+    commissions_at_open: float = 0.0
+    cumulative_funding_at_open: float = 0.0
+
     # - helpers for position processing
     _qty_multiplier: float = 1.0
     __pos_incr_qty: float = 0
@@ -944,6 +968,10 @@ class Position:
         r_pnl: float = 0.0,
         cumulative_funding: float = 0.0,
         commissions: float = 0.0,
+        episode_start_time: dt_64 | str | int | float | None = None,
+        r_pnl_at_open: float | None = None,
+        commissions_at_open: float | None = None,
+        cumulative_funding_at_open: float | None = None,
     ) -> None:
         self.instrument = instrument
 
@@ -957,6 +985,27 @@ class Position:
             self.quantity = quantity
             self.position_avg_price = pos_average_price
             self.__pos_incr_qty = abs(quantity)
+
+        # - episode baselines
+        # Round-trip path (restorer): the three at-open baselines are supplied -> assign verbatim
+        # (episode_start_time may legitimately be NaT/None, so we key off the baselines, not the time).
+        # Episode-at-init path: constructed open with baselines absent (legacy row or bare open
+        # construction) -> stamp the episode from the supplied lifetime accumulators. `episode_start_time`
+        # is the restore time when provided, else NaT ("opening never observed"). Flat construction keeps
+        # the zero defaults set by reset().
+        _baselines_provided = (
+            r_pnl_at_open is not None and commissions_at_open is not None and cumulative_funding_at_open is not None
+        )
+        if _baselines_provided:
+            self.episode_start_time = _as_dt64_or_nat(episode_start_time)
+            self.r_pnl_at_open = r_pnl_at_open
+            self.commissions_at_open = commissions_at_open
+            self.cumulative_funding_at_open = cumulative_funding_at_open
+        elif quantity != 0.0:
+            self.episode_start_time = _as_dt64_or_nat(episode_start_time)
+            self.r_pnl_at_open = self.r_pnl
+            self.commissions_at_open = self.commissions
+            self.cumulative_funding_at_open = self.cumulative_funding
 
     def reset(self) -> None:
         """
@@ -983,6 +1032,10 @@ class Position:
         self.max_notional = None
         self.cumulative_funding = 0.0
         self.last_funding_time = np.datetime64("NaT")  # type: ignore
+        self.episode_start_time = np.datetime64("NaT")  # type: ignore
+        self.r_pnl_at_open = 0.0
+        self.commissions_at_open = 0.0
+        self.cumulative_funding_at_open = 0.0
         self.__pos_incr_qty = 0
         self._qty_multiplier = self.instrument.quantity_multiplier
 
@@ -996,6 +1049,10 @@ class Position:
         exchange (already cash-settled) we cannot place a closing order, so we
         reconcile the in-memory position to flat. Unlike reset(), this preserves
         r_pnl so the record stays identical to a normally-closed position.
+
+        Episodes: no explicit change here. Going flat ends the current episode via the
+        canonical flat predicate (``abs(quantity) < lot_size``); the episode baselines are
+        left untouched so the closed episode's final values stay readable via the accessors.
         """
         self.quantity = 0.0
         self.market_value = 0.0
@@ -1027,16 +1084,32 @@ class Position:
         self.max_notional = pos.max_notional
         self.cumulative_funding = pos.cumulative_funding
         self.last_funding_time = pos.last_funding_time if hasattr(pos, "last_funding_time") else np.datetime64("NaT")
+        self.episode_start_time = getattr(pos, "episode_start_time", np.datetime64("NaT"))
+        self.r_pnl_at_open = getattr(pos, "r_pnl_at_open", 0.0)
+        self.commissions_at_open = getattr(pos, "commissions_at_open", 0.0)
+        self.cumulative_funding_at_open = getattr(pos, "cumulative_funding_at_open", 0.0)
         self.__pos_incr_qty = pos.__pos_incr_qty
 
-    def reconcile_size(self, quantity: float, avg_price: float) -> None:
+    def reconcile_size(self, quantity: float, avg_price: float, *, timestamp: dt_64 | None = None) -> None:
         """Authoritative size/avg-price correction (venue snapshot reconcile). Touches
         sizing fields only — accumulated accounting (r_pnl, commissions, funding) is
-        locally owned and must survive a snapshot."""
+        locally owned and must survive a snapshot.
+
+        Episodes: if this takes a flat position to open (first-connect recovery of a
+        pre-existing position whose true opening was never observed), stamp an episode
+        from the *current* accumulators — the honest lower bound, "episode starts now".
+        ``timestamp`` is the venue snapshot's time; falls back to ``last_update_time``.
+        """
+        was_open = self.is_open()
         self.quantity = quantity
         self.position_avg_price = avg_price
         self.position_avg_price_funds = avg_price  # conversion seam is fixed at 1.0 (AccountState.conversion_rate)
         self.__pos_incr_qty = abs(quantity)
+        if not was_open and self.is_open():
+            self.episode_start_time = timestamp if timestamp is not None else self.last_update_time
+            self.r_pnl_at_open = self.r_pnl
+            self.commissions_at_open = self.commissions
+            self.cumulative_funding_at_open = self.cumulative_funding
 
     @property
     def notional_value(self) -> float:
@@ -1085,6 +1158,9 @@ class Position:
         comms = 0
 
         if quantity != position:
+            # - whether the position is open *before* this deal (drives episode stamping below)
+            was_open = self.is_open()
+
             pos_change = position - quantity
             direction = np.sign(pos_change)
             prev_direction = np.sign(quantity)
@@ -1103,8 +1179,24 @@ class Position:
                 self.commissions += comms
                 return deal_pnl, comms
 
+            # - use the same flatness predicate the halves below use, so episode stamping / fee
+            #   attribution never disagree with the size mutation about which halves are present
+            has_closing = not np.isclose(qty_closing, 0.0)
+            has_opening = not np.isclose(qty_opening, 0.0)
+
+            # - fee attribution: when a single deal both closes and opens (a sign flip) the fee is split
+            #   pro-rata by |closing| : |opening|; otherwise the whole fee goes to the single side present.
+            abs_c, abs_o = abs(qty_closing), abs(qty_opening)
+            if has_closing and has_opening:
+                fee_closing = fee_amount * abs_c / (abs_c + abs_o)
+            elif has_closing:
+                fee_closing = fee_amount
+            else:
+                fee_closing = 0.0
+            fee_opening = fee_amount - fee_closing
+
             # - apply the realized close to the size
-            if not np.isclose(qty_closing, 0.0):
+            if has_closing:
                 self.__pos_incr_qty -= abs(qty_closing)
                 quantity += qty_closing
 
@@ -1116,7 +1208,7 @@ class Position:
                     self.__pos_incr_qty = 0
 
             # - if it has something to add to position let's update price and cost
-            if not np.isclose(qty_opening, 0.0):
+            if has_opening:
                 _abs_qty_open = abs(qty_opening)
 
                 pos_avg_price_raw = (_abs_qty_open * exec_price + self.__pos_incr_qty * self.position_avg_price) / (
@@ -1131,15 +1223,29 @@ class Position:
             self.position_avg_price_funds = self.position_avg_price / conversion_rate
             self.quantity = position
 
-            # - convert PnL to fund currency
+            # - the closing realization and its share of the fee belong to the OLD episode: book them
+            #   into the lifetime accumulators *before* stamping the new baselines.
             self.r_pnl += deal_pnl / conversion_rate
+            self.commissions += fee_closing / conversion_rate
+
+            # - episode stamping: a flat->open transition opens an episode; a sign flip always re-stamps
+            #   (its closing half was just attributed to the old episode above). The opening deal's own
+            #   fee (booked below) then lands INSIDE the new episode.
+            opens_episode = (not was_open and has_opening) or (has_closing and has_opening)
+            if opens_episode:
+                self.episode_start_time = _as_dt64_or_nat(time_as_nsec(timestamp))
+                self.r_pnl_at_open = self.r_pnl
+                self.commissions_at_open = self.commissions
+                self.cumulative_funding_at_open = self.cumulative_funding
+
+            # - the opening half's fee lands INSIDE the (possibly new) episode
+            self.commissions += fee_opening / conversion_rate
 
             # - update pnl
             self.update_market_price(time_as_nsec(timestamp), exec_price, conversion_rate)
 
-            # - calculate transaction costs
+            # - total transaction cost of this deal in funds currency (return contract: whole-deal fee)
             comms = fee_amount / conversion_rate
-            self.commissions += comms
 
         return deal_pnl, comms
 
@@ -1229,6 +1335,26 @@ class Position:
         Get the price PnL for this position excluding funding.
         """
         return self.pnl - self.cumulative_funding
+
+    def episode_pnl(self) -> float:
+        """Total P&L of the current episode (realized-since-open + unrealized + funding)."""
+        return self.pnl - self.r_pnl_at_open
+
+    def episode_funding(self) -> float:
+        """Funding accrued within the current episode."""
+        return self.cumulative_funding - self.cumulative_funding_at_open
+
+    def episode_commissions(self) -> float:
+        """Commissions paid within the current episode."""
+        return self.commissions - self.commissions_at_open
+
+    def episode_price_pnl(self) -> float:
+        """Episode P&L excluding funding (mirrors get_total_price_pnl)."""
+        return self.episode_pnl() - self.episode_funding()
+
+    def episode_net_pnl(self) -> float:
+        """Episode P&L with entry/exit costs included (the all-in figure)."""
+        return self.episode_pnl() - self.episode_commissions()
 
     def is_open(self) -> bool:
         return abs(self.quantity) >= self.instrument.lot_size

--- a/src/qubx/core/loggers.py
+++ b/src/qubx/core/loggers.py
@@ -117,6 +117,12 @@ class PositionsDumper(_BaseIntervalDumper):
             "current_price": position.last_update_price,
             "market_value_quoted": position.market_value_funds,
             "commissions_quoted": position.commissions,
+            "episode_start_time": None
+            if np.isnat(position.episode_start_time)
+            else str(position.episode_start_time),
+            "realized_pnl_at_open_quoted": position.r_pnl_at_open,
+            "commissions_at_open_quoted": position.commissions_at_open,
+            "funding_at_open_quoted": position.cumulative_funding_at_open,
         }
 
     def dump(self, interval_start_time: np.datetime64, actual_timestamp: np.datetime64):
@@ -155,6 +161,10 @@ class PortfolioLogger(PositionsDumper):
                 "market_value_quoted": p.market_value_funds,
                 "exchange_time": str(actual_timestamp),
                 "commissions_quoted": p.commissions,
+                "episode_start_time": None if np.isnat(p.episode_start_time) else str(p.episode_start_time),
+                "realized_pnl_at_open_quoted": p.r_pnl_at_open,
+                "commissions_at_open_quoted": p.commissions_at_open,
+                "funding_at_open_quoted": p.cumulative_funding_at_open,
             }
             # Only add funding for SWAP instruments
             if i.market_type == MarketType.SWAP:

--- a/src/qubx/loggers/postgres.py
+++ b/src/qubx/loggers/postgres.py
@@ -24,6 +24,10 @@ _TABLE_SCHEMAS: dict[str, list[tuple[str, str]]] = {
         ("current_price", "DOUBLE PRECISION"),
         ("market_value_quoted", "DOUBLE PRECISION"),
         ("commissions_quoted", "DOUBLE PRECISION"),
+        ("episode_start_time", "TIMESTAMPTZ"),
+        ("realized_pnl_at_open_quoted", "DOUBLE PRECISION"),
+        ("commissions_at_open_quoted", "DOUBLE PRECISION"),
+        ("funding_at_open_quoted", "DOUBLE PRECISION"),
     ],
     "portfolio": [
         ("timestamp", "TIMESTAMPTZ NOT NULL"),
@@ -39,6 +43,10 @@ _TABLE_SCHEMAS: dict[str, list[tuple[str, str]]] = {
         ("exchange_time", "TIMESTAMPTZ"),
         ("commissions_quoted", "DOUBLE PRECISION"),
         ("cumulative_funding", "DOUBLE PRECISION"),
+        ("episode_start_time", "TIMESTAMPTZ"),
+        ("realized_pnl_at_open_quoted", "DOUBLE PRECISION"),
+        ("commissions_at_open_quoted", "DOUBLE PRECISION"),
+        ("funding_at_open_quoted", "DOUBLE PRECISION"),
     ],
     "executions": [
         ("timestamp", "TIMESTAMPTZ NOT NULL"),

--- a/src/qubx/loggers/postgres.py
+++ b/src/qubx/loggers/postgres.py
@@ -155,6 +155,19 @@ class PostgresLogsWriter(LogsWriter):
                             columns=sql.SQL(col_defs),
                         )
                     )
+                    # Additive schema migration: CREATE IF NOT EXISTS is a no-op on a
+                    # pre-existing table, so columns added to _TABLE_SCHEMAS after the
+                    # table was first created would be missing — INSERTs would fail
+                    # (silently dropped by the write path's broad except) and the
+                    # restorer SELECT would error out. ADD COLUMN IF NOT EXISTS is
+                    # idempotent and cheap, and keeps deployed tables self-healing.
+                    for name, col_type in columns:
+                        cur.execute(
+                            sql.SQL("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col} " + col_type).format(
+                                table=sql.Identifier(tname),
+                                col=sql.Identifier(name),
+                            )
+                        )
                     # Index on strategy_name + timestamp for common queries
                     idx_name = f"idx_{tname}_strategy_ts"
                     cur.execute(

--- a/src/qubx/restorers/position.py
+++ b/src/qubx/restorers/position.py
@@ -22,6 +22,29 @@ from qubx.restorers.interfaces import IPositionRestorer
 from qubx.restorers.utils import find_latest_run_folder, latest_run_id, mongo_latest_run_id
 
 
+def _num_or_none(value) -> float | None:
+    """Coerce a restored numeric cell to float, mapping missing / NaN to None (legacy-row signal)."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if f != f else f  # f != f is True only for NaN
+
+
+def _time_or_none(value):
+    """Return the timestamp value, or None when it is missing / NaN / NaT (keeps strings as-is)."""
+    if value is None:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    return value
+
+
 class CsvPositionRestorer(IPositionRestorer):
     """
     Position restorer that reads positions from CSV files.
@@ -122,6 +145,14 @@ class CsvPositionRestorer(IPositionRestorer):
             quantity_col = "quantity" if "quantity" in row else "size"
             price_col = "avg_position_price" if "avg_position_price" in row else "avg_price"
 
+            # - episode baselines (absent on legacy rows -> episode-at-restore stamped by Position.__init__)
+            r_pnl_at_open = _num_or_none(row.get("realized_pnl_at_open_quoted"))
+            commissions_at_open = _num_or_none(row.get("commissions_at_open_quoted"))
+            cumulative_funding_at_open = _num_or_none(row.get("funding_at_open_quoted"))
+            episode_start_time = _time_or_none(row.get("episode_start_time"))
+            if r_pnl_at_open is None or commissions_at_open is None or cumulative_funding_at_open is None:
+                episode_start_time = row["timestamp"]  # restore time
+
             # Create a Position object
             position = Position(
                 instrument=instrument,
@@ -130,6 +161,10 @@ class CsvPositionRestorer(IPositionRestorer):
                 r_pnl=cast(float, row.get("realized_pnl_quoted", row.get("realized_pnl", 0.0))),
                 cumulative_funding=cast(float, row.get("funding_pnl_quoted", 0.0)),
                 commissions=cast(float, row.get("commissions_quoted", 0.0)),
+                episode_start_time=episode_start_time,
+                r_pnl_at_open=r_pnl_at_open,
+                commissions_at_open=commissions_at_open,
+                cumulative_funding_at_open=cumulative_funding_at_open,
             )
 
             timestamp = recognize_time(cast(str, row["timestamp"]))
@@ -228,6 +263,14 @@ class MongoDBPositionRestorer(IPositionRestorer):
                 cumulative_funding = log.get("funding_pnl_quoted", 0.0)
                 commissions = log.get("commissions_quoted", 0.0)
 
+                # - episode baselines (absent on legacy rows -> episode-at-restore in Position.__init__)
+                r_pnl_at_open = _num_or_none(log.get("realized_pnl_at_open_quoted"))
+                commissions_at_open = _num_or_none(log.get("commissions_at_open_quoted"))
+                cumulative_funding_at_open = _num_or_none(log.get("funding_at_open_quoted"))
+                episode_start_time = _time_or_none(log.get("episode_start_time"))
+                if r_pnl_at_open is None or commissions_at_open is None or cumulative_funding_at_open is None:
+                    episode_start_time = log.get("timestamp")  # restore time
+
                 position = Position(
                     instrument=instrument,
                     quantity=cast(float, quantity),
@@ -235,6 +278,10 @@ class MongoDBPositionRestorer(IPositionRestorer):
                     r_pnl=cast(float, r_pnl),
                     cumulative_funding=cast(float, cumulative_funding),
                     commissions=cast(float, commissions),
+                    episode_start_time=episode_start_time,
+                    r_pnl_at_open=r_pnl_at_open,
+                    commissions_at_open=commissions_at_open,
+                    cumulative_funding_at_open=cumulative_funding_at_open,
                 )
 
                 if current_price is not None:
@@ -284,7 +331,9 @@ class PostgresPositionRestorer(IPositionRestorer):
                     sql.SQL(
                         "SELECT DISTINCT ON (symbol, exchange, market_type) "
                         "symbol, exchange, market_type, quantity, avg_position_price, "
-                        "realized_pnl_quoted, current_price, funding_pnl_quoted, commissions_quoted, timestamp "
+                        "realized_pnl_quoted, current_price, funding_pnl_quoted, commissions_quoted, "
+                        "episode_start_time, realized_pnl_at_open_quoted, commissions_at_open_quoted, "
+                        "funding_at_open_quoted, timestamp "
                         "FROM {table} "
                         "WHERE strategy_name = %s AND run_id = %s AND timestamp >= %s "
                         "ORDER BY symbol, exchange, market_type, timestamp DESC"
@@ -294,7 +343,22 @@ class PostgresPositionRestorer(IPositionRestorer):
 
                 positions: dict[Instrument, Position] = {}
                 for log in cur.fetchall():
-                    symbol, exchange, market_type, quantity, avg_price, r_pnl, current_price, funding, commissions, ts = log
+                    (
+                        symbol,
+                        exchange,
+                        market_type,
+                        quantity,
+                        avg_price,
+                        r_pnl,
+                        current_price,
+                        funding,
+                        commissions,
+                        episode_start_time,
+                        r_pnl_at_open,
+                        commissions_at_open,
+                        cumulative_funding_at_open,
+                        ts,
+                    ) = log
 
                     if not (symbol and exchange and market_type):
                         continue
@@ -304,6 +368,14 @@ class PostgresPositionRestorer(IPositionRestorer):
                         logger.warning(f"Instrument not found for {symbol} on {exchange}")
                         continue
 
+                    # - episode baselines (NULL on legacy rows -> episode-at-restore in Position.__init__)
+                    r_pnl_at_open = _num_or_none(r_pnl_at_open)
+                    commissions_at_open = _num_or_none(commissions_at_open)
+                    cumulative_funding_at_open = _num_or_none(cumulative_funding_at_open)
+                    episode_start_time = _time_or_none(episode_start_time)
+                    if r_pnl_at_open is None or commissions_at_open is None or cumulative_funding_at_open is None:
+                        episode_start_time = ts  # restore time
+
                     position = Position(
                         instrument=instrument,
                         quantity=cast(float, quantity or 0.0),
@@ -311,6 +383,10 @@ class PostgresPositionRestorer(IPositionRestorer):
                         r_pnl=cast(float, r_pnl or 0.0),
                         cumulative_funding=cast(float, funding or 0.0),
                         commissions=cast(float, commissions or 0.0),
+                        episode_start_time=episode_start_time,
+                        r_pnl_at_open=r_pnl_at_open,
+                        commissions_at_open=commissions_at_open,
+                        cumulative_funding_at_open=cumulative_funding_at_open,
                     )
 
                     if current_price is not None:

--- a/tests/qubx/core/test_position_episodes.py
+++ b/tests/qubx/core/test_position_episodes.py
@@ -1,0 +1,356 @@
+"""
+Tests for Position "episodes" - the span from one flat->open transition to the next return to flat.
+
+Episodes are a view over the lifetime accumulators (r_pnl / commissions / cumulative_funding): the
+four baseline fields (episode_start_time, r_pnl_at_open, commissions_at_open, cumulative_funding_at_open)
+are stamped synchronously in the deal-processing path so strategies can read P&L scoped to the currently
+open position, entry costs included.
+
+Design: docs/specs/2026-07-21-position-episodes-design.md
+Impl:   docs/specs/2026-07-21-position-episodes-impl.md
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from pytest import approx
+
+from qubx.core.basics import Instrument, MarketType, Position
+from qubx.core.series import time_as_nsec
+
+TIME = lambda x: pd.Timestamp(x).asm8  # noqa: E731
+
+
+@pytest.fixture
+def instr() -> Instrument:
+    return Instrument(
+        symbol="BTCUSDT",
+        market_type=MarketType.SWAP,
+        exchange="binance",
+        base="BTC",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol="BTCUSDT",
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+    )
+
+
+class TestPositionEpisodes:
+    # 1
+    def test_open_from_flat_stamps_pre_deal(self, instr):
+        p = Position(instr)
+        assert not p.is_open()
+
+        t0 = TIME("2025-01-08 00:00:00")
+        p.update_position(t0, position=1.0, exec_price=50000.0, fee_amount=5.0)
+
+        # episode stamped at the opening deal, baselines taken from the PRE-deal accumulators
+        assert p.episode_start_time == t0
+        assert p.r_pnl_at_open == 0.0
+        assert p.commissions_at_open == 0.0  # stamped BEFORE the opening fee is booked
+        assert p.cumulative_funding_at_open == 0.0
+
+        # the entry fee lands inside the episode -> episode_net_pnl ~ -fee right after open
+        assert p.episode_pnl() == approx(0.0)
+        assert p.episode_commissions() == approx(5.0)
+        assert p.episode_net_pnl() == approx(-5.0)
+
+    # 2
+    def test_partial_trim_and_add_keep_baselines(self, instr):
+        p = Position(instr)
+        t0 = TIME("2025-01-08 00:00:00")
+        p.update_position(t0, position=2.0, exec_price=50000.0, fee_amount=4.0)
+
+        start, r_open, c_open, f_open = (
+            p.episode_start_time,
+            p.r_pnl_at_open,
+            p.commissions_at_open,
+            p.cumulative_funding_at_open,
+        )
+
+        # partial trim (same-side reduce) -> no re-stamp
+        p.change_position_by(TIME("2025-01-08 01:00:00"), amount=-1.0, exec_price=51000.0, fee_amount=2.0)
+        assert p.episode_start_time == start
+        assert (p.r_pnl_at_open, p.commissions_at_open, p.cumulative_funding_at_open) == (r_open, c_open, f_open)
+
+        # add (same-side increase) -> no re-stamp
+        p.change_position_by(TIME("2025-01-08 02:00:00"), amount=2.0, exec_price=52000.0, fee_amount=3.0)
+        assert p.episode_start_time == start
+        assert (p.r_pnl_at_open, p.commissions_at_open, p.cumulative_funding_at_open) == (r_open, c_open, f_open)
+
+    # 3
+    def test_full_close_preserves_final_episode(self, instr):
+        p = Position(instr)
+        t0 = TIME("2025-01-08 00:00:00")
+        p.update_position(t0, position=1.0, exec_price=50000.0, fee_amount=5.0)
+
+        # full close (long 1 @ 50000 -> flat @ 51000): +1000 realized
+        p.update_position(TIME("2025-01-08 01:00:00"), position=0.0, exec_price=51000.0, fee_amount=5.0)
+
+        assert not p.is_open()
+        # closed episode remains readable via the accessors (no re-stamp on close)
+        assert p.episode_start_time == t0
+        assert p.r_pnl_at_open == 0.0
+        assert p.commissions_at_open == 0.0
+        assert p.episode_pnl() == approx(1000.0)  # realized since open
+        assert p.episode_commissions() == approx(10.0)  # entry + exit fee
+        assert p.episode_net_pnl() == approx(990.0)
+
+    # 4
+    def test_reopen_restamps(self, instr):
+        p = Position(instr)
+        p.update_position(TIME("2025-01-08 00:00:00"), position=1.0, exec_price=50000.0, fee_amount=5.0)
+        p.update_position(TIME("2025-01-08 01:00:00"), position=0.0, exec_price=51000.0, fee_amount=5.0)
+
+        t_reopen = TIME("2025-01-08 02:00:00")
+        p.update_position(t_reopen, position=1.0, exec_price=52000.0, fee_amount=5.0)
+
+        # new episode: baselines capture everything realized in the closed episode
+        assert p.episode_start_time == t_reopen
+        assert p.r_pnl_at_open == approx(1000.0)  # closed episode's realized rolls into the baseline
+        assert p.commissions_at_open == approx(10.0)  # prior fees excluded from the new episode
+        assert p.episode_pnl() == approx(0.0)
+        assert p.episode_commissions() == approx(5.0)  # only the reopen fee
+        assert p.episode_net_pnl() == approx(-5.0)  # fresh entry honestly starts at -fee
+
+    # 5
+    def test_sign_flip_splits_pnl_and_fee(self, instr):
+        p = Position(instr)
+        p.update_position(TIME("2025-01-08 00:00:00"), position=4.0, exec_price=50000.0, fee_amount=4.0)
+
+        # flip long 4 -> short 2 in one deal @ 51000, total fee 8
+        #   closing half |4|, opening half |2| -> fee_closing = 8 * 4/6, fee_opening = 8 * 2/6
+        t_flip = TIME("2025-01-08 01:00:00")
+        p.update_position(t_flip, position=-2.0, exec_price=51000.0, fee_amount=8.0)
+
+        fee_closing = 8.0 * 4.0 / 6.0
+        fee_opening = 8.0 - fee_closing
+
+        # flip always re-stamps; closing pnl (+4000) and fee_closing belong to the OLD episode (in baselines)
+        assert p.episode_start_time == t_flip
+        assert p.r_pnl_at_open == approx(4000.0)
+        assert p.commissions_at_open == approx(4.0 + fee_closing)  # entry fee + closing share
+        # new (short) episode starts at ~ -fee_opening
+        assert p.episode_pnl() == approx(0.0)
+        assert p.episode_commissions() == approx(fee_opening)
+        assert p.episode_net_pnl() == approx(-fee_opening)
+
+    # 6
+    def test_funding_while_flat_attributed_to_old_episode(self, instr):
+        p = Position(instr)
+        p.update_position(TIME("2025-01-08 00:00:00"), position=1.0, exec_price=50000.0, fee_amount=0.0)
+        start = p.episode_start_time
+
+        # funding accrues DURING the episode -> attributed to it; a mid-episode settle never re-stamps
+        p.apply_funding_payment(TIME("2025-01-08 04:00:00"), -5.0)  # long pays
+        assert p.cumulative_funding == approx(-5.0)
+        assert p.episode_funding() == approx(-5.0)
+        assert p.episode_start_time == start  # book-without-size-change does not stamp
+
+        # close, then settle again while flat: a settlement is account truth even at qty=0, so it books
+        # into the lifetime accumulator and lands (baselines unchanged) in the just-closed episode.
+        p.update_position(TIME("2025-01-08 08:00:00"), position=0.0, exec_price=50000.0, fee_amount=0.0)
+        assert p.apply_funding_payment(TIME("2025-01-08 08:00:01"), -2.0) == -2.0
+        assert p.cumulative_funding == approx(-7.0)
+        assert p.episode_start_time == start  # close + flat settle never stamp
+
+        # reopen -> the prior episode's funding (incl. the while-flat settle) is baked into the baseline;
+        # the new episode's funding starts at 0.
+        t_reopen = TIME("2025-01-08 09:00:00")
+        p.update_position(t_reopen, position=1.0, exec_price=50000.0, fee_amount=0.0)
+        assert p.episode_start_time == t_reopen
+        assert p.cumulative_funding_at_open == approx(-7.0)
+        assert p.episode_funding() == approx(0.0)
+
+    # 7
+    def test_realize_only_never_stamps(self, instr):
+        # realize_only books the closing pnl + fee of a stale deal but leaves size/avg to a snapshot
+        # reconcile (situation II). It must NEVER stamp; the deltas flow into the CURRENT episode's
+        # lifetime accumulators (the correct recovery semantic).
+        p = Position(instr)
+        t0 = TIME("2025-01-08 00:00:00")
+        p.update_position(t0, position=2.0, exec_price=50000.0, fee_amount=4.0)
+
+        start = p.episode_start_time
+        r_open, c_open, f_open = p.r_pnl_at_open, p.commissions_at_open, p.cumulative_funding_at_open
+        prev_qty = p.quantity
+        assert p.episode_commissions() == approx(4.0)
+
+        # recover a stale partial-close deal (1 @ 51000, fee 2) already reflected in the venue size
+        deal_pnl, comms = p.change_position_by(
+            TIME("2025-01-08 01:00:00"), amount=-1.0, exec_price=51000.0, fee_amount=2.0, realize_only=True
+        )
+
+        # size untouched (snapshot owns it), and NO stamp happened
+        assert p.quantity == prev_qty
+        assert p.episode_start_time == start
+        assert (p.r_pnl_at_open, p.commissions_at_open, p.cumulative_funding_at_open) == (r_open, c_open, f_open)
+
+        # the recovered pnl + fee landed inside the current episode's lifetime accumulators
+        assert deal_pnl == approx(1000.0)
+        assert comms == approx(2.0)
+        assert p.r_pnl == approx(1000.0)
+        assert p.episode_commissions() == approx(6.0)  # entry 4 + recovered 2
+
+    # 8
+    def test_reconcile_size_flat_to_open_stamps_at_now(self, instr):
+        # An authoritative venue snapshot that takes a flat position to open (first-connect recovery of
+        # a pre-existing position whose true opening was never observed) stamps an episode "at now" from
+        # the current accumulators.
+        p = Position(instr)
+        assert not p.is_open()
+
+        t_recon = TIME("2025-01-08 12:00:00")
+        p.reconcile_size(0.5, 60000.0, timestamp=t_recon)
+
+        assert p.is_open()
+        assert p.episode_start_time == t_recon
+        assert p.r_pnl_at_open == approx(0.0)
+        assert p.commissions_at_open == approx(0.0)
+        assert p.cumulative_funding_at_open == approx(0.0)
+
+        # a subsequent reconcile that does NOT cross flat->open (open -> resized open) must not re-stamp
+        p.reconcile_size(0.75, 60500.0, timestamp=TIME("2025-01-08 13:00:00"))
+        assert p.episode_start_time == t_recon
+
+    # 9
+    def test_reset_clears_reset_by_position_copies_flatten_keeps(self, instr):
+        # reset() clears the four episode fields
+        p = Position(instr)
+        p.update_position(TIME("2025-01-08 00:00:00"), position=1.0, exec_price=50000.0, fee_amount=5.0)
+        assert not np.isnat(p.episode_start_time)
+        p.reset()
+        assert np.isnat(p.episode_start_time)
+        assert p.r_pnl_at_open == 0.0
+        assert p.commissions_at_open == 0.0
+        assert p.cumulative_funding_at_open == 0.0
+
+        # reset_by_position() copies the four episode fields
+        src = Position(instr)
+        src.update_position(TIME("2025-01-08 00:00:00"), position=2.0, exec_price=50000.0, fee_amount=4.0)
+        dst = Position(instr)
+        dst.reset_by_position(src)
+        assert dst.episode_start_time == src.episode_start_time
+        assert dst.r_pnl_at_open == src.r_pnl_at_open
+        assert dst.commissions_at_open == src.commissions_at_open
+        assert dst.cumulative_funding_at_open == src.cumulative_funding_at_open
+
+        # flatten() ends the episode via the flat predicate but PRESERVES the episode baselines
+        q = Position(instr)
+        t0 = TIME("2025-01-08 00:00:00")
+        q.update_position(t0, position=1.0, exec_price=50000.0, fee_amount=5.0)
+        q.update_market_price(time_as_nsec(TIME("2025-01-08 01:00:00")), 51000.0, 1.0)
+        q.flatten()
+        assert not q.is_open()
+        assert q.episode_start_time == t0  # preserved through the flatten-to-flat
+        assert q.r_pnl_at_open == 0.0
+        assert q.commissions_at_open == 0.0
+
+    # 10
+    def test_legacy_zero_baselines_degrade_to_lifetime(self, instr):
+        # accumulate lifetime state, then force legacy defaults (zero baselines / NaT start)
+        p = Position(instr)
+        p.update_position(TIME("2025-01-08 00:00:00"), position=2.0, exec_price=50000.0, fee_amount=4.0)
+        p.apply_funding_payment(TIME("2025-01-08 04:00:00"), -5.0)
+        p.update_market_price(time_as_nsec(TIME("2025-01-08 05:00:00")), 51000.0, 1.0)
+
+        p.episode_start_time = np.datetime64("NaT")
+        p.r_pnl_at_open = 0.0
+        p.commissions_at_open = 0.0
+        p.cumulative_funding_at_open = 0.0
+
+        # with zero baselines every episode accessor equals its lifetime counterpart
+        assert p.episode_pnl() == approx(p.pnl)
+        assert p.episode_funding() == approx(p.cumulative_funding)
+        assert p.episode_commissions() == approx(p.commissions)
+        assert p.episode_price_pnl() == approx(p.get_total_price_pnl())
+        assert p.episode_net_pnl() == approx(p.pnl - p.commissions)
+
+    # 11
+    def test_constructor_open_position_stamps_episode_at_init(self, instr):
+        # with explicit episode kwargs -> assigned verbatim (restorer round-trip path)
+        est = TIME("2025-01-01 00:00:00")
+        p = Position(
+            instr,
+            quantity=1.0,
+            pos_average_price=50000.0,
+            r_pnl=100.0,
+            cumulative_funding=-5.0,
+            commissions=3.0,
+            episode_start_time=est,
+            r_pnl_at_open=90.0,
+            commissions_at_open=2.0,
+            cumulative_funding_at_open=-4.0,
+        )
+        assert p.episode_start_time == est
+        assert p.r_pnl_at_open == 90.0
+        assert p.commissions_at_open == 2.0
+        assert p.cumulative_funding_at_open == -4.0
+
+        # constructed open WITHOUT episode kwargs -> episode-at-init from the supplied lifetime accumulators
+        p2 = Position(
+            instr, quantity=1.0, pos_average_price=50000.0, r_pnl=100.0, cumulative_funding=-5.0, commissions=3.0
+        )
+        assert np.isnat(p2.episode_start_time)  # opening never observed
+        assert p2.r_pnl_at_open == 100.0
+        assert p2.commissions_at_open == 3.0
+        assert p2.cumulative_funding_at_open == -5.0
+
+        # flat construction leaves the zero defaults
+        p3 = Position(instr)
+        assert np.isnat(p3.episode_start_time)
+        assert p3.r_pnl_at_open == 0.0
+        assert p3.commissions_at_open == 0.0
+        assert p3.cumulative_funding_at_open == 0.0
+
+    # 13
+    def test_simulation_open_funding_trim_close_reopen(self, instr):
+        p = Position(instr)
+
+        # --- open long 2 @ 50000, fee 4 ---
+        t0 = TIME("2025-01-08 00:00:00")
+        p.update_position(t0, position=2.0, exec_price=50000.0, fee_amount=4.0)
+        assert p.episode_start_time == t0
+        assert p.episode_pnl() == approx(0.0)
+        assert p.episode_commissions() == approx(4.0)
+        assert p.episode_net_pnl() == approx(-4.0)
+
+        # --- price moves to 51000 ---
+        p.update_market_price(time_as_nsec(TIME("2025-01-08 00:30:00")), 51000.0, 1.0)
+        assert p.episode_price_pnl() == approx(2000.0)  # 2 * (51000 - 50000)
+        assert p.episode_net_pnl() == approx(1996.0)
+
+        # --- funding settle (long pays): -(2 * 51000 * 0.0001) = -10.2 ---
+        p.apply_funding_payment(TIME("2025-01-08 01:00:00"), -10.2)
+        assert p.episode_funding() == approx(-10.2)
+        assert p.episode_price_pnl() == approx(2000.0)  # price component unchanged
+        assert p.episode_pnl() == approx(1989.8)
+        assert p.episode_start_time == t0  # funding never re-stamps
+
+        # --- trim to long 1 @ 51000, fee 2 (partial close, realizes +1000) ---
+        p.update_position(TIME("2025-01-08 02:00:00"), position=1.0, exec_price=51000.0, fee_amount=2.0)
+        assert p.episode_start_time == t0
+        assert p.episode_commissions() == approx(6.0)
+        assert p.episode_funding() == approx(-10.2)
+        assert p.episode_pnl() == approx(1989.8)  # total episode P&L unaffected by realizing part of it
+
+        # --- full close to 0 @ 52000, fee 2 (realizes +2000 more) ---
+        p.update_position(TIME("2025-01-08 03:00:00"), position=0.0, exec_price=52000.0, fee_amount=2.0)
+        assert not p.is_open()
+        assert p.episode_start_time == t0
+        assert p.episode_commissions() == approx(8.0)
+        assert p.episode_pnl() == approx(2989.8)  # 1000 + 2000 price - 10.2 funding
+        assert p.episode_net_pnl() == approx(2981.8)
+
+        # --- reopen long 1 @ 52000, fee 3 -> fresh episode ---
+        t_reopen = TIME("2025-01-08 04:00:00")
+        p.update_position(t_reopen, position=1.0, exec_price=52000.0, fee_amount=3.0)
+        assert p.episode_start_time == t_reopen
+        assert p.r_pnl_at_open == approx(2989.8)
+        assert p.cumulative_funding_at_open == approx(-10.2)
+        assert p.episode_pnl() == approx(0.0)
+        assert p.episode_funding() == approx(0.0)  # prior funding excluded from the new episode
+        assert p.episode_commissions() == approx(3.0)
+        assert p.episode_net_pnl() == approx(-3.0)

--- a/tests/qubx/restorers/test_restorers.py
+++ b/tests/qubx/restorers/test_restorers.py
@@ -351,6 +351,54 @@ class TestCsvPositionRestorer:
         assert isinstance(btc_position.position_avg_price, float)
         assert btc_position.position_avg_price > 0
 
+    def test_episode_fields_roundtrip_and_legacy(self, mock_lookup):
+        """Episode baselines round-trip through the CSV log; a legacy row (columns absent/NaN) gets
+        episode-at-restore: baselines = restored accumulators, episode_start_time = the row timestamp."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            run_folder = Path(temp_dir) / "run_20250308120000"
+            run_folder.mkdir()
+            ts = "2025-01-08 12:00:00"
+
+            # BTC: full episode fields present -> round-trip verbatim
+            # ETH: episode columns NaN (legacy) -> episode-at-restore
+            df = pd.DataFrame(
+                {
+                    "timestamp": [ts, ts],
+                    "symbol": ["BTCUSDT", "ETHUSDT"],
+                    "exchange": ["BINANCE", "BINANCE"],
+                    "market_type": ["FUTURE", "FUTURE"],
+                    "quantity": [1.0, 2.0],
+                    "avg_position_price": [50000.0, 3000.0],
+                    "realized_pnl_quoted": [100.0, 70.0],
+                    "funding_pnl_quoted": [-5.0, -1.0],
+                    "commissions_quoted": [3.0, 4.0],
+                    "current_price": [50100.0, 3050.0],
+                    "episode_start_time": ["2025-01-01 00:00:00", np.nan],
+                    "realized_pnl_at_open_quoted": [90.0, np.nan],
+                    "commissions_at_open_quoted": [2.0, np.nan],
+                    "funding_at_open_quoted": [-4.0, np.nan],
+                }
+            )
+            df.to_csv(run_folder / "test_strategy_positions.csv", index=False)
+
+            restorer = CsvPositionRestorer(base_dir=temp_dir, file_pattern="*_positions.csv")
+            positions = restorer.restore_positions()
+
+            btc = next(p for i, p in positions.items() if i.symbol == "BTCUSDT")
+            eth = next(p for i, p in positions.items() if i.symbol == "ETHUSDT")
+
+            # BTC: episode fields round-trip verbatim
+            assert btc.episode_start_time == pd.Timestamp("2025-01-01 00:00:00").asm8
+            assert btc.r_pnl_at_open == 90.0
+            assert btc.commissions_at_open == 2.0
+            assert btc.cumulative_funding_at_open == -4.0
+
+            # ETH: legacy -> episode-at-restore (baselines = accumulators, start = row timestamp)
+            assert eth.episode_start_time == pd.Timestamp(ts).asm8
+            assert eth.r_pnl_at_open == 70.0
+            assert eth.commissions_at_open == 4.0
+            assert eth.cumulative_funding_at_open == -1.0
+
 
 class TestMongoDBPositionRestorer:
     """Tests for MongoDB position restorer."""
@@ -411,6 +459,49 @@ class TestMongoDBPositionRestorer:
         assert btc_position is not None
         assert btc_position.position_avg_price > 0
         assert btc_position.quantity > 0
+
+    def test_episode_fields_roundtrip_and_legacy(self):
+        """Episode baselines round-trip through the Mongo log; a legacy doc (fields absent) gets
+        episode-at-restore: baselines = restored accumulators, episode_start_time = the doc timestamp."""
+        mock_client = mongomock.MongoClient(self._mongo_uri)
+        col = mock_client["default_logs_db"]["qubx_logs"]
+        ts = (datetime.now() - timedelta(days=1)).replace(microsecond=0)
+
+        # BTC: full episode fields present -> round-trip verbatim
+        col.insert_one(
+            {
+                "timestamp": ts, "symbol": "BTCUSDT", "exchange": "BINANCE.UM", "market_type": "SWAP",
+                "quantity": 1, "realized_pnl_quoted": 100.0, "avg_position_price": 90000,
+                "funding_pnl_quoted": -5.0, "commissions_quoted": 3.0,
+                "episode_start_time": "2025-01-01T00:00:00", "realized_pnl_at_open_quoted": 90.0,
+                "commissions_at_open_quoted": 2.0, "funding_at_open_quoted": -4.0,
+                "run_id": "run-1", "strategy_name": self._strategy_name, "log_type": "positions",
+            }
+        )
+        # ETH: legacy doc (no episode fields) -> episode-at-restore
+        col.insert_one(
+            {
+                "timestamp": ts, "symbol": "ETHUSDT", "exchange": "BINANCE.UM", "market_type": "SWAP",
+                "quantity": 2, "realized_pnl_quoted": 70.0, "avg_position_price": 3000,
+                "funding_pnl_quoted": -1.0, "commissions_quoted": 4.0,
+                "run_id": "run-1", "strategy_name": self._strategy_name, "log_type": "positions",
+            }
+        )
+
+        restorer = MongoDBPositionRestorer(strategy_name=self._strategy_name, mongo_client=mock_client)
+        result = restorer.restore_positions()
+        btc = next(p for i, p in result.items() if i.symbol == "BTCUSDT")
+        eth = next(p for i, p in result.items() if i.symbol == "ETHUSDT")
+
+        assert btc.episode_start_time == pd.Timestamp("2025-01-01T00:00:00").asm8
+        assert btc.r_pnl_at_open == 90.0
+        assert btc.commissions_at_open == 2.0
+        assert btc.cumulative_funding_at_open == -4.0
+
+        assert eth.episode_start_time == pd.Timestamp(ts).asm8
+        assert eth.r_pnl_at_open == 70.0
+        assert eth.commissions_at_open == 4.0
+        assert eth.cumulative_funding_at_open == -1.0
 
 
 # Signal restorer tests

--- a/tests/qubx/test_postgres.py
+++ b/tests/qubx/test_postgres.py
@@ -8,6 +8,7 @@ psycopg equivalent of mongomock.
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from qubx.core.basics import (
@@ -166,8 +167,9 @@ class TestPostgresPositionRestorer:
         # Second call: get positions
         cursor.fetchone.return_value = ("run-123",)
         cursor.fetchall.return_value = [
-            # symbol, exchange, market_type, quantity, avg_price, r_pnl, current_price, funding, commissions, ts
-            ("BTCUSDT", "BINANCE.UM", "SWAP", 1.5, 90000.0, 100.0, 91000.0, 5.0, 10.0, ts),
+            # symbol, exchange, market_type, quantity, avg_price, r_pnl, current_price, funding, commissions,
+            #   episode_start_time, r_pnl_at_open, commissions_at_open, funding_at_open, ts  (legacy: episode NULL)
+            ("BTCUSDT", "BINANCE.UM", "SWAP", 1.5, 90000.0, 100.0, 91000.0, 5.0, 10.0, None, None, None, None, ts),
         ]
 
         restorer = PostgresPositionRestorer(strategy_name=self._strategy_name, connection=conn)
@@ -182,7 +184,7 @@ class TestPostgresPositionRestorer:
         conn, cursor = _make_mock_connection()
         cursor.fetchall.return_value = [
             ("BTCUSDT", "BINANCE.UM", "SWAP", 1.0, 100.0, 0.0, 101.0, 0.0, 0.0,
-             datetime(2026, 7, 10, tzinfo=timezone.utc)),
+             None, None, None, None, datetime(2026, 7, 10, tzinfo=timezone.utc)),
         ]
         restorer = PostgresPositionRestorer(
             strategy_name="test_strategy", connection=conn, run_id="run-B"
@@ -192,6 +194,41 @@ class TestPostgresPositionRestorer:
         assert not cursor.fetchone.called  # injected → no latest-run lookup
         params = cursor.execute.call_args[0][1]
         assert "run-B" in params
+
+    def test_episode_fields_roundtrip(self, mock_lookup):
+        # episode baselines present in the row -> round-trip verbatim
+        conn, cursor = _make_mock_connection()
+        ts = datetime.now(timezone.utc) - timedelta(hours=1)
+        est = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        cursor.fetchone.return_value = ("run-123",)
+        cursor.fetchall.return_value = [
+            # ..., episode_start_time, r_pnl_at_open, commissions_at_open, funding_at_open, ts
+            ("BTCUSDT", "BINANCE.UM", "SWAP", 1.5, 90000.0, 100.0, 91000.0, -5.0, 3.0,
+             est, 90.0, 2.0, -4.0, ts),
+        ]
+        restorer = PostgresPositionRestorer(strategy_name=self._strategy_name, connection=conn)
+        btc = next(p for i, p in restorer.restore_positions().items() if i.symbol == "BTCUSDT")
+        assert btc.episode_start_time == pd.Timestamp(est).asm8
+        assert btc.r_pnl_at_open == 90.0
+        assert btc.commissions_at_open == 2.0
+        assert btc.cumulative_funding_at_open == -4.0
+
+    def test_episode_legacy_row_stamps_at_restore(self, mock_lookup):
+        # legacy row (episode columns NULL) -> episode-at-restore: baselines = restored accumulators,
+        # episode_start_time = the log-row timestamp
+        conn, cursor = _make_mock_connection()
+        ts = datetime(2025, 6, 1, 12, 0, tzinfo=timezone.utc)
+        cursor.fetchone.return_value = ("run-123",)
+        cursor.fetchall.return_value = [
+            ("BTCUSDT", "BINANCE.UM", "SWAP", 1.5, 90000.0, 100.0, 91000.0, -5.0, 3.0,
+             None, None, None, None, ts),
+        ]
+        restorer = PostgresPositionRestorer(strategy_name=self._strategy_name, connection=conn)
+        btc = next(p for i, p in restorer.restore_positions().items() if i.symbol == "BTCUSDT")
+        assert btc.episode_start_time == pd.Timestamp(ts).asm8
+        assert btc.r_pnl_at_open == 100.0
+        assert btc.commissions_at_open == 3.0
+        assert btc.cumulative_funding_at_open == -5.0
 
 
 # --- Signal restorer tests ---
@@ -420,8 +457,11 @@ class TestPostgresStateRestorer:
                 # Table existence check
                 return [("qubx_logs_positions",), ("qubx_logs_signals",), ("qubx_logs_balance",)]
             elif n == 2:
-                # Position restorer: fetch positions
-                return [("BTCUSDT", "BINANCE.UM", "SWAP", 1.0, 90000.0, 50.0, 91000.0, 5.0, 10.0, ts)]
+                # Position restorer: fetch positions (14 cols; legacy row -> episode fields NULL)
+                return [
+                    ("BTCUSDT", "BINANCE.UM", "SWAP", 1.0, 90000.0, 50.0, 91000.0, 5.0, 10.0,
+                     None, None, None, None, ts)
+                ]
             elif n == 3:
                 # Signal restorer: fetch signals (returns dicts via _load_data)
                 return []


### PR DESCRIPTION
## Summary

Implements [docs/specs/2026-07-21-position-episodes-design.md](docs/specs/2026-07-21-position-episodes-design.md) (+ impl spec, both in this PR).

`Position` gains **episode** tracking — the span from one flat→open transition to the next return to flat — as a pure view over the lifetime accumulators:

- 4 new fields (`episode_start_time`, `r_pnl_at_open`, `commissions_at_open`, `cumulative_funding_at_open`), stamped synchronously in `update_position` at flat→open (pre-opening-deal, so entry fees/crossed spread land *inside* the episode) and on sign flips (closing half + pro-rata fee share attributed to the old episode first).
- 5 accessors: `episode_pnl()`, `episode_funding()`, `episode_commissions()`, `episode_price_pnl()`, `episode_net_pnl()`.
- "Flat" is the existing canonical predicate (`abs(qty) < lot_size`) — no new epsilon.
- `reconcile_size` stamps episode-at-now on flat→open recovery (venue snapshot timestamp); `realize_only` untouched; `reset`/`reset_by_position`/`flatten` consistent.
- Persistence: 4 fields ride the position log records (both emit sites) + all three restorers (Csv/Mongo/Postgres) with legacy fallback (episode-at-restore, log-row timestamp). Postgres `_ensure_tables` now runs idempotent `ADD COLUMN IF NOT EXISTS` so pre-existing deployed tables self-migrate (this also fixes the pre-existing additive-column gap for any future schema addition).

Motivation: downstream (frab dashboard) needs P&L scoped to the current open position; strategy-side baseline sampling is structurally inexact (5s late, misses entry costs). Frab consumption is a separate sequenced PR after this releases.

## Verification

- **712 passed** in `tests/qubx/core` (700 baseline + 12 new, 0 skips); all existing tests pass unmodified (only mechanical widening of 3 postgres mock projection tuples). 78 passed across episodes/restorers/postgres focused files.
- **Adversarial review** (independent agent, twin-execution fuzzing vs pre-change code): return contract `(deal_pnl, comms)` bit-identical over 4,000 trials incl. flips and conversion rates; non-flip state (qty/avg/r_pnl/commissions/pnl) bit-identical over 16,419 checks; flip episode arithmetic hand-verified; flat-settle funding attribution covered; sub-lot dust divergence unreachable via production callers (20,000 fuzzed sequences). Its one confirmed finding (Postgres migration gap) is fixed in the final commit.

## Notes for review

- The delicate hunk is the `update_position` ordering refactor (closing realization + closing fee → episode stamp → opening fee). The whole-deal return value is computed independently of the split and is provably unchanged.
- On a single-deal sign flip the accumulated `commissions` field can differ from pre-change by ≤1 ULP (intended pro-rata split); no consumer reads it to that precision.
- Merging to main triggers the stable release pipeline; frab repin follows in its own PR once the version exists.