### PR TITLE
feat(ccxt): Binance portfolio margin — fix papi routing, add PM connector subclass

### DIFF
--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -207,7 +207,10 @@ class CcxtConnector(ChannelEmitter):
         except Exception:  # noqa: BLE001 — cancelled/loop-teardown; nothing to surface
             return
         if exc is not None:
-            logger.error(f"[{self.exchange_name}] background connector task failed: {exc!r}")
+            # Positional arg, NOT an f-string: venue error text can contain markup (e.g. a
+            # Binance HTML error page) that loguru's colorizer rejects as bad color tags —
+            # only the static format string is tag-parsed, args are inserted after.
+            logger.error("[{}] background connector task failed: {!r}", self.exchange_name, exc)
 
     def _run_sync(self, coro: Any, timeout: float | None = None) -> Any:
         """Run a coroutine on the exchange loop and block for the result.
@@ -1365,13 +1368,17 @@ class CcxtConnector(ChannelEmitter):
         leg's live orders as missing → false reconcile-away. None makes reconcile skip
         order diffing this tick (positions/balances still apply).
         """
+        # Venue exception text goes in as positional args (may contain HTML/markup that
+        # loguru's colorizer rejects when it appears in the format string — a raised log
+        # call here would sink the whole snapshot).
         if isinstance(raw_orders, BaseException):
-            logger.warning(f"[{self.exchange_name}] snapshot: fetch_open_orders failed: {raw_orders}")
+            logger.warning("[{}] snapshot: fetch_open_orders failed: {}", self.exchange_name, raw_orders)
             return None
         if isinstance(raw_trigger_orders, BaseException):
             logger.warning(
-                f"[{self.exchange_name}] snapshot: fetch_open_orders(trigger) failed: {raw_trigger_orders};"
-                " skipping order reconcile this tick"
+                "[{}] snapshot: fetch_open_orders(trigger) failed: {}; skipping order reconcile this tick",
+                self.exchange_name,
+                raw_trigger_orders,
             )
             return None
         open_orders: list[Order] = []
@@ -1426,7 +1433,7 @@ class CcxtConnector(ChannelEmitter):
 
         positions: list[Position] | None = None
         if isinstance(raw_positions, BaseException):
-            logger.warning(f"[{self.exchange_name}] snapshot: fetch_positions failed: {raw_positions}")
+            logger.warning("[{}] snapshot: fetch_positions failed: {}", self.exchange_name, raw_positions)
         else:
             positions = ccxt_convert_positions(raw_positions, ex.name, ex.markets)
             await self._fill_leverage_settings(positions)
@@ -1434,7 +1441,7 @@ class CcxtConnector(ChannelEmitter):
         balances: list[Balance] | None = None
         equity = available_margin = margin_ratio = withdrawable = None
         if isinstance(raw_balance, BaseException):
-            logger.warning(f"[{self.exchange_name}] snapshot: fetch_balance failed: {raw_balance}")
+            logger.warning("[{}] snapshot: fetch_balance failed: {}", self.exchange_name, raw_balance)
         else:
             balances = self._convert_balances(raw_balance)
             equity, available_margin, margin_ratio, withdrawable = self._extract_venue_figures(raw_balance)

--- a/src/qubx/connectors/ccxt/exchanges/__init__.py
+++ b/src/qubx/connectors/ccxt/exchanges/__init__.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import ccxt.pro as cxp
 
 from ..connector import CcxtConnector
+from .binance.connector import BinancePmCcxtConnector
 from .binance.exchange import BINANCE_UM_MM, BinancePortfolioMargin, BinanceQV, BinanceQVUSDM
 from .bitfinex.connector import BitfinexCcxtConnector
 from .gateio.gateio import GateioFutures
@@ -56,11 +57,14 @@ EXCHANGE_ALIASES = {
 # the bare ``okx``/``bitfinex`` aliases the factory may receive. Bitfinex's connector
 # subclass has NO dependency on the optional qubx-bitfinex-api package (it only needs
 # the base connector + shared mixin), so it is registered unconditionally.
+# The factory resolves by the configured VENUE name first, then the canonical name —
+# that's how ``binance.pm`` gets its own subclass while canonicalizing to BINANCE.UM.
 CUSTOM_CONNECTORS: dict[str, type[CcxtConnector]] = {
     "okx": OkxCcxtConnector,
     "okx.f": OkxCcxtConnector,
     "bitfinex": BitfinexCcxtConnector,
     "bitfinex.f": BitfinexCcxtConnector,
+    "binance.pm": BinancePmCcxtConnector,
 }
 
 READER_CAPABILITIES = {
@@ -93,7 +97,6 @@ cxp.okx_futures = OkxFutures  # type: ignore
 cxp.exchanges.append("binanceqv")
 cxp.exchanges.append("binanceqv_usdm")
 cxp.exchanges.append("binancepm")
-cxp.exchanges.append("binancepm_usdm")
 cxp.exchanges.append("binance_um_mm")
 cxp.exchanges.append("custom_krakenfutures")
 if _HAS_BITFINEX:

--- a/src/qubx/connectors/ccxt/exchanges/binance/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/connector.py
@@ -56,15 +56,6 @@ class BinancePmCcxtConnector(CcxtConnector):
             info_float(account, "virtualMaxWithdrawAmount"),
         )
 
-    async def _fetch_trigger_open_orders(self) -> list[dict]:
-        """PM has no working venue-wide conditional open-orders endpoint: ccxt 4.5.50 maps
-        the ``trigger: True`` sweep to ``GET /papi/v1/um/conditional/openOrders``, which
-        404s with an HTML error page (live-verified 2026-07-22). Treat as "no trigger
-        orders" so the full snapshot sweep survives; regular open orders still reconcile.
-        Caveat: conditional/stop orders on PM are unverified end-to-end — if the papi
-        conditional API is dead, placing them likely fails too."""
-        return []
-
     def get_adl_level(self, instrument: Instrument) -> int | None:
         # papi positionRisk has no adl field — query the dedicated endpoint. Response:
         # [{"symbol": ..., "adlQuantile": {"LONG": n, "SHORT": n} | {"BOTH": n}}]; the

--- a/src/qubx/connectors/ccxt/exchanges/binance/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/connector.py
@@ -11,13 +11,15 @@ the configured VENUE name (``binance.pm``) — the canonical name both venues sh
   figures are USD-denominated (vs USDT on fapi); the difference is treated as
   negligible, same as the base class treats fapi's USDT figures.
 - **ADL level**: papi positionRisk carries no adl field; PM exposes it on a dedicated
-  ``GET /papi/v1/um/adlQuantile`` endpoint — see ``get_adl_level``.
+  bulk ``GET /papi/v1/um/adlQuantile`` endpoint. One account-wide call per snapshot
+  stamps ``Position.adl_level`` (so ``ctx.get_adl_level`` — an AccountManager dict
+  read — works on PM) and refreshes a local cache that ``get_adl_level`` serves
+  without any network call.
 """
 
 from typing import Any
 
-from qubx import logger
-from qubx.core.basics import Instrument
+from qubx.core.basics import Instrument, Position
 
 from ...connector import CcxtConnector
 from ...utils import info_float, instrument_to_ccxt_symbol
@@ -34,8 +36,29 @@ def _account_figures(raw_balance: dict[str, Any]) -> dict[str, Any]:
     return account if isinstance(account, dict) else {}
 
 
+def _parse_adl_quantiles(rows: Any) -> dict[str, int]:
+    """Market id -> worst (max) ADL quantile across sides, from the papi adlQuantile
+    response: ``[{"symbol": ..., "adlQuantile": {"LONG": n, "SHORT": n} | {"BOTH": n}}]``."""
+    levels: dict[str, int] = {}
+    for row in rows if isinstance(rows, list) else []:
+        symbol = row.get("symbol")
+        quantiles = row.get("adlQuantile")
+        if symbol and isinstance(quantiles, dict) and quantiles:
+            try:
+                levels[symbol] = int(max(float(v) for v in quantiles.values()))
+            except (TypeError, ValueError):
+                continue
+    return levels
+
+
 class BinancePmCcxtConnector(CcxtConnector):
     """BINANCE.PM connector: papi account figures + papi ADL on top of the base."""
+
+    _adl_levels: dict[str, int]
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self._adl_levels = {}
 
     def _extract_venue_figures(
         self, raw_balance: dict[str, Any]
@@ -56,20 +79,35 @@ class BinancePmCcxtConnector(CcxtConnector):
             info_float(account, "virtualMaxWithdrawAmount"),
         )
 
-    def get_adl_level(self, instrument: Instrument) -> int | None:
-        # papi positionRisk has no adl field — query the dedicated endpoint. Response:
-        # [{"symbol": ..., "adlQuantile": {"LONG": n, "SHORT": n} | {"BOTH": n}}]; the
-        # worst (max) quantile across sides is the conservative per-instrument answer.
+    async def _fill_leverage_settings(self, positions: list[Position]) -> None:
+        # snapshot post-processing hook: leverage/max_notional from the base, then ADL
+        await super()._fill_leverage_settings(positions)
+        await self._fill_adl_levels(positions)
+
+    async def _fill_adl_levels(self, positions: list[Position]) -> None:
+        """Stamp ``Position.adl_level`` from ONE account-wide adlQuantile call per
+        snapshot and refresh the cache ``get_adl_level`` reads. Best-effort: a failure
+        leaves the previous cache and the positions' levels unchanged."""
+        if not positions:
+            return
         try:
-            market_id = self._em.exchange.market(instrument_to_ccxt_symbol(instrument))["id"]
-            rows = self._run_sync(self._em.exchange.papiGetUmAdlQuantile({"symbol": market_id}))
-            for row in rows if isinstance(rows, list) else []:
-                if row.get("symbol") != market_id:
-                    continue
-                quantiles = row.get("adlQuantile")
-                if isinstance(quantiles, dict) and quantiles:
-                    return int(max(float(v) for v in quantiles.values()))
-            return None
+            rows = await self._em.exchange.papiGetUmAdlQuantile()
         except Exception as e:  # noqa: BLE001
-            logger.error(f"[{self.exchange_name}] fetch adl quantile for {instrument.symbol}: {e}")
-            return None
+            self._dbg.debug("fetch adl quantiles failed: {}", e)
+            return
+        self._adl_levels = _parse_adl_quantiles(rows)
+        for pos in positions:
+            level = self._adl_levels.get(self._market_id(pos.instrument))
+            if level is not None:
+                pos.adl_level = level
+
+    def _market_id(self, instrument: Instrument) -> str:
+        try:
+            return self._em.exchange.market(instrument_to_ccxt_symbol(instrument))["id"]
+        except Exception:  # noqa: BLE001 — markets not loaded yet; Binance ids equal the symbol
+            return instrument.symbol
+
+    def get_adl_level(self, instrument: Instrument) -> int | None:
+        # local cache read (refreshed each snapshot) — never a blocking venue call;
+        # strategies normally read ctx.get_adl_level -> Position.adl_level anyway
+        return self._adl_levels.get(self._market_id(instrument))

--- a/src/qubx/connectors/ccxt/exchanges/binance/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/connector.py
@@ -1,0 +1,84 @@
+"""Binance portfolio-margin CcxtConnector subclass.
+
+Everything PM-specific on the Qubx side lives here, keeping the base ``CcxtConnector``
+(BINANCE.UM) free of portfolio-margin branches. Resolved from ``CUSTOM_CONNECTORS`` by
+the configured VENUE name (``binance.pm``) — the canonical name both venues share
+(``binance.um``) still resolves to the base class.
+
+- **Venue account figures**: PM's ``papiGetBalance`` is a per-asset list with no
+  account-level figures, so ``BinancePortfolioMargin.fetch_balance`` grafts
+  ``GET /papi/v1/account`` into ``info`` — see ``_extract_venue_figures``. The papi
+  figures are USD-denominated (vs USDT on fapi); the difference is treated as
+  negligible, same as the base class treats fapi's USDT figures.
+- **ADL level**: papi positionRisk carries no adl field; PM exposes it on a dedicated
+  ``GET /papi/v1/um/adlQuantile`` endpoint — see ``get_adl_level``.
+"""
+
+from typing import Any
+
+from qubx import logger
+from qubx.core.basics import Instrument
+
+from ...connector import CcxtConnector
+from ...utils import info_float, instrument_to_ccxt_symbol
+
+
+def _account_figures(raw_balance: dict[str, Any]) -> dict[str, Any]:
+    """The grafted ``GET /papi/v1/account`` dict from a PM balance payload, ``{}`` when
+    absent (graft failed or a non-PM payload reached us) — degrade to derived figures
+    rather than sink the snapshot."""
+    info = raw_balance.get("info")
+    if not isinstance(info, dict):
+        return {}
+    account = info.get("account")
+    return account if isinstance(account, dict) else {}
+
+
+class BinancePmCcxtConnector(CcxtConnector):
+    """BINANCE.PM connector: papi account figures + papi ADL on top of the base."""
+
+    def _extract_venue_figures(
+        self, raw_balance: dict[str, Any]
+    ) -> tuple[float | None, float | None, float | None, float | None]:
+        """(equity, available_margin, margin_ratio, withdrawable) from ``papiGetAccount``:
+        ``accountEquity`` (collateral + uPnL across um/cm/margin, USD),
+        ``totalAvailableBalance`` (margin available for new positions),
+        ``uniMMR`` (accountEquity / accountMaintMargin — same shape as AM's derived
+        ratio; reported as a 99999999 sentinel when maint margin is 0, mapped to None
+        so AM applies its own no-positions handling) and ``virtualMaxWithdrawAmount``."""
+        account = _account_figures(raw_balance)
+        maint = info_float(account, "accountMaintMargin")
+        margin_ratio = info_float(account, "uniMMR") if maint is not None and maint > 0 else None
+        return (
+            info_float(account, "accountEquity"),
+            info_float(account, "totalAvailableBalance"),
+            margin_ratio,
+            info_float(account, "virtualMaxWithdrawAmount"),
+        )
+
+    async def _fetch_trigger_open_orders(self) -> list[dict]:
+        """PM has no working venue-wide conditional open-orders endpoint: ccxt 4.5.50 maps
+        the ``trigger: True`` sweep to ``GET /papi/v1/um/conditional/openOrders``, which
+        404s with an HTML error page (live-verified 2026-07-22). Treat as "no trigger
+        orders" so the full snapshot sweep survives; regular open orders still reconcile.
+        Caveat: conditional/stop orders on PM are unverified end-to-end — if the papi
+        conditional API is dead, placing them likely fails too."""
+        return []
+
+    def get_adl_level(self, instrument: Instrument) -> int | None:
+        # papi positionRisk has no adl field — query the dedicated endpoint. Response:
+        # [{"symbol": ..., "adlQuantile": {"LONG": n, "SHORT": n} | {"BOTH": n}}]; the
+        # worst (max) quantile across sides is the conservative per-instrument answer.
+        try:
+            market_id = self._em.exchange.market(instrument_to_ccxt_symbol(instrument))["id"]
+            rows = self._run_sync(self._em.exchange.papiGetUmAdlQuantile({"symbol": market_id}))
+            for row in rows if isinstance(rows, list) else []:
+                if row.get("symbol") != market_id:
+                    continue
+                quantiles = row.get("adlQuantile")
+                if isinstance(quantiles, dict) and quantiles:
+                    return int(max(float(v) for v in quantiles.values()))
+            return None
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"[{self.exchange_name}] fetch adl quantile for {instrument.symbol}: {e}")
+            return None

--- a/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
@@ -4,7 +4,7 @@ import ccxt.pro as cxp
 import pandas as pd
 from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByTimestamp
 from ccxt.async_support.base.ws.client import Client
-from ccxt.base.errors import BadRequest, InsufficientFunds
+from ccxt.base.errors import BadRequest, InsufficientFunds, NotSupported
 from ccxt.base.precise import Precise
 from ccxt.base.types import (
     Any,
@@ -743,6 +743,23 @@ class BinancePortfolioMargin(BinanceQVUSDM):
         if isPortfolioMargin:
             return super().parse_balance_custom(response, "margin", marginMode, True)
         return super().parse_balance_custom(response, type, marginMode, isPortfolioMargin)
+
+    async def create_order(
+        self, symbol: str, type: OrderType, side: OrderSide, amount: float, price: Num = None, params={}
+    ) -> Order:
+        # Binance suspended the PM conditional-order service (papi um/conditional/*) in
+        # 2026-04 and it 404s to this day (live-verified 2026-07-22: both placement and
+        # query; the regular papi um/order rejects STOP_MARKET with -1116). Fail fast
+        # with a clean venue-verdict instead of surfacing an HTML 404 page. Client-side
+        # alternative: trackers with risk_controlling_side="client".
+        if any(k in params for k in ("triggerPrice", "stopPrice", "stopLossPrice", "takeProfitPrice")) or "stop" in str(
+            type
+        ):
+            raise NotSupported(
+                f"{self.id} conditional/stop orders are not available on Binance portfolio margin "
+                "(papi conditional API suspended since 2026-04) — use client-side risk management"
+            )
+        return await super().create_order(symbol, type, side, amount, price, params)
 
     async def fetch_balance(self, params={}) -> Balances:
         """papiGetBalance carries per-asset wallets but no account-level risk figures.

--- a/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
@@ -4,7 +4,7 @@ import ccxt.pro as cxp
 import pandas as pd
 from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByTimestamp
 from ccxt.async_support.base.ws.client import Client
-from ccxt.base.errors import BadRequest, InsufficientFunds, NotSupported
+from ccxt.base.errors import BadRequest, InsufficientFunds
 from ccxt.base.precise import Precise
 from ccxt.base.types import (
     Any,
@@ -744,22 +744,155 @@ class BinancePortfolioMargin(BinanceQVUSDM):
             return super().parse_balance_custom(response, "margin", marginMode, True)
         return super().parse_balance_custom(response, type, marginMode, isPortfolioMargin)
 
+    # Binance migrated PM conditional orders to the Algo Service on 2026-04-28: the old
+    # papi um/conditional/* endpoints 404 and ccxt (<= 4.5.50) still routes there. The
+    # replacement API (live-verified 2026-07-22) is fapi-algo-shaped but with renamed
+    # fields: trigger param is ``triggerPrice`` (NOT stopPrice), client id is
+    # ``clientAlgoId``, id is ``algoId``. ALGO_UPDATE WS events did not fire for
+    # NEW/CANCELED in testing — algo lifecycle is REST-confirmed; a triggered algo
+    # spawns a real order (``actualOrderId``) whose ORDER_TRADE_UPDATE/fills arrive on
+    # the normal stream. ccxt has no implicit methods for these (its abstract API map
+    # is pre-generated), hence raw ``self.request`` calls.
+    _ALGO_ORDER_PATH = "um/algo/order"
+    _ALGO_QUERY_PATH = "um/algo/algoOrder"
+    _ALGO_OPEN_PATH = "um/algo/openAlgoOrders"
+    _ALGO_STATUSES = {
+        "NEW": "open",
+        "WORKING": "open",
+        "CANCELED": "canceled",
+        "CANCELLED": "canceled",
+        "TRIGGERED": "closed",
+        "FINISHED": "closed",
+        "EXPIRED": "expired",
+        "REJECTED": "rejected",
+    }
+
+    def _is_trigger_params(self, type: OrderType, params: dict) -> bool:
+        return (
+            any(params.get(k) is not None for k in ("triggerPrice", "stopPrice", "stopLossPrice", "takeProfitPrice"))
+            or "stop" in str(type).lower()
+            or "take_profit" in str(type).lower()
+        )
+
+    def parse_algo_order(self, raw: dict, market=None) -> Order:
+        market = self.safe_market(self.safe_string(raw, "symbol"), market, None, "contract")
+        order_type = (self.safe_string_lower(raw, "orderType") or "").lower()
+        return self.safe_order(
+            {
+                "info": raw,
+                "id": self.safe_string(raw, "algoId"),
+                "clientOrderId": self.safe_string(raw, "clientAlgoId"),
+                "symbol": market["symbol"],
+                "timestamp": self.safe_integer(raw, "createTime"),
+                "lastUpdateTimestamp": self.safe_integer(raw, "updateTime"),
+                "type": "market" if order_type.endswith("market") else "limit",
+                "side": self.safe_string_lower(raw, "side"),
+                "price": self.omit_zero(self.safe_string(raw, "price")),
+                "triggerPrice": self.safe_number(raw, "triggerPrice"),
+                "amount": self.safe_number(raw, "quantity"),
+                "filled": self.safe_number(raw, "actualQty"),
+                "average": self.omit_zero(self.safe_string(raw, "actualPrice")),
+                "timeInForce": self.safe_string(raw, "timeInForce"),
+                "reduceOnly": self.safe_bool(raw, "reduceOnly"),
+                "status": self.safe_string(self._ALGO_STATUSES, self.safe_string(raw, "algoStatus", ""), "open"),
+            },
+            market,
+        )
+
     async def create_order(
         self, symbol: str, type: OrderType, side: OrderSide, amount: float, price: Num = None, params={}
     ) -> Order:
-        # Binance suspended the PM conditional-order service (papi um/conditional/*) in
-        # 2026-04 and it 404s to this day (live-verified 2026-07-22: both placement and
-        # query; the regular papi um/order rejects STOP_MARKET with -1116). Fail fast
-        # with a clean venue-verdict instead of surfacing an HTML 404 page. Client-side
-        # alternative: trackers with risk_controlling_side="client".
-        if any(k in params for k in ("triggerPrice", "stopPrice", "stopLossPrice", "takeProfitPrice")) or "stop" in str(
-            type
-        ):
-            raise NotSupported(
-                f"{self.id} conditional/stop orders are not available on Binance portfolio margin "
-                "(papi conditional API suspended since 2026-04) — use client-side risk management"
-            )
-        return await super().create_order(symbol, type, side, amount, price, params)
+        if not self._is_trigger_params(type, params):
+            return await super().create_order(symbol, type, side, amount, price, params)
+        await self.load_markets()
+        market = self.market(symbol)
+        trigger = self.safe_number_n(params, ["triggerPrice", "stopPrice", "stopLossPrice"])
+        take_profit = self.safe_number(params, "takeProfitPrice")
+        is_market = "market" in str(type).lower()
+        if take_profit is not None and trigger is None:
+            trigger = take_profit
+            algo_order_type = "TAKE_PROFIT_MARKET" if is_market else "TAKE_PROFIT"
+        else:
+            algo_order_type = "STOP_MARKET" if is_market else "STOP"
+        request: dict = {
+            "symbol": market["id"],
+            "side": str(side).upper(),
+            "type": algo_order_type,
+            "algoType": "CONDITIONAL",
+            "quantity": self.amount_to_precision(symbol, amount),
+            "triggerPrice": self.price_to_precision(symbol, trigger),
+        }
+        if not is_market:
+            if price is None:
+                raise BadRequest(f"{self.id} algo {algo_order_type} requires a price")
+            request["price"] = self.price_to_precision(symbol, price)
+            request["timeInForce"] = self.safe_string_upper(params, "timeInForce", "GTC")
+        cid = self.safe_string_2(params, "clientOrderId", "newClientOrderId")
+        if cid is not None:
+            request["clientAlgoId"] = cid
+        if self.safe_bool(params, "reduceOnly", False):
+            request["reduceOnly"] = "true"
+        working_type = self.safe_string(params, "workingType")
+        if working_type is not None:
+            request["workingType"] = working_type
+        response = await self.request(self._ALGO_ORDER_PATH, "papi", "POST", request)
+        return self.parse_algo_order(response, market)
+
+    async def cancel_order(self, id: str, symbol: str | None = None, params={}) -> Order:
+        if not self.safe_bool_n(params, ["trigger", "stop", "conditional"], False):
+            return await super().cancel_order(id, symbol, params)
+        if symbol is None:
+            raise BadRequest(f"{self.id} cancelOrder for algo orders requires a symbol")
+        await self.load_markets()
+        market = self.market(symbol)
+        request: dict = {"symbol": market["id"]}
+        cid = self.safe_string_n(params, ["origClientOrderId", "clientOrderId", "clientAlgoId"])
+        if id:
+            request["algoId"] = id
+        elif cid is not None:
+            request["clientAlgoId"] = cid
+        else:
+            raise BadRequest(f"{self.id} cancelOrder for algo orders requires an id or client order id")
+        response = await self.request(self._ALGO_ORDER_PATH, "papi", "DELETE", request)
+        return self.safe_order(
+            {
+                "info": response,
+                "id": id or None,
+                "clientOrderId": cid,
+                "symbol": market["symbol"],
+                "status": "canceled",
+            },
+            market,
+        )
+
+    async def fetch_order(self, id: str, symbol: str | None = None, params={}) -> Order:
+        if not self.safe_bool_n(params, ["trigger", "stop", "conditional"], False):
+            return await super().fetch_order(id, symbol, params)
+        await self.load_markets()
+        market = self.market(symbol) if symbol is not None else None
+        request: dict = {}
+        if market is not None:
+            request["symbol"] = market["id"]
+        cid = self.safe_string_n(params, ["origClientOrderId", "clientOrderId", "clientAlgoId"])
+        if id:
+            request["algoId"] = id
+        elif cid is not None:
+            request["clientAlgoId"] = cid
+        response = await self.request(self._ALGO_QUERY_PATH, "papi", "GET", request)
+        return self.parse_algo_order(response, market)
+
+    async def fetch_open_orders(self, symbol: str | None = None, since=None, limit=None, params={}) -> list[Order]:
+        if not self.safe_bool_n(params, ["trigger", "stop", "conditional"], False):
+            return await super().fetch_open_orders(symbol, since, limit, params)
+        await self.load_markets()
+        market = self.market(symbol) if symbol is not None else None
+        request: dict = {}
+        if market is not None:
+            request["symbol"] = market["id"]
+        response = await self.request(self._ALGO_OPEN_PATH, "papi", "GET", request)
+        rows = response if isinstance(response, list) else []
+        orders = [self.parse_algo_order(row, market) for row in rows]
+        return self.filter_by_symbol_since_limit(orders, market["symbol"] if market else None, since, limit)
 
     async def fetch_balance(self, params={}) -> Balances:
         """papiGetBalance carries per-asset wallets but no account-level risk figures.

--- a/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
@@ -9,6 +9,7 @@ from ccxt.base.precise import Precise
 from ccxt.base.types import (
     Any,
     Balances,
+    Market,
     Num,
     Order,
     OrderSide,
@@ -704,18 +705,68 @@ class BinanceQVUSDM(cxp.binanceusdm, BinanceQV):
 
 
 class BinancePortfolioMargin(BinanceQVUSDM):
+    """Binance portfolio-margin account (papi) trading UM instruments.
+
+    ``portfolioMargin: True`` routes every unified REST/WS method to the papi
+    endpoints, but only on the linear/inverse code paths: ccxt resolves the
+    market type from ``defaultType`` FIRST, and its spot/margin branches
+    (``watch_orders``, ``watch_balance``, ``authenticate``, ``fetch_open_orders``,
+    ``fetch_funding_history``) short-circuit to the spot ws-api / papi margin
+    surfaces before ever consulting the portfolioMargin flag. With the previous
+    ``defaultType: "margin"`` the user-data stream silently connected to the
+    spot ws-api (zero UM events — fills only surfaced via snapshot reconcile)
+    and venue-wide open orders were fetched from the papi MARGIN surface.
+    ``defaultType: "swap"`` (+ the ``defaultSubType: "linear"`` inherited from
+    binanceusdm) keeps every param-less call on the UM path: papi listen key
+    (``papiPostListenKey``) + ``/pm/ws`` stream, ``papiGetUmOpenOrders``,
+    ``papiGetUmIncome``. It also makes the connector's derivatives-venue gate
+    pass, so the balance push loop runs.
+    """
+
     def describe(self):
         return self.deep_extend(
             super().describe(),
             {
                 "options": {
-                    "defaultType": "margin",
+                    "defaultType": "swap",
                     "portfolioMargin": True,
-                    "defaultSubType": None,
                     "fetchMarkets": ["spot", "linear", "inverse"],
                 }
             },
         )
+
+    def parse_balance_custom(self, response, type=None, marginMode=None, isPortfolioMargin=False) -> Balances:
+        # With defaultType "swap" the routed type is linear, whose PM parse branch reports
+        # umWalletBalance + umUnrealizedPNL (unrealized in totals, UM wallet only). Pin the
+        # cross branch instead: total = totalWalletBalance (whole-account, realized-only),
+        # used = crossMarginLocked — the semantics the account processor expects.
+        if isPortfolioMargin:
+            return super().parse_balance_custom(response, "margin", marginMode, True)
+        return super().parse_balance_custom(response, type, marginMode, isPortfolioMargin)
+
+    async def fetch_balance(self, params={}) -> Balances:
+        """papiGetBalance carries per-asset wallets but no account-level risk figures.
+        Graft ``GET /papi/v1/account`` (accountEquity/uniMMR/virtualMaxWithdrawAmount/...)
+        into ``info`` so BinancePmCcxtConnector can surface venue figures from the same
+        snapshot payload. Best-effort: on failure ``account`` is None and the connector
+        falls back to derived figures, exactly as before."""
+        balances = await super().fetch_balance(params)
+        account = None
+        try:
+            account = await self.papiGetAccount()
+        except Exception:  # noqa: BLE001
+            pass
+        balances["info"] = {"balance": balances.get("info"), "account": account}
+        return balances
+
+    def parse_position_risk(self, position, market: Market = None):
+        # papi positionRisk carries neither marginType nor isolatedMargin, so ccxt leaves
+        # marginMode None — PM positions are always cross-margined.
+        parsed = super().parse_position_risk(position, market)
+        if parsed.get("marginMode") is None:
+            parsed["marginMode"] = "cross"
+            parsed["marginType"] = "cross"
+        return parsed
 
 
 class BINANCE_UM_MM(BinanceQVUSDM):

--- a/src/qubx/connectors/ccxt/factory.py
+++ b/src/qubx/connectors/ccxt/factory.py
@@ -149,17 +149,25 @@ def clear_exchange_manager_cache() -> None:
 
 def get_ccxt_connector(
     exchange_name: str,
+    venue_name: str | None = None,
     **kwargs,
 ) -> CcxtConnector:
     """Construct the right CcxtConnector subclass for the exchange.
 
-    Resolves the per-exchange subclass from ``CUSTOM_CONNECTORS`` keyed by the
-    lowercased framework exchange name (OKX/Bitfinex get the split orders/fills
-    streams), falling back to the base ``CcxtConnector`` for any unlisted exchange
-    (Binance, Hyperliquid, ...). The ``CUSTOM_CONNECTORS`` map carries both the dotted
-    (``okx.f``) and bare (``okx``) names, like ``EXCHANGE_ALIASES``.
+    Resolves the per-exchange subclass from ``CUSTOM_CONNECTORS`` — by the configured
+    venue name first (BINANCE.PM gets its PM subclass even though it canonicalizes to
+    BINANCE.UM), then by the lowercased canonical exchange name (OKX/Bitfinex get the
+    split orders/fills streams) — falling back to the base ``CcxtConnector`` for any
+    unlisted exchange (Binance, Hyperliquid, ...). The ``CUSTOM_CONNECTORS`` map
+    carries both the dotted (``okx.f``) and bare (``okx``) names, like
+    ``EXCHANGE_ALIASES``. The connector itself is always constructed with the
+    canonical ``exchange_name`` so its account events route to the canonical AM state.
     """
-    connector_cls = CUSTOM_CONNECTORS.get(exchange_name.lower(), CcxtConnector)
+    connector_cls = None
+    if venue_name is not None:
+        connector_cls = CUSTOM_CONNECTORS.get(venue_name.lower())
+    if connector_cls is None:
+        connector_cls = CUSTOM_CONNECTORS.get(exchange_name.lower(), CcxtConnector)
     return connector_cls(exchange_name=exchange_name, **kwargs)
 
 
@@ -192,6 +200,7 @@ def create_ccxt_connector(ctx: ConnectorBuildContext) -> CcxtConnector:
     # name is plumbing only (credentials lookup + ccxt exchange class, both above).
     return get_ccxt_connector(
         canonical_exchange(ctx.exchange_name),
+        venue_name=ctx.exchange_name,
         channel=ctx.channel,
         time_provider=ctx.time_provider,
         exchange_manager=exchange_manager,

--- a/src/qubx/connectors/ccxt/utils.py
+++ b/src/qubx/connectors/ccxt/utils.py
@@ -339,9 +339,12 @@ def ccxt_extract_leverage_settings(rows: list[dict] | None) -> dict[str, tuple[f
             leverage = row.get("shortLeverage")
         if leverage is None:
             leverage = info_float(raw, "leverage")
+        max_notional = info_float(raw, "maxNotionalValue")
+        if max_notional is None:
+            max_notional = info_float(raw, "maxNotional")  # papi um/account spelling
         out[symbol] = (
             float(leverage) if leverage is not None else None,
-            info_float(raw, "maxNotionalValue"),
+            max_notional,
         )
     return out
 

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -33,7 +33,13 @@ from qubx.connectors.ccxt.utils import ccxt_extract_leverage_settings
 
 
 def run(coro):
-    return asyncio.run(coro)
+    # NOT asyncio.run: that clears the thread's current event loop on exit, breaking
+    # later tests in the same worker that rely on asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _pm_exchange() -> BinancePortfolioMargin:
@@ -196,34 +202,176 @@ class TestBinancePmVenueFigures:
         assert self._connector()._extract_venue_figures({"info": [{"asset": "USDT"}]}) == (None, None, None, None)
 
 
-class TestPmTriggerOrders:
-    def test_conditional_create_order_fails_fast(self):
-        """The papi conditional API is suspended (404 live-verified 2026-07-22) — a stop
-        order must raise NotSupported synchronously, before any network call."""
-        import ccxt
+DOGE_MARKET = {
+    "id": "DOGEUSDT",
+    "lowercaseId": "dogeusdt",
+    "symbol": "DOGE/USDT:USDT",
+    "base": "DOGE",
+    "quote": "USDT",
+    "settle": "USDT",
+    "baseId": "DOGE",
+    "quoteId": "USDT",
+    "settleId": "USDT",
+    "type": "swap",
+    "spot": False,
+    "margin": False,
+    "swap": True,
+    "future": False,
+    "option": False,
+    "contract": True,
+    "linear": True,
+    "inverse": False,
+    "subType": "linear",
+    "active": True,
+    "taker": 0.0004,
+    "maker": 0.0002,
+    "contractSize": 1.0,
+    "expiry": None,
+    "expiryDatetime": None,
+    "strike": None,
+    "optionType": None,
+    "precision": {"amount": 1.0, "price": 0.00001},
+    "limits": {
+        "amount": {"min": 1.0, "max": None},
+        "price": {"min": None, "max": None},
+        "cost": {"min": None, "max": None},
+        "leverage": {"min": 1, "max": 75},
+    },
+    "info": {},
+    "created": None,
+    "marginModes": {"cross": True, "isolated": False},
+}
 
-        ex = _pm_exchange()
+ALGO_RESPONSE = {
+    "algoId": 4000001785373649,
+    "algoType": "CONDITIONAL",
+    "clientAlgoId": "qubx_DOGEUSDT_1",
+    "orderType": "STOP_MARKET",
+    "symbol": "DOGEUSDT",
+    "side": "SELL",
+    "positionSide": "BOTH",
+    "timeInForce": "GTC",
+    "quantity": "300",
+    "algoStatus": "NEW",
+    "actualOrderId": "",
+    "actualPrice": "0",
+    "actualQty": "0",
+    "triggerPrice": "0.050640",
+    "price": "0.000000",
+    "reduceOnly": False,
+    "createTime": 1784722758752,
+    "updateTime": 1784722758752,
+}
+
+
+def _pm_exchange_with_markets():
+    """PM exchange with preseeded DOGE market and a captured raw-request transport —
+    algo calls (place/cancel/query) never have implicit ccxt methods, so everything
+    goes through ``request``; capture it to assert paths and payloads offline."""
+    ex = _pm_exchange()
+    ex.set_markets([DOGE_MARKET])
+    calls = []
+
+    async def fake_request(path, api="public", method="GET", params={}, *args, **kwargs):
+        calls.append((path, api, method, dict(params)))
+        return dict(ALGO_RESPONSE)
+
+    ex.request = fake_request
+    return ex, calls
+
+
+class TestPmAlgoOrders:
+    """PM conditional orders migrated to the papi Algo Service on 2026-04-28 (old
+    um/conditional/* endpoints 404). Live-verified 2026-07-22: trigger param is
+    ``triggerPrice``, client id is ``clientAlgoId``, cancel/query by ``algoId``."""
+
+    def test_stop_market_routes_to_algo_endpoint(self):
+        # the exact shape prepare_ccxt_order_payload emits for STOP_MARKET
+        ex, calls = _pm_exchange_with_markets()
         try:
-            for kwargs in (
-                {"params": {"triggerPrice": 0.05}},
-                {"params": {"stopLossPrice": 0.05}},
-                {"type": "stop_market", "params": {}},
-            ):
-                order_type = kwargs.get("type", "market")
-                try:
-                    run(ex.create_order("DOGE/USDT:USDT", order_type, "sell", 150, None, kwargs["params"]))
-                    raise AssertionError(f"expected NotSupported for {kwargs}")
-                except ccxt.NotSupported:
-                    pass
+            order = run(
+                ex.create_order(
+                    "DOGE/USDT:USDT",
+                    "market",
+                    "sell",
+                    300,
+                    0.05064,
+                    {"triggerPrice": 0.05064, "clientOrderId": "qubx_DOGEUSDT_1", "timeInForce": "GTC", "type": "swap"},
+                )
+            )
+            path, api, method, req = calls[0]
+            assert (path, api, method) == ("um/algo/order", "papi", "POST")
+            assert req["type"] == "STOP_MARKET"
+            assert req["algoType"] == "CONDITIONAL"
+            assert req["triggerPrice"] == "0.05064"
+            assert req["clientAlgoId"] == "qubx_DOGEUSDT_1"
+            assert "stopPrice" not in req and "price" not in req
+            assert order["id"] == "4000001785373649"
+            assert order["status"] == "open"
+            assert order["triggerPrice"] == 0.05064
         finally:
             run(ex.close())
 
-    def test_trigger_open_orders_short_circuit(self):
-        # papi /um/conditional/openOrders 404s (live-verified 2026-07-22) — the PM
-        # override must not touch the exchange at all
-        connector = TestBinancePmVenueFigures._connector()
-        assert run(connector._fetch_trigger_open_orders()) == []
-        connector._em.exchange.fetch_open_orders.assert_not_called()
+    def test_stop_limit_carries_price_and_tif(self):
+        ex, calls = _pm_exchange_with_markets()
+        try:
+            run(ex.create_order("DOGE/USDT:USDT", "limit", "sell", 300, 0.0501, {"triggerPrice": 0.05064}))
+            _, _, _, req = calls[0]
+            assert req["type"] == "STOP"
+            assert req["price"] == "0.0501"
+            assert req["timeInForce"] == "GTC"
+        finally:
+            run(ex.close())
+
+    def test_non_trigger_orders_unaffected(self):
+        ex, calls = _pm_exchange_with_markets()
+        try:
+            try:
+                run(ex.create_order("DOGE/USDT:USDT", "limit", "buy", 300, 0.05, {}))
+            except Exception:
+                pass  # goes to the real papi order path (network) — only assert no algo call
+            assert calls == []
+        finally:
+            run(ex.close())
+
+    def test_cancel_by_algo_id_and_by_client_id(self):
+        ex, calls = _pm_exchange_with_markets()
+        try:
+            run(ex.cancel_order("4000001785373649", "DOGE/USDT:USDT", {"trigger": True}))
+            # the cid path used by cancel_order_with_client_order_id (id='')
+            run(ex.cancel_order("", "DOGE/USDT:USDT", {"trigger": True, "clientOrderId": "qubx_DOGEUSDT_1"}))
+            (p1, _, m1, r1), (p2, _, m2, r2) = calls
+            assert (p1, m1, r1.get("algoId")) == ("um/algo/order", "DELETE", "4000001785373649")
+            assert (p2, m2, r2.get("clientAlgoId")) == ("um/algo/order", "DELETE", "qubx_DOGEUSDT_1")
+            assert "algoId" not in r2
+        finally:
+            run(ex.close())
+
+    def test_fetch_order_and_open_orders_route_to_algo_queries(self):
+        ex, calls = _pm_exchange_with_markets()
+        try:
+            run(ex.fetch_order("4000001785373649", "DOGE/USDT:USDT", {"trigger": True}))
+            assert calls[-1][:3] == ("um/algo/algoOrder", "papi", "GET")
+
+            async def fake_list(path, api="public", method="GET", params={}, *args, **kwargs):
+                calls.append((path, api, method, dict(params)))
+                return [dict(ALGO_RESPONSE)]
+
+            ex.request = fake_list
+            orders = run(ex.fetch_open_orders("DOGE/USDT:USDT", params={"trigger": True}))
+            assert calls[-1][:3] == ("um/algo/openAlgoOrders", "papi", "GET")
+            assert len(orders) == 1 and orders[0]["clientOrderId"] == "qubx_DOGEUSDT_1"
+        finally:
+            run(ex.close())
+
+    def test_algo_status_mapping(self):
+        ex, _ = _pm_exchange_with_markets()
+        try:
+            for raw_status, unified in [("NEW", "open"), ("CANCELED", "canceled"), ("TRIGGERED", "closed")]:
+                parsed = ex.parse_algo_order(dict(ALGO_RESPONSE, algoStatus=raw_status))
+                assert parsed["status"] == unified, raw_status
+        finally:
+            run(ex.close())
 
 
 class TestVenueErrorLogging:

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -1,0 +1,251 @@
+"""Unit tests for Binance portfolio-margin (BINANCE.PM) support.
+
+Pins the PM routing fix and the PM-specific connector subclass:
+
+1. ``BinancePortfolioMargin`` options must resolve every param-less unified call onto
+   the linear/papi path. ccxt resolves the market type from ``defaultType`` BEFORE
+   consulting ``portfolioMargin``, and its spot/margin branches short-circuit — the
+   previous ``defaultType: "margin"`` sent the user-data stream to the spot ws-api
+   (zero UM events) and venue-wide open orders to the papi MARGIN surface.
+2. ``parse_balance_custom`` pins realized-only PM balance semantics (totalWalletBalance)
+   even though the routed type is linear.
+3. ``parse_position_risk`` defaults marginMode to cross (papi payloads carry neither
+   marginType nor isolatedMargin; PM is always cross).
+4. ``BinancePmCcxtConnector._extract_venue_figures`` reads the papiGetAccount dict the
+   exchange class grafts into fetch_balance's ``info`` (uniMMR sentinel mapped to None).
+5. The factory resolves ``CUSTOM_CONNECTORS`` by venue name first, canonical second.
+6. ``ccxt_extract_leverage_settings`` accepts papi's ``maxNotional`` spelling.
+
+Everything here runs fully offline.
+"""
+
+import asyncio
+import io
+from unittest.mock import MagicMock
+
+from qubx import logger
+from qubx.connectors.ccxt.connector import CcxtConnector
+from qubx.connectors.ccxt.exchanges import CUSTOM_CONNECTORS
+from qubx.connectors.ccxt.exchanges.binance.connector import BinancePmCcxtConnector
+from qubx.connectors.ccxt.exchanges.binance.exchange import BinancePortfolioMargin
+from qubx.connectors.ccxt.factory import get_ccxt_connector
+from qubx.connectors.ccxt.utils import ccxt_extract_leverage_settings
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _pm_exchange() -> BinancePortfolioMargin:
+    return BinancePortfolioMargin({"apiKey": "k", "secret": "s"})
+
+
+class TestBinancePmRouting:
+    def test_options_route_linear(self):
+        ex = _pm_exchange()
+        try:
+            assert ex.options["defaultType"] == "swap"
+            assert ex.options["defaultSubType"] == "linear"
+            assert ex.options["portfolioMargin"] is True
+            # papi ws base must exist for the PM user-data stream
+            assert ex.urls["api"]["ws"]["papi"].startswith("wss://")
+        finally:
+            run(ex.close())
+
+    def test_watch_and_fetch_paths_resolve_linear(self):
+        """The exact decisions watch_orders / fetch_open_orders make param-less: any
+        non-linear outcome regresses to the spot ws-api / papi margin surfaces."""
+        ex = _pm_exchange()
+        try:
+            for method in ("watchOrders", "watchBalance", "authenticate", "fetchOpenOrders"):
+                t, params = ex.handle_market_type_and_params(method, None, {})
+                st, _ = ex.handle_sub_type_and_params(method, None, params)
+                assert ex.is_linear(t, st), f"{method} resolved type={t} subType={st} — not linear"
+                assert t not in ("spot", "margin")
+        finally:
+            run(ex.close())
+
+
+class TestBinancePmBalanceParse:
+    PM_BALANCE_ROW = {
+        "asset": "USDT",
+        "totalWalletBalance": "386.01",
+        "crossMarginFree": "386.01",
+        "crossMarginLocked": "1.5",
+        "crossMarginBorrowed": "0",
+        "crossMarginInterest": "0",
+        "umWalletBalance": "300.0",
+        "umUnrealizedPNL": "5.0",
+        "cmWalletBalance": "0",
+        "cmUnrealizedPNL": "0",
+    }
+
+    def test_pm_totals_are_realized_only(self):
+        ex = _pm_exchange()
+        try:
+            # type "linear" is what the swap defaultType routes — the PM pin must still
+            # produce whole-account realized-only totals, not umWallet + unrealized PnL
+            parsed = ex.parse_balance_custom([self.PM_BALANCE_ROW], "linear", None, True)
+            assert parsed["USDT"]["total"] == 386.01
+            assert parsed["USDT"]["used"] == 1.5
+        finally:
+            run(ex.close())
+
+    def test_non_pm_passthrough(self):
+        ex = _pm_exchange()
+        try:
+            futures_account = {"assets": [{"asset": "USDT", "availableBalance": "10", "initialMargin": "2", "walletBalance": "12"}]}
+            parsed = ex.parse_balance_custom(futures_account, None, None, False)
+            assert parsed["USDT"]["total"] == 12.0
+        finally:
+            run(ex.close())
+
+
+class TestBinancePmPositionRisk:
+    PAPI_ROW = {
+        "symbol": "BTCUSDT",
+        "positionAmt": "0.01",
+        "entryPrice": "44525.0",
+        "markPrice": "45464.17",
+        "unRealizedProfit": "9.39",
+        "liquidationPrice": "38007.16",
+        "leverage": "100",
+        "positionSide": "BOTH",
+        "updateTime": 1707371879042,
+        "maxNotionalValue": "500000.0",
+        "notional": "454.64",
+    }
+
+    MARKET = {
+        "id": "BTCUSDT",
+        "symbol": "BTC/USDT:USDT",
+        "contract": True,
+        "linear": True,
+        "contractSize": 1.0,
+        "precision": {"amount": 0.001, "price": 0.1},
+    }
+
+    def test_margin_mode_defaults_to_cross(self):
+        ex = _pm_exchange()
+        try:
+            parsed = ex.parse_position_risk(self.PAPI_ROW, self.MARKET)
+            assert parsed["marginMode"] == "cross"
+        finally:
+            run(ex.close())
+
+    def test_explicit_margin_mode_is_kept(self):
+        ex = _pm_exchange()
+        try:
+            row = dict(self.PAPI_ROW, marginType="isolated", isolatedMargin="1.0")
+            parsed = ex.parse_position_risk(row, self.MARKET)
+            assert parsed["marginMode"] == "isolated"
+        finally:
+            run(ex.close())
+
+
+class TestBinancePmVenueFigures:
+    @staticmethod
+    def _connector() -> BinancePmCcxtConnector:
+        return BinancePmCcxtConnector(
+            exchange_name="BINANCE.UM",
+            channel=MagicMock(),
+            time_provider=MagicMock(),
+            exchange_manager=MagicMock(),
+            data_provider=MagicMock(),
+        )
+
+    def test_reads_grafted_papi_account(self):
+        figures = self._connector()._extract_venue_figures(
+            {
+                "info": {
+                    "balance": [{"asset": "USDT"}],
+                    "account": {
+                        "accountEquity": "404.51",
+                        "totalAvailableBalance": "359.52",
+                        "uniMMR": "731.2",
+                        "accountMaintMargin": "0.55",
+                        "virtualMaxWithdrawAmount": "358.0",
+                    },
+                }
+            }
+        )
+        assert figures == (404.51, 359.52, 731.2, 358.0)
+
+    def test_unimmr_sentinel_maps_to_none(self):
+        # no positions: accountMaintMargin 0 and uniMMR is a 99999999 sentinel
+        figures = self._connector()._extract_venue_figures(
+            {
+                "info": {
+                    "balance": [],
+                    "account": {
+                        "accountEquity": "404.51",
+                        "totalAvailableBalance": "404.51",
+                        "uniMMR": "99999999",
+                        "accountMaintMargin": "0.0",
+                        "virtualMaxWithdrawAmount": "404.51",
+                    },
+                }
+            }
+        )
+        assert figures == (404.51, 404.51, None, 404.51)
+
+    def test_missing_graft_degrades_to_none(self):
+        # raw papiGetBalance list info (graft failed) must not sink the snapshot
+        assert self._connector()._extract_venue_figures({"info": [{"asset": "USDT"}]}) == (None, None, None, None)
+
+
+class TestPmTriggerOrders:
+    def test_trigger_open_orders_short_circuit(self):
+        # papi /um/conditional/openOrders 404s (live-verified 2026-07-22) — the PM
+        # override must not touch the exchange at all
+        connector = TestBinancePmVenueFigures._connector()
+        assert run(connector._fetch_trigger_open_orders()) == []
+        connector._em.exchange.fetch_open_orders.assert_not_called()
+
+
+class TestVenueErrorLogging:
+    def test_merge_open_orders_survives_html_error_text(self):
+        """Venue errors can carry raw HTML (Binance 404 pages). With a colorized sink,
+        f-stringing that into loguru's format string raises ValueError inside the
+        snapshot task — the positional-args form must survive it."""
+        connector = TestBinancePmVenueFigures._connector()
+        html_error = Exception("404 Not Found <!DOCTYPE html>\n<html>\n<head></head></html>")
+        sink_id = logger.add(io.StringIO(), colorize=True, level="WARNING")
+        try:
+            assert connector._merge_open_orders(html_error, []) is None
+            assert connector._merge_open_orders([], html_error) is None
+        finally:
+            logger.remove(sink_id)
+
+
+class TestPmConnectorResolution:
+    def test_registered_for_venue_name(self):
+        assert CUSTOM_CONNECTORS["binance.pm"] is BinancePmCcxtConnector
+
+    def test_factory_resolves_venue_before_canonical(self):
+        kwargs = dict(
+            channel=MagicMock(),
+            time_provider=MagicMock(),
+            exchange_manager=MagicMock(),
+            data_provider=MagicMock(),
+        )
+        pm = get_ccxt_connector("BINANCE.UM", venue_name="BINANCE.PM", **kwargs)
+        assert type(pm) is BinancePmCcxtConnector
+        assert pm.exchange_name == "BINANCE.UM"  # account events stay keyed canonical
+
+        um = get_ccxt_connector("BINANCE.UM", venue_name="BINANCE.UM", **kwargs)
+        assert type(um) is CcxtConnector
+
+        um_no_venue = get_ccxt_connector("BINANCE.UM", **kwargs)
+        assert type(um_no_venue) is CcxtConnector
+
+
+class TestLeverageSettingsSpelling:
+    def test_papi_max_notional_spelling(self):
+        rows = [
+            {"symbol": "BTC/USDT:USDT", "longLeverage": 5, "info": {"maxNotional": "480000000"}},
+            {"symbol": "ETH/USDT:USDT", "longLeverage": 10, "info": {"maxNotionalValue": "10000000"}},
+        ]
+        settings = ccxt_extract_leverage_settings(rows)
+        assert settings["BTC/USDT:USDT"] == (5.0, 480000000.0)
+        assert settings["ETH/USDT:USDT"] == (10.0, 10000000.0)

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -389,6 +389,68 @@ class TestVenueErrorLogging:
             logger.remove(sink_id)
 
 
+class TestPmAdlLevels:
+    """PM has no adl in positionRisk — one bulk adlQuantile call per snapshot stamps
+    Position.adl_level and refreshes a cache; get_adl_level is a dict read (never a
+    blocking venue call — safe to iterate from the strategy thread)."""
+
+    ADL_ROWS = [
+        {"symbol": "DOGEUSDT", "adlQuantile": {"LONG": 2, "SHORT": 1}},
+        {"symbol": "BTCUSDT", "adlQuantile": {"BOTH": 3}},
+    ]
+
+    @staticmethod
+    def _connector_with_adl(rows):
+        connector = TestBinancePmVenueFigures._connector()
+
+        async def fake_adl(*args, **kwargs):
+            return rows
+
+        connector._em.exchange.papiGetUmAdlQuantile = fake_adl
+        connector._em.exchange.market = MagicMock(side_effect=Exception("markets not loaded"))
+        return connector
+
+    @staticmethod
+    def _position(symbol: str) -> MagicMock:
+        pos = MagicMock()
+        pos.instrument.symbol = symbol
+        pos.adl_level = None
+        pos.leverage = 1.0
+        pos.max_notional = 1.0  # short-circuits the base leverage fill (no fetch_leverages)
+        return pos
+
+    def test_fill_stamps_positions_and_cache(self):
+        connector = self._connector_with_adl(self.ADL_ROWS)
+        doge, btc = self._position("DOGEUSDT"), self._position("BTCUSDT")
+        run(connector._fill_adl_levels([doge, btc]))
+        assert doge.adl_level == 2  # max(LONG, SHORT)
+        assert btc.adl_level == 3
+        assert connector.get_adl_level(doge.instrument) == 2
+        assert connector.get_adl_level(btc.instrument) == 3
+
+    def test_get_adl_level_never_calls_venue(self):
+        connector = self._connector_with_adl(self.ADL_ROWS)
+        instrument = MagicMock()
+        instrument.symbol = "DOGEUSDT"
+        assert connector.get_adl_level(instrument) is None  # empty cache, no network
+        connector._run_sync = MagicMock(side_effect=AssertionError("must not block on venue"))
+        assert connector.get_adl_level(instrument) is None
+
+    def test_fetch_failure_keeps_previous_cache(self):
+        connector = self._connector_with_adl(self.ADL_ROWS)
+        doge = self._position("DOGEUSDT")
+        run(connector._fill_adl_levels([doge]))
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("venue down")
+
+        connector._em.exchange.papiGetUmAdlQuantile = boom
+        fresh = self._position("DOGEUSDT")
+        run(connector._fill_adl_levels([fresh]))
+        assert connector.get_adl_level(doge.instrument) == 2  # cache preserved
+        assert fresh.adl_level is None  # nothing stamped on failure
+
+
 class TestPmConnectorResolution:
     def test_registered_for_venue_name(self):
         assert CUSTOM_CONNECTORS["binance.pm"] is BinancePmCcxtConnector

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -94,7 +94,9 @@ class TestBinancePmBalanceParse:
     def test_non_pm_passthrough(self):
         ex = _pm_exchange()
         try:
-            futures_account = {"assets": [{"asset": "USDT", "availableBalance": "10", "initialMargin": "2", "walletBalance": "12"}]}
+            futures_account = {
+                "assets": [{"asset": "USDT", "availableBalance": "10", "initialMargin": "2", "walletBalance": "12"}]
+            }
             parsed = ex.parse_balance_custom(futures_account, None, None, False)
             assert parsed["USDT"]["total"] == 12.0
         finally:
@@ -195,6 +197,27 @@ class TestBinancePmVenueFigures:
 
 
 class TestPmTriggerOrders:
+    def test_conditional_create_order_fails_fast(self):
+        """The papi conditional API is suspended (404 live-verified 2026-07-22) — a stop
+        order must raise NotSupported synchronously, before any network call."""
+        import ccxt
+
+        ex = _pm_exchange()
+        try:
+            for kwargs in (
+                {"params": {"triggerPrice": 0.05}},
+                {"params": {"stopLossPrice": 0.05}},
+                {"type": "stop_market", "params": {}},
+            ):
+                order_type = kwargs.get("type", "market")
+                try:
+                    run(ex.create_order("DOGE/USDT:USDT", order_type, "sell", 150, None, kwargs["params"]))
+                    raise AssertionError(f"expected NotSupported for {kwargs}")
+                except ccxt.NotSupported:
+                    pass
+        finally:
+            run(ex.close())
+
     def test_trigger_open_orders_short_circuit(self):
         # papi /um/conditional/openOrders 404s (live-verified 2026-07-22) — the PM
         # override must not touch the exchange at all


### PR DESCRIPTION
## Summary

Makes `BINANCE.PM` (Binance portfolio margin) actually work end-to-end. The venue existed (`binancepm` ccxt class, canonicalization, credentials plumbing) but had never been verified live — and the user-data stream was dead by construction.

### Root cause

ccxt resolves the market type from `defaultType` **before** consulting the `portfolioMargin` option, and its spot/margin branches short-circuit. With the previous `defaultType: "margin"`:

- `watch_orders` / `watch_balance` / `authenticate` connected to the **spot ws-api** — the papi listen key (`papiPostListenKey`) and `/pm/ws` stream were never used. Zero UM order/fill/balance events, no error: fills only appeared via the ~30s snapshot reconcile as synthetic executions (`:fill-reconcile` trade ids), so commission/r_pnl accounting from real deals never happened.
- Venue-wide `fetch_open_orders()` queried `papiGetMarginOpenOrders` (spot-margin surface) — resting UM orders were invisible to the reconcile sweep (false orphan-cancel risk).
- The connector's `_is_derivatives_venue()` gate evaluated PM as non-derivatives, so the balance push loop never started.

### Fix

- `BinancePortfolioMargin`: `defaultType: "swap"` (+ inherited `defaultSubType: "linear"`) routes every param-less REST/WS call onto the UM/papi path; `parse_balance_custom` pins realized-only balance semantics (`totalWalletBalance`) that the linear parse branch would pollute with unrealized PnL; `parse_position_risk` defaults `marginMode` to cross; `fetch_balance` grafts `GET /papi/v1/account` into `info` (papiGetBalance is a per-asset list with no account-level figures).
- New `BinancePmCcxtConnector` (all Qubx-side PM behavior in its own code path, resolved by **venue name** — the factory checks `CUSTOM_CONNECTORS` for the configured venue before the canonical name): venue figures from papiGetAccount (`accountEquity`/`totalAvailableBalance`/`uniMMR`/`virtualMaxWithdrawAmount`, uniMMR no-position sentinel mapped to None), ADL via `GET /papi/v1/um/adlQuantile`, and a short-circuit for the trigger open-orders sweep — ccxt 4.5.50 maps it to `GET /papi/v1/um/conditional/openOrders`, which **404s with an HTML error page** (live-verified 2026-07-22).
- `ccxt_extract_leverage_settings` accepts papi's `maxNotional` spelling alongside `maxNotionalValue`.
- Snapshot/spawn error logging passes venue exception text as loguru **positional args**: an HTML error page f-stringed into the format string raises `ValueError` in loguru's colorizer, which previously killed the whole snapshot task *and* masked the real error. (The f-string-exception pattern exists at other log sites too — only the snapshot-path sites that demonstrably bit are fixed here.)
- Removed the dead `binancepm_usdm` registry entry.

### Live verification (real PM account, DOGEUSDT round trips)

| Check | Before | After |
|---|---|---|
| Order fill events | ~30s late via reconcile, synthetic executions | real-time WS (~135ms), venue trade ids |
| Realized PnL | never (no deals) | deal-based, correct |
| Balance updates | snapshot-only | instant `ACCOUNT_UPDATE` push |
| Venue account figures | all None (derived) | `accountEquity`/available/withdrawable from papiGetAccount |
| Venue-wide open orders | papi margin surface | `papiGetUmOpenOrders` |
| Full snapshot sweep | died on conditional 404 + colorizer crash | survives, no tracebacks |

### Caveats

- **Stop orders on PM route through the new papi Algo Service.** Binance [suspended the old conditional endpoints in 2026-04](https://www.binance.com/en/support/announcement/detail/13980e4145ee41259d32f985161d81b6) and replaced them with `/papi/v1/um/algo/*` ([changelog 2026-04-14](https://developers.binance.com/docs/derivatives/change-log)); ccxt <= 4.5.50 still routes to the dead endpoints. `BinancePortfolioMargin` now overrides `create_order`/`cancel_order`/`fetch_order`/`fetch_open_orders` to hit the algo API for trigger orders (renamed fields: `triggerPrice`, `clientAlgoId`, `algoId`). Live-verified including a real trigger: the fired stop spawns an order carrying the **original clientAlgoId as its clientOrderId**, and its NEW/partial/FILLED events arrive real-time on `/pm/ws` — cid-keyed tracking correlates stop executions with no extra plumbing. `ALGO_UPDATE` events did not fire for NEW/CANCELED in testing; the algo lifecycle is REST-confirmed + swept via `openAlgoOrders`.
- Per-position initial margin on PM is ccxt-computed (`notional/leverage`; papi positionRisk carries no `initialMargin` field, unlike fapi v3) — matched venue values at 5x in testing; venue-reported per-position IM would need `papiGetUmAccount` rows.
- papi account figures are USD-denominated (fapi's are USDT) — treated as equivalent, same as the base class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
