### PR TITLE
refactor(core): typed Transfer record for ITransferManager

### DIFF
--- a/src/qubx/backtester/transfers.py
+++ b/src/qubx/backtester/transfers.py
@@ -1,9 +1,8 @@
 import uuid
-from typing import Any
 
 from qubx import logger
 from qubx.core.account_manager import AccountManager
-from qubx.core.basics import ITimeProvider
+from qubx.core.basics import ITimeProvider, Transfer, TransferStatus
 from qubx.core.interfaces import ITransferManager
 
 
@@ -17,7 +16,7 @@ class SimulationTransferManager(ITransferManager):
     def __init__(self, account_manager: AccountManager, time_provider: ITimeProvider):
         self._account = account_manager
         self._time = time_provider
-        self._transfers: dict[str, dict[str, Any]] = {}
+        self._transfers: dict[str, Transfer] = {}
 
     def transfer_funds(self, from_exchange: str, to_exchange: str, currency: str, amount: float) -> str:
         if amount <= 0:
@@ -36,23 +35,23 @@ class SimulationTransferManager(ITransferManager):
         self._account.adjust_balance(to_exchange, currency, amount)
 
         transaction_id = f"sim_{uuid.uuid4().hex[:12]}"
-        self._transfers[transaction_id] = {
-            "transaction_id": transaction_id,
-            "timestamp": self._time.time(),
-            "from_exchange": from_exchange,
-            "to_exchange": to_exchange,
-            "currency": currency,
-            "amount": amount,
-            "status": "completed",  # transfers are instant in simulation
-        }
+        self._transfers[transaction_id] = Transfer(
+            transaction_id=transaction_id,
+            from_exchange=from_exchange,
+            to_exchange=to_exchange,
+            currency=currency,
+            amount=amount,
+            status=TransferStatus.COMPLETED,  # transfers are instant in simulation
+            timestamp=self._time.time(),
+        )
         logger.debug(f"[SimTransfer] {amount:.8f} {currency} {from_exchange} -> {to_exchange} ({transaction_id})")
         return transaction_id
 
-    def get_transfer_status(self, transaction_id: str) -> dict[str, Any]:
-        record = self._transfers.get(transaction_id)
-        if record is None:
+    def get_transfer_status(self, transaction_id: str) -> Transfer:
+        transfer = self._transfers.get(transaction_id)
+        if transfer is None:
             raise ValueError(f"Transfer not found: {transaction_id}")
-        return dict(record)
+        return transfer
 
-    def get_transfers(self) -> dict[str, dict[str, Any]]:
-        return {tid: dict(rec) for tid, rec in self._transfers.items()}
+    def get_transfers(self) -> dict[str, Transfer]:
+        return dict(self._transfers)

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -640,10 +640,13 @@ def recognize_simulation_data_config(
     )
 
 
+_TRANSFERS_LOG_COLUMNS = ["transaction_id", "from_exchange", "to_exchange", "currency", "amount", "status"]
+
+
 def collect_transfers_log(transfer_manager: ITransferManager | None) -> pd.DataFrame | None:
     """Build the transfers-log DataFrame from a transfer manager.
 
-    ``ITransferManager.get_transfers() -> dict[tid, record]`` (default no-op; the
+    ``ITransferManager.get_transfers() -> dict[tid, Transfer]`` (default no-op; the
     SimulationTransferManager overrides it). We reproduce the legacy frame shape: one row
     per transfer, ``timestamp`` as the index, the remaining record fields as columns. No
     transfers (incl. the no-op default) -> empty frame with the legacy schema; no manager
@@ -652,12 +655,22 @@ def collect_transfers_log(transfer_manager: ITransferManager | None) -> pd.DataF
     if transfer_manager is None:
         return None
     try:
-        records = list(transfer_manager.get_transfers().values())
-        if not records:
-            return pd.DataFrame(
-                columns=["transaction_id", "from_exchange", "to_exchange", "currency", "amount", "status"]
-            )
-        return pd.DataFrame(records).set_index("timestamp")
+        transfers = list(transfer_manager.get_transfers().values())
+        if not transfers:
+            return pd.DataFrame(columns=_TRANSFERS_LOG_COLUMNS)
+        rows = [
+            {
+                "timestamp": t.timestamp,
+                "transaction_id": t.transaction_id,
+                "from_exchange": t.from_exchange,
+                "to_exchange": t.to_exchange,
+                "currency": t.currency,
+                "amount": t.amount,
+                "status": str(t.status),
+            }
+            for t in transfers
+        ]
+        return pd.DataFrame(rows).set_index("timestamp")
     except Exception as e:
         logger.error(f"Failed to get transfers log: {e}")
         return None

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -908,6 +908,57 @@ class Balance:
         self.last_update_time = balance.last_update_time
 
 
+class TransferStatus(StrEnum):
+    """Normalized status of an inter-exchange fund transfer.
+
+    Live services expose a venue-native status (kept on ``Transfer.raw_status``); this is the
+    3-state vocabulary the framework and strategies reason about. Values are lowercase to match
+    the transfers-log column content and the historical status strings.
+    """
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in (TransferStatus.COMPLETED, TransferStatus.FAILED)
+
+
+@dataclass(frozen=True)
+class Transfer:
+    """A single inter-exchange fund transfer tracked by an ``ITransferManager``.
+
+    Immutable: managers replace the tracked instance on each refresh rather than mutating it,
+    so a value handed to a caller never changes underfoot (the live manager is read from both
+    the strategy and the control-server threads).
+    """
+
+    transaction_id: str
+    from_exchange: str
+    to_exchange: str
+    currency: str
+    amount: float
+    status: TransferStatus
+    timestamp: dt_64
+    raw_status: str | None = None  # venue-native status; None for simulation
+    failure_reason: str | None = None  # populated when status is FAILED
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe mapping (datetime64 -> str, status -> its value) for wire/reporting."""
+        return {
+            "transaction_id": self.transaction_id,
+            "timestamp": str(self.timestamp),
+            "from_exchange": self.from_exchange,
+            "to_exchange": self.to_exchange,
+            "currency": self.currency,
+            "amount": self.amount,
+            "status": str(self.status),
+            "raw_status": self.raw_status,
+            "failure_reason": self.failure_reason,
+        }
+
+
 DEFAULT_MAINTENANCE_MARGIN = 0.05
 
 

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -28,6 +28,7 @@ from qubx.core.basics import (
     Signal,
     TargetPosition,
     TransactionCostsCalculator,
+    Transfer,
     dt_64,
     td_64,
 )
@@ -959,12 +960,12 @@ class StrategyContext(IStrategyContext):
         return self._transfer_manager.transfer_funds(from_exchange, to_exchange, currency, amount)
 
     @check_transfer_manager
-    def get_transfer_status(self, transaction_id: str) -> dict[str, Any]:
+    def get_transfer_status(self, transaction_id: str) -> Transfer:
         assert self._transfer_manager is not None
         return self._transfer_manager.get_transfer_status(transaction_id)
 
     @check_transfer_manager
-    def get_transfers(self) -> dict[str, dict[str, Any]]:
+    def get_transfers(self) -> dict[str, Transfer]:
         assert self._transfer_manager is not None
         return self._transfer_manager.get_transfers()
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -39,6 +39,7 @@ from qubx.core.basics import (
     TargetPosition,
     Timestamped,
     TransactionCostsCalculator,
+    Transfer,
     TriggerEvent,
     dt_64,
     td_64,
@@ -1187,7 +1188,7 @@ class ITransferManager:
         """
         ...
 
-    def get_transfer_status(self, transaction_id: str) -> dict[str, Any]:
+    def get_transfer_status(self, transaction_id: str) -> Transfer:
         """
         Get the status of a transfer.
 
@@ -1195,11 +1196,11 @@ class ITransferManager:
             transaction_id: Transaction ID
 
         Returns:
-            dict[str, Any]: Transfer status
+            Transfer: The transfer record (raises if the id is unknown).
         """
         ...
 
-    def get_transfers(self) -> dict[str, dict[str, Any]]:
+    def get_transfers(self) -> dict[str, Transfer]:
         """Recorded transfers keyed by transaction id, for reporting (e.g. the backtest
         transfers log).
 

--- a/tests/qubx/backtester/test_transfers.py
+++ b/tests/qubx/backtester/test_transfers.py
@@ -13,7 +13,7 @@ from qubx.backtester.utils import (
     recognize_simulation_data_config,
 )
 from qubx.core.account_manager import SimulatedAccountManager
-from qubx.core.basics import Balance, Instrument, ITimeProvider, MarketType
+from qubx.core.basics import Balance, Instrument, ITimeProvider, MarketType, Transfer, TransferStatus
 from qubx.core.initializer import BasicStrategyInitializer
 from qubx.core.interfaces import IStrategy, IStrategyInitializer, ITransferManager
 from qubx.data.registry import StorageRegistry
@@ -34,6 +34,31 @@ def _am():
     return am
 
 
+def test_transfer_status_is_terminal():
+    assert TransferStatus.COMPLETED.is_terminal
+    assert TransferStatus.FAILED.is_terminal
+    assert not TransferStatus.PENDING.is_terminal
+
+
+def test_transfer_to_dict_is_json_safe():
+    t = Transfer(
+        transaction_id="tx1",
+        from_exchange="E1",
+        to_exchange="E2",
+        currency="USDC",
+        amount=100.0,
+        status=TransferStatus.COMPLETED,
+        timestamp=np.datetime64("2026-05-28T00:00:00", "ms"),
+        raw_status="COMPLETED",
+    )
+    d = t.to_dict()
+    assert d["transaction_id"] == "tx1"
+    assert d["status"] == "completed"  # enum -> its value
+    assert isinstance(d["timestamp"], str) and d["timestamp"].startswith("2026-05-28")
+    assert d["raw_status"] == "COMPLETED"
+    assert d["failure_reason"] is None
+
+
 def test_transfer_moves_balance_between_exchanges():
     am = _am()
     tm = SimulationTransferManager(am, _T())
@@ -45,10 +70,10 @@ def test_transfer_moves_balance_between_exchanges():
     assert am.get_balance("USDT", exchange="E2").total == 300.0
     assert am.get_balance("USDT", exchange="E2").free == 300.0
     status = tm.get_transfer_status(txid)
-    assert status["amount"] == 300.0
-    assert status["from_exchange"] == "E1"
-    assert status["to_exchange"] == "E2"
-    assert status["status"] == "completed"
+    assert status.amount == 300.0
+    assert status.from_exchange == "E1"
+    assert status.to_exchange == "E2"
+    assert status.status == TransferStatus.COMPLETED
     assert txid in tm.get_transfers()
 
 


### PR DESCRIPTION
## Summary

`ITransferManager` returned transfer records as `dict[str, Any]`, so every caller reached into stringly-typed keys with no autocomplete or type-checking. This replaces that with a typed **`Transfer`** dataclass + **`TransferStatus`** enum — one source of truth for the transfer shape.

## Contract change

| method | before | after |
|--------|--------|-------|
| `get_transfer_status(txid)` | `dict[str, Any]` | `Transfer` |
| `get_transfers()` | `dict[str, dict[str, Any]]` | `dict[str, Transfer]` |
| `transfer_funds(...)` | `str` | `str` (unchanged) |

## New types (`qubx/core/basics.py`)

```python
class TransferStatus(StrEnum):        # normalized 3-state vocabulary
    PENDING = "pending"; COMPLETED = "completed"; FAILED = "failed"
    @property
    def is_terminal(self) -> bool: ...

@dataclass(frozen=True)
class Transfer:
    transaction_id: str
    from_exchange: str
    to_exchange: str
    currency: str
    amount: float
    status: TransferStatus
    timestamp: dt_64
    raw_status: str | None = None       # venue-native status; None for sim
    failure_reason: str | None = None   # set when status is FAILED
    def to_dict(self) -> dict[str, Any]: ...   # JSON-safe (timestamp->str, status->value)
```

## Design notes

- **`frozen=True`** — a live manager is read from both the strategy and the control-server threads. Immutability means a refresh *replaces* the tracked instance instead of mutating it, removing the need for defensive copies and the old "record shape changes underfoot" quirk.
- **Lowercase enum values** — keeps the transfers-log column content byte-identical, and as a `StrEnum` keeps `status == "completed"` comparisons valid.
- **`raw_status` / `failure_reason` optional** — the one class models both the 7-field simulation record and the 9-field live record.
- **`to_dict()`** — a single home for the JSON/wire representation.

## Implementations

- `SimulationTransferManager` builds `Transfer` objects (immutable, no per-call copies).
- `collect_transfers_log` projects them into the **same** transfers-log DataFrame — columns, order, index, and the lowercase `"completed"` status string all unchanged.

## Testing

- `tests/qubx/backtester/test_transfers.py` — updated to attribute access; added `to_dict` (JSON-safe) and `is_terminal` tests. **14 passed.**
- Full backtester suite **110 passed** · `ruff check` clean.

## Downstream

The live `XChangesTransferService` (quantkit) and the `frab` strategy consume these methods and will be updated to `Transfer` in lockstep dependency bumps.