### PR TITLE
fix(sim): deterministic subscription commit order

### DIFF
--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -211,7 +211,9 @@ class SubscriptionManager(ISubscriptionManager):
         self._pending_stream_unsubscriptions[subscription_type].update(instruments)
 
     def _get_updated_subs(self) -> list[str]:
-        return list(
+        # sorted: commit order is behavior-relevant in the backtester (last-processed sub decides
+        # OME quote priming) and set order is hash-seed dependent
+        return sorted(
             set(self._pending_stream_unsubscriptions.keys())
             | set(self._pending_stream_subscriptions.keys())
             | self._pending_global_subscriptions

--- a/tests/qubx/core/subscription_test.py
+++ b/tests/qubx/core/subscription_test.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from unittest.mock import Mock, call
 
 import pytest
@@ -113,6 +114,38 @@ class TestSubscriptionStuff:
             call(DataType.ORDERBOOK, instruments, reset=True),
         ]
         self.mock_broker.subscribe.assert_has_calls(expected_calls, any_order=True)
+
+    def test_get_updated_subs_returns_canonically_sorted_order(self):
+        """Regression: commit() iterates _get_updated_subs() and, in the backtester,
+        whichever subscription type is processed LAST decides whether the instrument's
+        OME quote gets re-primed or wiped (BasicSimulatedExchange.on_subscribe evicts the
+        primed quote on every call; only OHLC-like data re-primes it, funding_payment can't).
+        Raw set()-union order is PYTHONHASHSEED-dependent, so the list must be sorted().
+        """
+        instrument = self._get_instrument("BTCUSDT")
+
+        # - order A: as frab would build it up (global ohlc sub, then global funding sub, ...)
+        self.manager._pending_global_subscriptions.add("ohlc(1h)")
+        self.manager._pending_global_subscriptions.add("funding_payment")
+        self.manager._pending_stream_subscriptions["orderbook"].add(instrument)
+        self.manager._pending_stream_unsubscriptions["trade"].add(instrument)
+        result_a = self.manager._get_updated_subs()
+
+        # - order B: same four type strings, rebuilt from scratch in reverse insertion order
+        self.manager._pending_global_subscriptions = set()
+        self.manager._pending_global_unsubscriptions = set()
+        self.manager._pending_stream_subscriptions = defaultdict(set)
+        self.manager._pending_stream_unsubscriptions = defaultdict(set)
+
+        self.manager._pending_stream_unsubscriptions["trade"].add(instrument)
+        self.manager._pending_stream_subscriptions["orderbook"].add(instrument)
+        self.manager._pending_global_subscriptions.add("funding_payment")
+        self.manager._pending_global_subscriptions.add("ohlc(1h)")
+        result_b = self.manager._get_updated_subs()
+
+        expected = ["funding_payment", "ohlc(1h)", "orderbook", "trade"]
+        assert result_a == expected
+        assert result_b == expected
 
     def test_ohlc_warmup(self):
         instruments = {self._get_instrument("BTCUSDT"), self._get_instrument("ETHUSDT")}


### PR DESCRIPTION
Second determinism fix in the family of #347, root-caused via the frab refactor's equivalence gate.

## Problem

`SubscriptionManager._get_updated_subs()` returns `list(set | set | ...)` over subscription-type strings — hash-seed-ordered. `commit()` processes types in that order, and in the backtester `BasicSimulatedExchange.on_subscribe()` evicts + re-primes the instrument's OME quote on every call; types like `funding_payment` cannot prime a quote. So whichever type commits LAST decides whether the instrument ends with a usable quote or `bbo=None` → entry orders silently fail to fill (`ome.py` "no quote for …"), get retried an hour later at different size, and the capital cascade contaminates the whole backtest. Across 12 `PYTHONHASHSEED` values the mismatch pattern is predicted 100% by the ordering of `{"ohlc(1h)", "funding_payment"}` in this union.

## Fix

`sorted(...)` — same stopgap pattern as #347. Note this is determinism only: it happens to pick the good order for this type pair (`funding_payment` sorts before `ohlc(1h)`, so ohlc primes last). The underlying eviction-reprime behavior of `on_subscribe` is the real defect and is filed separately (see linked issue).

## Tests

New unit test asserting `_get_updated_subs()` is insertion-order-invariant and canonical; RED confirmed under PYTHONHASHSEED 0 and 4 (different wrong orderings), GREEN after. Caveat: with CI's unpinned hash seed the test's regression detection is per-run probabilistic (~23/24). Suites: backtester + core clean; ruff clean.