### PR TITLE
fix(sim): deterministic universe diff order and stream tie-breaks

### DIFF
--- a/src/qubx/backtester/iteratedstream.py
+++ b/src/qubx/backtester/iteratedstream.py
@@ -81,7 +81,9 @@ class IteratedDataStreamsSlicer(Iterator[SlicerOutData]):
 
     def _build_initial_iteration_seq(self):
         _init_seq = {k: self._time_func(self._buffers[k][-1]) for k in self._keys if self._buffers[k]}
-        _init_seq = dict(sorted(_init_seq.items(), key=lambda item: item[1]))
+        # (time, key): equal-timestamp streams must not tie-break by dict insertion
+        # order, which is arrival/hash-order dependent across processes.
+        _init_seq = dict(sorted(_init_seq.items(), key=lambda item: (item[1], item[0])))
         self._keys = deque(_init_seq.keys())
 
     def _load_next_chunk_to_buffer(self, index: str) -> list[Timestamped]:

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -184,12 +184,13 @@ class UniverseManager(IUniverseManager):
         prev_set = self._instruments.copy()
 
         # - determine instruments to remove depending on if_has_position_then policy
-        may_be_removed = list(prev_set - new_set)
+        may_be_removed = sorted(prev_set - new_set)
 
         # - split instruments into removable and keepable
         to_remove, to_keep = self._get_what_can_be_removed_or_kept(may_be_removed, skip_callback, if_has_position_then)
 
-        to_add = list(new_set - prev_set)
+        # sorted: set-diff order is hash-seed dependent and leaks into stream/subscription order (nondeterministic backtests)
+        to_add = sorted(new_set - prev_set)
         self.__do_add_instruments(to_add)
         self.__do_remove_instruments(to_remove)
 
@@ -233,7 +234,8 @@ class UniverseManager(IUniverseManager):
         instruments = self._drop_gone(instruments)
         # Then drop blacklisted instruments (same order as set_universe: gone -> blacklist).
         instruments = self._filter_blacklisted(instruments)
-        to_add = list(set([instr for instr in instruments if instr not in self._instruments]))
+        # sorted: same set-iteration hash-seed nondeterminism as set_universe's diff (see above)
+        to_add = sorted(set([instr for instr in instruments if instr not in self._instruments]))
         self.__do_add_instruments(to_add)
         self.__cleanup_removal_queue(instruments)
         self._strategy.on_universe_change(self._context, to_add, [])

--- a/tests/qubx/backtester/test_iterated_data_slicer.py
+++ b/tests/qubx/backtester/test_iterated_data_slicer.py
@@ -169,14 +169,17 @@ class TestSimulatedDataStuff:
             if k == 11: slicer += {'x10': iter(data4)}
             k += 1
             ti = t[2].time
+        # NOTE: ties (same timestamp across streams, e.g. 'x10'/D1 vs 'x3'/C1 at 00:10) are now
+        # broken by canonical (time, key) order instead of insertion order, so 'x10' < 'x3'
+        # (lexicographic string compare) puts D1 before C1 from that point on.
         assert r == [
-            'A1', 'A1', 'A1', 'A1', 
-            'B1', 'B1', 'B1', 
-            'B1', 'C1', 'B1', 'C1', 
-            'B1', 'C1', 'D1', 
-            'C1', 'D1', 'B1', 'C1', 'D1', 'B1', 'C1', 'D1', 'B1', 'C1', 'D1', 'B1', 'C1', 'D1', 'B1', 'C1', 'D1', 
-            'B2', 'C1', 'D1', 'B2', 'C1', 'D1', 'B2', 'C2', 'D1', 'B2', 'C2', 'D1', 'B2', 
-            'C2', 'B2', 'C2', 'B2', 'C2', 'B2', 'C2', 'B2', 'C2', 'B2', 'C2', 'B2', 
+            'A1', 'A1', 'A1', 'A1',
+            'B1', 'B1', 'B1',
+            'B1', 'C1', 'B1', 'C1',
+            'B1', 'D1', 'C1',
+            'D1', 'C1', 'B1', 'D1', 'C1', 'B1', 'D1', 'C1', 'B1', 'D1', 'C1', 'B1', 'D1', 'C1', 'B1', 'D1', 'C1',
+            'B2', 'D1', 'C1', 'B2', 'D1', 'C1', 'B2', 'D1', 'C2', 'B2', 'D1', 'C2', 'B2',
+            'C2', 'B2', 'C2', 'B2', 'C2', 'B2', 'C2', 'B2', 'C2', 'B2', 'C2', 'B2',
             'C2', 'C2', 'C2'
         ]
         # fmt: on
@@ -201,12 +204,42 @@ class TestSimulatedDataStuff:
             r.append(t[2].data)
 
         assert r == [
-            'A1', 'A1', 
-            'C1', 'A1', 'C1', 'A1', 'C1', 'D1', 
-            'E1', 'A1', 'C1', 'D1', 'E1', 'A1', 'C1', 'D1', 'E1', 'B1', 'A1', 'C1', 'D1', 'E1', 
-            'B1', 'A1', 'C1', 'D1', 'E1', 'B1', 'A1', 'C1', 'D1', 'E1', 'B1', 'A1', 'C1', 'D1', 
-            'E1', 'B1', 'A1', 'C1', 'D1', 'E1', 'B1', 'C1', 'D1', 'E1', 'B1', 'D1', 'E1', 'B1', 'D1', 'E1', 
+            'A1', 'A1',
+            'C1', 'A1', 'C1', 'A1', 'C1', 'D1',
+            'E1', 'A1', 'C1', 'D1', 'E1', 'A1', 'C1', 'D1', 'E1', 'B1', 'A1', 'C1', 'D1', 'E1',
+            'B1', 'A1', 'C1', 'D1', 'E1', 'B1', 'A1', 'C1', 'D1', 'E1', 'B1', 'A1', 'C1', 'D1',
+            'E1', 'B1', 'A1', 'C1', 'D1', 'E1', 'B1', 'C1', 'D1', 'E1', 'B1', 'D1', 'E1', 'B1', 'D1', 'E1',
             'B1', 'B1', 'B1'
         ]
 
         # fmt: on
+
+    def test_iterator_slicer_tie_break_is_insertion_order_independent(self):
+        # regression: equal-timestamp streams must tie-break by a canonical key order,
+        # not by the order they happened to be put() into the slicer (dict insertion order,
+        # which in production comes from a hash-seed-dependent set-diff)
+        events_a = DummyTimeEvent.from_seq("2020-01-01 00:00", 4, "1Min", "A")
+        events_b = DummyTimeEvent.from_seq("2020-01-01 00:00", 4, "1Min", "B")
+
+        def run(order: list[str]) -> list[tuple[str, int]]:
+            streams = {"A": iter([events_a]), "B": iter([events_b])}
+            slicer = IteratedDataStreamsSlicer()
+            slicer += {k: streams[k] for k in order}
+            seq = []
+            for t in slicer:
+                if not t:
+                    continue
+                seq.append((t[0], t[2].time))
+            return seq
+
+        seq_ab = run(["A", "B"])
+        seq_ba = run(["B", "A"])
+
+        assert seq_ab == seq_ba, "tie-break order must not depend on stream put() order"
+
+        # canonical: at every shared timestamp, keys must come out in sorted (key) order
+        by_time: dict[int, list[str]] = {}
+        for k, t in seq_ab:
+            by_time.setdefault(t, []).append(k)
+        for t, keys in by_time.items():
+            assert keys == sorted(keys), f"tie at t={t} not canonically key-ordered: {keys}"

--- a/tests/qubx/core/universe_manager_test.py
+++ b/tests/qubx/core/universe_manager_test.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 
-from qubx.core.basics import DataType, Instrument
+from qubx.core.basics import DataType, Instrument, MarketType
 from qubx.core.mixins.universe import UniverseManager
 
 
@@ -65,15 +65,26 @@ def universe_manager(mock_dependencies):
     )
 
 
-def test_set_universe_adds_new_instruments(universe_manager, mock_dependencies, mocker: MockerFixture):
-    instruments = list(
-        set(
-            [
-                mocker.Mock(spec=Instrument, symbol="BTCUSDT"),
-                mocker.Mock(spec=Instrument, symbol="ETHUSDT"),
-            ]
-        )
+def _make_instrument(symbol: str, min_size: float = 0.0) -> Instrument:
+    # - real (non-mock) Instrument: needed because sort order relies on the
+    # - dataclass-generated __lt__, which Mock(spec=Instrument) does not provide
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SPOT,
+        exchange="BINANCE",
+        base=symbol.replace("USDT", ""),
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol=symbol,
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=min_size,
     )
+
+
+def test_set_universe_adds_new_instruments(universe_manager, mock_dependencies):
+    # - deliberately unsorted: to_add must come out sorted regardless of input order
+    instruments = [_make_instrument("ETHUSDT"), _make_instrument("BTCUSDT")]
     mock_dependencies["subscription_manager"].auto_subscribe = True
 
     universe_manager.set_universe(instruments)
@@ -82,7 +93,7 @@ def test_set_universe_adds_new_instruments(universe_manager, mock_dependencies, 
     mock_dependencies["subscription_manager"].subscribe.assert_called_once()
     mock_dependencies["subscription_manager"].commit.assert_called_once()
     mock_dependencies["strategy"].on_universe_change.assert_called_once_with(
-        mock_dependencies["context"], instruments, []
+        mock_dependencies["context"], sorted(instruments), []
     )
 
 
@@ -114,12 +125,12 @@ def test_set_universe_with_skip_callback(universe_manager, mock_dependencies, mo
 def test_set_universe_with_position_close(universe_manager, mock_dependencies, mocker: MockerFixture):
     ctx = mock_dependencies["context"]
 
-    sol = mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0)
+    sol = _make_instrument("SOLUSDT")
     universe_manager.set_universe(
         [
-            btc := mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0),
-            eth := mocker.Mock(spec=Instrument, symbol="ETHUSDT", min_size=0.0),
-            ltc := mocker.Mock(spec=Instrument, symbol="LTCUSDT", min_size=0.0),
+            btc := _make_instrument("BTCUSDT"),
+            eth := _make_instrument("ETHUSDT"),
+            ltc := _make_instrument("LTCUSDT"),
         ]
     )
     mock_dependencies["account"].positions = {btc: mocker.Mock(quantity=1.0)}
@@ -138,12 +149,12 @@ def test_set_universe_with_position_wait_for_close(universe_manager, mock_depend
     account = mock_dependencies["account"]
     strategy = mock_dependencies["strategy"]
 
-    sol = mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0)
+    sol = _make_instrument("SOLUSDT")
     universe_manager.set_universe(
         [
-            btc := mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0),
-            eth := mocker.Mock(spec=Instrument, symbol="ETHUSDT", min_size=0.0),
-            ltc := mocker.Mock(spec=Instrument, symbol="LTCUSDT", min_size=0.0),
+            btc := _make_instrument("BTCUSDT"),
+            eth := _make_instrument("ETHUSDT"),
+            ltc := _make_instrument("LTCUSDT"),
         ]
     )
     # - set position for btc
@@ -169,12 +180,12 @@ def test_set_universe_with_position_wait_for_change(universe_manager, mock_depen
     account = mock_dependencies["account"]
     strategy = mock_dependencies["strategy"]
 
-    sol = mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0)
+    sol = _make_instrument("SOLUSDT")
     universe_manager.set_universe(
         [
-            btc := mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0),
-            eth := mocker.Mock(spec=Instrument, symbol="ETHUSDT", min_size=0.0),
-            ltc := mocker.Mock(spec=Instrument, symbol="LTCUSDT", min_size=0.0),
+            btc := _make_instrument("BTCUSDT"),
+            eth := _make_instrument("ETHUSDT"),
+            ltc := _make_instrument("LTCUSDT"),
         ]
     )
     # - set position for btc
@@ -201,11 +212,11 @@ def test_set_universe_with_position_wait_for_change(universe_manager, mock_depen
     assert universe_manager._removal_queue == {}
 
 
-def test_set_universe_filters_delisting_instruments(universe_manager, mock_dependencies, mocker: MockerFixture):
+def test_set_universe_filters_delisting_instruments(universe_manager, mock_dependencies):
     """Test that delisting filter is applied to instruments being added to universe."""
-    btc = mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0)
-    eth = mocker.Mock(spec=Instrument, symbol="ETHUSDT", min_size=0.0)
-    delisting_instrument = mocker.Mock(spec=Instrument, symbol="SOLUSDT", min_size=0.0)
+    btc = _make_instrument("BTCUSDT")
+    eth = _make_instrument("ETHUSDT")
+    delisting_instrument = _make_instrument("SOLUSDT")
 
     # Configure the mock detector to filter out the delisting instrument
     mock_dependencies["delisting_detector"].filter_delistings.side_effect = lambda instruments: [
@@ -246,11 +257,37 @@ def test_set_universe_filters_delisting_even_with_skip_callback(
     assert delisting_instrument not in universe_manager.instruments
 
 
-def test_set_universe_keeps_non_delisting_instruments(universe_manager, mock_dependencies, mocker: MockerFixture):
+def test_set_universe_adds_instruments_in_sorted_order(universe_manager, mock_dependencies):
+    """Regression: to_add must be canonically sorted, not raw set-diff (hash-seed dependent) order."""
+    # - deliberately shuffled, not alphabetical
+    shuffled = [_make_instrument(s) for s in ["SOLUSDT", "ADAUSDT", "LTCUSDT", "BTCUSDT", "ETHUSDT"]]
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    universe_manager.set_universe(shuffled)
+
+    add_instruments = mock_dependencies["strategy"].on_universe_change.call_args.args[1]
+    assert add_instruments == sorted(shuffled)
+    assert [i.symbol for i in add_instruments] == ["ADAUSDT", "BTCUSDT", "ETHUSDT", "LTCUSDT", "SOLUSDT"]
+
+
+def test_add_instruments_adds_in_sorted_order(universe_manager, mock_dependencies):
+    """Regression: add_instruments' to_add must be canonically sorted, not raw set() iteration order."""
+    # - deliberately shuffled, not alphabetical
+    shuffled = [_make_instrument(s) for s in ["SOLUSDT", "ADAUSDT", "LTCUSDT", "BTCUSDT", "ETHUSDT"]]
+    mock_dependencies["subscription_manager"].auto_subscribe = True
+
+    universe_manager.add_instruments(shuffled)
+
+    add_instruments = mock_dependencies["strategy"].on_universe_change.call_args.args[1]
+    assert add_instruments == sorted(shuffled)
+    assert [i.symbol for i in add_instruments] == ["ADAUSDT", "BTCUSDT", "ETHUSDT", "LTCUSDT", "SOLUSDT"]
+
+
+def test_set_universe_keeps_non_delisting_instruments(universe_manager, mock_dependencies):
     """Test that instruments without delist dates pass through the filter."""
     instruments = [
-        mocker.Mock(spec=Instrument, symbol="BTCUSDT", min_size=0.0),
-        mocker.Mock(spec=Instrument, symbol="ETHUSDT", min_size=0.0),
+        _make_instrument("BTCUSDT"),
+        _make_instrument("ETHUSDT"),
     ]
 
     # Default mock behavior is to return all instruments (no filtering)


### PR DESCRIPTION
Re-land of #346 onto `main` — #346 was mistakenly based on the stale `dev` branch (its release run was cancelled before tagging/publishing; nothing shipped from it).

## Problem

Backtests with dynamic universes diverge run-to-run: `UniverseManager.set_universe` / `add_instruments` materialize instrument set-diffs with `list(set - set)` (iteration order varies with `PYTHONHASHSEED`), and `IteratedDataStreamsSlicer._build_initial_iteration_seq` tie-breaks equal-timestamp streams by dict insertion order — i.e. by that hash-scrambled order. Observed downstream (frab): a newly added instrument's first fill lands before/after the next hourly strategy event ~50/50 across runs, cascading into different position sizes for the whole backtest.

## Fix (ordering-only; no event set or values change)

- `sorted()` on the `to_add` / `may_be_removed` diffs in `set_universe` and on `to_add` in `add_instruments` (`Instrument` is `@dataclass(order=True)`); main's `_drop_gone`/`_filter_blacklisted` preprocessing in `add_instruments` is untouched. `remove_instruments` verified unaffected (no set-diff).
- `(time, key)` tie-break in `_build_initial_iteration_seq`.

## Tests

- New slicer tie-break regression (same streams, opposite `put()` order → identical sequence) + universe-diff / `add_instruments` ordering tests; stable across multiple `PYTHONHASHSEED` values.
- One pre-existing hardcoded slicer sequence updated (verified identical multiset, pure reorder); universe tests switched from non-orderable `Mock(spec=Instrument)` to real instruments.
- On this branch: focused 31/31 (seeds 0 & 42), `tests/qubx/backtester` 111/111, `tests/qubx/core` 804/804, ruff clean.