### PR TITLE
feat(core): BulkRestLoop — warmup/snapshots/history off the websocket loop (5/7)

### DIFF
--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -148,6 +148,7 @@ class CcxtConnector(ChannelEmitter):
         time_provider: ITimeProvider,
         exchange_manager: ExchangeManager,
         data_provider: IDataProvider,
+        bulk_exchange_manager: ExchangeManager | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         cancel_timeout: int = 30,
         cancel_retry_interval: int = 2,
@@ -162,6 +163,14 @@ class CcxtConnector(ChannelEmitter):
         self.channel = channel
         self._time = time_provider
         self._em = exchange_manager
+        # Second exchange instance on the process-wide BulkRestLoop (quantkit#106): the
+        # periodic account snapshot (4-way REST gather) and hist-deals recovery run there
+        # so they can never occupy the realtime loop that drives the account WS stream and
+        # order submit/cancel. When no separate bulk instance is provided (unit tests,
+        # bespoke constructions), bulk-class calls run on the single realtime instance —
+        # exactly the pre-bulk-loop behavior. The bulk instance is independent and NOT
+        # auto-recreated (see create_ccxt_connector).
+        self._bulk_em = bulk_exchange_manager or exchange_manager
         self._data_provider = data_provider
         self._explicit_loop = loop
         self.cancel_timeout = cancel_timeout
@@ -198,6 +207,15 @@ class CcxtConnector(ChannelEmitter):
         loop = self._explicit_loop or self._em.exchange.asyncio_loop
         return AsyncThreadLoop(loop)
 
+    @property
+    def _bulk_loop(self) -> AsyncThreadLoop:
+        """AsyncThreadLoop bound to the bulk exchange's loop (the BulkRestLoop in live).
+
+        Coroutines touching ``self._bulk_em.exchange`` MUST run here — a ccxt
+        exchange's aiohttp session is bound to its own loop.
+        """
+        return AsyncThreadLoop(self._bulk_em.exchange.asyncio_loop)
+
     def _spawn(self, coro: Any) -> None:
         """Fire-and-forget a coroutine on the exchange loop.
 
@@ -208,6 +226,15 @@ class CcxtConnector(ChannelEmitter):
         future = self._loop.submit(coro)
         # The Future is otherwise discarded; surface any uncaught exception in the
         # coroutine (e.g. post-success emit work) instead of silently dead-lettering it.
+        future.add_done_callback(self._log_spawn_error)
+
+    def _spawn_bulk(self, coro: Any) -> None:
+        """Fire-and-forget a coroutine on the bulk exchange loop (see ``_spawn``).
+
+        Used by the bulk-REST paths (snapshot, hist-deals) so they never occupy the
+        realtime loop. Stubbed separately in tests to assert loop routing.
+        """
+        future = self._bulk_loop.submit(coro)
         future.add_done_callback(self._log_spawn_error)
 
     def _log_spawn_error(self, future: Any) -> None:
@@ -746,19 +773,22 @@ class CcxtConnector(ChannelEmitter):
             adl = info_float(raw, "adlQuantile")
         return int(adl) if adl is not None else None
 
-    async def _fill_leverage_settings(self, positions: list[Position]) -> None:
+    async def _fill_leverage_settings(self, positions: list[Position], ex: ccxt.pro.Exchange) -> None:
         """Fill ``leverage``/``max_notional`` from symbolConfig for positions the position
         payload left blank (Binance v3 carries neither — see ccxt_extract_leverage_settings).
 
         Best-effort: a failure leaves the fields None, exactly as before. Never overwrites a
         value the position payload did supply, so venues that do carry them are untouched.
+
+        ``ex`` is the calling snapshot's (bulk) exchange — the awaited fetch must run on
+        the loop the snapshot was spawned on.
         """
-        if not positions or not self._em.exchange.has.get("fetchLeverages"):
+        if not positions or not ex.has.get("fetchLeverages"):
             return
         if all(p.leverage is not None and p.max_notional is not None for p in positions):
             return
         try:
-            rows = await self._em.exchange.fetch_leverages()
+            rows = await ex.fetch_leverages()
         except Exception as e:  # noqa: BLE001
             logger.debug(f"[{self.exchange_name}] fetch_leverages failed: {e}")
             return
@@ -1280,7 +1310,8 @@ class CcxtConnector(ChannelEmitter):
 
     def request_hist_deals(self, instrument: Instrument, since: dt_64) -> None:
         # Read the symbol off the instrument SYNCHRONOUSLY (see cancel_order).
-        self._spawn(self._hist_deals_async(instrument, instrument_to_ccxt_symbol(instrument), since))
+        # Bulk-class REST (recovery fetch, not latency-critical) -> bulk loop.
+        self._spawn_bulk(self._hist_deals_async(instrument, instrument_to_ccxt_symbol(instrument), since))
 
     async def _hist_deals_async(self, instrument: Instrument, symbol: str, since: dt_64) -> None:
         """Fetch trades since ``since`` and emit one DealEvent per trade.
@@ -1296,7 +1327,7 @@ class CcxtConnector(ChannelEmitter):
         since_ms = int(since.astype("datetime64[ms]").astype("int64"))
         logger.debug(f"[{self.exchange_name}] hist-deals: fetch_my_trades {symbol} since {since}")
         try:
-            raw_trades = await self._em.exchange.fetch_my_trades(symbol, since=since_ms)
+            raw_trades = await self._bulk_em.exchange.fetch_my_trades(symbol, since=since_ms)
         except NetworkError as e:
             logger.warning(f"[{self.exchange_name}] hist deals fetch for {symbol} since {since} failed: {e}")
             return
@@ -1397,7 +1428,7 @@ class CcxtConnector(ChannelEmitter):
             )
         )
 
-    async def _fetch_trigger_open_orders(self) -> list[dict]:
+    async def _fetch_trigger_open_orders(self, ex: ccxt.pro.Exchange) -> list[dict]:
         """Fetch untriggered stop/conditional ("algo") open orders.
 
         Binance USDⓂ serves these from a SEPARATE endpoint, disjoint from the regular
@@ -1405,9 +1436,12 @@ class CcxtConnector(ChannelEmitter):
         A venue with no such surface raises NotSupported/BadRequest → treated as "no
         trigger orders" ([]); transient errors propagate (the caller leaves order
         reconcile for the next tick rather than orphaning unseen stops).
+
+        ``ex`` is passed explicitly (the snapshot's bulk exchange) so the awaited call
+        runs on the same loop the caller was spawned on.
         """
         try:
-            return await self._em.exchange.fetch_open_orders(params={"trigger": True})
+            return await ex.fetch_open_orders(params={"trigger": True})
         except (ccxt.NotSupported, ccxt.BadRequest) as e:
             logger.debug(f"[{self.exchange_name}] snapshot: no trigger open-orders surface ({e}); regular only")
             return []
@@ -1449,15 +1483,20 @@ class CcxtConnector(ChannelEmitter):
         return open_orders
 
     def request_snapshot(self, include_orders: bool = True) -> None:
-        self._spawn(self._snapshot_async(include_orders))
+        # The snapshot's 4-way gather is the heaviest routine REST call — bulk loop.
+        self._spawn_bulk(self._snapshot_async(include_orders))
 
     async def _snapshot_async(self, include_orders: bool = True) -> None:
         """Fetch account state concurrently and emit a snapshot.
 
+        Runs on the bulk exchange/loop (quantkit#106): the 4-way gather is the heaviest
+        routine REST call and must not occupy the realtime loop that drives the account
+        WS stream and order submit/cancel.
+
         include_orders=True  -> open orders + algo/trigger orders + positions + balances (startup
         discovery + periodic sweep). include_orders=False -> positions + balances ONLY (steady
-        state): the open-orders / algo legs carry high REST weight and, sharing ccxt's throttle
-        with order placement, delay order sends by seconds — so steady snapshots skip them
+        state): the open-orders / algo legs carry high REST weight and, sharing the venue rate
+        budget with order placement, delay order sends by seconds — so steady snapshots skip them
         (open_orders=None -> reconcile leaves order state untouched; orders are tracked via the WS
         stream + the periodic full sweep).
 
@@ -1465,12 +1504,12 @@ class CcxtConnector(ChannelEmitter):
         ``return_exceptions=True`` keeps one failing fetch from sinking the others; a failed (or
         skipped) leg is left None so reconcile won't wipe state it didn't actually observe.
         """
-        ex = self._em.exchange
+        ex = self._bulk_em.exchange
         as_of: dt_64 = self._time.time()
         if include_orders:
             raw_orders, raw_trigger_orders, raw_positions, raw_balance = await asyncio.gather(
                 ex.fetch_open_orders(),
-                self._fetch_trigger_open_orders(),
+                self._fetch_trigger_open_orders(ex),
                 ex.fetch_positions(),
                 ex.fetch_balance(),
                 return_exceptions=True,
@@ -1487,7 +1526,7 @@ class CcxtConnector(ChannelEmitter):
             logger.warning("[{}] snapshot: fetch_positions failed: {}", self.exchange_name, raw_positions)
         else:
             positions = ccxt_convert_positions(raw_positions, ex.name, ex.markets)
-            await self._fill_leverage_settings(positions)
+            await self._fill_leverage_settings(positions, ex)
 
         balances: list[Balance] | None = None
         equity = available_margin = margin_ratio = withdrawable = None
@@ -1605,6 +1644,11 @@ class CcxtConnector(ChannelEmitter):
             self._run_sync(self._em.exchange.close(), timeout=10)
         except Exception as e:  # noqa: BLE001
             logger.warning(f"[{self.exchange_name}] Error during disconnect: {e}")
+        if self._bulk_em is not self._em:
+            try:
+                self._bulk_loop.run_sync(self._bulk_em.exchange.close(), timeout=10)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"[{self.exchange_name}] Error closing bulk exchange during disconnect: {e}")
 
     def is_ws_ready(self) -> bool:
         return self._ws_ready

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -36,6 +36,7 @@ class CcxtDataProvider(IDataProvider):
         **kwargs,
     ):
         from qubx.connectors.ccxt.factory import get_ccxt_exchange_manager
+        from qubx.utils.misc import get_bulk_rest_loop
 
         settings = ctx.credentials.get_exchange_settings(ctx.exchange_name)
         self._exchange_manager = get_ccxt_exchange_manager(
@@ -46,11 +47,27 @@ class CcxtDataProvider(IDataProvider):
             loop=ctx.loop,
             **kwargs,
         )
+        # Second instance on the process-wide BulkRestLoop (quantkit#106): warmup fetches
+        # and get_ohlc history requests run here so their REST bursts can never starve the
+        # realtime loop's websocket keepalives. watch_* subscriptions stay on the realtime
+        # instance above. The bulk instance is independent and NOT auto-recreated — no
+        # start_monitoring(), no recreation callbacks; a failed bulk fetch surfaces to its
+        # caller (warmup logs/raises, get_ohlc raises to the strategy).
+        self._bulk_exchange_manager = get_ccxt_exchange_manager(
+            exchange=ctx.exchange_name,
+            use_testnet=settings.testnet,
+            health_monitor=ctx.health_monitor,
+            time_provider=ctx.time_provider,
+            loop=get_bulk_rest_loop().loop,
+            **kwargs,
+        )
         self.orderbook_limit = orderbook_limit
 
-        # Attach rate limiter to exchange manager (overrides CCXT's built-in throttle)
+        # Attach rate limiter to exchange manager (overrides CCXT's built-in throttle).
+        # The SAME limiter goes on both instances so the venue budget spans both loops.
         if ctx.rate_limiter is not None:
             self._exchange_manager.attach_rate_limiter(ctx.rate_limiter)
+            self._bulk_exchange_manager.attach_rate_limiter(ctx.rate_limiter)
 
         self.time_provider = ctx.time_provider
         self.channel = ctx.channel
@@ -78,11 +95,20 @@ class CcxtDataProvider(IDataProvider):
             exchange_manager=self._exchange_manager,
             exchange_id=self._exchange_id,
         )
+        # Separate handler instances bound to the bulk exchange: warmup() and
+        # get_historical_ohlc() coroutines await ccxt calls on whichever exchange the
+        # handler holds, so REST-only handlers get the bulk instance while the
+        # subscription (watch_*) handlers above keep the realtime one.
+        self._bulk_handler_factory = DataTypeHandlerFactory(
+            data_provider=self,
+            exchange_manager=self._bulk_exchange_manager,
+            exchange_id=self._exchange_id,
+        )
         self._warmup_service = WarmupService(
-            handler_factory=self._data_type_handler_factory,
+            handler_factory=self._bulk_handler_factory,
             channel=ctx.channel,
             exchange_id=self._exchange_id,
-            exchange_manager=self._exchange_manager,
+            exchange_manager=self._bulk_exchange_manager,
             warmup_timeout=warmup_timeout,
         )
         self._last_quotes = defaultdict(lambda: None)
@@ -96,6 +122,11 @@ class CcxtDataProvider(IDataProvider):
     def _loop(self) -> AsyncThreadLoop:
         """Get current AsyncThreadLoop for the exchange."""
         return AsyncThreadLoop(self._exchange_manager.exchange.asyncio_loop)
+
+    @property
+    def _bulk_loop(self) -> AsyncThreadLoop:
+        """AsyncThreadLoop for the bulk exchange (the BulkRestLoop in live)."""
+        return AsyncThreadLoop(self._bulk_exchange_manager.exchange.asyncio_loop)
 
     @property
     def is_simulation(self) -> bool:
@@ -207,9 +238,13 @@ class CcxtDataProvider(IDataProvider):
         return self._last_quotes.get(instrument, None)
 
     def get_ohlc(self, instrument: Instrument, timeframe: str, nbarsback: int) -> list[Bar]:
-        """Get historical OHLC data (delegated to OhlcDataHandler)."""
-        # Get OHLC handler from factory
-        ohlc_handler = self._data_type_handler_factory.get_handler("ohlc")
+        """Get historical OHLC data (delegated to OhlcDataHandler).
+
+        Runs on the bulk exchange/loop: this is strategy-triggered REST history
+        (ctx.ohlc with length), which must not occupy the realtime websocket loop.
+        """
+        # Get OHLC handler from the bulk factory (REST fetch -> bulk exchange)
+        ohlc_handler = self._bulk_handler_factory.get_handler("ohlc")
         if ohlc_handler is None:
             raise ValueError(f"{self._exchange_id}: OHLC handler not available")
 
@@ -221,7 +256,7 @@ class CcxtDataProvider(IDataProvider):
         async def _get_historical():
             return await ohlc_handler.get_historical_ohlc(instrument, timeframe, nbarsback)
 
-        return self._loop.submit(_get_historical()).result(60)
+        return self._bulk_loop.submit(_get_historical()).result(60)
 
     def start(self):
         # Eagerly load markets so is_instrument_listed() is authoritative before the
@@ -260,7 +295,7 @@ class CcxtDataProvider(IDataProvider):
                 except Exception as e:
                     logger.error(f"Error stopping subscription {subscription_type}: {e}")
 
-            # Stop ExchangeManager monitoring
+            # Stop ExchangeManager monitoring (the bulk manager never started monitoring)
             self._exchange_manager.stop_monitoring()
 
             # Close exchange connection
@@ -270,6 +305,12 @@ class CcxtDataProvider(IDataProvider):
                 future.result(5)
             else:
                 del self._exchange_manager
+
+            # Close the bulk exchange session (distinct instance on the BulkRestLoop)
+            if self._bulk_exchange_manager is not self._exchange_manager and hasattr(
+                self._bulk_exchange_manager.exchange, "close"
+            ):
+                self._bulk_loop.submit(self._bulk_exchange_manager.exchange.close()).result(5)  # type: ignore
 
             # Note: AsyncThreadLoop stop is handled by its own lifecycle
 

--- a/src/qubx/connectors/ccxt/exchanges/binance/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/connector.py
@@ -19,6 +19,8 @@ the configured VENUE name (``binance.pm``) — the canonical name both venues sh
 
 from typing import Any
 
+import ccxt.pro
+
 from qubx.core.basics import Instrument, Position
 
 from ...connector import CcxtConnector
@@ -79,19 +81,22 @@ class BinancePmCcxtConnector(CcxtConnector):
             info_float(account, "virtualMaxWithdrawAmount"),
         )
 
-    async def _fill_leverage_settings(self, positions: list[Position]) -> None:
+    async def _fill_leverage_settings(self, positions: list[Position], ex: ccxt.pro.Exchange) -> None:
         # snapshot post-processing hook: leverage/max_notional from the base, then ADL
-        await super()._fill_leverage_settings(positions)
-        await self._fill_adl_levels(positions)
+        await super()._fill_leverage_settings(positions, ex)
+        await self._fill_adl_levels(positions, ex)
 
-    async def _fill_adl_levels(self, positions: list[Position]) -> None:
+    async def _fill_adl_levels(self, positions: list[Position], ex: ccxt.pro.Exchange) -> None:
         """Stamp ``Position.adl_level`` from ONE account-wide adlQuantile call per
         snapshot and refresh the cache ``get_adl_level`` reads. Best-effort: a failure
-        leaves the previous cache and the positions' levels unchanged."""
+        leaves the previous cache and the positions' levels unchanged.
+
+        ``ex`` is the calling snapshot's (bulk) exchange — the awaited call must run on
+        the loop the snapshot was spawned on."""
         if not positions:
             return
         try:
-            rows = await self._em.exchange.papiGetUmAdlQuantile()
+            rows = await ex.papiGetUmAdlQuantile()
         except Exception as e:  # noqa: BLE001
             self._dbg.debug("fetch adl quantiles failed: {}", e)
             return

--- a/src/qubx/connectors/ccxt/factory.py
+++ b/src/qubx/connectors/ccxt/factory.py
@@ -108,10 +108,16 @@ def get_ccxt_exchange_manager(
 
     Returns ExchangeManager wrapper that handles exchange recreation
     during data stall scenarios via self-monitoring. Instances are cached
-    by (exchange, api_key, secret, use_testnet) to enable sharing across
+    by (exchange, api_key, secret, use_testnet, loop) to enable sharing across
     data provider, account processor, and broker.
+
+    The loop is part of the cache key so one venue can hold TWO instances: the
+    realtime one on the runner's shared websocket loop, and a bulk one on the
+    process-wide ``BulkRestLoop`` (``get_bulk_rest_loop``) for warmup/history/
+    snapshot traffic. A ccxt exchange's aiohttp session is bound to its loop, so
+    instances must never be shared across loops.
     """
-    cache_key = (exchange.lower(), api_key, secret, use_testnet, check_interval_seconds)
+    cache_key = (exchange.lower(), api_key, secret, use_testnet, check_interval_seconds, loop)
 
     if cache_key in _exchange_manager_cache:
         return _exchange_manager_cache[cache_key]
@@ -178,7 +184,18 @@ def create_ccxt_connector(ctx: ConnectorBuildContext) -> CcxtConnector:
     cached manager from the unauthenticated one ``CcxtDataProvider`` uses for market data
     (the manager cache keys on api_key/secret) — and resolves the per-exchange
     ``CcxtConnector`` subclass via ``get_ccxt_connector``.
+
+    Two authenticated instances are built (quantkit#106): the realtime one on the
+    runner's shared websocket loop (account streams, order submit/cancel, status
+    probes) and a bulk one on the process-wide ``BulkRestLoop`` (periodic account
+    snapshots, hist-deals recovery). The bulk instance is independent and NOT
+    auto-recreated: its manager never starts stall monitoring (staleness is a
+    stream property of the realtime instance), and a failed bulk call surfaces to
+    its caller, which already handles fetch errors per leg. ``force_recreation``
+    keeps working for the realtime instance only.
     """
+    from qubx.utils.misc import get_bulk_rest_loop
+
     creds = ctx.credentials.get_exchange_credentials(ctx.exchange_name)
     exchange_manager = get_ccxt_exchange_manager(
         exchange=ctx.exchange_name,
@@ -190,10 +207,22 @@ def create_ccxt_connector(ctx: ConnectorBuildContext) -> CcxtConnector:
         loop=ctx.loop,
         **(creds.model_extra or {}),
     )
+    bulk_exchange_manager = get_ccxt_exchange_manager(
+        exchange=ctx.exchange_name,
+        use_testnet=creds.testnet,
+        api_key=creds.api_key,
+        secret=creds.secret,
+        health_monitor=ctx.health_monitor,
+        time_provider=ctx.time_provider,
+        loop=get_bulk_rest_loop().loop,
+        **(creds.model_extra or {}),
+    )
     # Share the same per-exchange limiter the data provider uses (closes the gap where the
-    # order-placing side was previously unthrottled).
+    # order-placing side was previously unthrottled). The SAME limiter is attached to both
+    # instances so the venue budget spans the realtime and the bulk loop.
     if ctx.rate_limiter is not None:
         exchange_manager.attach_rate_limiter(ctx.rate_limiter)
+        bulk_exchange_manager.attach_rate_limiter(ctx.rate_limiter)
     # The connector self-reports the canonical (instrument-universe) exchange so the
     # account events it stamps (balances/snapshots) route to the same AM state its
     # instruments do: a BINANCE.PM account trades BINANCE.UM instruments — the venue
@@ -204,6 +233,7 @@ def create_ccxt_connector(ctx: ConnectorBuildContext) -> CcxtConnector:
         channel=ctx.channel,
         time_provider=ctx.time_provider,
         exchange_manager=exchange_manager,
+        bulk_exchange_manager=bulk_exchange_manager,
         data_provider=ctx.data_provider,
         loop=ctx.loop,
         health_monitor=ctx.health_monitor,

--- a/src/qubx/connectors/ccxt/warmup_service.py
+++ b/src/qubx/connectors/ccxt/warmup_service.py
@@ -17,14 +17,19 @@ from .handlers import DataTypeHandlerFactory
 
 
 class WarmupService:
-    """Service responsible for warming up historical data using data type handlers."""
+    """Service responsible for warming up historical data using data type handlers.
 
-    # Interim throttle (quantkit#106): warmup shares the event loop with the venue
-    # websockets and their keepalives — an unthrottled burst of warmup groups can
-    # occupy the loop long enough for keepalives to lapse and streams to die
-    # silently (2026-07-29 incident). Cap concurrent groups and force a scheduling
-    # gap after each so keepalive tasks always get the loop. Removed once bulk REST
-    # moves to its own loop.
+    Loop-agnostic: warmup coroutines run on whatever loop the given exchange manager's
+    exchange lives on. In live that is the bulk exchange on the process-wide BulkRestLoop
+    (quantkit#106) — the handler factory passed in must be bound to the SAME manager so
+    the fetches actually await on that loop.
+    """
+
+    # Throttle (quantkit#106): originally added while warmup still shared the realtime
+    # websocket loop (an unthrottled burst starved keepalives — 2026-07-29 incident).
+    # Warmup now runs on the dedicated BulkRestLoop, so the throttle no longer protects
+    # keepalives; it stays to bound REST burst pressure on the venue and to keep the
+    # bulk loop responsive for concurrent snapshot/history work.
     WARMUP_MAX_CONCURRENCY: int = 3
     WARMUP_YIELD_S: float = 0.05
 

--- a/src/qubx/rate_limiting/backend.py
+++ b/src/qubx/rate_limiting/backend.py
@@ -5,6 +5,7 @@ Provides the interface and in-memory implementation for token bucket state.
 Redis backend can be added later for cross-bot coordination.
 """
 
+import threading
 import time
 from abc import ABC, abstractmethod
 
@@ -59,15 +60,21 @@ class InMemoryBackend(IRateLimitBackend):
 
     Each key gets its own TokenBucketRateLimiter instance.
     Suitable for single-bot usage without cross-bot coordination.
+
+    Loop-agnostic (quantkit#106): the same backend is shared by the realtime websocket
+    loop and the BulkRestLoop. The buckets' math is synchronous under a threading.Lock
+    (see TokenBucketRateLimiter); only bucket creation is guarded here.
     """
 
     def __init__(self):
         self._limiters: dict[str, TokenBucketRateLimiter] = {}
+        self._lock = threading.Lock()
 
     def _get_or_create(self, key: str, capacity: float, refill_rate: float) -> TokenBucketRateLimiter:
-        if key not in self._limiters:
-            self._limiters[key] = TokenBucketRateLimiter(capacity, refill_rate, name=key)
-        return self._limiters[key]
+        with self._lock:
+            if key not in self._limiters:
+                self._limiters[key] = TokenBucketRateLimiter(capacity, refill_rate, name=key)
+            return self._limiters[key]
 
     async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
         limiter = self._get_or_create(key, capacity, refill_rate)
@@ -84,5 +91,4 @@ class InMemoryBackend(IRateLimitBackend):
     async def set_remaining(self, key: str, remaining: float) -> None:
         limiter = self._limiters.get(key)
         if limiter is not None:
-            limiter._tokens = remaining
-            limiter._last_refill = time.monotonic()
+            limiter.set_tokens(remaining)

--- a/src/qubx/rate_limiting/pools.py
+++ b/src/qubx/rate_limiting/pools.py
@@ -3,10 +3,19 @@
 Each pool type encapsulates its own gate behavior, acquisition logic,
 sync mechanism, and metrics state. The engine delegates to pools
 polymorphically — no pool_type branching in the engine.
+
+Loop-agnostic (quantkit#106): one ExchangeRateLimiter spans a venue's realtime
+websocket loop AND the process-wide BulkRestLoop, so pool state must be usable from
+coroutines on multiple event loops. Gate truth lives in ``_MultiLoopGate`` (plain
+bool + per-loop mirror events), gate reopen runs on a ``threading.Timer`` (no
+loop-bound task), and mutable pool state is guarded by a ``threading.Lock``.
 """
 
 import asyncio
+import threading
+import time
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from qubx import logger
 
@@ -22,16 +31,92 @@ class RateLimitGateTimeout(Exception):
         self.pool_name = pool_name
 
 
+class _MultiLoopGate:
+    """Open/closed gate awaitable from coroutines on multiple event loops.
+
+    ``asyncio.Event`` is loop-affine: ``wait()`` parks a future on the waiting loop and
+    ``set()`` completes it without cross-thread scheduling, so a single Event cannot
+    serve both the realtime and the bulk REST loop. Here the authoritative state is a
+    plain bool behind a ``threading.Lock``; every loop that waits gets its own mirror
+    ``asyncio.Event``, flipped via ``loop.call_soon_threadsafe`` so wakeups always
+    happen on the waiter's own loop.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._open = True
+        self._events: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Event] = WeakKeyDictionary()
+
+    @property
+    def is_open(self) -> bool:
+        with self._lock:
+            return self._open
+
+    def open(self) -> None:
+        self._set_state(True)
+
+    def close(self) -> None:
+        self._set_state(False)
+
+    def _set_state(self, is_open: bool) -> None:
+        with self._lock:
+            self._open = is_open
+            for loop, event in list(self._events.items()):
+                try:
+                    loop.call_soon_threadsafe(event.set if is_open else event.clear)
+                except RuntimeError:
+                    continue  # loop already closed — its waiters are gone anyway
+
+    def _event_for_running_loop(self) -> asyncio.Event:
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            event = self._events.get(loop)
+            if event is None:
+                event = asyncio.Event()
+                if self._open:
+                    event.set()
+                self._events[loop] = event
+            return event
+
+    async def wait_open(self, timeout: float) -> None:
+        """Wait until the gate is open; raises ``TimeoutError`` on expiry.
+
+        The bool is the authority — the mirror event only provides the sleep. The loop
+        re-checks after every wakeup so a gate extension (close while waiting) keeps the
+        waiter parked, and a mirror that briefly lags its scheduled clear/set callback
+        (queued on this very loop) only costs an extra yield, never a lost wakeup.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            event = self._event_for_running_loop()
+            if self.is_open:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError
+            await asyncio.wait_for(event.wait(), timeout=remaining)
+
+
 class BasePool:
-    """Base pool with gate mechanism and metrics tracking."""
+    """Base pool with gate mechanism and metrics tracking.
+
+    Gate reopen scheduling is epoch-guarded: every transition (close, extension,
+    reset, sync-reopen) bumps ``_gate_epoch`` under ``_state_lock``, and a pending
+    reopen timer only fires if its captured epoch is still current — a stale timer
+    from a superseded close can never reopen a freshly-closed gate.
+
+    Metrics counters (``hits``/``total_wait``/``consumed``) are updated without the
+    lock; cross-thread drift is cosmetic and not worth serializing every acquire.
+    """
 
     def __init__(self, config: PoolConfig, exchange: str, scope_id: str):
         self._config = config
         self._exchange = exchange
         self._scope_id = scope_id
-        self._gate = asyncio.Event()
-        self._gate.set()
-        self._gate_task: asyncio.Task | None = None
+        self._gate = _MultiLoopGate()
+        self._gate_timer: threading.Timer | None = None
+        self._gate_epoch = 0
+        self._state_lock = threading.Lock()
         self.hits: int = 0
         self.total_wait: float = 0
         self.consumed: float = 0
@@ -50,7 +135,7 @@ class BasePool:
 
     @property
     def is_gate_closed(self) -> bool:
-        return not self._gate.is_set()
+        return not self._gate.is_open
 
     def update_scope_id(self, scope_id: str) -> None:
         self._scope_id = scope_id
@@ -65,17 +150,29 @@ class BasePool:
         raise NotImplementedError
 
     def reset_gate(self) -> None:
-        """Reopen gate and cancel any pending reopen task."""
-        self._gate.set()
-        self._cancel_gate_task()
+        """Reopen gate and invalidate any pending reopen timer."""
+        self._open_gate_now()
 
     async def get_state(self) -> dict[str, Any]:
         raise NotImplementedError
 
-    def _cancel_gate_task(self) -> None:
-        if self._gate_task is not None and not self._gate_task.done():
-            self._gate_task.cancel()
-        self._gate_task = None
+    def _open_gate_now(self) -> None:
+        with self._state_lock:
+            self._gate_epoch += 1
+            self._cancel_gate_timer()
+            self._gate.open()
+
+    def _close_gate_now(self) -> None:
+        with self._state_lock:
+            self._gate_epoch += 1
+            self._cancel_gate_timer()
+            self._gate.close()
+
+    def _cancel_gate_timer(self) -> None:
+        """Cancel a pending reopen timer. Caller holds ``_state_lock``."""
+        if self._gate_timer is not None:
+            self._gate_timer.cancel()
+        self._gate_timer = None
 
     def _base_state(self, remaining: float, capacity: float) -> dict[str, Any]:
         return {
@@ -110,10 +207,10 @@ class RatePool(BasePool):
         self._key = self._make_key()
 
     async def acquire(self, weight: float, gate_max_wait: float) -> None:
-        if not self._gate.is_set():
+        if not self._gate.is_open:
             try:
-                await asyncio.wait_for(self._gate.wait(), timeout=gate_max_wait)
-            except asyncio.TimeoutError:
+                await self._gate.wait_open(gate_max_wait)
+            except TimeoutError:
                 raise RateLimitGateTimeout(
                     f"{self._exchange}: gate for pool '{self.name}' did not reopen "
                     f"within {gate_max_wait:.0f}s",
@@ -125,19 +222,28 @@ class RatePool(BasePool):
         self.consumed += weight
 
     def close_gate(self, cooldown: float, reason: str) -> None:
-        verb = "extended" if not self._gate.is_set() else "closed"
+        verb = "extended" if not self._gate.is_open else "closed"
         logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name} ({cooldown:.1f}s): {reason}")
-        self._gate.clear()
-        self._cancel_gate_task()
-        self._gate_task = asyncio.ensure_future(self._reopen_after(cooldown))
+        with self._state_lock:
+            self._gate_epoch += 1
+            epoch = self._gate_epoch
+            self._cancel_gate_timer()
+            self._gate.close()
+            # threading.Timer, not an asyncio task: reopen must not be bound to any of
+            # the loops acquiring from this pool (the closing loop may not be the only
+            # waiter, and a timer is cancellable from any thread).
+            timer = threading.Timer(cooldown, self._reopen_after, args=(epoch, cooldown))
+            timer.daemon = True
+            self._gate_timer = timer
+        timer.start()
 
-    async def _reopen_after(self, delay: float) -> None:
-        try:
-            await asyncio.sleep(delay)
-            self._gate.set()
-            logger.info(f"Rate limit gate reopened for {self._exchange}:{self.name} after {delay:.1f}s")
-        except asyncio.CancelledError:
-            pass
+    def _reopen_after(self, epoch: int, delay: float) -> None:
+        with self._state_lock:
+            if epoch != self._gate_epoch:
+                return  # superseded by a later close/extension/reset
+            self._gate_timer = None
+            self._gate.open()
+        logger.info(f"Rate limit gate reopened for {self._exchange}:{self.name} after {delay:.1f}s")
 
     def sync(self, remaining: float, capacity: float | None = None) -> None:
         try:
@@ -165,24 +271,28 @@ class QuotaPool(BasePool):
         return self._remaining
 
     async def acquire(self, weight: float, gate_max_wait: float) -> None:
-        if not self._gate.is_set() or self._remaining <= 0:
-            if self._remaining <= 0:
-                self.close_gate(self._config.cooldown, "quota depleted")
-            raise RateLimitGateTimeout(
-                f"{self._exchange}: quota pool '{self.name}' depleted",
-                pool_name=self.name,
-            )
-        self._remaining = max(0, self._remaining - weight)
-        self.consumed += weight
+        with self._state_lock:
+            depleted = self._remaining <= 0
+            if not depleted and self._gate.is_open:
+                # atomic check-and-decrement — no over-issue across loops
+                self._remaining = max(0, self._remaining - weight)
+                self.consumed += weight
+                return
+        if depleted:
+            self.close_gate(self._config.cooldown, "quota depleted")
+        raise RateLimitGateTimeout(
+            f"{self._exchange}: quota pool '{self.name}' depleted",
+            pool_name=self.name,
+        )
 
     def close_gate(self, cooldown: float, reason: str) -> None:
-        verb = "extended" if not self._gate.is_set() else "closed"
+        verb = "extended" if not self._gate.is_open else "closed"
         logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name} ({cooldown:.1f}s): {reason}")
-        self._gate.clear()
-        self._cancel_gate_task()
+        self._close_gate_now()
 
     def sync(self, remaining: float, capacity: float | None = None) -> None:
-        self._remaining = remaining
+        with self._state_lock:
+            self._remaining = remaining
         if remaining <= 0:
             self.close_gate(self._config.cooldown, f"quota {self.name} depleted (remaining={remaining})")
         else:
@@ -190,9 +300,8 @@ class QuotaPool(BasePool):
             # real account quota (best approximation when exchange only reports remaining)
             if capacity is None:
                 self._config.capacity = max(self._config.capacity, remaining)
-            if not self._gate.is_set():
-                self._cancel_gate_task()
-                self._gate.set()
+            if not self._gate.is_open:
+                self._open_gate_now()
                 logger.info(
                     f"Rate limit gate reopened for {self._exchange}:{self.name} (remaining={remaining})"
                 )

--- a/src/qubx/utils/misc.py
+++ b/src/qubx/utils/misc.py
@@ -504,6 +504,30 @@ class BackgroundEventLoop:
         self._thread.join()
 
 
+_bulk_rest_loop: BackgroundEventLoop | None = None
+_bulk_rest_loop_lock = Lock()
+
+
+def get_bulk_rest_loop() -> BackgroundEventLoop:
+    """Process-wide event loop dedicated to bulk REST traffic (quantkit#106).
+
+    Live connectors route heavy, bursty REST work here — warmup fetches, OHLC history
+    requests, periodic account snapshots, hist-deals recovery — so it can never occupy
+    the realtime websocket loop long enough to starve keepalives, ``watch_*`` streams,
+    or order submit/cancel (the 2026-07 incident). Latency-critical traffic stays on the
+    realtime loop.
+
+    Created lazily on first call and shared by all venues. Only live connector
+    construction paths call this — simulation never touches ccxt factories or loops, so
+    no thread is spawned in backtests.
+    """
+    global _bulk_rest_loop
+    with _bulk_rest_loop_lock:
+        if _bulk_rest_loop is None:
+            _bulk_rest_loop = BackgroundEventLoop(name="BulkRestLoop")
+        return _bulk_rest_loop
+
+
 def synchronized(func: Callable):
     """Decorator that ensures only one thread can execute the decorated function at a time."""
     lock = Lock()

--- a/src/qubx/utils/rate_limiter.py
+++ b/src/qubx/utils/rate_limiter.py
@@ -6,6 +6,7 @@ across different exchange connectors to comply with API rate limits.
 """
 
 import asyncio
+import threading
 import time
 from functools import wraps
 from typing import Callable, Optional
@@ -19,6 +20,17 @@ class TokenBucketRateLimiter:
 
     The token bucket algorithm allows bursts of requests up to the capacity,
     then enforces the average rate defined by refill_rate.
+
+    Loop-agnostic (quantkit#106): one bucket may be shared by coroutines running on
+    DIFFERENT event loops (the realtime websocket loop and the BulkRestLoop). The
+    bucket math is synchronous under a ``threading.Lock``; only the wait is an
+    ``asyncio.sleep`` on the caller's own loop, so no asyncio primitive ever crosses
+    loops.
+
+    Waiters sleep outside the lock and re-contend on wakeup, re-validating against the
+    CURRENT bucket state — important because ``set_tokens`` (exchange header sync) can
+    move the balance while they sleep. Fairness is best-effort rather than FIFO; total
+    issuance still can't exceed capacity + refill (check-and-decrement is atomic).
 
     Usage:
         >>> limiter = TokenBucketRateLimiter(capacity=100, refill_rate=100)
@@ -40,10 +52,10 @@ class TokenBucketRateLimiter:
 
         self._tokens = float(capacity)
         self._last_refill = time.monotonic()
-        self._lock = asyncio.Lock()
+        self._lock = threading.Lock()
 
     def _refill_tokens(self) -> None:
-        """Refill tokens based on elapsed time since last refill."""
+        """Refill tokens based on elapsed time since last refill. Caller holds ``_lock``."""
         now = time.monotonic()
         elapsed = now - self._last_refill
 
@@ -68,12 +80,12 @@ class TokenBucketRateLimiter:
         if weight > self.capacity:
             raise ValueError(f"Requested weight {weight} exceeds bucket capacity {self.capacity} for {self.name}")
 
-        async with self._lock:
-            while True:
+        while True:
+            with self._lock:
                 # Refill tokens based on elapsed time
                 self._refill_tokens()
 
-                # Check if we have enough tokens
+                # Check if we have enough tokens (atomic check-and-decrement)
                 if self._tokens >= weight:
                     self._tokens -= weight
                     return
@@ -82,15 +94,15 @@ class TokenBucketRateLimiter:
                 tokens_needed = weight - self._tokens
                 wait_time = tokens_needed / self.refill_rate
 
-                # Log warning for significant delays
-                if wait_time > 1.0:
-                    logger.debug(
-                        f"Rate limiter {self.name}: waiting {wait_time:.2f}s "
-                        f"(need {tokens_needed:.1f} tokens, refill rate: {self.refill_rate}/s)"
-                    )
+            # Log warning for significant delays
+            if wait_time > 1.0:
+                logger.debug(
+                    f"Rate limiter {self.name}: waiting {wait_time:.2f}s "
+                    f"(need {tokens_needed:.1f} tokens, refill rate: {self.refill_rate}/s)"
+                )
 
-                # Release lock while waiting to allow other tasks to check
-                await asyncio.sleep(wait_time)
+            # Sleep on the caller's own loop, outside the lock, then re-contend
+            await asyncio.sleep(wait_time)
 
     def get_available_tokens(self) -> float:
         """
@@ -99,8 +111,18 @@ class TokenBucketRateLimiter:
         Returns:
             Current token count
         """
-        self._refill_tokens()
-        return self._tokens
+        with self._lock:
+            self._refill_tokens()
+            return self._tokens
+
+    def set_tokens(self, tokens: float) -> None:
+        """
+        Force-set the current token count (external sync with exchange-reported
+        state), resetting the refill clock.
+        """
+        with self._lock:
+            self._tokens = tokens
+            self._last_refill = time.monotonic()
 
 
 class RateLimiterRegistry:

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -422,7 +422,7 @@ class TestPmAdlLevels:
     def test_fill_stamps_positions_and_cache(self):
         connector = self._connector_with_adl(self.ADL_ROWS)
         doge, btc = self._position("DOGEUSDT"), self._position("BTCUSDT")
-        run(connector._fill_adl_levels([doge, btc]))
+        run(connector._fill_adl_levels([doge, btc], connector._bulk_em.exchange))
         assert doge.adl_level == 2  # max(LONG, SHORT)
         assert btc.adl_level == 3
         assert connector.get_adl_level(doge.instrument) == 2
@@ -439,14 +439,14 @@ class TestPmAdlLevels:
     def test_fetch_failure_keeps_previous_cache(self):
         connector = self._connector_with_adl(self.ADL_ROWS)
         doge = self._position("DOGEUSDT")
-        run(connector._fill_adl_levels([doge]))
+        run(connector._fill_adl_levels([doge], connector._bulk_em.exchange))
 
         async def boom(*args, **kwargs):
             raise RuntimeError("venue down")
 
         connector._em.exchange.papiGetUmAdlQuantile = boom
         fresh = self._position("DOGEUSDT")
-        run(connector._fill_adl_levels([fresh]))
+        run(connector._fill_adl_levels([fresh], connector._bulk_em.exchange))
         assert connector.get_adl_level(doge.instrument) == 2  # cache preserved
         assert fresh.adl_level is None  # nothing stamped on failure
 

--- a/tests/qubx/connectors/ccxt/test_bulk_loop.py
+++ b/tests/qubx/connectors/ccxt/test_bulk_loop.py
@@ -1,0 +1,430 @@
+"""Bulk REST loop routing (quantkit#106).
+
+Verifies the three seams that move bulk REST off the realtime websocket loop:
+
+- the exchange-manager cache keys on the loop, so one venue holds a realtime AND a
+  bulk instance (same instance on repeated calls, distinct across loops);
+- CcxtDataProvider wires warmup + get_ohlc history to the bulk instance/loop while
+  subscriptions keep the realtime one;
+- CcxtConnector runs account snapshots and hist-deals recovery on the bulk loop while
+  order paths stay on the realtime loop.
+
+Loop identity is asserted with real BackgroundEventLoops and fake exchanges that
+record ``asyncio.get_running_loop()`` inside their fetch coroutines.
+"""
+
+import asyncio
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+
+from qubx.connectors.ccxt.connector import CcxtConnector
+from qubx.connectors.ccxt.data import CcxtDataProvider
+from qubx.connectors.ccxt.factory import clear_exchange_manager_cache, get_ccxt_exchange_manager
+from qubx.connectors.ccxt.handlers.ohlc import OhlcDataHandler
+from qubx.connectors.plugin import BuildContext
+from qubx.core.basics import CtrlChannel, Instrument, MarketType
+from qubx.health.dummy import DummyHealthMonitor
+from qubx.utils.misc import BackgroundEventLoop, get_bulk_rest_loop
+from tests.qubx.core.utils_test import DummyTimeProvider
+
+
+def _instrument() -> Instrument:
+    return Instrument(
+        symbol="BTCUSDT",
+        market_type=MarketType.SWAP,
+        exchange="BINANCE.UM",
+        base="BTC",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol="BTC/USDT:USDT",
+        tick_size=0.1,
+        lot_size=0.001,
+        min_size=0.001,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Factory cache keys on the loop
+# --------------------------------------------------------------------------- #
+class TestExchangeManagerCachePerLoop:
+    @pytest.fixture(autouse=True)
+    def _clean_cache(self):
+        clear_exchange_manager_cache()
+        yield
+        clear_exchange_manager_cache()
+
+    @pytest.fixture
+    def two_loops(self):
+        a, b = asyncio.new_event_loop(), asyncio.new_event_loop()
+        yield a, b
+        a.close()
+        b.close()
+
+    def _manager(self, loop):
+        return get_ccxt_exchange_manager(
+            "okx",
+            health_monitor=DummyHealthMonitor(),
+            time_provider=DummyTimeProvider(),
+            loop=loop,
+        )
+
+    def test_same_loop_returns_cached_instance(self, two_loops):
+        loop, _ = two_loops
+        assert self._manager(loop) is self._manager(loop)
+
+    def test_different_loop_returns_distinct_instance(self, two_loops):
+        loop_a, loop_b = two_loops
+        em_a, em_b = self._manager(loop_a), self._manager(loop_b)
+        assert em_a is not em_b
+        # Distinct ccxt exchange objects, each bound to its own loop (aiohttp sessions
+        # are loop-affine — instances must never be shared across loops).
+        assert em_a.exchange is not em_b.exchange
+        assert em_a.exchange.asyncio_loop is loop_a
+        assert em_b.exchange.asyncio_loop is loop_b
+
+    def test_recreation_params_keep_the_instance_loop(self, two_loops):
+        """force_recreation must recreate the exchange on the SAME loop the manager was
+        created for (the bulk manager never triggers this automatically, but the
+        factory params must stay coherent for both)."""
+        loop_a, loop_b = two_loops
+        em_a, em_b = self._manager(loop_a), self._manager(loop_b)
+        assert em_a._factory_params["loop"] is loop_a
+        assert em_b._factory_params["loop"] is loop_b
+
+
+# --------------------------------------------------------------------------- #
+# Data provider: warmup + history on the bulk instance/loop
+# --------------------------------------------------------------------------- #
+def _build_data_provider(monkeypatch=None):
+    """CcxtDataProvider with the factory patched to hand out one mock manager per loop.
+
+    Returns (data_provider, managers_by_loop, calls) where calls collects the factory
+    call kwargs.
+    """
+    managers: dict = {}
+    calls: list[dict] = []
+
+    def fake_get_manager(**kwargs):
+        calls.append(kwargs)
+        loop = kwargs["loop"]
+        key = id(loop)
+        if key not in managers:
+            em = Mock()
+            em.exchange = Mock()
+            em.exchange.name = "TEST"
+            em.exchange.apiKey = None
+            em.exchange.asyncio_loop = loop
+            managers[key] = em
+        return managers[key]
+
+    credentials = Mock()
+    settings = Mock()
+    settings.testnet = False
+    credentials.get_exchange_settings = Mock(return_value=settings)
+
+    channel = CtrlChannel("test")
+    channel.control.set()
+
+    ctx = BuildContext(
+        exchange_name="TEST",
+        time_provider=DummyTimeProvider(),
+        channel=channel,
+        credentials=credentials,
+        health_monitor=DummyHealthMonitor(),
+        loop=Mock(name="realtime-loop"),
+    )
+    with patch("qubx.connectors.ccxt.factory.get_ccxt_exchange_manager", side_effect=fake_get_manager):
+        dp = CcxtDataProvider(ctx, max_ws_retries=3, warmup_timeout=10)
+    return dp, managers, calls
+
+
+class TestDataProviderBulkWiring:
+    def test_bulk_manager_is_distinct_and_on_bulk_loop(self):
+        dp, _, calls = _build_data_provider()
+        assert dp._bulk_exchange_manager is not dp._exchange_manager
+        # Second factory call requested the process-wide BulkRestLoop
+        bulk_calls = [c for c in calls if c["loop"] is get_bulk_rest_loop().loop]
+        assert len(bulk_calls) == 1
+        assert dp._bulk_exchange_manager.exchange.asyncio_loop is get_bulk_rest_loop().loop
+
+    def test_warmup_service_bound_to_bulk_manager(self):
+        """Warmup coroutines submit to the warmup service's manager loop — binding the
+        bulk manager (and a handler factory holding the same manager) IS the reroute."""
+        dp, _, _ = _build_data_provider()
+        assert dp._warmup_service._exchange_manager is dp._bulk_exchange_manager
+        assert dp._warmup_service._handler_factory is dp._bulk_handler_factory
+        assert dp._bulk_handler_factory._exchange_manager is dp._bulk_exchange_manager
+
+    def test_subscription_handlers_stay_on_realtime_manager(self):
+        dp, _, _ = _build_data_provider()
+        assert dp._data_type_handler_factory._exchange_manager is dp._exchange_manager
+
+    def test_get_ohlc_history_runs_on_bulk_loop(self):
+        """ctx.ohlc's REST history request executes on the bulk loop, not the realtime one."""
+        dp, _, _ = _build_data_provider()
+
+        seen_loops: list[asyncio.AbstractEventLoop] = []
+
+        class LoopRecordingHandler(OhlcDataHandler):
+            def __init__(self):  # bypass BaseDataTypeHandler init — only the coroutine matters
+                pass
+
+            async def get_historical_ohlc(self, instrument, timeframe, nbarsback):
+                seen_loops.append(asyncio.get_running_loop())
+                return []
+
+        with patch.object(dp._bulk_handler_factory, "get_handler", return_value=LoopRecordingHandler()):
+            bars = dp.get_ohlc(_instrument(), "1m", 10)
+
+        assert bars == []
+        assert seen_loops == [get_bulk_rest_loop().loop]
+
+    def test_warmup_executes_on_bulk_loop(self):
+        """End-to-end: execute_warmup drives the handler coroutine on the bulk loop."""
+        dp, _, _ = _build_data_provider()
+
+        seen_loops: list[asyncio.AbstractEventLoop] = []
+
+        async def tracking_warmup(**kwargs):
+            seen_loops.append(asyncio.get_running_loop())
+
+        handler = Mock()
+        handler.warmup = tracking_warmup
+        with patch.object(dp._bulk_handler_factory, "get_handler", return_value=handler):
+            dp.warmup({("ohlc", _instrument()): "1h"})
+
+        assert seen_loops == [get_bulk_rest_loop().loop]
+
+
+# --------------------------------------------------------------------------- #
+# Connector: snapshot + hist-deals on the bulk loop, orders on the realtime loop
+# --------------------------------------------------------------------------- #
+class _FakeExchange:
+    """Minimal ccxt stand-in whose fetch coroutines record their running loop."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self.name = "binance"
+        self.has: dict = {}
+        self.markets: dict = {}
+        self.apiKey = "k"
+        self.asyncio_loop = loop
+        self.seen_loops: dict[str, asyncio.AbstractEventLoop] = {}
+
+    async def fetch_open_orders(self, params=None):
+        self.seen_loops["fetch_open_orders" + ("_trigger" if params else "")] = asyncio.get_running_loop()
+        return []
+
+    async def fetch_positions(self):
+        self.seen_loops["fetch_positions"] = asyncio.get_running_loop()
+        return []
+
+    async def fetch_balance(self):
+        self.seen_loops["fetch_balance"] = asyncio.get_running_loop()
+        return {"total": {}, "used": {}}
+
+    async def fetch_my_trades(self, symbol, since=None):
+        self.seen_loops["fetch_my_trades"] = asyncio.get_running_loop()
+        return []
+
+
+@pytest.fixture
+def rt_and_bulk_loops():
+    rt = BackgroundEventLoop(name="test-realtime")
+    bulk = BackgroundEventLoop(name="test-bulk")
+    yield rt, bulk
+    rt.stop()
+    bulk.stop()
+
+
+def _make_live_connector(rt: BackgroundEventLoop, bulk: BackgroundEventLoop):
+    rt_exchange = _FakeExchange(rt.loop)
+    bulk_exchange = _FakeExchange(bulk.loop)
+
+    em, bulk_em = Mock(), Mock()
+    em.exchange = rt_exchange
+    bulk_em.exchange = bulk_exchange
+
+    sent: list = []
+    channel = Mock()
+    channel.send = Mock(side_effect=lambda e: sent.append(e))
+
+    conn = CcxtConnector(
+        exchange_name="BINANCE.UM",
+        channel=channel,
+        time_provider=DummyTimeProvider(),
+        exchange_manager=em,
+        bulk_exchange_manager=bulk_em,
+        data_provider=Mock(),
+    )
+    return conn, sent, rt_exchange, bulk_exchange
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+class TestConnectorBulkRouting:
+    def test_loop_properties_route_to_distinct_loops(self, rt_and_bulk_loops):
+        rt, bulk = rt_and_bulk_loops
+        conn, _, _, _ = _make_live_connector(rt, bulk)
+        assert conn._loop.loop is rt.loop
+        assert conn._bulk_loop.loop is bulk.loop
+
+    def test_snapshot_fetches_run_on_bulk_loop(self, rt_and_bulk_loops):
+        rt, bulk = rt_and_bulk_loops
+        conn, sent, rt_exchange, bulk_exchange = _make_live_connector(rt, bulk)
+
+        conn.request_snapshot()
+        _wait_until(lambda: len(sent) == 1)
+
+        assert rt_exchange.seen_loops == {}  # realtime instance untouched
+        assert set(bulk_exchange.seen_loops) == {
+            "fetch_open_orders",
+            "fetch_open_orders_trigger",
+            "fetch_positions",
+            "fetch_balance",
+        }
+        assert all(loop is bulk.loop for loop in bulk_exchange.seen_loops.values())
+
+    def test_hist_deals_fetch_runs_on_bulk_loop(self, rt_and_bulk_loops):
+        import numpy as np
+
+        rt, bulk = rt_and_bulk_loops
+        conn, _, rt_exchange, bulk_exchange = _make_live_connector(rt, bulk)
+
+        conn.request_hist_deals(_instrument(), np.datetime64("2026-07-01T00:00:00"))
+        _wait_until(lambda: "fetch_my_trades" in bulk_exchange.seen_loops)
+
+        assert bulk_exchange.seen_loops["fetch_my_trades"] is bulk.loop
+        assert rt_exchange.seen_loops == {}
+
+    def test_order_status_probe_stays_on_realtime_loop(self, rt_and_bulk_loops):
+        """Latency-critical order paths keep the realtime loop — only bulk-class REST moved."""
+        rt, bulk = rt_and_bulk_loops
+        conn, _, _, _ = _make_live_connector(rt, bulk)
+
+        seen: list[asyncio.AbstractEventLoop] = []
+
+        async def probe():
+            seen.append(asyncio.get_running_loop())
+
+        conn._spawn(probe())
+        _wait_until(lambda: len(seen) == 1)
+        assert seen[0] is rt.loop
+
+    def test_without_bulk_manager_falls_back_to_single_instance(self, rt_and_bulk_loops):
+        """No bulk manager (tests / bespoke constructions) -> pre-bulk-loop behavior:
+        everything on the realtime instance."""
+        rt, _ = rt_and_bulk_loops
+        rt_exchange = _FakeExchange(rt.loop)
+        em = Mock()
+        em.exchange = rt_exchange
+        conn = CcxtConnector(
+            exchange_name="BINANCE.UM",
+            channel=Mock(send=Mock()),
+            time_provider=DummyTimeProvider(),
+            exchange_manager=em,
+            data_provider=Mock(),
+        )
+        assert conn._bulk_em is conn._em
+        assert conn._bulk_loop.loop is rt.loop
+
+
+# --------------------------------------------------------------------------- #
+# create_ccxt_connector passes a bulk manager on the BulkRestLoop
+# --------------------------------------------------------------------------- #
+class TestCreateConnectorBulkManager:
+    def test_factory_builds_bulk_manager_on_bulk_loop(self):
+        from qubx.connectors.ccxt.factory import create_ccxt_connector
+        from qubx.connectors.plugin import ConnectorBuildContext
+
+        calls: list[dict] = []
+
+        def fake_get_manager(**kwargs):
+            calls.append(kwargs)
+            em = Mock()
+            em.exchange = Mock()
+            em.exchange.asyncio_loop = kwargs["loop"]
+            return em
+
+        creds_provider = Mock()
+        creds = Mock()
+        creds.testnet = False
+        creds.api_key, creds.secret = "k", "s"
+        creds.model_extra = None
+        creds_provider.get_exchange_credentials = Mock(return_value=creds)
+
+        rt_loop = Mock(name="realtime-loop")
+        ctx = ConnectorBuildContext(
+            exchange_name="BINANCE.UM",
+            time_provider=DummyTimeProvider(),
+            channel=Mock(),
+            credentials=creds_provider,
+            health_monitor=DummyHealthMonitor(),
+            loop=rt_loop,
+            rate_limiter=None,
+            data_provider=Mock(),
+        )
+        with patch("qubx.connectors.ccxt.factory.get_ccxt_exchange_manager", side_effect=fake_get_manager):
+            conn = create_ccxt_connector(ctx)
+
+        assert [c["loop"] for c in calls] == [rt_loop, get_bulk_rest_loop().loop]
+        assert conn._em is not conn._bulk_em
+        assert conn._bulk_em.exchange.asyncio_loop is get_bulk_rest_loop().loop
+
+    def test_shared_rate_limiter_attached_to_both_instances(self):
+        from qubx.connectors.ccxt.factory import create_ccxt_connector
+        from qubx.connectors.plugin import ConnectorBuildContext
+
+        managers: list = []
+
+        def fake_get_manager(**kwargs):
+            em = Mock()
+            em.exchange = Mock()
+            em.exchange.asyncio_loop = kwargs["loop"]
+            managers.append(em)
+            return em
+
+        creds_provider = Mock()
+        creds = Mock()
+        creds.testnet = False
+        creds.api_key, creds.secret = "k", "s"
+        creds.model_extra = None
+        creds_provider.get_exchange_credentials = Mock(return_value=creds)
+
+        rate_limiter = Mock()
+        ctx = ConnectorBuildContext(
+            exchange_name="BINANCE.UM",
+            time_provider=DummyTimeProvider(),
+            channel=Mock(),
+            credentials=creds_provider,
+            health_monitor=DummyHealthMonitor(),
+            loop=Mock(name="realtime-loop"),
+            rate_limiter=rate_limiter,
+            data_provider=Mock(),
+        )
+        with patch("qubx.connectors.ccxt.factory.get_ccxt_exchange_manager", side_effect=fake_get_manager):
+            create_ccxt_connector(ctx)
+
+        assert len(managers) == 2
+        for em in managers:
+            em.attach_rate_limiter.assert_called_once_with(rate_limiter)
+
+
+def test_fake_exchange_is_awaitable_sanity():
+    """Guard: the _FakeExchange coroutines behave like ccxt's (awaitable, loop-aware)."""
+    loop = asyncio.new_event_loop()
+    try:
+        ex = _FakeExchange(loop)
+        result = loop.run_until_complete(ex.fetch_balance())
+        assert result == {"total": {}, "used": {}}
+        assert ex.seen_loops["fetch_balance"] is loop
+    finally:
+        loop.close()

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
@@ -103,6 +103,10 @@ def _make_connector(
 
     captured: list = []
     conn._spawn = Mock(side_effect=lambda coro: captured.append(coro))
+    # Bulk-class paths (snapshot, hist-deals) spawn on the bulk loop; capture them the
+    # same way — with no separate bulk manager, _bulk_em is _em and the coroutines run
+    # against the same fake exchange.
+    conn._spawn_bulk = Mock(side_effect=lambda coro: captured.append(coro))
     conn._captured = captured  # type: ignore[attr-defined]
     return conn, sent, exchange
 

--- a/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
@@ -77,6 +77,9 @@ def _make_connector(cls: type[CcxtConnector], exchange: Mock | None = None) -> t
 
     captured: list = []
     conn._spawn = Mock(side_effect=lambda coro: captured.append(coro))
+    # Bulk-class paths (snapshot, hist-deals) spawn on the bulk loop; capture them too
+    # (with no separate bulk manager, _bulk_em is _em — same fake exchange).
+    conn._spawn_bulk = Mock(side_effect=lambda coro: captured.append(coro))
     conn._captured = captured  # type: ignore[attr-defined]
     return conn, sent, exchange
 

--- a/tests/qubx/connectors/ccxt/test_data_provider.py
+++ b/tests/qubx/connectors/ccxt/test_data_provider.py
@@ -171,7 +171,8 @@ class TestBasicFunctionality:
         mock_async_thread_loop = Mock()
         mock_async_thread_loop.submit.return_value = mock_future
 
-        with patch.object(data_provider._data_type_handler_factory, "get_handler", return_value=mock_ohlc_handler):
+        # get_ohlc history is bulk-class REST -> served by the bulk handler factory
+        with patch.object(data_provider._bulk_handler_factory, "get_handler", return_value=mock_ohlc_handler):
             # Patch AsyncThreadLoop in the data module
             with patch("qubx.connectors.ccxt.data.AsyncThreadLoop", return_value=mock_async_thread_loop):
                 bars = data_provider.get_ohlc(btc_instrument, "1m", 1)
@@ -180,7 +181,7 @@ class TestBasicFunctionality:
 
     def test_get_ohlc_no_handler_raises_error(self, data_provider, btc_instrument):
         """Test OHLC retrieval when handler is not available."""
-        with patch.object(data_provider._data_type_handler_factory, "get_handler", return_value=None):
+        with patch.object(data_provider._bulk_handler_factory, "get_handler", return_value=None):
             with pytest.raises(ValueError, match="OHLC handler not available"):
                 data_provider.get_ohlc(btc_instrument, "1m", 10)
 
@@ -188,7 +189,7 @@ class TestBasicFunctionality:
         """Test OHLC retrieval when wrong handler type is returned."""
         mock_wrong_handler = Mock()  # Not an OhlcDataHandler
 
-        with patch.object(data_provider._data_type_handler_factory, "get_handler", return_value=mock_wrong_handler):
+        with patch.object(data_provider._bulk_handler_factory, "get_handler", return_value=mock_wrong_handler):
             with pytest.raises(ValueError, match="Expected OhlcDataHandler"):
                 data_provider.get_ohlc(btc_instrument, "1m", 10)
 

--- a/tests/qubx/rate_limiting/test_multiloop.py
+++ b/tests/qubx/rate_limiting/test_multiloop.py
@@ -1,0 +1,267 @@
+"""Rate limiter correctness across two real event loops (quantkit#106).
+
+One ExchangeRateLimiter (LOCAL in-memory backend) is shared by a venue's realtime
+websocket loop and the process-wide BulkRestLoop. These tests drive acquires from two
+real ``BackgroundEventLoop`` threads and assert:
+
+- token accounting is shared (no double budget, no over-issue),
+- gates close/reopen for waiters on BOTH loops (per-loop mirror events, no cross-loop
+  ``asyncio.Event`` usage),
+- gate timeouts and resets behave identically on either loop.
+"""
+
+import time
+from concurrent.futures import Future
+
+import pytest
+
+from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, ExchangeRateLimiter, PoolConfig
+from qubx.rate_limiting.engine import RateLimitGateTimeout
+from qubx.utils.misc import BackgroundEventLoop
+from qubx.utils.rate_limiter import TokenBucketRateLimiter
+
+
+@pytest.fixture
+def two_loops():
+    a = BackgroundEventLoop(name="rl-test-realtime")
+    b = BackgroundEventLoop(name="rl-test-bulk")
+    yield a, b
+    a.stop()
+    b.stop()
+
+
+def _config(
+    *,
+    capacity: float = 100.0,
+    refill_rate: float = 0.001,
+    cooldown: float = 0.5,
+    gate_max_wait: float = 1.0,
+    quota_capacity: float = 100.0,
+) -> ExchangeRateLimitConfig:
+    return ExchangeRateLimitConfig(
+        pools={
+            "rest": PoolConfig(
+                name="rest",
+                scope="ip",
+                capacity=capacity,
+                refill_rate=refill_rate,
+                pool_type="rate",
+                cooldown=cooldown,
+            ),
+            "quota": PoolConfig(
+                name="quota",
+                scope="address",
+                capacity=quota_capacity,
+                refill_rate=0,
+                pool_type="quota",
+                cooldown=cooldown,
+            ),
+        },
+        endpoint_map={
+            "rest_call": EndpointCosts([("rest", 1)]),
+            "quota_call": EndpointCosts([("quota", 1)]),
+        },
+        default_costs=EndpointCosts([]),
+        gate_max_wait=gate_max_wait,
+    )
+
+
+def _submit_acquires(loop: BackgroundEventLoop, limiter: ExchangeRateLimiter, endpoint: str, n: int) -> Future:
+    async def do_acquires():
+        for _ in range(n):
+            await limiter.acquire(endpoint)
+
+    return loop.submit(do_acquires())
+
+
+class TestSharedTokens:
+    def test_tokens_shared_across_two_loops(self, two_loops):
+        """20 acquires split across two loops consume ONE shared budget (~80 of 100 left)."""
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config(refill_rate=0.001))
+
+        fa = _submit_acquires(a, limiter, "rest_call", 10)
+        fb = _submit_acquires(b, limiter, "rest_call", 10)
+        fa.result(5)
+        fb.result(5)
+
+        state = a.run_sync(limiter.get_pool_state("rest"), timeout=5)
+        assert state is not None
+        assert state["remaining"] == pytest.approx(80, abs=1)
+        assert state["consumed"] == pytest.approx(20)
+
+    def test_over_capacity_waits_for_shared_refill(self, two_loops):
+        """Draining beyond capacity from two loops blocks on the SAME refill clock."""
+        a, b = two_loops
+        # capacity 6, refill 10/s: 10 total acquires need 4 extra tokens -> >= 0.4s
+        limiter = ExchangeRateLimiter("test", _config(capacity=6, refill_rate=10.0))
+
+        t0 = time.monotonic()
+        fa = _submit_acquires(a, limiter, "rest_call", 5)
+        fb = _submit_acquires(b, limiter, "rest_call", 5)
+        fa.result(10)
+        fb.result(10)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed >= 0.3  # would be ~0 if each loop had its own bucket
+
+    def test_quota_pool_no_over_issue_across_loops(self, two_loops):
+        """Exactly quota_capacity acquires across two loops succeed; the pool hits 0, not negative."""
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config(quota_capacity=100))
+
+        fa = _submit_acquires(a, limiter, "quota_call", 50)
+        fb = _submit_acquires(b, limiter, "quota_call", 50)
+        fa.result(5)
+        fb.result(5)
+
+        assert limiter.get_quota_remaining("quota") == 0
+        with pytest.raises(RateLimitGateTimeout):
+            a.run_sync(limiter.acquire("quota_call"), timeout=5)
+
+
+class TestGatesAcrossLoops:
+    def test_gate_closed_blocks_waiters_on_both_loops_until_timer_reopen(self, two_loops):
+        """A 429 reported from anywhere gates BOTH loops; the timer reopen wakes both."""
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config(gate_max_wait=5.0))
+
+        limiter.report_limit_hit(pool_name="rest", retry_after=0.4, reason="test 429")
+        assert limiter.is_gate_closed("rest")
+
+        t0 = time.monotonic()
+        fa = _submit_acquires(a, limiter, "rest_call", 1)
+        fb = _submit_acquires(b, limiter, "rest_call", 1)
+        fa.result(5)
+        fb.result(5)
+        elapsed = time.monotonic() - t0
+
+        assert elapsed >= 0.3  # both waited for the reopen, not just the closing loop
+        assert not limiter.is_gate_closed("rest")
+
+    def test_gate_timeout_raises_on_both_loops(self, two_loops):
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config(gate_max_wait=0.15))
+
+        limiter.report_limit_hit(pool_name="rest", retry_after=10.0, reason="long cooldown")
+
+        for loop in (a, b):
+            with pytest.raises(RateLimitGateTimeout) as exc_info:
+                loop.run_sync(limiter.acquire("rest_call"), timeout=5)
+            assert exc_info.value.pool_name == "rest"
+
+    def test_reset_gates_wakes_waiters_on_both_loops(self, two_loops):
+        """reset_gates() from a plain thread (no loop) reopens for waiters on both loops."""
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config(gate_max_wait=10.0))
+
+        limiter.report_limit_hit(pool_name="rest", retry_after=60.0, reason="stuck gate")
+        fa = _submit_acquires(a, limiter, "rest_call", 1)
+        fb = _submit_acquires(b, limiter, "rest_call", 1)
+        time.sleep(0.1)  # let both park on their per-loop mirror events
+        assert not fa.done() and not fb.done()
+
+        limiter.reset_gates()
+        fa.result(2)
+        fb.result(2)
+        assert not limiter.is_gate_closed("rest")
+
+    def test_gate_extension_keeps_both_loops_parked(self, two_loops):
+        """A second hit while closed extends the cooldown; a stale first timer must not reopen early."""
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config(gate_max_wait=10.0))
+
+        limiter.report_limit_hit(pool_name="rest", retry_after=0.2, reason="first hit")
+        time.sleep(0.05)
+        limiter.report_limit_hit(pool_name="rest", retry_after=0.6, reason="extension")
+
+        t0 = time.monotonic()
+        fa = _submit_acquires(a, limiter, "rest_call", 1)
+        fb = _submit_acquires(b, limiter, "rest_call", 1)
+        fa.result(5)
+        fb.result(5)
+        elapsed = time.monotonic() - t0
+
+        # The first (0.2s) timer was superseded — waiters see the extended cooldown.
+        assert elapsed >= 0.4
+
+    def test_quota_sync_reopens_for_other_loop(self, two_loops):
+        """Quota depleted (gate closed) then synced positive — the OTHER loop can acquire again."""
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config())
+
+        limiter.sync_from_exchange("quota", remaining=0)
+        assert limiter.is_gate_closed("quota")
+        with pytest.raises(RateLimitGateTimeout):
+            a.run_sync(limiter.acquire("quota_call"), timeout=5)
+
+        limiter.sync_from_exchange("quota", remaining=10)
+        b.run_sync(limiter.acquire("quota_call"), timeout=5)
+        assert limiter.get_quota_remaining("quota") == 9
+
+
+class TestTokenBucketTwoLoops:
+    def test_token_bucket_shared_by_two_real_loops(self, two_loops):
+        """The LOCAL bucket primitive itself is loop-agnostic: interleaved acquires from
+        two loops never trip a loop-affinity error and never over-issue."""
+        a, b = two_loops
+        bucket = TokenBucketRateLimiter(capacity=50, refill_rate=0.001, name="two-loop")
+
+        async def take(n: int) -> None:
+            for _ in range(n):
+                await bucket.acquire(1)
+
+        fa = a.submit(take(25))
+        fb = b.submit(take(25))
+        fa.result(5)
+        fb.result(5)
+
+        assert bucket.get_available_tokens() == pytest.approx(0, abs=1)
+
+    def test_token_bucket_refill_wait_spans_loops(self, two_loops):
+        a, b = two_loops
+        bucket = TokenBucketRateLimiter(capacity=4, refill_rate=10.0, name="two-loop-wait")
+
+        async def take(n: int) -> None:
+            for _ in range(n):
+                await bucket.acquire(1)
+
+        t0 = time.monotonic()
+        fa = a.submit(take(4))
+        fb = b.submit(take(4))
+        fa.result(10)
+        fb.result(10)
+        elapsed = time.monotonic() - t0
+
+        # 8 tokens from a 4-token bucket at 10/s -> at least ~0.4s of shared refill
+        assert elapsed >= 0.3
+
+    def test_set_tokens_visible_across_loops(self, two_loops):
+        a, _ = two_loops
+        bucket = TokenBucketRateLimiter(capacity=100, refill_rate=0.001, name="sync")
+
+        a.run_sync(bucket.acquire(60), timeout=5)
+        bucket.set_tokens(5.0)
+        assert bucket.get_available_tokens() == pytest.approx(5, abs=1)
+
+
+class TestMirrorEventHygiene:
+    def test_no_cross_loop_event_usage(self, two_loops):
+        """Each loop gets its OWN mirror event — the gate never awaits one loop's Event
+        from another loop (which asyncio forbids)."""
+        a, b = two_loops
+        limiter = ExchangeRateLimiter("test", _config(gate_max_wait=5.0))
+        pool = limiter._pools["rest"]
+
+        # Park a waiter on each loop while the gate is closed
+        limiter.report_limit_hit(pool_name="rest", retry_after=0.3, reason="hygiene")
+        fa = _submit_acquires(a, limiter, "rest_call", 1)
+        fb = _submit_acquires(b, limiter, "rest_call", 1)
+        time.sleep(0.1)
+
+        events = dict(pool._gate._events)
+        assert set(events.keys()) == {a.loop, b.loop}
+        assert events[a.loop] is not events[b.loop]
+
+        fa.result(5)
+        fb.result(5)

--- a/tests/qubx/utils/test_async_loop.py
+++ b/tests/qubx/utils/test_async_loop.py
@@ -82,3 +82,44 @@ def test_async_thread_loop_run_sync_and_submit():
         assert atl.submit(seven()).result(1) == 7
     finally:
         bel.stop()
+
+
+# --------------------------------------------------------------------------- #
+# BulkRestLoop singleton (quantkit#106)
+# --------------------------------------------------------------------------- #
+class TestBulkRestLoop:
+    def test_lazy_creation_and_singleton(self, monkeypatch):
+        """No loop exists until first call; repeated calls return the same running loop."""
+        from qubx.utils import misc
+
+        monkeypatch.setattr(misc, "_bulk_rest_loop", None)
+
+        first = misc.get_bulk_rest_loop()
+        assert isinstance(first, BackgroundEventLoop)
+        assert first.loop.is_running()
+        assert first._thread.name == "BulkRestLoop"
+        assert misc.get_bulk_rest_loop() is first
+
+    def test_distinct_from_caller_loops(self):
+        from qubx.utils.misc import get_bulk_rest_loop
+
+        bel = BackgroundEventLoop(name="not-the-bulk-loop")
+        try:
+            assert get_bulk_rest_loop().loop is not bel.loop
+        finally:
+            bel.stop()
+
+    def test_simulation_import_does_not_create_bulk_loop(self):
+        """Live-only: importing the backtester (simulation entry point) must not spin up
+        the BulkRestLoop — simulation never touches ccxt factories or loops. Run in a
+        subprocess so loops created by other tests in this process can't pollute it."""
+        import subprocess
+        import sys
+
+        code = (
+            "import qubx.backtester  # noqa: F401\n"
+            "from qubx.utils import misc\n"
+            "assert misc._bulk_rest_loop is None, 'backtester import created the BulkRestLoop'\n"
+        )
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
PR 5/7 (stacked on #354). Spec §B.1, quantkit#106. **DRAFT — do not merge.**

Traffic-class split: watch streams/keepalives/order actions stay on the realtime loop; warmup, `ctx.ohlc` history, account snapshots (the 4-way gather), and hist-deals recovery move to a lazy process-wide **BulkRestLoop** via a second cached exchange instance per venue (loop in the factory cache key). Bulk instance is deliberately NOT auto-recreated (documented; failed bulk calls surface to callers that already handle fetch errors).

Rate limiter now spans both loops: local backend loop-agnostic (threading.Lock bucket math, per-loop mirror gate events flipped via call_soon_threadsafe, epoch-guarded reopens); redis backend already per-loop. A/B control run proved the old backend breaks cross-loop.

Sim purity enforced by a subprocess test (`import qubx.backtester` leaves the bulk singleton None). PR4's throttle now protects the bulk loop.

Tests: full fast suite **2310 passed / 0 failed × 3 runs**. Reviewer notes: funding poller intentionally left on realtime (hourly, cheap); one timing-marginal pre-existing test documented in the PR-5 report (`test_shared_limiter_across_storage_and_manager` — if it flakes in CI the fix belongs in the test's budget margins).

https://claude.ai/code/session_017fBtVL9NcmHosCbkZmYBXg