### PR TITLE
feat(account): loud stream-integrity violations + producer-side staleness (3/7)

### DIFF
--- a/src/qubx/connectors/ccxt/connection_manager.py
+++ b/src/qubx/connectors/ccxt/connection_manager.py
@@ -27,6 +27,8 @@ from ccxt.pro import Exchange
 
 from qubx import logger
 from qubx.core.basics import CtrlChannel
+from qubx.core.interfaces import IHealthMonitor
+from qubx.health import DummyHealthMonitor
 from qubx.utils.misc import AsyncThreadLoop
 
 from .exceptions import CcxtSymbolNotRecognized
@@ -65,12 +67,19 @@ class ConnectionManager:
         max_ws_retries: int = 10,
         subscription_manager: SubscriptionManager | None = None,
         cleanup_timeout: float = 3.0,
+        health_monitor: IHealthMonitor | None = None,
     ):
         self._exchange_id = exchange_id
         self._exchange_manager = exchange_manager
         self.max_ws_retries = max_ws_retries
         self._subscription_manager = subscription_manager
         self._cleanup_timeout = cleanup_timeout
+        # A.4 producer-side staleness (market data): record_stream_event at the producer edge
+        # (this shared read loop, not per-handler) so the central staleness monitor
+        # (SubscriptionManager._monitor_subscription_status) can tell "wire is fine, consumer is
+        # blocked" apart from a genuinely dead stream. Defaults to the no-op ledger — same
+        # default-to-DummyHealthMonitor pattern as CcxtConnector/AccountManager.
+        self._health_monitor = health_monitor or DummyHealthMonitor()
 
         # Stream state management
         self._is_stream_enabled: dict[str, bool] = defaultdict(lambda: False)
@@ -122,6 +131,11 @@ class ConnectionManager:
             try:
                 await subscriber()
                 n_retry = 0  # Reset retry counter on success
+                # A.4 producer-side staleness: record at the wire, not the (possibly blocked)
+                # consumer — mirrors CcxtConnector._run_ws_loop's record_stream_event for
+                # account streams. One call per successful round-trip regardless of how many
+                # instruments/messages this subscriber batched internally.
+                self._health_monitor.record_stream_event(self._exchange_id, subscription_type)
 
                 # Mark subscription as active on first successful data reception
                 if not connection_established and self._subscription_manager:
@@ -156,9 +170,7 @@ class ConnectionManager:
                 continue
             except (RateLimitExceeded, DDoSProtection) as e:
                 # Rate limit hit — report to rate limiter if available and backoff
-                logger.warning(
-                    f"<yellow>{self._exchange_id}</yellow> Rate limited in {stream_name}: {e}"
-                )
+                logger.warning(f"<yellow>{self._exchange_id}</yellow> Rate limited in {stream_name}: {e}")
                 if hasattr(self, "_exchange_manager") and self._exchange_manager.rate_limiter:
                     self._exchange_manager.rate_limiter.report_limit_hit(
                         pool_name="ccxt_rest", reason=f"{e.__class__.__name__}: {e}"

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -331,18 +331,26 @@ class CcxtConnector(ChannelEmitter):
         # touch the live, AM-mutated object. ``symbol`` is what most venues (e.g. Binance) need.
         # A stop/conditional order lives on the venue's trigger surface, so the cancel must
         # target it (else Binance answers -2011 for a live order and the cancel silently fails).
+        # ``instrument`` rides along too (also read synchronously) so the already-gone probe
+        # below can fetch status without ever touching the live Order from the async task.
         is_trigger = order.type in (OrderType.STOP_MARKET, OrderType.STOP_LIMIT)
         self._spawn(
             self._cancel_async(
                 order.client_order_id,
                 order.venue_order_id,
                 instrument_to_ccxt_symbol(order.instrument),
+                order.instrument,
                 is_trigger,
             )
         )
 
     async def _cancel_async(
-        self, client_order_id: str | None, venue_order_id: str | None, symbol: str, is_trigger: bool = False
+        self,
+        client_order_id: str | None,
+        venue_order_id: str | None,
+        symbol: str,
+        instrument: Instrument,
+        is_trigger: bool = False,
     ) -> None:
         """A successful REST cancel ack emits OrderCanceledEvent immediately; the WS
         read side also emits one and AM dedups. A definitive venue cancel-rejection
@@ -360,8 +368,20 @@ class CcxtConnector(ChannelEmitter):
             return
         if ok is None:
             # Order already gone at the venue (filled/expired/canceled before our cancel landed).
-            # Emit nothing — the WS terminal + snapshot reconciler resolve the true terminal state.
-            logger.debug(f"[{self.exchange_name}] cancel: {client_order_id or venue_order_id} already gone; no event")
+            # This is the incident shape: a definitive "gone" verdict on a cancel is exactly what
+            # a swallowed fill looks like (the venue filled the order right before our cancel
+            # landed) — so probe status immediately instead of waiting for the next periodic
+            # sweep. WARNING + a stream-integrity violation make it operator-visible, and
+            # spawning the existing status-fetch primitive routes the fetched terminal state
+            # through the normal event path (the deficit-fill synthesizer in reducer.py books
+            # any missed fill within seconds). Does not change cancel_order's return contract —
+            # still nothing emitted from THIS call; the status fetch emits its own event(s).
+            logger.warning(
+                f"[{self.exchange_name}] cancel: {client_order_id or venue_order_id} already gone at venue "
+                "(found terminal on cancel) — fetching status to recover any missed fill"
+            )
+            self._health_monitor.record_stream_violation(self.exchange_name, "executions", "cancel_found_terminal")
+            self._spawn(self._order_status_async(client_order_id, venue_order_id, symbol, instrument, is_trigger))
             return
         if ok:
             self._emit_canceled_from_response(client_order_id, venue_order_id, response)
@@ -757,9 +777,7 @@ class CcxtConnector(ChannelEmitter):
                 return (None, None)
             symbol = instrument_to_ccxt_symbol(instrument)
             rows = self._run_sync(self._em.exchange.fetch_leverages([symbol]))
-            settings = ccxt_extract_leverage_settings(
-                list(rows.values()) if isinstance(rows, dict) else rows
-            )
+            settings = ccxt_extract_leverage_settings(list(rows.values()) if isinstance(rows, dict) else rows)
             return settings.get(symbol, (None, None))
         except Exception as e:  # noqa: BLE001
             logger.error(f"[{self.exchange_name}] fetch leverage settings for {instrument.symbol}: {e}")

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -65,6 +65,7 @@ class CcxtDataProvider(IDataProvider):
             exchange_manager=self._exchange_manager,
             max_ws_retries=max_ws_retries,
             subscription_manager=self._subscription_manager,
+            health_monitor=self._health_monitor,
         )
         self._subscription_orchestrator = SubscriptionOrchestrator(
             exchange_id=self._exchange_id,

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -19,6 +19,7 @@ from qubx.core.account_manager.config import AccountManagerConfig
 from qubx.core.account_manager.diffs import Differ
 from qubx.core.account_manager.reconciler import (
     Reconciler,
+    RecordViolation,
     RequestHistDeals,
     RequestSnapshot,
     RequestStatus,
@@ -364,6 +365,11 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
         # Everything else goes through the reducer; order/deal events additionally drive the
         # Reconciler's tasks (coverage, resolve-by-event).
         result = reducer.apply(state, event, now)
+        if result.deficit_fill:
+            # A.4 loudness: the reducer already logged the ERROR (it has the remainder/price
+            # context); this is just the metric side, which needs the health_monitor
+            # collaborator the reducer deliberately doesn't hold.
+            self._health_monitor.record_stream_violation(state.exchange, "executions", "deficit_fill")
         if isinstance(event, OrderEvent):
             self._execute(state, rec.on_event(state, event, now))
 
@@ -409,6 +415,11 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
                                 f"<y>{instrument.symbol}</y> since {since} -> connector.request_hist_deals"
                             )
                             connector.request_hist_deals(instrument, since)
+
+                    case RecordViolation(kind=kind):
+                        # A.4 loudness: the Reconciler already logged the ERROR (it's pure/I/O-free
+                        # and doesn't hold the health_monitor) — this is just the metric side.
+                        self._health_monitor.record_stream_violation(state.exchange, "executions", kind)
 
                     case _:
                         logger.warning(f"[{state.exchange}] unknown reconcile action: {action!r}")

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -29,6 +29,7 @@ from qubx.core.account_manager.diffs import (
     PositionFieldMismatch,
     PositionSizeMismatch,
 )
+from qubx.core.account_manager.reducer import fill_qty_epsilon
 from qubx.core.account_manager.state import AccountState, VenueAccountFigures
 from qubx.core.account_manager.state_machine import can_transition
 from qubx.core.basics import EXTERNAL_CID_PREFIX, Instrument, Order, OrderOrigin, OrderStatus, Position
@@ -83,7 +84,17 @@ class RouteEvent:
     event: object
 
 
-Action = RequestStatus | RequestSnapshot | RequestHistDeals | RouteEvent | OrderPartiallyFilledEvent
+@dataclass(frozen=True)
+class RecordViolation:
+    # - A.4 loudness: the snapshot diff (or a task it spawned) discovered something a live
+    #   stream should have delivered and didn't. The Reconciler already logged the ERROR (it's
+    #   pure/I/O-free and has no health_monitor); this asks the AM to call
+    #   health_monitor.record_stream_violation(exchange, "executions", kind) — the stream is
+    #   always "executions" here, only ``kind`` distinguishes the site.
+    kind: str
+
+
+Action = RequestStatus | RequestSnapshot | RequestHistDeals | RouteEvent | RecordViolation | OrderPartiallyFilledEvent
 
 
 class Tick:
@@ -161,7 +172,7 @@ class ResolveMissingOrder(Task):
         match inp:
             case OrderIn():
                 self._done = True  # - any event for our id resolves it (normal path applies it)
-                return []
+                return self._check_resolved_with_fills(state)
             case SnapshotIn(snap=snap):
                 # - reappeared open, or just applied terminal → no longer missing
                 order = state.get_order(self._cid)
@@ -172,6 +183,29 @@ class ResolveMissingOrder(Task):
             case _:
                 return []
 
+    def _check_resolved_with_fills(self, state: AccountState) -> list[Action]:
+        """A.4 loudness: this order was missing from a snapshot and just resolved (via the
+        normal event path — reducer.apply already ran before the Reconciler sees the event, see
+        AccountManager._apply_to_state) to a terminal status carrying real fills. That is exactly
+        the incident shape: the live stream never delivered this fill, only the reconcile-driven
+        status fetch (or an out-of-band event) recovered it. A terminal CANCELED/EXPIRED/REJECTED
+        with no fills is a benign resolution (the stream just raced the snapshot) — not a
+        violation.
+        """
+        order = state.get_order(self._cid)
+        if (
+            order is not None
+            and order.status.is_terminal
+            and order.filled_quantity > fill_qty_epsilon(order.instrument)
+        ):
+            _log.error(
+                f"[{state.exchange}] reconcile: missing order <g>{self._cid}</g> resolved "
+                f"<r>{order.status}</r> with filled={order.filled_quantity} — the live stream never "
+                "delivered this fill, only the reconcile fetch recovered it"
+            )
+            return [RecordViolation(kind="missing_order_filled")]
+        return []
+
     def _on_tick(self, state: AccountState, now: np.datetime64) -> list[Action]:
         if now < self._next_fetch_at:
             return []
@@ -180,13 +214,15 @@ class ResolveMissingOrder(Task):
             self._next_fetch_at = now + self._wait
             return [RequestStatus(cid=self._cid, venue_id=self._venue_id, instrument=self._instrument)]
         # - budget exhausted → route LOST via the bus (never silent: a silent mutate is invisible
-        #   and the later WS dup gets deduped, so the strategy would miss it)
-        _log.warning(
+        #   and the later WS dup gets deduped, so the strategy would miss it). A.4: this is a
+        #   stream-integrity violation, not a routine outcome — ERROR (was WARNING) + the metric.
+        _log.error(
             f"[{state.exchange}] reconcile give-up on order <g>{self._cid}</g> (vid=<blue>{self._venue_id}</blue>) "
             f"-> <r>LOST</r> after {self._retries} status fetches with no venue answer"
         )
         self._done = True
         return [
+            RecordViolation(kind="order_lost"),
             RouteEvent(
                 OrderLostEvent(
                     instrument=self._instrument,
@@ -194,7 +230,7 @@ class ResolveMissingOrder(Task):
                     venue_order_id=self._venue_id,
                     reason=f"reconcile give-up after {self._retries} status fetches",
                 )
-            )
+            ),
         ]
 
     def _matches(self, event: object) -> bool:
@@ -448,8 +484,22 @@ class Reconciler:
                         if (ev := self._reconcile_order(state, snap_order)) is not None:
                             actions.append(RouteEvent(ev))
 
-                    # - size diff = missed deals
-                    case PositionSizeMismatch(origin=snap_pos) | OriginalPositionMissing(position=snap_pos):
+                    # - size diff = missed deals. In-session (spawn_confirm) this is a live stream
+                    #   that should have delivered the fill and didn't — A.4 loudness. The FIRST
+                    #   reconcile after start (spawn_confirm=False) is startup adoption, not a
+                    #   stream failure, so it stays quiet (see _reconcile_missed_position).
+                    case PositionSizeMismatch(origin=snap_pos):
+                        changed.append(self._reconcile_missed_position(state, snap, now, snap_pos, spawn_confirm))
+                        if spawn_confirm:
+                            _log.error(
+                                f"[{state.exchange}] reconcile: <y>{snap_pos.instrument}</y> position size "
+                                "drifted in-session — the live stream never delivered the missing fill(s)"
+                            )
+                            actions.append(RecordViolation(kind="position_mismatch"))
+
+                    # - venue has a position we don't track at all (not necessarily a stream miss —
+                    #   could be a manual/external trade) -> recover it, no violation.
+                    case OriginalPositionMissing(position=snap_pos):
                         changed.append(self._reconcile_missed_position(state, snap, now, snap_pos, spawn_confirm))
 
                     # - avg/margin only = figure refresh, no missed deals
@@ -457,11 +507,19 @@ class Reconciler:
                         if state.reconcile_position_from_snapshot(snap_pos):
                             changed.append(state.get_position(snap_pos.instrument))
 
-                    # - local holds it, venue flat = missed the close
+                    # - local holds it, venue flat = missed the close. Same A.4 reasoning as the
+                    #   size-mismatch arm above: in-session, this is the stream failing to deliver
+                    #   the closing fill(s).
                     case LocalPositionMissing(position=local_pos):
                         changed.append(
                             self._flatten_missed_close(state, snap, now, local_pos.instrument, spawn_confirm)
                         )
+                        if spawn_confirm:
+                            _log.error(
+                                f"[{state.exchange}] reconcile: <y>{local_pos.instrument}</y> missed close — "
+                                "the live stream never delivered the closing fill(s)"
+                            )
+                            actions.append(RecordViolation(kind="position_mismatch"))
 
                     case BalanceMismatch(origin=snap_bal) | OriginalBalanceMissing(balance=snap_bal):
                         # - push-wins: a WS push at/after the snapshot's as_of supersedes it (venue event

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -96,6 +96,13 @@ class ApplyResult:
     balance: Balance | None = None
     # positions reconciled by a snapshot (Reconciler path) — PM fires on_position_change per entry
     positions: list[Position] = field(default_factory=list)
+    # True when _reconcile_fill_gap booked a synthetic deficit fill (A.4 loudness): the live
+    # stream under-delivered what the venue's terminal report counted. Metadata only — never
+    # part of the suppress signal below (it's only ever set alongside deal/position, which
+    # already make the result non-empty). The AccountManager reads this to record a
+    # stream-integrity violation (it holds the health_monitor collaborator; the reducer stays a
+    # pure state-mutation function with no I/O dependency).
+    deficit_fill: bool = False
 
     def is_empty(self) -> bool:
         """All fields None — the suppress signal (see module docstring): no callback fires."""
@@ -350,6 +357,14 @@ def _reconcile_fill_gap(state: AccountState, order: Order, event: OrderFilledEve
 
     Returns None (no gap) when the connector didn't supply the cumulative figure (sim/backtest,
     split-stream venues), so behaviour is unchanged unless a connector opts in by setting it.
+
+    A.4 loudness: when the gap is actually booked (not deduped — see the trade-id note below),
+    this logs at ERROR. The live stream should have delivered this execution and silently
+    didn't; the incident that motivated this (a swallowed cancel-found-terminal, 25 minutes of
+    invisible unhedged divergence) is exactly this path firing. ``_handle_fill`` surfaces the
+    fact via ``ApplyResult.deficit_fill`` so the AccountManager (which holds the health_monitor
+    collaborator; this module stays a pure, I/O-free state mutator) can also record a
+    ``record_stream_violation(exchange, "executions", "deficit_fill")``.
     """
     venue_filled = event.venue_filled_quantity
     if venue_filled is None or order.instrument is None:
@@ -361,6 +376,8 @@ def _reconcile_fill_gap(state: AccountState, order: Order, event: OrderFilledEve
     if price is None:
         return None
     synthetic = Deal(
+        # Deterministic trade_id (order-scoped, not event-scoped): a re-delivered terminal
+        # report for the same order dedups here rather than double-booking the gap.
         trade_id=f"{order.venue_order_id or order.client_order_id}:fill-reconcile",
         order_id=order.venue_order_id or "",
         time=now,
@@ -368,7 +385,14 @@ def _reconcile_fill_gap(state: AccountState, order: Order, event: OrderFilledEve
         price=price,
         aggressive=False,
     )
-    return _apply_execution(state, order, synthetic, now, update_time=event.last_update_time)
+    booked = _apply_execution(state, order, synthetic, now, update_time=event.last_update_time)
+    if booked is not None:
+        logger.error(
+            f"[{state.exchange}] {order.client_order_id} stream under-delivered fills: venue cumulative "
+            f"{venue_filled} vs booked {order.filled_quantity} — synthesized a {remainder} deficit fill "
+            f"@ {price} (the live stream never delivered this execution)"
+        )
+    return booked
 
 
 def _handle_fill(state: AccountState, event: OrderFilledEvent, now: np.datetime64) -> ApplyResult:
@@ -387,11 +411,15 @@ def _handle_fill(state: AccountState, event: OrderFilledEvent, now: np.datetime6
     position = _book_deal(state, order.instrument, deal) if deal is not None and order.instrument is not None else None
     # Terminal fill-gap: book executions the venue counted but never delivered as deals so
     # position AND realized PnL converge now, not size-only at the next snapshot.
+    deficit_fill = False
     if (gap := _reconcile_fill_gap(state, order, event, now)) is not None and order.instrument is not None:
         position = _book_deal(state, order.instrument, gap)
         deal = deal or gap
+        deficit_fill = True
     order = transition(state, order.client_order_id, OrderStatus.FILLED, now, update_time=event.last_update_time)
-    return ApplyResult(order=order, order_change=OrderChange.FILLED, deal=deal, position=position)
+    return ApplyResult(
+        order=order, order_change=OrderChange.FILLED, deal=deal, position=position, deficit_fill=deficit_fill
+    )
 
 
 def _handle_partial_fill(state: AccountState, event: OrderPartiallyFilledEvent, now: np.datetime64) -> ApplyResult:

--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -12,6 +12,16 @@ from qubx.utils.misc import synchronized
 
 from .utils import EXCHANGE_MAPPINGS
 
+# Mirrors qubx.health.base.STALE_THRESHOLDS, in seconds — the StreamHealth ledger's ages are
+# time.monotonic() seconds (A.1), not the td_64/dt_64 domain the consumer-side is_stale() uses.
+# Duplicated rather than imported to avoid core/mixins depending on a concrete IHealthMonitor
+# implementation (core only depends on the interface; BaseHealthMonitor is a plugin of it).
+_STREAM_STALE_THRESHOLDS_S: dict[str, float] = {
+    "quote": 600.0,
+    "orderbook": 600.0,
+    "trade": 1800.0,
+}
+
 
 class SubscriptionManager(ISubscriptionManager):
     _time_provider: ITimeProvider
@@ -38,6 +48,7 @@ class SubscriptionManager(ISubscriptionManager):
         auto_subscribe: bool = True,
         default_base_subscription: str = DataType.NONE,
         monitor_interval_seconds: float = 30.0,
+        resub_backlog_threshold: int = 1000,
     ) -> None:
         self._time_provider = time_provider
         self._data_providers = data_providers
@@ -53,6 +64,9 @@ class SubscriptionManager(ISubscriptionManager):
         self._pending_stream_unsubscriptions = defaultdict(set)
         self._auto_subscribe = auto_subscribe
         self._monitor_interval_seconds = monitor_interval_seconds
+        # A.4: a busy/blocked ProcessorThread must not trigger resub churn on top of an already
+        # overloaded loop — guard the [1/4]..[4/4] flow on the shared channel's backlog.
+        self._resub_backlog_threshold = resub_backlog_threshold
         self._init_connection_status_callbacks()
         self._init_subscription_monitoring()
 
@@ -318,11 +332,37 @@ class SubscriptionManager(ISubscriptionManager):
                 if data_provider.is_simulation or not data_provider.is_connected():
                     continue
                 instruments = data_provider.get_subscribed_instruments(data_type)
-                for instrument in instruments:
-                    if self._health_monitor.is_stale(instrument, data_type):
-                        exch_sub_to_stale_instr[data_provider.exchange()][data_type].add(instrument)
+                if not instruments:
+                    continue
+                exchange = data_provider.exchange()
+                # A.4: prefer the producer-side StreamHealth ledger when it has entries for this
+                # exchange's stream (ccxt data providers feed record_stream_event at the wire —
+                # see ConnectionManager.listen_to_stream). It is exchange-wide, so unlike the
+                # consumer-side timestamp below it can't be fooled by a blocked ProcessorThread
+                # (processing.py's on_data_arrival call) — a long fit makes every subscribed
+                # instrument look stale even though the wire is fine. A data provider that
+                # records nothing (third-party, e.g. xdata) never populates the ledger, so it
+                # falls through to today's consumer-side check unchanged (back-compat).
+                producer_age = self._health_monitor.get_stream_health(exchange).ages.get(data_type)
+                if producer_age is not None:
+                    event_age_s, _drive_age_s = producer_age
+                    threshold_s = _STREAM_STALE_THRESHOLDS_S.get(data_type)
+                    if threshold_s is not None and event_age_s > threshold_s:
+                        exch_sub_to_stale_instr[exchange][data_type].update(instruments)
+                else:
+                    for instrument in instruments:
+                        if self._health_monitor.is_stale(instrument, data_type):
+                            exch_sub_to_stale_instr[exchange][data_type].add(instrument)
 
         if not exch_sub_to_stale_instr:
+            return
+
+        # A.4: a consumer that's already behind must not be piled on with resub churn — that's
+        # extra loop load exactly when the loop is already overloaded, and (pre-producer-side-
+        # preference above) is often what made the staleness look real in the first place.
+        backlog = self._health_monitor.get_queue_size()
+        if backlog > self._resub_backlog_threshold:
+            logger.info(f"skipping resubscription: channel backlog {backlog} — consumer is behind")
             return
 
         for exchange, sub_to_stale_instr in exch_sub_to_stale_instr.items():

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -28,6 +28,7 @@ from qubx.core.events import (
     OrderAcceptedEvent,
     OrderCanceledEvent,
     OrderCancelRejectedEvent,
+    OrderFilledEvent,
     OrderRejectedEvent,
     OrderUpdatedEvent,
     OrderUpdateRejectedEvent,
@@ -61,6 +62,7 @@ def _make_connector(
     *,
     exchange: Mock | None = None,
     data_provider: Mock | None = None,
+    health_monitor: Mock | None = None,
 ) -> tuple[CcxtConnector, list, Mock]:
     """Build a connector with a capturing channel and a mocked exchange.
 
@@ -92,6 +94,7 @@ def _make_connector(
         time_provider=DummyTimeProvider(),
         exchange_manager=em,
         data_provider=data_provider,
+        health_monitor=health_monitor,
     )
 
     captured: list = []
@@ -435,25 +438,82 @@ async def test_cancel_by_cloid_uses_cloid_endpoint() -> None:
     assert isinstance(sent[0], OrderCanceledEvent)
 
 
+def _raw_status(status: str, *, trades: list | None = None) -> dict:
+    # Minimal ccxt fetch_order payload for the status-probe path: enough for
+    # ccxt_convert_order_info (info/id/timestamp/side/status) and for _instrument_for_symbol
+    # to resolve via the connector's own symbol cache (see _seed_symbol_cache below).
+    return {
+        "info": {},
+        "id": "VENUE123",
+        "clientOrderId": "qubx_BTCUSDT_1",
+        "symbol": "BTC/USDT:USDT",
+        "timestamp": 1700000000000,
+        "side": "buy",
+        "price": 100.0,
+        "amount": 1.0,
+        "status": status,
+        "trades": trades or [],
+    }
+
+
+def _seed_symbol_cache(conn: CcxtConnector) -> None:
+    conn._symbol_to_instrument["BTC/USDT:USDT"] = _instrument()
+
+
 @pytest.mark.asyncio
-async def test_cancel_acked_order_gone_at_venue_emits_nothing_no_retry() -> None:
+async def test_cancel_acked_order_gone_at_venue_emits_nothing_directly_no_retry() -> None:
     # An ACKED order (has venue id) that the venue already removed (filled/expired/canceled)
     # before our cancel lands answers -2011 "Unknown order sent". Because it was acked, that is
     # DEFINITIVE ("gone"), not the submit/cancel race — so the connector must NOT retry and must
-    # emit nothing (the WS terminal + snapshot reconciler resolve it), avoiding the 32s retry storm.
+    # emit nothing DIRECTLY from _cancel_async itself, avoiding the 32s retry storm. It DOES probe
+    # status immediately now (incident fix) — see test_cancel_gone_at_venue_probes_status below
+    # for the warning/violation/spawn assertions; here we only pin the no-retry contract.
     exchange = Mock()
     exchange.has = {"editOrder": True}
     exchange.cancel_order = AsyncMock(
         side_effect=ccxt.ExchangeError('binanceusdm {"code":-2011,"msg":"Unknown order sent."}')
     )
+    exchange.fetch_order = AsyncMock(return_value=_raw_status("canceled"))
     conn, sent, _ = _make_connector(exchange=exchange)
+    _seed_symbol_cache(conn)
 
     with patch("qubx.connectors.ccxt.connector.asyncio.sleep", AsyncMock()):
         conn.cancel_order(_order(venue_order_id="VENUE123"))
         await _drive(conn)
 
     exchange.cancel_order.assert_awaited_once()  # - definitive 'gone' -> no retry storm
-    assert sent == []  # - neither canceled nor cancel-rejected; WS/snapshot resolve the terminal
+
+
+@pytest.mark.asyncio
+async def test_cancel_gone_at_venue_probes_status() -> None:
+    # The incident: an already-filled maker order's cancel is rejected as "already gone" at the
+    # venue. The old code emitted nothing at all and silently waited for the next periodic sweep
+    # (25 minutes of invisible unhedged divergence). Now: WARNING + a stream-integrity violation
+    # + an immediate status fetch, reusing the same primitive request_order_status uses
+    # (_order_status_async) so the recovered terminal status/fill flows through the normal event
+    # path within seconds instead of the next sweep.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.cancel_order = AsyncMock(
+        side_effect=ccxt.ExchangeError('binanceusdm {"code":-2011,"msg":"Unknown order sent."}')
+    )
+    exchange.fetch_order = AsyncMock(return_value=_raw_status("closed"))  # closed, no trades
+    hm = Mock()
+    conn, sent, _ = _make_connector(exchange=exchange, health_monitor=hm)
+    _seed_symbol_cache(conn)
+
+    with patch("qubx.connectors.ccxt.connector.asyncio.sleep", AsyncMock()):
+        conn.cancel_order(_order(venue_order_id="VENUE123"))
+        await _drive(conn)
+
+    hm.record_stream_violation.assert_called_once_with("BINANCE.UM", "executions", "cancel_found_terminal")
+    exchange.fetch_order.assert_awaited_once_with("VENUE123", "BTC/USDT:USDT")
+    # the recovered terminal status flows through the normal event path (ACCEPTED synth + a
+    # status-only FILLED, since the closed order carries no trades — the same "carried no
+    # trades" gap path the deficit-fill synthesizer books downstream in the AccountManager).
+    assert isinstance(sent[-1], OrderFilledEvent)
+    assert sent[-1].venue_order_id == "VENUE123"
+    assert sent[-1].fill is None
 
 
 @pytest.mark.asyncio

--- a/tests/qubx/connectors/ccxt/test_connection_manager.py
+++ b/tests/qubx/connectors/ccxt/test_connection_manager.py
@@ -16,6 +16,7 @@ from ccxt import BadSymbol, ExchangeClosedByUser, ExchangeError, ExchangeNotAvai
 from qubx.connectors.ccxt.connection_manager import ConnectionManager
 from qubx.connectors.ccxt.exceptions import CcxtSymbolNotRecognized
 from qubx.connectors.ccxt.subscription_manager import SubscriptionManager
+from qubx.health.dummy import DummyHealthMonitor
 from qubx.utils.misc import AsyncThreadLoop
 
 
@@ -29,7 +30,7 @@ class TestConnectionManager:
         loop.submit = MagicMock()
         return loop
 
-    @pytest.fixture  
+    @pytest.fixture
     def mock_exchange_manager(self, mock_async_loop):
         """Create a mock ExchangeManager for testing."""
         exchange_manager = MagicMock()
@@ -53,6 +54,60 @@ class TestConnectionManager:
             max_ws_retries=3,
             subscription_manager=subscription_manager,
         )
+
+    def test_default_health_monitor_is_dummy_and_safe(self, subscription_manager, mock_exchange_manager):
+        """No health_monitor passed at construction -> falls back to DummyHealthMonitor (the
+        sim/no-op contract, same default-to-Dummy pattern as CcxtConnector/AccountManager)."""
+        manager = ConnectionManager(
+            exchange_id="test_exchange",
+            exchange_manager=mock_exchange_manager,
+            max_ws_retries=3,
+            subscription_manager=subscription_manager,
+        )
+        assert isinstance(manager._health_monitor, DummyHealthMonitor)
+
+    async def test_listen_to_stream_records_producer_side_event_on_success(self, connection_manager, mock_async_loop):
+        """A.4: a successful subscriber() round-trip records a producer-side stream_event —
+        the wire-level signal the central staleness monitor prefers over the (possibly blocked)
+        consumer-side timestamp."""
+        hm = MagicMock()
+        connection_manager._health_monitor = hm
+        mock_subscriber = AsyncMock()
+        mock_exchange = MagicMock()
+        mock_ctrl_channel = MagicMock()
+        mock_ctrl_channel.control.is_set.side_effect = [True, False]
+
+        await connection_manager.listen_to_stream(
+            subscriber=mock_subscriber,
+            exchange=mock_exchange,
+            channel=mock_ctrl_channel,
+            subscription_type="orderbook",
+            stream_name="test_stream",
+        )
+
+        hm.record_stream_event.assert_called_once_with("test_exchange", "orderbook")
+
+    async def test_listen_to_stream_does_not_record_event_on_failure(self, connection_manager, mock_async_loop):
+        """A subscriber() that raises must NOT record an event — only a genuine round-trip
+        counts (mirrors _run_ws_loop's drive-vs-event split on the account-stream side)."""
+        hm = MagicMock()
+        connection_manager._health_monitor = hm
+        mock_subscriber = AsyncMock()
+        mock_subscriber.side_effect = NetworkError("Connection lost")
+        mock_exchange = MagicMock()
+        mock_ctrl_channel = MagicMock()
+        mock_ctrl_channel.control.is_set.side_effect = [True, False]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await connection_manager.listen_to_stream(
+                subscriber=mock_subscriber,
+                exchange=mock_exchange,
+                channel=mock_ctrl_channel,
+                subscription_type="orderbook",
+                stream_name="test_stream",
+            )
+
+        hm.record_stream_event.assert_not_called()
 
     def test_initialization(self, subscription_manager, mock_exchange_manager):
         """Test that ConnectionManager initializes with correct state."""
@@ -400,9 +455,9 @@ class TestConnectionManager:
         mock_unsub_future = MagicMock()
         mock_unsub_future.running.return_value = False
         mock_loop.submit.return_value = mock_unsub_future
-        
+
         # Patch AsyncThreadLoop creation to return our mock
-        with patch('qubx.connectors.ccxt.connection_manager.AsyncThreadLoop', return_value=mock_loop):
+        with patch("qubx.connectors.ccxt.connection_manager.AsyncThreadLoop", return_value=mock_loop):
             # Execute - should not raise exception
             connection_manager.stop_stream(stream_name, wait=False)
 
@@ -477,7 +532,10 @@ class TestConnectionManager:
     def test_set_subscription_manager(self, mock_exchange_manager):
         """Test setting subscription manager after initialization."""
         manager = ConnectionManager(
-            exchange_id="test_exchange", exchange_manager=mock_exchange_manager, max_ws_retries=3, subscription_manager=None
+            exchange_id="test_exchange",
+            exchange_manager=mock_exchange_manager,
+            max_ws_retries=3,
+            subscription_manager=None,
         )
 
         # Initially no subscription manager

--- a/tests/qubx/core/account_manager/reconciler_test.py
+++ b/tests/qubx/core/account_manager/reconciler_test.py
@@ -18,6 +18,7 @@ from qubx.core.account_manager.diffs import Differ
 from qubx.core.account_manager.reconciler import (
     HIST_DEALS_LOOKBACK,
     Reconciler,
+    RecordViolation,
     RequestHistDeals,
     RequestSnapshot,
     RequestStatus,
@@ -30,6 +31,7 @@ from qubx.core.events import (
     DealEvent,
     OrderAcceptedEvent,
     OrderCanceledEvent,
+    OrderFilledEvent,
     OrderLostEvent,
     OrderPartiallyFilledEvent,
 )
@@ -202,6 +204,47 @@ def test_missing_order_resolved_by_arriving_event_drops_task():
     assert rec.active_keys() == set()  # task done & dropped — no LOST
 
 
+def test_missing_order_resolved_with_fills_records_violation():
+    # A.4 loudness / the incident shape: the AM applies the incoming event via reducer.apply
+    # BEFORE routing it to the reconciler (see AccountManager._apply_to_state), so by the time
+    # this task sees the OrderIn, state already reflects the terminal-with-fills order. The order
+    # was missing from a snapshot (LocalOrderMissing) and only the reconcile-driven status fetch
+    # (or an out-of-band event) revealed it filled — the live stream never delivered this fill.
+    rec = _reconciler()
+    st = _local(_order("X1"))
+    rec.on_snapshot(st, _origin(open_orders=[]), T0)
+    assert rec.active_keys() == {"X1"}
+
+    event = OrderFilledEvent(
+        instrument=_inst(),
+        client_order_id="X1",
+        venue_order_id="v_X1",
+        fill=None,
+        venue_filled_quantity=1.0,
+        venue_avg_price=50_000.0,
+    )
+    reducer.apply(st, event, _passed_seconds(T0, 4))  # mirrors the AM's apply-then-route order
+    out = rec.on_event(st, event, _passed_seconds(T0, 4))
+
+    assert out == [RecordViolation(kind="missing_order_filled")]
+    assert rec.active_keys() == set()  # resolved — no LOST
+
+
+def test_missing_order_resolved_by_canceled_with_no_fill_records_nothing():
+    # A benign resolution — the order simply canceled with nothing filled, the stream just raced
+    # the snapshot — is NOT a stream-integrity violation.
+    rec = _reconciler()
+    st = _local(_order("X1"))
+    rec.on_snapshot(st, _origin(open_orders=[]), T0)
+
+    event = OrderCanceledEvent(instrument=_inst(), client_order_id="X1", venue_order_id="v_X1")
+    reducer.apply(st, event, _passed_seconds(T0, 4))
+    out = rec.on_event(st, event, _passed_seconds(T0, 4))
+
+    assert out == []
+    assert rec.active_keys() == set()
+
+
 def test_unacked_missing_order_detected_by_cid_fallback_ends_lost():
     # X1 never got its venue ack (venue_order_id=None) and is absent from the snapshot —
     # the Differ can't match by venue id, falls back to cid, still flags it missing.
@@ -212,8 +255,10 @@ def test_unacked_missing_order_detected_by_cid_fallback_ends_lost():
     rec.on_tick(st, _passed_seconds(T0, 3))  # retry 1
     rec.on_tick(st, _passed_seconds(T0, 5))  # retry 2
     out = rec.on_tick(st, _passed_seconds(T0, 7))  # give up -> routes a LOST event (no silent mutate)
-    assert [type(a) for a in out] == [RouteEvent]
-    assert isinstance(out[0].event, OrderLostEvent) and out[0].event.client_order_id == "X1"
+    # A.4: give-up is a stream-integrity violation, not just a routine LOST.
+    assert [type(a) for a in out] == [RecordViolation, RouteEvent]
+    assert out[0] == RecordViolation(kind="order_lost")
+    assert isinstance(out[1].event, OrderLostEvent) and out[1].event.client_order_id == "X1"
     assert rec.active_keys() == set()
 
 
@@ -227,8 +272,9 @@ def test_missing_order_with_no_answer_ends_lost():
     rec.on_tick(st, _passed_seconds(T0, 3))  # retry 1 -> RequestStatus
     rec.on_tick(st, _passed_seconds(T0, 5))  # retry 2 -> RequestStatus
     out = rec.on_tick(st, _passed_seconds(T0, 7))  # exhausted -> routes a LOST event
-    assert [type(a) for a in out] == [RouteEvent]
-    assert isinstance(out[0].event, OrderLostEvent) and out[0].event.client_order_id == "X1"
+    assert [type(a) for a in out] == [RecordViolation, RouteEvent]
+    assert out[0] == RecordViolation(kind="order_lost")
+    assert isinstance(out[1].event, OrderLostEvent) and out[1].event.client_order_id == "X1"
     assert rec.active_keys() == set()
 
 
@@ -255,8 +301,8 @@ def test_missing_one_order_with_no_answer_ends_lost():
     rec.on_tick(st, _passed_seconds(T0, 5))  # retry 2 -> RequestStatus
     out = rec.on_tick(st, _passed_seconds(T0, 7))  # exhausted -> routes a LOST event for X1
 
-    assert [type(a) for a in out] == [RouteEvent]
-    assert isinstance(out[0].event, OrderLostEvent) and out[0].event.client_order_id == "X1"
+    assert [type(a) for a in out] == [RecordViolation, RouteEvent]
+    assert isinstance(out[1].event, OrderLostEvent) and out[1].event.client_order_id == "X1"
     assert st.get_order("X2").status == OrderStatus.ACCEPTED  # type: ignore # untouched
     assert rec.active_keys() == set()
     D_OFF()
@@ -441,7 +487,10 @@ def test_in_session_position_size_diff_spawns_confirm_task():
     assert pos.quantity == 0.005  # type: ignore
     assert pos.r_pnl == 5.0  # type: ignore
     assert rec.active_keys() == {"BTCUSDT"}  # ConfirmPositionBySnapshot task owns the symbol
-    assert a == []
+    # A.4: an in-session size drift is a stream-integrity violation (the live stream should have
+    # delivered the missing fill) — unlike the first-reconcile-after-start case (see
+    # test_first_snapshot_position_diff_does_not_request_hist_deals below), which stays quiet.
+    assert a == [RecordViolation(kind="position_mismatch")]
 
 
 def test_venue_figures_applied_from_snapshot():
@@ -568,7 +617,9 @@ def test_local_position_missing_flattens_and_spawns_confirm_task():
     assert pos.quantity == 0.0  # type: ignore # flattened (venue authoritative)
     assert pos.r_pnl == 7.0  # type: ignore # local accounting preserved
     assert rec.active_keys() == {"BTCUSDT"}  # confirm task to recover the closing deals
-    assert a == []
+    # A.4: a missed close in-session is a stream-integrity violation (the live stream should
+    # have delivered the closing fill).
+    assert a == [RecordViolation(kind="position_mismatch")]
     D_OFF()
 
 

--- a/tests/qubx/core/subscription_test.py
+++ b/tests/qubx/core/subscription_test.py
@@ -1,9 +1,10 @@
-from unittest.mock import Mock, call
+from collections import Counter
+from unittest.mock import Mock, call, patch
 
 import pytest
 
 from qubx.core.basics import DataType, Instrument
-from qubx.core.interfaces import StrategyState
+from qubx.core.interfaces import StrategyState, StreamHealth
 from qubx.core.lookups import lookup
 from qubx.core.mixins.subscription import SubscriptionManager
 from qubx.health.dummy import DummyHealthMonitor
@@ -133,3 +134,112 @@ class TestSubscriptionStuff:
             | {(DataType.TRADE, i): "10m" for i in instruments}
         )
         self.mock_broker.warmup.assert_called_once_with(expected_warmup)
+
+
+class TestSubscriptionStaleness:
+    """A.4: the staleness monitor prefers producer-side StreamHealth ages when the ledger has
+    entries for an exchange's market-data stream (fixing the blocked-consumer false positive —
+    processing.py:892's on_data_arrival call is consumer-side and can't tell "loop is busy" apart
+    from "stream is dead"), falls back to today's consumer-side is_stale() when the ledger has no
+    entries (third-party data providers, e.g. xdata, record nothing — CRITICAL back-compat), and
+    skips the whole [1/4]..[4/4] remediation cycle when the shared channel is backlogged.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.exchange = "BINANCE.UM"
+        self.instrument = lookup.find_symbol(self.exchange, "BTCUSDT")
+        assert self.instrument is not None
+
+        self.data_provider = Mock()
+        self.data_provider.is_simulation = False
+        self.data_provider.is_connected.return_value = True
+        self.data_provider.exchange.return_value = self.exchange
+        # Only "quote" carries a subscribed instrument; "orderbook"/"trade" are skipped
+        # (not subscribed) so each test only has one stream in play.
+        self.data_provider.get_subscribed_instruments.side_effect = (
+            lambda data_type: [self.instrument] if data_type == "quote" else []
+        )
+
+        self.hm = Mock()
+        self.hm.get_stream_health.return_value = StreamHealth(ages={}, violations=Counter())
+        self.hm.get_queue_size.return_value = 0
+        self.hm.is_stale.return_value = False
+
+        self.manager = SubscriptionManager(Mock(), [self.data_provider], self.hm, StrategyState())
+
+    def test_producer_side_fresh_skips_consumer_check_and_resub(self):
+        # The ledger has a fresh event for "quote" -> trusted directly; the per-instrument
+        # consumer-side check (which a blocked ProcessorThread would fool) is never consulted.
+        self.hm.get_stream_health.return_value = StreamHealth(ages={"quote": (5.0, 5.0)}, violations=Counter())
+
+        self.manager._monitor_subscription_status()
+
+        self.hm.is_stale.assert_not_called()
+        self.data_provider.unsubscribe.assert_not_called()
+        self.data_provider.subscribe.assert_not_called()
+
+    def test_producer_side_stale_flags_without_consumer_check(self):
+        # The ledger itself shows the stream is genuinely stale (event_age past threshold) ->
+        # flagged directly, still without ever consulting the consumer-side timestamp.
+        self.hm.get_stream_health.return_value = StreamHealth(ages={"quote": (700.0, 700.0)}, violations=Counter())
+
+        with patch("qubx.core.mixins.subscription.time.sleep"):
+            self.manager._monitor_subscription_status()
+
+        self.hm.is_stale.assert_not_called()
+        self.data_provider.unsubscribe.assert_called_once_with("quote", {self.instrument})
+        self.data_provider.subscribe.assert_called_once_with("quote", {self.instrument})
+
+    def test_falls_back_to_consumer_side_when_ledger_has_no_entries(self):
+        # No producer-side entries for this exchange/stream (e.g. a third-party data provider
+        # like xdata that never calls record_stream_event) -> today's exact behavior, unchanged.
+        self.hm.get_stream_health.return_value = StreamHealth(ages={}, violations=Counter())
+        self.hm.is_stale.return_value = True
+
+        with patch("qubx.core.mixins.subscription.time.sleep"):
+            self.manager._monitor_subscription_status()
+
+        self.hm.is_stale.assert_called_once_with(self.instrument, "quote")
+        self.data_provider.unsubscribe.assert_called_once_with("quote", {self.instrument})
+        self.data_provider.subscribe.assert_called_once_with("quote", {self.instrument})
+
+    def test_falls_back_and_stays_healthy_when_consumer_side_not_stale(self):
+        self.hm.get_stream_health.return_value = StreamHealth(ages={}, violations=Counter())
+        self.hm.is_stale.return_value = False
+
+        self.manager._monitor_subscription_status()
+
+        self.data_provider.unsubscribe.assert_not_called()
+
+    def test_backlog_guard_skips_resub_cycle(self):
+        # Even a genuinely stale stream must not trigger resub churn while the shared channel is
+        # backlogged — that's extra loop load exactly when the loop is already overloaded.
+        self.hm.is_stale.return_value = True
+        self.hm.get_queue_size.return_value = 5_000
+
+        self.manager._monitor_subscription_status()
+
+        self.data_provider.unsubscribe.assert_not_called()
+        self.data_provider.subscribe.assert_not_called()
+
+    def test_backlog_at_threshold_does_not_skip(self):
+        # Strictly greater-than: a backlog exactly at the configured threshold still runs.
+        self.hm.is_stale.return_value = True
+        self.hm.get_queue_size.return_value = 1000  # default threshold
+
+        with patch("qubx.core.mixins.subscription.time.sleep"):
+            self.manager._monitor_subscription_status()
+
+        self.data_provider.unsubscribe.assert_called_once_with("quote", {self.instrument})
+
+    def test_backlog_guard_is_configurable(self):
+        manager = SubscriptionManager(
+            Mock(), [self.data_provider], self.hm, StrategyState(), resub_backlog_threshold=10
+        )
+        self.hm.is_stale.return_value = True
+        self.hm.get_queue_size.return_value = 20
+
+        manager._monitor_subscription_status()
+
+        self.data_provider.unsubscribe.assert_not_called()

--- a/tests/qubx/core/test_account_manager_apply.py
+++ b/tests/qubx/core/test_account_manager_apply.py
@@ -57,12 +57,13 @@ def _Inst() -> Instrument:
     )
 
 
-def _am():
+def _am(health_monitor=None):
     return AccountManager(
         connectors={"binance": MagicMock()},
         base_currencies={"binance": "USDT"},
         time=_T(),
         account_id="test",
+        health_monitor=health_monitor,
     )
 
 
@@ -886,7 +887,8 @@ def test_filled_books_gap_for_dropped_ws_fills():
     # arrive as deals; the terminal FILLED carries fill=None plus the venue's cumulative
     # filled_quantity. The reducer books the unbooked remainder so position AND filled_quantity
     # converge now, instead of size-only at the next snapshot reconcile.
-    am = _am()
+    hm = MagicMock()
+    am = _am(health_monitor=hm)
     inst = _Inst()
     state = am.get_state("binance")
     add_order(state, status=OrderStatus.ACCEPTED, instrument=inst, quantity=1.0)
@@ -911,11 +913,14 @@ def test_filled_books_gap_for_dropped_ws_fills():
     assert state.get_position(inst).quantity == 1.0  # full position, not 0.3
     assert r.deal is not None and abs(r.deal.amount - 0.7) < 1e-9  # the synthetic gap fill is surfaced
     assert r.deal.fee_amount is None  # a synthesized fill carries no fee
+    # A.4 loudness: a booked deficit fill is a stream-integrity violation.
+    hm.record_stream_violation.assert_called_once_with("binance", "executions", "deficit_fill")
 
 
 def test_filled_books_gap_on_top_of_a_delivered_last_deal():
     # FILLED carries the last real deal AND the venue cumulative still exceeds what we booked.
-    am = _am()
+    hm = MagicMock()
+    am = _am(health_monitor=hm)
     inst = _Inst()
     state = am.get_state("binance")
     add_order(state, status=OrderStatus.ACCEPTED, instrument=inst, quantity=1.0)
@@ -937,11 +942,13 @@ def test_filled_books_gap_on_top_of_a_delivered_last_deal():
     o = state.get_order("cid-1")
     assert o.filled_quantity == 1.0  # 0.3 + 0.2 + 0.5 gap
     assert state.get_position(inst).quantity == 1.0
+    hm.record_stream_violation.assert_called_once_with("binance", "executions", "deficit_fill")
 
 
 def test_filled_no_gap_when_cumulative_matches_booked():
     # When the venue cumulative equals the sum we booked, no synthetic fill is created.
-    am = _am()
+    hm = MagicMock()
+    am = _am(health_monitor=hm)
     inst = _Inst()
     state = am.get_state("binance")
     add_order(state, status=OrderStatus.ACCEPTED, instrument=inst, quantity=1.0)
@@ -958,6 +965,7 @@ def test_filled_no_gap_when_cumulative_matches_booked():
     assert state.get_order("cid-1").filled_quantity == 1.0
     assert state.get_position(inst).quantity == 1.0
     assert r.deal.trade_id == "t1"  # the real delivered deal, not a synthetic gap
+    hm.record_stream_violation.assert_not_called()  # no gap -> no violation
 
 
 def test_filled_without_venue_cumulative_is_unchanged():

--- a/tests/qubx/core/test_account_manager_snapshot.py
+++ b/tests/qubx/core/test_account_manager_snapshot.py
@@ -46,13 +46,14 @@ def _instrument(symbol="BTCUSDT", exchange="binance") -> Instrument:
     )
 
 
-def _am(exchange="binance", cfg=None):
+def _am(exchange="binance", cfg=None, health_monitor=None):
     return AccountManager(
         connectors={exchange: MagicMock()},
         base_currencies={exchange: "USDT"},
         time=_T(),
         cfg=cfg or AccountManagerConfig(snapshot_grace_ms=5_000),
         account_id="test",
+        health_monitor=health_monitor,
     )
 
 
@@ -563,6 +564,41 @@ def test_size_drift_snapshot_corrects_size_but_preserves_accounting():
     assert pos.commissions == 6.78
     assert pos.cumulative_funding == 9.99
     assert result.positions == [pos]
+
+
+def test_in_session_position_drift_records_stream_violation():
+    # A.4 loudness, end-to-end through the AccountManager: an in-session position-size drift is
+    # exactly what a live stream should have delivered a fill for and didn't. The Reconciler's
+    # RecordViolation action must reach health_monitor.record_stream_violation via AM._execute
+    # (RecordViolation case) — not just the raw Reconciler unit tests (reconciler_test.py).
+    hm = MagicMock()
+    am = _am(health_monitor=hm)
+    state = am._states["binance"]
+    inst = _instrument()
+    pos = Position(instrument=inst, quantity=1.0, pos_average_price=50_000.0)
+    state.set_position(inst, pos)
+
+    # first snapshot after start (matches local) consumes the first-reconcile allowance — no
+    # violation on startup adoption.
+    am._time.t = np.datetime64("2026-05-28T00:59:00")
+    am.apply(
+        _snap_event(
+            as_of="2026-05-28T00:59:00",
+            positions=[Position(instrument=inst, quantity=1.0, pos_average_price=50_000.0)],
+        )
+    )
+    hm.record_stream_violation.assert_not_called()
+
+    # in-session drift: the venue now reports a different size — the live stream missed a fill.
+    am._time.t = np.datetime64("2026-05-28T01:00:00")
+    am.apply(
+        _snap_event(
+            as_of="2026-05-28T01:00:00",
+            positions=[Position(instrument=inst, quantity=2.0, pos_average_price=49_000.0)],
+        )
+    )
+
+    hm.record_stream_violation.assert_called_once_with("binance", "executions", "position_mismatch")
 
 
 def test_snapshot_margin_and_mark_refresh_even_when_size_unchanged():


### PR DESCRIPTION
PR 3/7 (stacked on #352). Spec §A.4 + recap correction 3, quantkit#105. **DRAFT — do not merge.**

- Cancel-already-gone now WARNs, records a `cancel_found_terminal` violation, and probes order status via the existing fetch primitive → the deficit-fill synthesizer books the missed fill in seconds (in the incident this alone converts 25 min of silence into recovery at 15:18:31)
- Reconciler integrity events (missing-order-filled, synthetic deficit fill, position mismatch, order-lost give-up) → ERROR + per-kind stream violations; recovery behavior unchanged. Reconciler stays pure via a new `RecordViolation` action
- Producer-side market-data staleness recording in the ccxt read loop; staleness monitor prefers producer ages, falls back to today's consumer-side behavior for non-adopting providers (xdata unaffected)
- Backlog-aware resub guard: skip the [1/4]..[4/4] cycle when channel backlog > 1000 (a blocked consumer must not trigger resub churn — the incident's phantom-stale XRP cycles)

Tests: full fast suite 2278 passed / 0 failed. Reviewer note: `AwaitOrderConfirm`'s give-up path left at WARNING (spec names only ResolveMissingOrder) — flag if broader intent.

https://claude.ai/code/session_017fBtVL9NcmHosCbkZmYBXg