### PR TITLE
feat(emitters): ensure_table + emit_record on CSVMetricEmitter

### DIFF
--- a/src/qubx/emitters/csv.py
+++ b/src/qubx/emitters/csv.py
@@ -4,8 +4,10 @@ CSV Metric Emitter.
 This module provides an implementation of IMetricEmitter that exports metrics to a CSV file.
 """
 
+import csv
 import datetime
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +51,8 @@ class CSVMetricEmitter(BaseMetricEmitter):
             file_path = os.path.join(os.getcwd(), "metrics.csv")
 
         self._file_path = Path(file_path)
+        self._record_fields: dict[str, list[str]] = {}
+        self._warned_undeclared: set[str] = set()
         self._initialize_file()
 
     def _initialize_file(self) -> None:
@@ -168,8 +172,7 @@ class CSVMetricEmitter(BaseMetricEmitter):
             if not deals_file_path.exists():
                 with open(deals_file_path, "w") as f:
                     f.write(
-                        "timestamp,symbol,exchange,amount,price,aggressive,"
-                        "fee_amount,fee_currency,deal_id,order_id\n"
+                        "timestamp,symbol,exchange,amount,price,aggressive,fee_amount,fee_currency,deal_id,order_id\n"
                     )
 
             with open(deals_file_path, "a") as f:
@@ -185,3 +188,73 @@ class CSVMetricEmitter(BaseMetricEmitter):
 
         except Exception as e:
             logger.error(f"[CSVMetricEmitter] Failed to emit deals: {e}")
+
+    def _record_path(self, table: str) -> Path:
+        return self._file_path.parent / f"{table}.csv"
+
+    def ensure_table(
+        self,
+        table: str,
+        columns: dict[str, str],
+        symbol_columns: Sequence[str] = (),
+        dedup_keys: Sequence[str] | None = None,
+        partition_by: str = "DAY",
+    ) -> None:
+        """
+        Declare a strategy-owned table as one CSV file beside the metrics file.
+        """
+        try:
+            if isinstance(symbol_columns, str):
+                raise ValueError(f"symbol_columns must be a sequence of names, not a bare string: {symbol_columns!r}")
+
+            fields = ["timestamp", *self._default_tags]
+            for name in ("run_id", "is_live", *symbol_columns, *columns):
+                if name not in fields:
+                    fields.append(name)
+
+            self._record_fields[table] = fields
+
+            path = self._record_path(table)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if not path.exists():
+                with open(path, "w", newline="") as f:
+                    csv.DictWriter(f, fieldnames=fields).writeheader()
+        except Exception as e:
+            logger.error(f"[CSVMetricEmitter] Failed to ensure table '{table}': {e}")
+
+    def emit_record(
+        self, table: str, record: dict[str, Any], symbol_columns: Sequence[str] = (), timestamp: dt_64 | None = None
+    ) -> None:
+        """
+        Append one row to a strategy-owned table, mirroring the QuestDB emitter's scope tags
+        """
+        try:
+            if isinstance(symbol_columns, str):
+                raise ValueError(f"symbol_columns must be a sequence of names, not a bare string: {symbol_columns!r}")
+            if self._context is not None and timestamp is None:
+                timestamp = self._context.time()
+            row = {k: v for k, v in record.items() if v is not None}
+            row.pop("timestamp", None)
+            row.update(self._default_tags)
+            if self._context is not None:
+                row["is_live"] = not self._context.is_simulation
+            row["timestamp"] = str(timestamp) if timestamp is not None else str(time_now())
+
+            path = self._record_path(table)
+            fields = self._record_fields.get(table)
+            if fields is None:
+                # - undeclared table: take the schema from this first row
+                fields = ["timestamp", *(k for k in row if k != "timestamp")]
+                self._record_fields[table] = fields
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with open(path, "w", newline="") as f:
+                    csv.DictWriter(f, fieldnames=fields).writeheader()
+            elif (unknown := set(row) - set(fields)) and table not in self._warned_undeclared:
+                self._warned_undeclared.add(table)
+                logger.warning(f"[CSVMetricEmitter] '{table}': dropping undeclared columns {sorted(unknown)}")
+
+            with open(path, "a", newline="") as f:
+                csv.DictWriter(f, fieldnames=fields, restval="", extrasaction="ignore").writerow(row)
+
+        except Exception as e:
+            logger.error(f"[CSVMetricEmitter] Failed to emit record to '{table}': {e}")

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -1,5 +1,6 @@
 """Tests for strategy-owned tables: ensure_table + emit_record (spec §2)."""
 
+import csv as csv_mod
 import datetime
 from unittest.mock import MagicMock
 
@@ -9,6 +10,7 @@ import pytest
 import qubx.emitters.questdb as qdb_mod
 from qubx.core.interfaces import IMetricEmitter
 from qubx.emitters.composite import CompositeMetricEmitter
+from qubx.emitters.csv import CSVMetricEmitter
 from qubx.emitters.questdb import QuestDBMetricEmitter
 
 
@@ -207,3 +209,54 @@ class TestEmitRecord:
     def test_unsupported_timestamp_type_is_caught_and_logged(self, emitter):
         emitter.emit_record("t", {"a": 1.0}, timestamp=object())  # must not raise (error logged)
         assert emitter._sender.rows == []  # nothing was queued/emitted
+
+
+class TestCSVRecords:
+    def _emitter(self, tmp_path):
+        return CSVMetricEmitter(file_path=str(tmp_path / "metrics.csv"), tags={"strategy": "LoeTest"})
+
+    def test_ensure_table_writes_a_header_file_per_table(self, tmp_path):
+        em = self._emitter(tmp_path)
+        em.ensure_table("loe.execution", {"price": "DOUBLE"}, symbol_columns=("kind", "symbol"))
+
+        path = tmp_path / "loe.execution.csv"
+        header = path.read_text().splitlines()[0].split(",")
+        assert header[0] == "timestamp"
+        assert {"kind", "symbol", "price", "strategy", "run_id", "is_live"} <= set(header)
+
+    def test_emit_record_appends_one_row_per_call(self, tmp_path):
+        em = self._emitter(tmp_path)
+        em.ensure_table("loe.execution", {"price": "DOUBLE"}, symbol_columns=("kind", "symbol"))
+        em.emit_record(
+            "loe.execution",
+            {"kind": "FILL", "symbol": "SLPUSDT", "price": 0.1001},
+            timestamp=np.datetime64("2026-07-01T00:00:00", "ns"),
+        )
+        em.emit_record("loe.execution", {"kind": "PHASE_END", "symbol": "SLPUSDT"})
+
+        rows = list(csv_mod.DictReader((tmp_path / "loe.execution.csv").read_text().splitlines()))
+        assert [r["kind"] for r in rows] == ["FILL", "PHASE_END"]
+        assert rows[0]["price"] == "0.1001"
+        assert rows[0]["timestamp"].startswith("2026-07-01T00:00:00")
+        assert rows[0]["strategy"] == "LoeTest"
+        # a column the row does not carry stays blank rather than shifting the line
+        assert rows[1]["price"] == ""
+
+    def test_emit_record_without_ensure_table_still_writes(self, tmp_path):
+        em = self._emitter(tmp_path)
+        em.emit_record("adhoc.table", {"a": 1.0})
+
+        rows = list(csv_mod.DictReader((tmp_path / "adhoc.table.csv").read_text().splitlines()))
+        assert rows[0]["a"] == "1.0"
+
+    def test_rejects_bare_string_symbol_columns(self, tmp_path):
+        # a bare string iterates as characters -> would mint bogus single-letter columns in the header
+        em = self._emitter(tmp_path)
+        em.ensure_table("t", {}, symbol_columns="pair")  # must not raise (logged), no file written
+        assert not (tmp_path / "t.csv").exists()
+
+    def test_a_write_failure_does_not_raise(self, tmp_path):
+        em = self._emitter(tmp_path)
+        em.ensure_table("loe.execution", {"price": "DOUBLE"})
+        em._record_path = lambda table: tmp_path / "no_such_dir" / "x" / "y.csv"
+        em.emit_record("loe.execution", {"price": 1.0})  # must not raise


### PR DESCRIPTION
Records were QuestDB-only: the IMetricEmitter defaults are no-ops, so CSVMetricEmitter accepted emit_record and silently dropped every row.

One CSV file per table beside the metrics file, matching how this emitter already writes signals_<stem>.csv and deals_<stem>.csv. Scope tags, the designated timestamp and the None-value drop mirror the QuestDB emitter, as does the bare-string symbol_columns guard. Header comes from ensure_table; an undeclared table takes its schema from the first row. DictWriter uses restval="" and extrasaction="ignore", so a row missing a column stays aligned instead of shifting the line.