### PR TITLE
feat: strategy-owned QuestDB tables — ensure_table + emit_record on IMetricEmitter

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -14,6 +14,7 @@ This module includes:
 
 import datetime
 import traceback
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Callable, Literal, Protocol, runtime_checkable
 
@@ -2607,6 +2608,54 @@ class IMetricEmitter:
             instrument: Instrument the deals belong to
             deals: List of deals to emit
             account: Account viewer to get account information like total capital, leverage, etc.
+        """
+        pass
+
+    def ensure_table(
+        self,
+        table: str,
+        columns: dict[str, str],
+        symbol_columns: Sequence[str] = (),
+        dedup_keys: Sequence[str] | None = None,
+        partition_by: str = "DAY",
+    ) -> None:
+        """
+        Declare a strategy-owned table with an explicit schema.
+
+        Implementations that persist to a SQL store should create the table if it
+        does not exist (idempotent). Scope columns (strategy, run_id, is_live and
+        any configured default tags) are added automatically — callers declare only
+        their own columns. Default is a no-op.
+
+        Args:
+            table: Table name (e.g. "frab.trades")
+            columns: Column name -> type (DOUBLE | LONG | STRING | BOOLEAN | TIMESTAMP)
+            symbol_columns: Column names to create as indexed SYMBOL columns
+            dedup_keys: Optional designated-timestamp-first dedup key columns
+            partition_by: Partitioning unit (default DAY)
+        """
+        pass
+
+    def emit_record(
+        self,
+        table: str,
+        record: dict[str, Any],
+        symbol_columns: Sequence[str] = (),
+        timestamp: dt_64 | None = None,
+    ) -> None:
+        """
+        Emit one structured row to a strategy-owned table.
+
+        Scope tags (strategy, run_id, is_live, configured default tags) are injected
+        automatically and OVERWRITE caller keys of the same name. Values map to
+        column types naturally (float->DOUBLE, int->LONG, bool->BOOLEAN, str->STRING,
+        datetime-like->TIMESTAMP). None values are skipped. Default is a no-op.
+
+        Args:
+            table: Table name (should have been declared via ensure_table)
+            record: Column name -> value for this row
+            symbol_columns: Which keys are SYMBOL columns (used if the table was not declared)
+            timestamp: Designated timestamp of the row (defaults to context time / now)
         """
         pass
 

--- a/src/qubx/emitters/composite.py
+++ b/src/qubx/emitters/composite.py
@@ -5,7 +5,8 @@ This module provides a composite implementation of IMetricEmitter that delegates
 """
 
 import datetime
-from typing import Dict, List, Optional
+from collections.abc import Sequence
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
@@ -116,6 +117,35 @@ class CompositeMetricEmitter(BaseMetricEmitter):
                 emitter.emit_deals(time, instrument, deals, account)
             except Exception as e:
                 logger.error(f"Error emitting deals to {emitter.__class__.__name__}: {e}")
+
+    def ensure_table(
+        self,
+        table: str,
+        columns: dict[str, str],
+        symbol_columns: Sequence[str] = (),
+        dedup_keys: Sequence[str] | None = None,
+        partition_by: str = "DAY",
+    ) -> None:
+        for emitter in self._emitters:
+            try:
+                emitter.ensure_table(
+                    table, columns, symbol_columns=symbol_columns, dedup_keys=dedup_keys, partition_by=partition_by
+                )
+            except Exception as e:
+                logger.error(f"Error ensuring table on {emitter.__class__.__name__}: {e}")
+
+    def emit_record(
+        self,
+        table: str,
+        record: dict[str, Any],
+        symbol_columns: Sequence[str] = (),
+        timestamp: dt_64 | None = None,
+    ) -> None:
+        for emitter in self._emitters:
+            try:
+                emitter.emit_record(table, record, symbol_columns=symbol_columns, timestamp=timestamp)
+            except Exception as e:
+                logger.error(f"Error emitting record to {emitter.__class__.__name__}: {e}")
 
     def set_context(self, context: IStrategyContext) -> None:
         """

--- a/src/qubx/emitters/composite.py
+++ b/src/qubx/emitters/composite.py
@@ -126,6 +126,16 @@ class CompositeMetricEmitter(BaseMetricEmitter):
         dedup_keys: Sequence[str] | None = None,
         partition_by: str = "DAY",
     ) -> None:
+        """
+        Declare a strategy-owned table on all configured emitters.
+
+        Args:
+            table: Table name (e.g. "frab.trades")
+            columns: Column name -> type (DOUBLE | LONG | STRING | BOOLEAN | TIMESTAMP)
+            symbol_columns: Column names to create as indexed SYMBOL columns
+            dedup_keys: Optional designated-timestamp-first dedup key columns
+            partition_by: Partitioning unit (default DAY)
+        """
         for emitter in self._emitters:
             try:
                 emitter.ensure_table(
@@ -141,6 +151,15 @@ class CompositeMetricEmitter(BaseMetricEmitter):
         symbol_columns: Sequence[str] = (),
         timestamp: dt_64 | None = None,
     ) -> None:
+        """
+        Emit one structured row to a strategy-owned table on all configured emitters.
+
+        Args:
+            table: Table name (should have been declared via ensure_table)
+            record: Column name -> value for this row
+            symbol_columns: Which keys are SYMBOL columns (used if the table was not declared)
+            timestamp: Designated timestamp of the row (defaults to context time / now)
+        """
         for emitter in self._emitters:
             try:
                 emitter.emit_record(table, record, symbol_columns=symbol_columns, timestamp=timestamp)

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -331,7 +331,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             decl.setdefault("run_id", "STRING")
             decl["is_live"] = "BOOLEAN"
             for name in symbol_columns:
-                decl[name] = "SYMBOL"
+                decl.setdefault(name, "SYMBOL")  # never overrides reserved scope columns (e.g. run_id, timestamp)
             for name, typ in columns.items():
                 t = typ.upper()
                 if t not in self.RECORD_COLUMN_TYPES:
@@ -379,16 +379,22 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             if sym_names is None:
                 sym_names = set(symbol_columns) | (set(self.SYMBOL_TAGS) & set(row))
             symbols = {k: str(row.pop(k)) for k in list(row) if k in sym_names}
-            columns = {
-                k: (self._convert_timestamp(v) if isinstance(v, (pd.Timestamp, np.datetime64)) or hasattr(v, "astype") else v)
-                for k, v in row.items()
-            }
+            columns: dict[str, Any] = {}
+            for k, v in row.items():
+                if isinstance(v, (pd.Timestamp, np.datetime64, datetime.datetime)):
+                    columns[k] = self._convert_timestamp(v)
+                elif isinstance(v, np.generic):  # numpy scalar (float64/int64/bool_/...) -> native Python
+                    columns[k] = v.item()
+                else:
+                    columns[k] = v
             at = self._convert_timestamp(timestamp) if timestamp is not None else datetime.datetime.now()
             self._executor.submit(self._emit_record_to_questdb, table, symbols, columns, at)
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to queue record for '{table}': {e}")
 
-    def _emit_record_to_questdb(self, table: str, symbols: dict, columns: dict, at) -> None:
+    def _emit_record_to_questdb(
+        self, table: str, symbols: dict[str, str], columns: dict[str, Any], at: datetime.datetime
+    ) -> None:
         try:
             if self._sender is not None:
                 self._sender.row(table, symbols=symbols, columns=columns, at=at)

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -325,6 +325,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
     ) -> None:
         """Create a strategy-owned table with explicit types (spec: strategy-tables §2.0)."""
         try:
+            if isinstance(symbol_columns, str):
+                raise ValueError(f"symbol_columns must be a sequence of names, not a bare string: {symbol_columns!r}")
             decl: dict[str, str] = {"timestamp": "TIMESTAMP"}
             for key in self._default_tags:  # scope columns, injected first
                 decl[key] = "SYMBOL" if key in self.SYMBOL_TAGS else "STRING"
@@ -343,7 +345,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
                 f"TIMESTAMP(timestamp) PARTITION BY {partition_by} WAL"
             )
             if dedup_keys:
-                ddl += f" DEDUP UPSERT KEYS({', '.join(dedup_keys)})"
+                quoted_keys = ", ".join(f'"{k}"' for k in dedup_keys)
+                ddl += f" DEDUP UPSERT KEYS({quoted_keys})"
             ddl += ";"
             QuestDBClient(host=self._host, port=8812).execute(ddl)
             self._declared_columns[table] = set(decl)
@@ -359,18 +362,33 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         symbol_columns: Sequence[str] = (),
         timestamp: dt_64 | None = None,
     ) -> None:
-        """Emit one row to a strategy-owned table (spec: strategy-tables §2.1)."""
+        """Emit one row to a strategy-owned table (spec: strategy-tables §2.1).
+
+        The designated timestamp is taken only from the `timestamp` parameter (falling
+        back to the context's current time, then wall-clock `now()`) — a `"timestamp"`
+        key present in `record` is dropped so it can't collide with it.
+        """
         if self._sender is None:
             return
         try:
+            if isinstance(symbol_columns, str):
+                raise ValueError(f"symbol_columns must be a sequence of names, not a bare string: {symbol_columns!r}")
             if self._context is not None and timestamp is None:
                 timestamp = self._context.time()
             row = {k: v for k, v in record.items() if v is not None}
+            row.pop("timestamp", None)  # designated timestamp comes only from the `timestamp` parameter
             row.update(self._default_tags)  # scope tags overwrite caller keys
             if self._context is not None:
                 row["is_live"] = not self._context.is_simulation
             declared = self._declared_columns.get(table)
-            if declared is not None:
+            if declared is None:
+                if table not in self._warned_undeclared:
+                    self._warned_undeclared.add(table)
+                    logger.warning(
+                        f"[QuestDBMetricEmitter] table '{table}' not declared via ensure_table — "
+                        "ILP auto-create with inferred types"
+                    )
+            else:
                 unknown = set(row) - declared
                 if unknown and table not in self._warned_undeclared:
                     self._warned_undeclared.add(table)

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -5,6 +5,7 @@ This module provides an implementation of IMetricEmitter that exports metrics to
 """
 
 import datetime
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, cast
 
@@ -28,6 +29,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
     """
 
     SYMBOL_TAGS = ["symbol", "exchange", "type", "environment", "strategy"]
+    RECORD_COLUMN_TYPES = {"DOUBLE", "LONG", "STRING", "BOOLEAN", "TIMESTAMP", "SYMBOL"}
 
     def __init__(
         self,
@@ -71,6 +73,11 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._last_flush = None
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="questdb_emitter")
         self._stopped = False
+
+        # Strategy-owned tables declared via ensure_table: name -> column/symbol sets.
+        self._declared_columns: dict[str, set[str]] = {}
+        self._declared_symbols: dict[str, set[str]] = {}
+        self._warned_undeclared: set[str] = set()
 
         # Create signals table if it doesn't exist
         self._ensure_signals_table_exists()
@@ -307,6 +314,86 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             self._executor.submit(self._emit_deals_to_questdb, time, instrument, deals, account)
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to queue deals emission: {e}")
+
+    def ensure_table(
+        self,
+        table: str,
+        columns: dict[str, str],
+        symbol_columns: Sequence[str] = (),
+        dedup_keys: Sequence[str] | None = None,
+        partition_by: str = "DAY",
+    ) -> None:
+        """Create a strategy-owned table with explicit types (spec: strategy-tables §2.0)."""
+        try:
+            decl: dict[str, str] = {"timestamp": "TIMESTAMP"}
+            for key in self._default_tags:  # scope columns, injected first
+                decl[key] = "SYMBOL" if key in self.SYMBOL_TAGS else "STRING"
+            decl.setdefault("run_id", "STRING")
+            decl["is_live"] = "BOOLEAN"
+            for name in symbol_columns:
+                decl[name] = "SYMBOL"
+            for name, typ in columns.items():
+                t = typ.upper()
+                if t not in self.RECORD_COLUMN_TYPES:
+                    raise ValueError(f"unsupported column type {typ!r} for column {name!r}")
+                decl.setdefault(name, t)  # symbol_columns take precedence
+            cols_sql = ", ".join(f'"{n}" {t}' for n, t in decl.items())
+            ddl = (
+                f'CREATE TABLE IF NOT EXISTS "{table}" ({cols_sql}) '
+                f"TIMESTAMP(timestamp) PARTITION BY {partition_by} WAL"
+            )
+            if dedup_keys:
+                ddl += f" DEDUP UPSERT KEYS({', '.join(dedup_keys)})"
+            ddl += ";"
+            QuestDBClient(host=self._host, port=8812).execute(ddl)
+            self._declared_columns[table] = set(decl)
+            self._declared_symbols[table] = {n for n, t in decl.items() if t == "SYMBOL"}
+            logger.info(f"[QuestDBMetricEmitter] Ensured table '{table}' exists")
+        except Exception as e:
+            logger.error(f"[QuestDBMetricEmitter] Failed to ensure table '{table}': {e}")
+
+    def emit_record(
+        self,
+        table: str,
+        record: dict[str, Any],
+        symbol_columns: Sequence[str] = (),
+        timestamp: dt_64 | None = None,
+    ) -> None:
+        """Emit one row to a strategy-owned table (spec: strategy-tables §2.1)."""
+        if self._sender is None:
+            return
+        try:
+            if self._context is not None and timestamp is None:
+                timestamp = self._context.time()
+            row = {k: v for k, v in record.items() if v is not None}
+            row.update(self._default_tags)  # scope tags overwrite caller keys
+            if self._context is not None:
+                row["is_live"] = not self._context.is_simulation
+            declared = self._declared_columns.get(table)
+            if declared is not None:
+                unknown = set(row) - declared
+                if unknown and table not in self._warned_undeclared:
+                    self._warned_undeclared.add(table)
+                    logger.warning(f"[QuestDBMetricEmitter] '{table}': undeclared columns {sorted(unknown)}")
+            sym_names = self._declared_symbols.get(table)
+            if sym_names is None:
+                sym_names = set(symbol_columns) | (set(self.SYMBOL_TAGS) & set(row))
+            symbols = {k: str(row.pop(k)) for k in list(row) if k in sym_names}
+            columns = {
+                k: (self._convert_timestamp(v) if isinstance(v, (pd.Timestamp, np.datetime64)) or hasattr(v, "astype") else v)
+                for k, v in row.items()
+            }
+            at = self._convert_timestamp(timestamp) if timestamp is not None else datetime.datetime.now()
+            self._executor.submit(self._emit_record_to_questdb, table, symbols, columns, at)
+        except Exception as e:
+            logger.error(f"[QuestDBMetricEmitter] Failed to queue record for '{table}': {e}")
+
+    def _emit_record_to_questdb(self, table: str, symbols: dict, columns: dict, at) -> None:
+        try:
+            if self._sender is not None:
+                self._sender.row(table, symbols=symbols, columns=columns, at=at)
+        except Exception as e:
+            logger.error(f"[QuestDBMetricEmitter] Failed to emit record to '{table}': {e}")
 
     def _emit_signals_to_questdb(
         self,

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -1,0 +1,34 @@
+"""Tests for strategy-owned tables: ensure_table + emit_record (spec §2)."""
+
+from unittest.mock import MagicMock
+
+from qubx.core.interfaces import IMetricEmitter
+from qubx.emitters.composite import CompositeMetricEmitter
+
+
+class TestInterfaceDefaults:
+    def test_ensure_table_is_noop(self):
+        IMetricEmitter().ensure_table("t", {"a": "DOUBLE"})  # must not raise
+
+    def test_emit_record_is_noop(self):
+        IMetricEmitter().emit_record("t", {"a": 1.0})  # must not raise
+
+
+class TestCompositeForwarding:
+    def test_forwards_to_children(self):
+        child_a, child_b = MagicMock(spec=IMetricEmitter), MagicMock(spec=IMetricEmitter)
+        comp = CompositeMetricEmitter([child_a, child_b])
+        comp.ensure_table("frab.trades", {"net_pnl": "DOUBLE"}, symbol_columns=("pair",), dedup_keys=("timestamp", "trade_id"))
+        comp.emit_record("frab.trades", {"net_pnl": 1.5}, symbol_columns=("pair",))
+        for child in (child_a, child_b):
+            child.ensure_table.assert_called_once_with(
+                "frab.trades", {"net_pnl": "DOUBLE"}, symbol_columns=("pair",), dedup_keys=("timestamp", "trade_id"), partition_by="DAY"
+            )
+            child.emit_record.assert_called_once_with("frab.trades", {"net_pnl": 1.5}, symbol_columns=("pair",), timestamp=None)
+
+    def test_child_error_is_isolated(self):
+        bad, good = MagicMock(spec=IMetricEmitter), MagicMock(spec=IMetricEmitter)
+        bad.emit_record.side_effect = RuntimeError("boom")
+        comp = CompositeMetricEmitter([bad, good])
+        comp.emit_record("t", {"a": 1.0})  # must not raise
+        good.emit_record.assert_called_once()

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -96,7 +96,7 @@ class TestEnsureTable:
         assert '"pair" SYMBOL' in ddl_sql
         assert '"net_pnl" DOUBLE' in ddl_sql
         assert '"entry_time" TIMESTAMP' in ddl_sql
-        assert "TIMESTAMP(timestamp) PARTITION BY DAY WAL DEDUP UPSERT KEYS(timestamp, trade_id)" in ddl_sql
+        assert 'TIMESTAMP(timestamp) PARTITION BY DAY WAL DEDUP UPSERT KEYS("timestamp", "trade_id")' in ddl_sql
         assert emitter._declared_symbols["frab.trades"] >= {"pair", "asset", "strategy", "environment"}
 
     def test_rejects_unknown_type(self, emitter):
@@ -113,6 +113,12 @@ class TestEnsureTable:
         # run_id is a reserved scope column (STRING) -> symbol_columns must not flip it to SYMBOL
         assert '"run_id" STRING' in ddl_sql
         assert '"pair" SYMBOL' in ddl_sql
+
+    def test_rejects_bare_string_symbol_columns(self, emitter):
+        # a bare string iterates as characters ("p", "a", "i", "r", ...) -> would mint bogus
+        # single-letter SYMBOL columns; must be rejected instead, not silently misinterpreted.
+        emitter.ensure_table("t", {}, symbol_columns="pair")  # must not raise (logged), no DDL executed
+        emitter._ddl_client_for_test.execute.assert_not_called()
 
 
 class TestEmitRecord:
@@ -172,3 +178,32 @@ class TestEmitRecord:
         assert emitter._sender.rows[0][2]["net_pnl"] == 1.0
         assert emitter._sender.rows[1][2]["net_pnl"] == 2.0
         warning.assert_called_once()  # but the undeclared-column warning fires only once
+
+    def test_undeclared_table_warns_once_across_multiple_emits(self, emitter, monkeypatch):
+        warning = MagicMock()
+        monkeypatch.setattr(qdb_mod.logger, "warning", warning)
+
+        emitter.emit_record("frab.undeclared", {"ev": 1.0})
+        emitter.emit_record("frab.undeclared", {"ev": 2.0})
+
+        assert len(emitter._sender.rows) == 2  # rows are still written both times
+        assert emitter._sender.rows[0][2]["ev"] == 1.0
+        assert emitter._sender.rows[1][2]["ev"] == 2.0
+        warning.assert_called_once()  # but the "not declared via ensure_table" warning fires only once
+        msg = warning.call_args[0][0]
+        assert "frab.undeclared" in msg
+        assert "not declared via ensure_table" in msg
+
+    def test_rejects_bare_string_symbol_columns(self, emitter):
+        emitter.emit_record("t", {"a": 1.0}, symbol_columns="pair")  # must not raise (logged), no row emitted
+        assert emitter._sender.rows == []
+
+    def test_record_timestamp_key_is_dropped(self, emitter):
+        emitter.emit_record("frab.trades", {"net_pnl": 1.0, "timestamp": datetime.datetime(2020, 1, 1)})
+        _, _, columns, _ = emitter._sender.rows[0]
+        assert "timestamp" not in columns
+        assert columns["net_pnl"] == 1.0
+
+    def test_unsupported_timestamp_type_is_caught_and_logged(self, emitter):
+        emitter.emit_record("t", {"a": 1.0}, timestamp=object())  # must not raise (error logged)
+        assert emitter._sender.rows == []  # nothing was queued/emitted

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -3,6 +3,7 @@
 import datetime
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 import qubx.emitters.questdb as qdb_mod
@@ -102,6 +103,17 @@ class TestEnsureTable:
         emitter.ensure_table("t", {"x": "JSONB"})  # must not raise (logged), and no DDL executed
         emitter._ddl_client_for_test.execute.assert_not_called()
 
+    def test_symbol_columns_do_not_override_reserved_scope_types(self, emitter):
+        emitter.ensure_table(
+            "frab.reserved",
+            {"net_pnl": "DOUBLE"},
+            symbol_columns=("run_id", "pair"),
+        )
+        ddl_sql = emitter._ddl_client_for_test.execute.call_args[0][0]
+        # run_id is a reserved scope column (STRING) -> symbol_columns must not flip it to SYMBOL
+        assert '"run_id" STRING' in ddl_sql
+        assert '"pair" SYMBOL' in ddl_sql
+
 
 class TestEmitRecord:
     def test_scope_tags_overwrite_and_symbols_split(self, emitter):
@@ -135,3 +147,28 @@ class TestEmitRecord:
     def test_errors_never_raise(self, emitter):
         emitter._sender = None
         emitter.emit_record("t", {"a": 1.0})  # early return, no raise
+
+    def test_numpy_scalar_columns_pass_through_natively(self, emitter):
+        emitter.emit_record("frab.trades", {"score": np.float64(1.5)})
+        _, _, columns, _ = emitter._sender.rows[0]
+        assert columns["score"] == 1.5
+        assert isinstance(columns["score"], float) and not isinstance(columns["score"], np.floating)
+
+    def test_numpy_datetime64_column_converted_to_datetime(self, emitter):
+        emitter.emit_record("frab.trades", {"entry_time": np.datetime64("2026-07-24T12:00:00")})
+        _, _, columns, _ = emitter._sender.rows[0]
+        assert isinstance(columns["entry_time"], datetime.datetime)
+        assert not isinstance(columns["entry_time"], np.datetime64)
+
+    def test_warns_once_per_table_for_undeclared_keys(self, emitter, monkeypatch):
+        warning = MagicMock()
+        monkeypatch.setattr(qdb_mod.logger, "warning", warning)
+        emitter.ensure_table("frab.trades", {"net_pnl": "DOUBLE"})
+
+        emitter.emit_record("frab.trades", {"net_pnl": 1.0, "surprise": "x"})
+        emitter.emit_record("frab.trades", {"net_pnl": 2.0, "surprise": "y"})
+
+        assert len(emitter._sender.rows) == 2  # row is still written both times
+        assert emitter._sender.rows[0][2]["net_pnl"] == 1.0
+        assert emitter._sender.rows[1][2]["net_pnl"] == 2.0
+        warning.assert_called_once()  # but the undeclared-column warning fires only once

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -1,9 +1,14 @@
 """Tests for strategy-owned tables: ensure_table + emit_record (spec §2)."""
 
+import datetime
 from unittest.mock import MagicMock
 
+import pytest
+
+import qubx.emitters.questdb as qdb_mod
 from qubx.core.interfaces import IMetricEmitter
 from qubx.emitters.composite import CompositeMetricEmitter
+from qubx.emitters.questdb import QuestDBMetricEmitter
 
 
 class TestInterfaceDefaults:
@@ -32,3 +37,101 @@ class TestCompositeForwarding:
         comp = CompositeMetricEmitter([bad, good])
         comp.emit_record("t", {"a": 1.0})  # must not raise
         good.emit_record.assert_called_once()
+
+
+class FakeSender:
+    def __init__(self):
+        self.rows: list[tuple] = []
+
+    def row(self, table, symbols=None, columns=None, at=None):
+        self.rows.append((table, symbols, columns, at))
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class SyncExecutor:
+    def submit(self, fn, *args, **kwargs):
+        fn(*args, **kwargs)
+
+    def shutdown(self, **kwargs):
+        pass
+
+
+@pytest.fixture
+def emitter(monkeypatch):
+    ddl = MagicMock()
+    monkeypatch.setattr(qdb_mod, "QuestDBClient", MagicMock(return_value=ddl))
+    # Sender is a Cython extension type (immutable); patch the module-level name instead
+    # of Sender.from_conf directly (setattr on the class raises TypeError: immutable type).
+    monkeypatch.setattr(qdb_mod, "Sender", MagicMock(from_conf=MagicMock(side_effect=RuntimeError("no net"))))
+    em = QuestDBMetricEmitter(host="qdb", tags={"strategy": "bot-1", "run_id": "r-1", "environment": "dev"})
+    em._sender = FakeSender()
+    em._executor = SyncExecutor()
+    ddl.reset_mock()  # drop the signals/deals DDL calls from __init__
+    em._ddl_client_for_test = ddl
+    return em
+
+
+class TestEnsureTable:
+    def test_generates_create_table_with_scope_columns_and_dedup(self, emitter):
+        emitter.ensure_table(
+            "frab.trades",
+            {"trade_id": "STRING", "entry_time": "TIMESTAMP", "net_pnl": "DOUBLE"},
+            symbol_columns=("pair", "asset"),
+            dedup_keys=("timestamp", "trade_id"),
+        )
+        ddl_sql = emitter._ddl_client_for_test.execute.call_args[0][0]
+        assert 'CREATE TABLE IF NOT EXISTS "frab.trades"' in ddl_sql
+        assert '"timestamp" TIMESTAMP' in ddl_sql
+        # scope columns injected: strategy/environment are SYMBOL_TAGS -> SYMBOL, run_id STRING, is_live BOOLEAN
+        assert '"strategy" SYMBOL' in ddl_sql
+        assert '"environment" SYMBOL' in ddl_sql
+        assert '"run_id" STRING' in ddl_sql
+        assert '"is_live" BOOLEAN' in ddl_sql
+        assert '"pair" SYMBOL' in ddl_sql
+        assert '"net_pnl" DOUBLE' in ddl_sql
+        assert '"entry_time" TIMESTAMP' in ddl_sql
+        assert "TIMESTAMP(timestamp) PARTITION BY DAY WAL DEDUP UPSERT KEYS(timestamp, trade_id)" in ddl_sql
+        assert emitter._declared_symbols["frab.trades"] >= {"pair", "asset", "strategy", "environment"}
+
+    def test_rejects_unknown_type(self, emitter):
+        emitter.ensure_table("t", {"x": "JSONB"})  # must not raise (logged), and no DDL executed
+        emitter._ddl_client_for_test.execute.assert_not_called()
+
+
+class TestEmitRecord:
+    def test_scope_tags_overwrite_and_symbols_split(self, emitter):
+        emitter.ensure_table("frab.trades", {"net_pnl": "DOUBLE", "trade_id": "STRING"}, symbol_columns=("pair",))
+        emitter.emit_record(
+            "frab.trades",
+            {"pair": "SOL:BIN:HPL", "net_pnl": 1.5, "trade_id": "SOL:123", "strategy": "SPOOFED"},
+            timestamp=datetime.datetime(2026, 7, 24, 12, 0, 0),
+        )
+        table, symbols, columns, at = emitter._sender.rows[0]
+        assert table == "frab.trades"
+        assert symbols["strategy"] == "bot-1"  # injected wins over caller "SPOOFED"
+        assert symbols["pair"] == "SOL:BIN:HPL"
+        assert columns["net_pnl"] == 1.5
+        assert columns["trade_id"] == "SOL:123"
+        assert "is_live" not in columns  # no context set -> is_live is not injected at all
+        assert at == datetime.datetime(2026, 7, 24, 12, 0, 0)
+
+    def test_none_values_skipped_and_datetime_columns_converted(self, emitter):
+        emitter.emit_record("frab.trades", {"ev": None, "entry_time": datetime.datetime(2026, 7, 24)})
+        _, _, columns, _ = emitter._sender.rows[0]
+        assert "ev" not in columns
+        assert isinstance(columns["entry_time"], datetime.datetime)
+
+    def test_undeclared_table_uses_symbol_columns_arg(self, emitter):
+        emitter.emit_record("frab.decisions", {"pair": "X", "ev": 1.0}, symbol_columns=("pair",))
+        _, symbols, columns, _ = emitter._sender.rows[0]
+        assert symbols["pair"] == "X"
+        assert columns["ev"] == 1.0
+
+    def test_errors_never_raise(self, emitter):
+        emitter._sender = None
+        emitter.emit_record("t", {"a": 1.0})  # early return, no raise


### PR DESCRIPTION
## What

Public API for **strategy-owned QuestDB tables** on `IMetricEmitter`:

- **`ensure_table(table, columns, symbol_columns, dedup_keys, partition_by)`** — declares a table with exact column types via `CREATE TABLE IF NOT EXISTS ... TIMESTAMP(timestamp) PARTITION BY <p> WAL [DEDUP UPSERT KEYS(...)]`, generalizing the existing `qubx.signals`/`qubx.deals` DDL pattern (pg-wire :8812). Scope columns (`strategy`, `run_id`, `is_live`, configured tags) are injected into the schema automatically.
- **`emit_record(table, record, symbol_columns, timestamp)`** — emits one structured row over ILP. Scope tags overwrite caller keys (a strategy cannot mis-scope rows); values map naturally (float→DOUBLE, datetime-likes→TIMESTAMP, numpy scalars coerced to native); `None` values skipped; warns once per table on undeclared keys and on emits to undeclared tables.

No-op defaults on the interface, forwarding on `CompositeMetricEmitter` — all existing emitters unaffected.

## Why

First consumer is frab's closed-trade ledger (`frab.trades`) and decision audit table (`frab.decisions`) — one typed row per event instead of pivoting a dozen `qubx.metrics` rows. Design doc: `xlydian-platform/docs/superpowers/specs/2026-07-24-frab-trades-decisions-observability-design.md` §2.

## Hardening (caught in review)

- numpy scalars (`np.float64` etc.) were routed through timestamp conversion by an over-broad `hasattr(v, "astype")` check → silently corrupted numeric columns to near-epoch datetimes; now only real datetime-likes convert, `np.generic` coerces via `.item()`
- `symbol_columns` could clobber reserved scope-column types (`run_id`→SYMBOL, broken `TIMESTAMP(timestamp)`) → `setdefault`
- bare-string `symbol_columns` footgun guarded; caller `"timestamp"` keys popped (designated ts comes only from the `timestamp=` param); dedup keys quoted in DDL
- errors never propagate into strategy code on any path (matches existing emitter policy)

## Tests

- 19 new tests in `tests/qubx/emitters/strategy_tables_test.py` (89 total emitter tests passing, TDD RED/GREEN throughout)
- Full unit suite at head: 2217 passed, 5 skipped; 13 `test_postgres_e2e.py` errors are environmental (no local Postgres) and fail identically on `main`

⚠️ Merging to `main` triggers the automatic stable release pipeline — the released version feeds the frab PR (dependency bump) next.
