### PR TITLE
feat(health): StreamHealth ledger + ccxt account-watch read-timeout (1/7)

### DIFF
--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -71,8 +71,9 @@ from qubx.core.events import (
     OrderUpdateRejectedEvent,
 )
 from qubx.core.exceptions import InvalidOrderParameters
-from qubx.core.interfaces import IDataProvider, ITimeProvider
+from qubx.core.interfaces import IDataProvider, IHealthMonitor, ITimeProvider
 from qubx.core.utils import recognize_time
+from qubx.health import DummyHealthMonitor
 from qubx.utils.misc import AsyncThreadLoop
 from qubx.utils.time import to_timedelta
 
@@ -83,8 +84,8 @@ from .utils import (
     ccxt_convert_deal_info,
     ccxt_convert_order_info,
     ccxt_convert_positions,
-    ccxt_extract_leverage_settings,
     ccxt_extract_deals_from_exec,
+    ccxt_extract_leverage_settings,
     ccxt_find_instrument,
     info_float,
     instrument_to_ccxt_symbol,
@@ -133,6 +134,12 @@ class CcxtConnector(ChannelEmitter):
     # make_client_id actually produces, so producer and classifier can never drift.
     cid_framework_prefix: str = FRAMEWORK_CID_PREFIX
 
+    # Read-timeout wrapping the account-stream `await watch()` (A.2) — venue-overridable.
+    # Purpose is NOT death detection (a quiet account is normal); it guarantees a periodic
+    # re-drive of watch() so `stream_drive_age` is meaningful, and forces ccxt to touch its
+    # client state so a torn-down transport surfaces as an exception instead of a hang.
+    ACCOUNT_WATCH_TIMEOUT_S: float = 60.0
+
     def __init__(
         self,
         *,
@@ -146,6 +153,7 @@ class CcxtConnector(ChannelEmitter):
         cancel_retry_interval: int = 2,
         max_cancel_retries: int = 10,
         max_ws_retries: int = 10,
+        health_monitor: IHealthMonitor | None = None,
         **kwargs: Any,
     ):
         self.exchange_name = exchange_name
@@ -160,6 +168,7 @@ class CcxtConnector(ChannelEmitter):
         self.cancel_retry_interval = cancel_retry_interval
         self.max_cancel_retries = max_cancel_retries
         self.max_ws_retries = max_ws_retries
+        self._health_monitor = health_monitor or DummyHealthMonitor()
 
         # Memoized ccxt-symbol -> Instrument resolution shared by the WS loop and the
         # snapshot/order-status converters (ccxt_find_instrument populates it lazily).
@@ -805,6 +814,7 @@ class CcxtConnector(ChannelEmitter):
                 handle=self._handle_ws_order,
                 stream="executions",
                 mark_ready=True,
+                is_account_stream=True,
             )
         ]
         # D4 scope: the balance push handler parses Binance ACCOUNT_UPDATE shapes. Other
@@ -821,6 +831,7 @@ class CcxtConnector(ChannelEmitter):
                     stream="balance",
                     mark_ready=False,
                     iterate=False,  # watch_balance resolves one Balances dict, not a list
+                    is_account_stream=True,
                 )
             )
         return streams
@@ -844,6 +855,7 @@ class CcxtConnector(ChannelEmitter):
         stream: str,
         mark_ready: bool,
         iterate: bool = True,
+        is_account_stream: bool = False,
     ) -> None:
         """Generic WS subscription loop: ``await watch()`` → ``handle(raw)`` per item.
 
@@ -866,20 +878,41 @@ class CcxtConnector(ChannelEmitter):
         given-up stream is the AccountManager liveness reconnect. ``iterate=False``
         passes the resolved value to ``handle`` whole (``watch_balance`` returns a
         single Balances dict, not a list of updates).
+
+        Every iteration records a StreamHealth drive (A.1) regardless of outcome, and a
+        successful await records a stream event. ``is_account_stream=True`` (account/execution
+        streams only — market-data loops keep their current unbounded await) additionally
+        wraps the await in ``asyncio.wait_for(ACCOUNT_WATCH_TIMEOUT_S)``: on timeout this is a
+        heartbeat, not an error (a quiet account is normal) — it just loops back around, which
+        re-drives ``watch()`` and re-records the drive on the next iteration (A.2).
         """
         n_retry = 0
         while self.channel.control.is_set():
             if mark_ready:
                 self._ws_ready = True
             watch_started = time.monotonic()
+            self._health_monitor.record_stream_drive(self.exchange_name, stream)
             try:
-                updates = await watch()
+                updates = await (
+                    asyncio.wait_for(watch(), timeout=self.ACCOUNT_WATCH_TIMEOUT_S) if is_account_stream else watch()
+                )
                 n_retry = 0
+                self._health_monitor.record_stream_event(self.exchange_name, stream)
                 if iterate:
                     for raw in updates:
                         handle(raw)
                 else:
                     handle(updates)
+            except TimeoutError:
+                # Read-timeout heartbeat (is_account_stream only): no traffic within
+                # ACCOUNT_WATCH_TIMEOUT_S is expected for a quiet account, so this is NOT an
+                # error — keep it below WARNING. The next iteration's top-of-loop drive call
+                # re-drives watch(), which is what actually forces ccxt to touch its client
+                # state (a torn-down transport then surfaces as an exception, not a hang).
+                logger.debug(
+                    f"[{self.exchange_name}] {stream} watch heartbeat ({self.ACCOUNT_WATCH_TIMEOUT_S}s, no traffic)"
+                )
+                continue
             except CcxtSymbolNotRecognized:
                 continue
             except CancelledError:

--- a/src/qubx/connectors/ccxt/exchanges/_two_stream.py
+++ b/src/qubx/connectors/ccxt/exchanges/_two_stream.py
@@ -58,12 +58,14 @@ class _TwoStreamCcxtConnector(CcxtConnector):
                 handle=self._handle_ws_order,
                 stream="orders",
                 mark_ready=True,
+                is_account_stream=True,
             ),
             self._run_ws_loop(
                 watch=self._em.exchange.watch_my_trades,
                 handle=self._handle_ws_trade,
                 stream="my_trades",
                 mark_ready=False,
+                is_account_stream=True,
             ),
         ]
 

--- a/src/qubx/connectors/ccxt/factory.py
+++ b/src/qubx/connectors/ccxt/factory.py
@@ -206,6 +206,7 @@ def create_ccxt_connector(ctx: ConnectorBuildContext) -> CcxtConnector:
         exchange_manager=exchange_manager,
         data_provider=ctx.data_provider,
         loop=ctx.loop,
+        health_monitor=ctx.health_monitor,
     )
 
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -14,8 +14,9 @@ This module includes:
 
 import datetime
 import traceback
+from collections import Counter
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Literal, Protocol, runtime_checkable
 
 import numpy as np
@@ -1665,6 +1666,20 @@ class LatencyMetrics:
     order_cancel: float
 
 
+@dataclass
+class StreamHealth:
+    """Liveness snapshot for one exchange's registered WS streams.
+
+    ``ages`` maps stream name -> ``(last_event_age_s, last_drive_age_s)``, both in
+    seconds since ``time.monotonic()`` (``float("inf")`` if never recorded). ``violations``
+    counts ``record_stream_violation`` calls per stream. An exchange with no registered
+    streams (unknown, or a plugin that hasn't adopted the ledger) reports empty ``ages``.
+    """
+
+    ages: dict[str, tuple[float, float]] = field(default_factory=dict)
+    violations: Counter[str] = field(default_factory=Counter)
+
+
 class IHealthWriter(Protocol):
     """
     Interface for recording health metrics.
@@ -1753,6 +1768,42 @@ class IHealthWriter(Protocol):
 
         Returns:
             Decorator function that times the decorated function.
+        """
+        ...
+
+    def record_stream_event(self, exchange: str, stream: str) -> None:
+        """
+        Record that a message was delivered on a WS stream (producer-side).
+
+        Args:
+            exchange: Exchange name
+            stream: Stream name (e.g. "executions", "balance", "orders", "my_trades")
+        """
+        ...
+
+    def record_stream_drive(self, exchange: str, stream: str) -> None:
+        """
+        Record that a WS read loop woke up / (re-)armed its watch call.
+
+        Called once per loop iteration regardless of outcome, so a parked-forever
+        task or a starved loop shows up as a growing drive age even when the stream
+        never delivers a message (e.g. a quiet account stream).
+
+        Args:
+            exchange: Exchange name
+            stream: Stream name
+        """
+        ...
+
+    def record_stream_violation(self, exchange: str, stream: str, kind: str) -> None:
+        """
+        Record a stream integrity violation (e.g. a reconcile finding the stream
+        should have delivered something it didn't).
+
+        Args:
+            exchange: Exchange name
+            stream: Stream name
+            kind: Violation kind, for logging/labeling context
         """
         ...
 
@@ -1895,6 +1946,18 @@ class IHealthReader(Protocol):
 
         Returns:
             HealthMetrics object for the exchange
+        """
+        ...
+
+    def get_stream_health(self, exchange: str) -> StreamHealth:
+        """
+        Get the StreamHealth ledger snapshot (event/drive ages + violations) for an exchange.
+
+        Args:
+            exchange: Exchange name
+
+        Returns:
+            StreamHealth with empty ages for an exchange with no registered streams.
         """
         ...
 

--- a/src/qubx/health/base.py
+++ b/src/qubx/health/base.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from typing import Callable
 
@@ -8,7 +8,7 @@ import numpy as np
 
 from qubx import logger
 from qubx.core.basics import CtrlChannel, DataType, Instrument, dt_64, td_64
-from qubx.core.interfaces import IHealthMonitor, IMetricEmitter, ITimeProvider, LatencyMetrics
+from qubx.core.interfaces import IHealthMonitor, IMetricEmitter, ITimeProvider, LatencyMetrics, StreamHealth
 from qubx.core.utils import recognize_timeframe
 from qubx.utils import convert_tf_str_td64
 from qubx.utils.collections import DequeFloat64, DequeIndicator
@@ -84,6 +84,16 @@ class BaseHealthMonitor(IHealthMonitor):
 
         # Connection tracking (per exchange)
         self._is_connected_callbacks = {}  # dict[exchange, Callable[[], bool]]
+
+        # StreamHealth ledger (per exchange per stream) - fed from asyncio loop threads
+        # (one or more per exchange), read by the emitter thread -> needs its own lock
+        # (unlike the rest of this class's dicts, which rely on GIL-atomic single-key
+        # get/set and are never read+written as a compound operation across threads).
+        self._stream_lock = threading.Lock()
+        self._stream_names: dict[str, set[str]] = defaultdict(set)
+        self._stream_last_event: dict[tuple[str, str], float] = {}  # (exchange, stream) -> monotonic
+        self._stream_last_drive: dict[tuple[str, str], float] = {}  # (exchange, stream) -> monotonic
+        self._stream_violations: dict[str, Counter[str]] = defaultdict(Counter)  # exchange -> Counter[stream]
 
         # Execution latency tracking (unchanged)
         self._execution_latency = defaultdict(lambda: DequeIndicator(buffer_size))
@@ -237,6 +247,45 @@ class BaseHealthMonitor(IHealthMonitor):
             except Exception:
                 return False
         return True  # Default to True if no callback registered
+
+    def record_stream_event(self, exchange: str, stream: str) -> None:
+        """Record that a message was delivered on a WS stream (producer-side)."""
+        now = time.monotonic()
+        with self._stream_lock:
+            self._stream_last_event[(exchange, stream)] = now
+            self._stream_names[exchange].add(stream)
+
+    def record_stream_drive(self, exchange: str, stream: str) -> None:
+        """Record that a WS read loop woke up / (re-)armed its watch call."""
+        now = time.monotonic()
+        with self._stream_lock:
+            self._stream_last_drive[(exchange, stream)] = now
+            self._stream_names[exchange].add(stream)
+
+    def record_stream_violation(self, exchange: str, stream: str, kind: str) -> None:
+        """Record a stream integrity violation. ``kind`` is caller context only (logging);
+        the ledger counts violations per (exchange, stream) for the `stream_violations_total`
+        metric — it does not break the count down by kind."""
+        with self._stream_lock:
+            self._stream_violations[exchange][stream] += 1
+            self._stream_names[exchange].add(stream)
+
+    def get_stream_health(self, exchange: str) -> StreamHealth:
+        """StreamHealth snapshot for `exchange`: ages (seconds since last event/drive,
+        `float("inf")` if never recorded) and violation counts, per registered stream.
+        An exchange with no registered streams (never driven or eventd) returns empty ages."""
+        now = time.monotonic()
+        with self._stream_lock:
+            streams = self._stream_names.get(exchange, set())
+            ages = {}
+            for stream in streams:
+                last_event = self._stream_last_event.get((exchange, stream))
+                last_drive = self._stream_last_drive.get((exchange, stream))
+                event_age = now - last_event if last_event is not None else float("inf")
+                drive_age = now - last_drive if last_drive is not None else float("inf")
+                ages[stream] = (event_age, drive_age)
+            violations = Counter(self._stream_violations.get(exchange, Counter()))
+        return StreamHealth(ages=ages, violations=violations)
 
     def get_last_event_time(self, instrument: Instrument, event_type: str) -> dt_64 | None:
         return self._last_event_time.get((instrument, event_type))
@@ -503,6 +552,10 @@ class BaseHealthMonitor(IHealthMonitor):
     def _get_exchanges(self) -> list[str]:
         return list(set(ex for ex, _ in self._data_latency.keys()))
 
+    def _get_stream_exchanges(self) -> list[str]:
+        with self._stream_lock:
+            return list(self._stream_names.keys())
+
     def _emit(self) -> None:
         """Emit all metrics to the configured emitter."""
         if not self._emit_health or self._emitter is None:
@@ -517,6 +570,9 @@ class BaseHealthMonitor(IHealthMonitor):
         exchanges = self._get_exchanges()
         for exchange in exchanges:
             self._emit_exchange_latencies(exchange)
+
+        for exchange in self._get_stream_exchanges():
+            self._emit_stream_health(exchange)
 
     def _emit_exchange_latencies(self, exchange: str) -> None:
         current_time = self.time_provider.time()
@@ -541,3 +597,21 @@ class BaseHealthMonitor(IHealthMonitor):
             tags=tags,
             timestamp=current_time,
         )
+
+    def _emit_stream_health(self, exchange: str) -> None:
+        """Emit the StreamHealth ledger (A.1/A.2) per (exchange, stream): event/drive ages
+        in seconds and cumulative violation count. Feeds the Grafana alert on drive_age /
+        violations (A.4) without any per-connector emission code."""
+        current_time = self.time_provider.time()
+        health = self.get_stream_health(exchange)
+        assert self._emitter is not None
+        for stream, (event_age, drive_age) in health.ages.items():
+            tags = {"type": "health", "exchange": exchange, "stream": stream}
+            self._emitter.emit(name="stream_event_age", value=event_age, tags=tags, timestamp=current_time)
+            self._emitter.emit(name="stream_drive_age", value=drive_age, tags=tags, timestamp=current_time)
+            self._emitter.emit(
+                name="stream_violations_total",
+                value=float(health.violations.get(stream, 0)),
+                tags=tags,
+                timestamp=current_time,
+            )

--- a/src/qubx/health/dummy.py
+++ b/src/qubx/health/dummy.py
@@ -1,7 +1,8 @@
+from collections import Counter
 from typing import Callable
 
 from qubx.core.basics import Instrument, dt_64, td_64
-from qubx.core.interfaces import IHealthMonitor, LatencyMetrics
+from qubx.core.interfaces import IHealthMonitor, LatencyMetrics, StreamHealth
 
 
 class DummyHealthMonitor(IHealthMonitor):
@@ -36,6 +37,18 @@ class DummyHealthMonitor(IHealthMonitor):
 
     def set_is_connected(self, exchange: str, is_connected: Callable[[], bool]) -> None:
         pass
+
+    def record_stream_event(self, exchange: str, stream: str) -> None:
+        pass
+
+    def record_stream_drive(self, exchange: str, stream: str) -> None:
+        pass
+
+    def record_stream_violation(self, exchange: str, stream: str, kind: str) -> None:
+        pass
+
+    def get_stream_health(self, exchange: str) -> StreamHealth:
+        return StreamHealth(ages={}, violations=Counter())
 
     def watch(self, name: str = ""):
         def decorator(func):

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_stream_health.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_stream_health.py
@@ -1,0 +1,137 @@
+"""Unit tests for `_run_ws_loop`'s StreamHealth ledger wiring (A.1) and the
+account-stream read-timeout heartbeat (A.2).
+
+Mocked ccxt — no credentials, no real loop/thread. `_run_ws_loop` is driven directly
+as an asyncio task, mirroring the `_subscribe_executions` drive pattern already used
+by the ws-ready tests in test_ccxt_connector_reads.py: `conn.channel.control.is_set`
+is toggled from inside the fake `watch` to end the loop deterministically.
+"""
+
+import asyncio
+import contextlib
+from unittest.mock import Mock
+
+import pytest
+
+from qubx.connectors.ccxt.connector import CcxtConnector
+from qubx.health.dummy import DummyHealthMonitor
+from tests.qubx.core.utils_test import DummyTimeProvider
+
+
+def _make_connector(*, health_monitor: Mock | None = None) -> tuple[CcxtConnector, Mock]:
+    exchange = Mock()
+    exchange.name = "binance"
+
+    em = Mock()
+    em.exchange = exchange
+    em.register_recreation_callback = Mock()
+
+    dp = Mock()
+    channel = Mock()
+    channel.control = Mock()
+    channel.control.is_set = Mock(return_value=True)
+
+    hm = health_monitor if health_monitor is not None else Mock()
+    conn = CcxtConnector(
+        exchange_name="BINANCE.UM",
+        channel=channel,
+        time_provider=DummyTimeProvider(),
+        exchange_manager=em,
+        data_provider=dp,
+        health_monitor=hm,
+    )
+    return conn, hm
+
+
+def test_default_health_monitor_is_dummy_and_safe() -> None:
+    """No health_monitor passed at construction -> falls back to DummyHealthMonitor
+    (the sim/no-op contract every IHealthMonitor implementation must satisfy)."""
+    exchange = Mock()
+    exchange.name = "binance"
+    em = Mock()
+    em.exchange = exchange
+    conn = CcxtConnector(
+        exchange_name="BINANCE.UM",
+        channel=Mock(),
+        time_provider=DummyTimeProvider(),
+        exchange_manager=em,
+        data_provider=Mock(),
+    )
+    assert isinstance(conn._health_monitor, DummyHealthMonitor)
+
+
+@pytest.mark.asyncio
+async def test_account_stream_timeout_records_drive_not_event() -> None:
+    """A.2: a watch() that never resolves must time out at ACCOUNT_WATCH_TIMEOUT_S,
+    record a drive each time around (heartbeat), never record an event, and keep
+    looping rather than raising or exiting. Readiness stays optimistic across the
+    heartbeat timeout — a quiet account stream is normal, not an error."""
+    conn, hm = _make_connector()
+    conn.ACCOUNT_WATCH_TIMEOUT_S = 0.02  # keep the test fast
+    handle = Mock()
+
+    block = asyncio.Event()
+
+    async def _watch():
+        await block.wait()  # never resolves within the timeout
+
+    task = asyncio.ensure_future(
+        conn._run_ws_loop(
+            watch=_watch, handle=handle, stream="executions", mark_ready=True, is_account_stream=True
+        )
+    )
+    await asyncio.sleep(conn.ACCOUNT_WATCH_TIMEOUT_S * 10)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert hm.record_stream_drive.call_count >= 2
+    for call in hm.record_stream_drive.call_args_list:
+        assert call.args == ("BINANCE.UM", "executions")
+    hm.record_stream_event.assert_not_called()
+    handle.assert_not_called()
+    assert conn.is_ws_ready() is True
+
+
+@pytest.mark.asyncio
+async def test_account_stream_message_records_drive_then_event_then_handles() -> None:
+    """A.1: a watch() that resolves with a message records the drive, then the event,
+    then hands the message to `handle` — in that order."""
+    conn, hm = _make_connector()
+    calls: list[str] = []
+    hm.record_stream_drive.side_effect = lambda *a: calls.append("drive")
+    hm.record_stream_event.side_effect = lambda *a: calls.append("event")
+    handle = Mock(side_effect=lambda *a: calls.append("handle"))
+
+    async def _watch():
+        conn.channel.control.is_set = Mock(return_value=False)  # stop after this iteration
+        return [{"id": "1"}]
+
+    await conn._run_ws_loop(
+        watch=_watch, handle=handle, stream="executions", mark_ready=True, is_account_stream=True
+    )
+
+    assert calls == ["drive", "event", "handle"]
+    hm.record_stream_drive.assert_called_once_with("BINANCE.UM", "executions")
+    hm.record_stream_event.assert_called_once_with("BINANCE.UM", "executions")
+    handle.assert_called_once_with({"id": "1"})
+
+
+@pytest.mark.asyncio
+async def test_market_data_stream_not_gated_by_account_timeout() -> None:
+    """is_account_stream defaults to False: a market-data-style loop sharing
+    _run_ws_loop must NOT be bounded by ACCOUNT_WATCH_TIMEOUT_S (current market-data
+    behavior preserved) even when the timeout is shorter than the watch's real latency."""
+    conn, hm = _make_connector()
+    conn.ACCOUNT_WATCH_TIMEOUT_S = 0.01
+    handle = Mock()
+
+    async def _watch():
+        await asyncio.sleep(conn.ACCOUNT_WATCH_TIMEOUT_S * 5)  # longer than the account timeout
+        conn.channel.control.is_set = Mock(return_value=False)
+        return [{"id": "1"}]
+
+    await conn._run_ws_loop(watch=_watch, handle=handle, stream="orderbook", mark_ready=False)
+
+    handle.assert_called_once_with({"id": "1"})
+    hm.record_stream_event.assert_called_once_with("BINANCE.UM", "orderbook")

--- a/tests/qubx/health/test_base.py
+++ b/tests/qubx/health/test_base.py
@@ -1,4 +1,6 @@
+import threading
 import time
+from collections import Counter
 from datetime import datetime, timedelta
 from typing import Generator
 from unittest.mock import MagicMock
@@ -7,7 +9,7 @@ import numpy as np
 import pytest
 
 from qubx.core.basics import CtrlChannel, Instrument, dt_64
-from qubx.core.interfaces import IMetricEmitter, ITimeProvider, LatencyMetrics
+from qubx.core.interfaces import ITimeProvider, LatencyMetrics, StreamHealth
 from qubx.core.lookups import lookup
 from qubx.health.base import BaseHealthMonitor
 from qubx.health.dummy import DummyHealthMonitor
@@ -62,6 +64,18 @@ class TestDummyHealthMonitor:
 
         # Verify no state change after operations
         assert monitor.get_data_latency("test_exchange", "test_event") == 0.0
+
+    def test_dummy_monitor_stream_health_is_noop(self) -> None:
+        """DummyHealthMonitor accepts the stream-health calls as pure no-ops (sim/dummy
+        must never trip the ledger's fail-closed "unknown = unhealthy" semantics)."""
+        monitor = DummyHealthMonitor()
+
+        monitor.record_stream_event("BINANCE.UM", "executions")
+        monitor.record_stream_drive("BINANCE.UM", "executions")
+        monitor.record_stream_violation("BINANCE.UM", "executions", "cancel_found_terminal")
+
+        health = monitor.get_stream_health("BINANCE.UM")
+        assert health == StreamHealth(ages={}, violations=Counter())
 
     def test_dummy_monitor_watch_decorator(self) -> None:
         """Test that DummyHealthMonitor's watch decorator returns function unchanged."""
@@ -778,3 +792,121 @@ class TestBaseHealthMonitor:
         assert (instrument1, event_type1) not in monitor._active_subscriptions
         assert (instrument1, event_type2) in monitor._active_subscriptions
         assert (instrument2, event_type1) in monitor._active_subscriptions
+
+
+class _FakeClock:
+    """A controllable stand-in for ``time.monotonic`` — the StreamHealth ledger uses
+    monotonic time deliberately (immune to the NTP backward steps that affect the
+    dt_64/ITimeProvider math elsewhere in this class), so it needs its own fake clock
+    rather than ``MockTimeProvider``."""
+
+    def __init__(self, start: float = 1_000.0):
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+class TestStreamHealthLedger:
+    """A.1: record_stream_event/drive/violation + get_stream_health on BaseHealthMonitor."""
+
+    @pytest.fixture
+    def clock(self, monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
+        fake = _FakeClock()
+        monkeypatch.setattr(time, "monotonic", fake)
+        return fake
+
+    @pytest.fixture
+    def ledger(self, clock: _FakeClock) -> BaseHealthMonitor:
+        return BaseHealthMonitor(MockTimeProvider())
+
+    def test_unknown_exchange_returns_empty_ages(self, ledger: BaseHealthMonitor) -> None:
+        """An exchange the ledger has never heard of (no plugin adoption yet) reports
+        empty ages, distinct from a registered-but-never-driven stream (which is inf)."""
+        assert ledger.get_stream_health("NO_SUCH_EXCHANGE") == StreamHealth(ages={}, violations=Counter())
+
+    def test_record_event_and_drive_ages(self, ledger: BaseHealthMonitor, clock: _FakeClock) -> None:
+        ledger.record_stream_drive("BINANCE.UM", "executions")
+        ledger.record_stream_event("BINANCE.UM", "executions")
+        clock.advance(5.0)
+
+        event_age, drive_age = ledger.get_stream_health("BINANCE.UM").ages["executions"]
+        assert event_age == pytest.approx(5.0)
+        assert drive_age == pytest.approx(5.0)
+
+    def test_drive_only_stream_has_infinite_event_age(self, ledger: BaseHealthMonitor, clock: _FakeClock) -> None:
+        # A loop that drives but never sees traffic (quiet account stream) or a plugin
+        # that hasn't adopted record_stream_event at all must read infinitely stale on
+        # the event axis — fail-closed per A.1, never silently healthy.
+        ledger.record_stream_drive("HYPERLIQUID", "executions")
+        clock.advance(3.0)
+
+        event_age, drive_age = ledger.get_stream_health("HYPERLIQUID").ages["executions"]
+        assert event_age == float("inf")
+        assert drive_age == pytest.approx(3.0)
+
+    def test_ages_are_independent_per_stream(self, ledger: BaseHealthMonitor, clock: _FakeClock) -> None:
+        ledger.record_stream_drive("BINANCE.UM", "executions")
+        clock.advance(2.0)
+        ledger.record_stream_drive("BINANCE.UM", "balance")
+        clock.advance(1.0)
+
+        ages = ledger.get_stream_health("BINANCE.UM").ages
+        assert ages["executions"][1] == pytest.approx(3.0)
+        assert ages["balance"][1] == pytest.approx(1.0)
+
+    def test_ages_independent_per_exchange(self, ledger: BaseHealthMonitor, clock: _FakeClock) -> None:
+        ledger.record_stream_drive("BINANCE.UM", "executions")
+        clock.advance(10.0)
+        ledger.record_stream_drive("OKX", "orders")
+
+        assert "orders" not in ledger.get_stream_health("BINANCE.UM").ages
+        assert ledger.get_stream_health("OKX").ages["orders"][1] == pytest.approx(0.0)
+
+    def test_violations_counted_per_stream(self, ledger: BaseHealthMonitor) -> None:
+        ledger.record_stream_violation("BINANCE.UM", "executions", "cancel_found_terminal")
+        ledger.record_stream_violation("BINANCE.UM", "executions", "position_size_mismatch")
+        ledger.record_stream_violation("BINANCE.UM", "balance", "order_lost")
+
+        violations = ledger.get_stream_health("BINANCE.UM").violations
+        assert violations["executions"] == 2
+        assert violations["balance"] == 1
+
+    def test_violation_alone_registers_stream_with_infinite_ages(self, ledger: BaseHealthMonitor) -> None:
+        # A pure violation with no prior drive/event still surfaces the stream (so its
+        # (inf, inf) ages are visible) instead of silently dropping it from the ledger.
+        ledger.record_stream_violation("BINANCE.UM", "executions", "order_lost")
+
+        health = ledger.get_stream_health("BINANCE.UM")
+        assert health.ages["executions"] == (float("inf"), float("inf"))
+        assert health.violations["executions"] == 1
+
+    def test_thread_safety_smoke(self, ledger: BaseHealthMonitor) -> None:
+        """Concurrent producers (one per exchange asyncio-loop thread in production)
+        hammering the ledger while readers poll it (the emitter thread) must not
+        corrupt counts or raise."""
+        n_threads = 8
+        n_calls = 500
+        errors: list[Exception] = []
+
+        def _hammer() -> None:
+            try:
+                for _ in range(n_calls):
+                    ledger.record_stream_drive("BINANCE.UM", "executions")
+                    ledger.record_stream_event("BINANCE.UM", "executions")
+                    ledger.record_stream_violation("BINANCE.UM", "executions", "kind")
+                    ledger.get_stream_health("BINANCE.UM")
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        threads = [threading.Thread(target=_hammer) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert ledger.get_stream_health("BINANCE.UM").violations["executions"] == n_threads * n_calls


### PR DESCRIPTION
PR 1/7 of the stream-liveness + loop-topology design (quantkit#105/#106, incident quantkit#104). Spec: xlydian-platform `docs/superpowers/specs/2026-07-29-qubx-stream-liveness-and-onfit-threading-design.md` §A.1/§A.2.

**DRAFT — do not merge.** Stack base; PRs 2-6 build on this branch. Targeting main because `dev` is 227+ commits stale (and pushing dev fires the dev release pipeline); merge order/timing is the reviewer's call.

- `StreamHealth` dataclass + four stream methods on the health-monitor contract (monotonic clocks, immune to the NTP steps that blinded wall-clock math in the incident)
- `BaseHealthMonitor` thread-safe ledger + emission of `stream_event_age`/`stream_drive_age`/`stream_violations_total` per (exchange, stream) via the existing emitter thread
- ccxt `_run_ws_loop` feeds drive/event; account/execution streams get `asyncio.wait_for` read-timeout (`ACCOUNT_WATCH_TIMEOUT_S=60`, venue-overridable) used as a heartbeat re-drive, not a death sentence
- Sim untouched (DummyHealthMonitor no-ops)

Tests: full suite 2232 passed / 0 failed; new ledger + connector-loop tests. Note for PR2: verify the QuestDB ILP emitter tolerates `inf` age values (never-adopted plugin case) — PR2 will clamp at emission.

https://claude.ai/code/session_017fBtVL9NcmHosCbkZmYBXg