### PR TITLE
fix(runner): build data providers with the canonical exchange name

### DIFF
--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -5,7 +5,7 @@ import socket
 import tempfile
 import time
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import reduce
 from pathlib import Path
 from threading import Thread
@@ -555,7 +555,14 @@ def create_strategy_context(
             params=dict(exchange_config.params),
         )
         _dp_name = (exchange_config.data_provider or exchange_config.connector).lower()
-        _data_provider = ConnectorRegistry.get_data_provider(_dp_name, _base_ctx)
+        # Market data is public and belongs to the CANONICAL exchange: a BINANCE.PM venue
+        # trades BINANCE.UM instruments, and data plugins key their catalogs/subscriptions
+        # by the configured exchange name (e.g. xdata's "EXCHANGE:TYPE:SYMBOL" catalog),
+        # so a venue-named provider misses every canonical instrument — is_instrument_listed
+        # returns False and the universe manager sweeps the whole venue as delisted. The
+        # venue name stays on the CONNECTOR context only (credentials + order routing).
+        _data_ctx = replace(_base_ctx, exchange_name=exchange_name) if exchange_name != venue_name else _base_ctx
+        _data_provider = ConnectorRegistry.get_data_provider(_dp_name, _data_ctx)
         _exchange_to_data_provider[exchange_name] = _data_provider
         # Per-exchange connector: paper wraps the OME in a SimulatedConnector (synchronous
         # execution); live builds the real connector. Everything downstream is identical.

--- a/tests/qubx/utils/runner/test_runner.py
+++ b/tests/qubx/utils/runner/test_runner.py
@@ -341,6 +341,13 @@ class TestRunStrategyYaml:
         assert {i.exchange for i in ctx._initial_instruments} == {"BINANCE.UM"}
         acc_manager.get_exchange_settings.assert_any_call("BINANCE.PM")
 
+        # - the DATA provider is built with the canonical exchange too: data plugins key
+        #   catalogs/subscriptions by ctx.exchange_name (xdata "EXCHANGE:TYPE:SYMBOL"),
+        #   so a venue-named provider reports every canonical instrument as unlisted and
+        #   the universe manager sweeps the venue as delisted (observed live on BINANCE.PM)
+        _, dp_ctx = mock_create_data_provider.call_args[0]
+        assert dp_ctx.exchange_name == "BINANCE.UM"
+
         # - paper capital seeded into the canonical AM state
         balance = ctx.account.get_balance("USDT", exchange="BINANCE.UM")
         assert balance is not None


### PR DESCRIPTION
## Summary

Live finding on the first BINANCE.PM bot (v11.dynamic.bhpl, dev): the **UniverseManager swept all 673 Binance instruments as "delisted (gone)"** right after warmup.

Root cause: the runner builds the data provider's `BuildContext` with the configured **venue** name. Data plugins key their catalogs and subscription requests by `ctx.exchange_name` — qubx-xdata builds `"EXCHANGE:TYPE:SYMBOL"` keys — so on a `BINANCE.PM` venue the provider asked the xdata catalog for `BINANCE.PM:SWAP:BTCUSDT`, which doesn't exist (the catalog speaks canonical `BINANCE.UM`). `is_instrument_listed` returned False for everything → universe emptied. Live subscriptions through the same provider were equally mis-keyed.

Fix: the DATA provider now gets a canonicalized context (`dataclasses.replace`) while the CONNECTOR keeps the venue context (credentials + papi order routing). Market data is public and belongs to the instrument universe — the same principle the rest of the PM design already follows (#340).

Side effect for `connector: ccxt` on a PM venue: public market data now uses the canonical UM class (`binanceqv_usdm`) instead of `binancepm` — same public endpoints, faster startup (no spot/inverse market loading on the MD instance).

## Test
Extended the R13 canonicalization regression to assert the data-provider context is canonical. Full suite: 2186 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)