### PR TITLE
feat(core): FitExecutor — on_fit off the ProcessorThread, dark behind config (6/7)

### DIFF
--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -37,6 +37,7 @@ from qubx.core.detectors import DelistingDetector
 from qubx.core.errors import BaseErrorEvent, ErrorLevel
 from qubx.core.events import ChannelMessage
 from qubx.core.exceptions import QueueTimeout, ReadOnlyConnector, StrategyExceededMaxNumberOfRuntimeFailuresError
+from qubx.core.fit_executor import FitCycleState
 from qubx.core.helpers import (
     BasicScheduler,
     set_parameters_to_object,
@@ -82,6 +83,7 @@ from .mixins import (
     TradingManager,
     UniverseManager,
 )
+from .mixins.market import CachedMarketDataHolder
 
 DEFAULT_POSITION_TRACKER: Callable[[], PositionsTracker] = lambda: PositionsTracker(
     FixedSizer(1.0, amount_in_quote=False)
@@ -169,6 +171,8 @@ class StrategyContext(IStrategyContext):
         rate_limiting_config: Any | None = None,
         event_loop: asyncio.AbstractEventLoop | None = None,
         read_only: bool = False,
+        fit_executor: str = "inline",
+        fit_soft_deadline_s: float = 120.0,
     ) -> None:
         self._read_only = read_only
         self._account_manager = account_manager
@@ -222,6 +226,11 @@ class StrategyContext(IStrategyContext):
         if __position_gathering is None:
             __position_gathering = position_gathering if position_gathering is not None else SimplePositionGatherer()
 
+        # B.2 threaded fit: one shared token identifies fit-thread ctx calls across the
+        # managers and the read accessors below. Inert (a single None check) unless a
+        # threaded fit is in flight — simulation and inline mode never arm it.
+        self._fit_state = FitCycleState()
+
         self._subscription_manager = SubscriptionManager(
             time_provider=self._time_provider,
             data_providers=self._data_providers,
@@ -230,6 +239,7 @@ class StrategyContext(IStrategyContext):
             default_base_subscription=DataType.ORDERBOOK[0, 1]
             if not self._data_providers[0].is_simulation
             else DataType.NONE,
+            fit_state=self._fit_state,
         )
 
         self._market_data_provider = MarketManager(
@@ -261,6 +271,7 @@ class StrategyContext(IStrategyContext):
             position_gathering=__position_gathering,
             delisting_detector=self._delisting_detector,
             instrument_service=self._instrument_service,
+            fit_state=self._fit_state,
         )
         self._trading_manager = TradingManager(
             context=self,
@@ -288,7 +299,17 @@ class StrategyContext(IStrategyContext):
             health_monitor=self._health_monitor,
             delisting_detector=self._delisting_detector,
             data_throttler=data_throttler,
+            fit_executor=fit_executor,
+            fit_soft_deadline_s=fit_soft_deadline_s,
+            fit_state=self._fit_state,
         )
+
+        # - thread-mode fit executor (live only): arm the market-cache series lock so
+        #   ProcessorThread appends serialize against fit-thread snapshot reads
+        if fit_executor == "thread" and not self._data_providers[0].is_simulation:
+            _cache = self._market_data_provider.get_market_data_cache()
+            if isinstance(_cache, CachedMarketDataHolder):
+                _cache.enable_concurrent_fit_reads(self._fit_state)
 
         # Late-wire the processing manager into the account manager (the AM is built
         # before the PM exists) so its periodic ticks can register.
@@ -640,20 +661,30 @@ class StrategyContext(IStrategyContext):
 
     # balance and position information
     def get_balances(self, exchange: str | None = None) -> list[Balance]:
-        return self.account.get_balances(exchange)
+        _balances = self.account.get_balances(exchange)
+        # B.2 threaded fit: hand the fit thread shallow copies of the live account views
+        # so its iteration can't race ProcessorThread mutations (dict-size-changed
+        # guard). Everywhere else (ProcessorThread / simulation) views pass through
+        # unchanged — the check is a single None test when no threaded fit is in flight.
+        if self._fit_state.is_fit_thread():
+            return list(_balances)
+        return _balances
 
     def get_balance(self, currency: str, exchange: str | None = None) -> Balance:
         return self.account.get_balance(currency, exchange)
 
     def get_positions(self, exchange: str | None = None) -> dict[Instrument, Position]:
-        return self.account.get_positions(exchange)
+        _positions = self.account.get_positions(exchange)
+        if self._fit_state.is_fit_thread():
+            return dict(_positions)
+        return _positions
 
     def get_position(self, instrument: Instrument) -> Position:
         return self.account.get_position(instrument)
 
     @property
     def positions(self):
-        return self.account.get_positions()
+        return self.get_positions()
 
     def get_orders(
         self,
@@ -661,7 +692,10 @@ class StrategyContext(IStrategyContext):
         exchange: str | None = None,
         origin: OrderOrigin | None = None,
     ) -> dict[str, Order]:
-        return self.account.get_orders(instrument, exchange, origin)
+        _orders = self.account.get_orders(instrument, exchange, origin)
+        if self._fit_state.is_fit_thread():
+            return dict(_orders)
+        return _orders
 
     def find_order_by_id(self, order_id: str) -> Order | None:
         return self.account.find_order_by_id(order_id)
@@ -677,7 +711,10 @@ class StrategyContext(IStrategyContext):
         return self.account.get_leverage(instrument)
 
     def get_leverages(self, exchange: str | None = None) -> dict[Instrument, float]:
-        return self.account.get_leverages(exchange)
+        _leverages = self.account.get_leverages(exchange)
+        if self._fit_state.is_fit_thread():
+            return dict(_leverages)
+        return _leverages
 
     def get_net_leverage(self, exchange: str | None = None) -> float:
         return self.account.get_net_leverage(exchange)
@@ -895,6 +932,12 @@ class StrategyContext(IStrategyContext):
 
     def commit(self):
         return self._subscription_manager.commit()
+
+    def prepare(self, instruments: list[Instrument]) -> None:
+        return self._subscription_manager.prepare(instruments)
+
+    def discard_prewarmed(self) -> None:
+        return self._subscription_manager.discard_prewarmed()
 
     @property
     def auto_subscribe(self) -> bool:

--- a/src/qubx/core/fit_executor.py
+++ b/src/qubx/core/fit_executor.py
@@ -1,0 +1,132 @@
+"""Threaded on_fit execution (quantkit#106, design §B.2).
+
+Live-only machinery for running ``strategy.on_fit`` on a dedicated worker thread
+("StrategyFitThread") so the ProcessorThread keeps draining the channel (order/account
+applies, market-cache updates, AM ticks, schedules) while a slow fit computes — the
+2026-07 incident was a 7-minute on_fit freezing all event processing.
+
+Single-mutator invariant: the fit thread only *computes and records*. Intercepted ctx
+calls (set_universe / add_instruments / remove_instruments / subscribe / schedule /
+set_fit_schedule) are recorded on the :class:`FitCycleState`; ``emit_signal`` is buffered
+there too. When the fit body returns, a single :class:`FitCommitData` is posted on the
+CtrlChannel and the ProcessorThread applies everything atomically — every ctx mutation
+still happens on the ProcessorThread.
+
+Simulation never constructs a :class:`FitExecutor` and never calls
+:meth:`FitCycleState.begin`, so backtests keep today's inline path exactly.
+"""
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from queue import Queue
+from threading import Thread
+
+from qubx import logger
+from qubx.core.basics import Signal
+
+# Channel d_type under which a FitCommitData rides the CtrlChannel as a
+# (None, FIT_COMMIT_EVENT, FitCommitData, False) tuple; dispatched to
+# ProcessingManager._handle_fit_commit via the auto-registered handler map.
+FIT_COMMIT_EVENT = "fit_commit"
+
+
+@dataclass(frozen=True, slots=True)
+class FitCommitData:
+    """Outcome of one threaded fit, applied atomically by the ProcessorThread.
+
+    ``ops`` are zero-arg callables replaying the intercepted ctx mutations in call
+    order (they run on the ProcessorThread, where the fit-thread interception no
+    longer triggers, so each takes today's normal path). ``signals`` are the
+    fit-emitted signals, drained into the normal pipeline in emission order.
+    """
+
+    ops: tuple[Callable[[], None], ...] = ()
+    signals: tuple[Signal, ...] = ()
+    duration_s: float = 0.0
+
+
+class FitCycleState:
+    """Shared token for the currently-running threaded fit cycle.
+
+    Managers (universe / subscription / processing) and the context consult
+    :meth:`is_fit_thread` to decide between today's direct path and the
+    record-for-commit path. Inert unless :meth:`begin` was called from the fit
+    worker — in simulation and inline mode the check is a single ``None`` test.
+    """
+
+    __slots__ = ("_lock", "_thread_ident", "_ops", "_signals")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._thread_ident: int | None = None
+        self._ops: list[Callable[[], None]] = []
+        self._signals: list[Signal] = []
+
+    def begin(self, thread_ident: int) -> None:
+        """Arm the cycle: called by the fit worker at the start of the fit body."""
+        with self._lock:
+            self._thread_ident = thread_ident
+            self._ops.clear()
+            self._signals.clear()
+
+    def end(self) -> tuple[tuple[Callable[[], None], ...], tuple[Signal, ...]]:
+        """Disarm and capture everything recorded during the cycle."""
+        with self._lock:
+            ops, signals = tuple(self._ops), tuple(self._signals)
+            self._thread_ident = None
+            self._ops.clear()
+            self._signals.clear()
+            return ops, signals
+
+    def is_fit_thread(self) -> bool:
+        """True only when called from the fit worker while a threaded fit is in flight."""
+        ident = self._thread_ident
+        return ident is not None and ident == threading.get_ident()
+
+    def record(self, op: Callable[[], None]) -> None:
+        """Record a deferred ctx mutation for ProcessorThread replay at the commit."""
+        with self._lock:
+            self._ops.append(op)
+
+    def buffer_signals(self, signals: list[Signal]) -> None:
+        """Buffer fit-emitted signals; drained into the normal pipeline at the commit."""
+        with self._lock:
+            self._signals.extend(signals)
+
+
+class FitExecutor:
+    """Single-thread worker ("StrategyFitThread") owned by the processing layer.
+
+    A plain daemon thread + queue rather than a ThreadPoolExecutor: pool threads are
+    non-daemon and joined at interpreter exit, so a wedged on_fit would hang shutdown.
+    Constructed only in live thread mode — never in simulation.
+    """
+
+    def __init__(self, name: str = "StrategyFitThread") -> None:
+        self._queue: Queue[Callable[[], None] | None] = Queue()
+        self._thread = Thread(target=self._loop, daemon=True, name=name)
+        self._started = False
+
+    def submit(self, fn: Callable[[], None]) -> None:
+        """Enqueue a fit body. Called only from the ProcessorThread (the
+        ``_fit_is_running`` gate guarantees at most one fit in flight)."""
+        if not self._started:
+            self._thread.start()
+            self._started = True
+        self._queue.put(fn)
+
+    def stop(self) -> None:
+        self._queue.put(None)
+
+    def _loop(self) -> None:
+        while True:
+            fn = self._queue.get()
+            if fn is None:
+                return
+            try:
+                fn()
+            except Exception:
+                # The fit body has its own error handling + commit-posting finally;
+                # anything reaching here is a framework bug — log loudly, keep serving.
+                logger.exception("[FitExecutor] :: fit task raised outside its own error handling")

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1151,6 +1151,21 @@ class ISubscriptionManager:
         """
         ...
 
+    def prepare(self, instruments: list[Instrument]) -> None:
+        """
+        Prefetch warmup history for instruments about to be added by a deferred
+        (fit-thread) universe change — the slow half of commit(), safe to run off the
+        ProcessorThread. Default implementation is a no-op.
+        """
+        return None
+
+    def discard_prewarmed(self) -> None:
+        """
+        Drop any pre-warmed warmup entries recorded by prepare() that were not consumed
+        by a commit. Default implementation is a no-op.
+        """
+        return None
+
     @property
     def auto_subscribe(self) -> bool:
         """

--- a/src/qubx/core/mixins/market.py
+++ b/src/qubx/core/mixins/market.py
@@ -1,4 +1,6 @@
+import threading
 from collections import defaultdict
+from contextlib import nullcontext
 from typing import Any
 
 import numpy as np
@@ -7,6 +9,7 @@ import pandas as pd
 from qubx import logger
 from qubx.core.basics import SW, DataType, Instrument, ITimeProvider, dt_64, td_64
 from qubx.core.exceptions import SymbolNotFound
+from qubx.core.fit_executor import FitCycleState
 from qubx.core.helpers import extract_price
 from qubx.core.interfaces import IDataProvider, IMarketDataCache, IMarketManager, IUniverseManager
 from qubx.core.lookups import lookup
@@ -29,6 +32,9 @@ INVERSE_EXCHANGE_MAPPINGS = {mapping: exchange for exchange, mapping in EXCHANGE
 #   if current time is very close to bar's end
 MIN_TIMEFRAMES_GAP_TO_REQUEST_PROVIDER = 1.5
 
+# - reusable no-op context for the lock-free (simulation / inline-fit) append path
+_NO_LOCK = nullcontext()
+
 
 class CachedMarketDataHolder(IMarketDataCache):
     """
@@ -47,8 +53,23 @@ class CachedMarketDataHolder(IMarketDataCache):
         self._updates = dict()
         self._generic_series = defaultdict(dict)
         self._max_series_length = max_buffer_size
+        # B.2 threaded fit: when enabled, OHLCV appends take the per-holder lock and
+        # fit-thread reads return locked snapshots. None (the default — simulation and
+        # inline mode) keeps today's zero-lock semantics.
+        self._fit_state: FitCycleState | None = None
+        self._series_lock = threading.RLock()
         if default_timeframe:
             self.update_default_timeframe(default_timeframe)
+
+    def enable_concurrent_fit_reads(self, fit_state: FitCycleState) -> None:
+        """Arm the per-holder series lock for the threaded fit executor (live thread
+        mode only): OHLCV appends serialize against fit-thread reads, and the
+        fit-thread read path returns a copy. Never called in simulation/inline mode."""
+        self._fit_state = fit_state
+
+    def _append_lock(self):
+        # - single attribute check on the (hot) simulation/inline path
+        return self._series_lock if self._fit_state is not None else _NO_LOCK
 
     def update_default_timeframe(self, default_timeframe: str):
         self.default_timeframe = convert_tf_str_td64(default_timeframe)
@@ -101,6 +122,17 @@ class CachedMarketDataHolder(IMarketDataCache):
 
     @SW.watch("CachedMarketDataHolder")
     def get_ohlcv(
+        self, instrument: Instrument, timeframe: str | td_64 | None = None, max_size: float | int = np.inf
+    ) -> OHLCV:
+        if self._fit_state is not None and self._fit_state.is_fit_thread():
+            # - threaded fit read: snapshot under the lock so the fit's iteration can't
+            #   race ProcessorThread appends (which also take the lock). The copy has no
+            #   indicators attached — on_fit must not attach live indicators in thread mode.
+            with self._series_lock:
+                return self._get_ohlcv_series(instrument, timeframe, max_size).clone()
+        return self._get_ohlcv_series(instrument, timeframe, max_size)
+
+    def _get_ohlcv_series(
         self, instrument: Instrument, timeframe: str | td_64 | None = None, max_size: float | int = np.inf
     ) -> OHLCV:
         if timeframe is None:
@@ -204,6 +236,15 @@ class CachedMarketDataHolder(IMarketDataCache):
            - Skipping bars that are already present
            - Adding newer bars to the front
         """
+        if self._fit_state is not None and self._fit_state.is_fit_thread():
+            # - threaded fit fetch-merge (ctx.ohlc with length): mutate under the lock,
+            #   hand the fit a snapshot (same contract as the fit-thread get_ohlcv)
+            with self._series_lock:
+                return self._update_by_bars(instrument, timeframe, bars).clone()
+        with self._append_lock():
+            return self._update_by_bars(instrument, timeframe, bars)
+
+    def _update_by_bars(self, instrument: Instrument, timeframe: str | td_64, bars: list[Bar]) -> OHLCV:
         if instrument not in self._ohlcvs:
             self._ohlcvs[instrument] = {}
 
@@ -235,6 +276,10 @@ class CachedMarketDataHolder(IMarketDataCache):
 
     @SW.watch("CachedMarketDataHolder")
     def update_by_bar(self, instrument: Instrument, bar: Bar):
+        with self._append_lock():
+            self._update_by_bar(instrument, bar)
+
+    def _update_by_bar(self, instrument: Instrument, bar: Bar):
         self._updates[instrument] = bar
 
         _last_bar = self._last_bar[instrument]
@@ -273,16 +318,21 @@ class CachedMarketDataHolder(IMarketDataCache):
 
     @SW.watch("CachedMarketDataHolder")
     def update_by_quote(self, instrument: Instrument, quote: Quote):
-        self._updates[instrument] = quote
-        series = self._ohlcvs.get(instrument)
-        if series:
-            for ser in series.values():
-                if len(ser) > 0 and ser[0].time > quote.time:
-                    continue
-                ser.update(quote.time, quote.mid_price(), 0)
+        with self._append_lock():
+            self._updates[instrument] = quote
+            series = self._ohlcvs.get(instrument)
+            if series:
+                for ser in series.values():
+                    if len(ser) > 0 and ser[0].time > quote.time:
+                        continue
+                    ser.update(quote.time, quote.mid_price(), 0)
 
     @SW.watch("CachedMarketDataHolder")
     def update_by_trade(self, instrument: Instrument, trade: Trade):
+        with self._append_lock():
+            self._update_by_trade(instrument, trade)
+
+    def _update_by_trade(self, instrument: Instrument, trade: Trade):
         self._updates[instrument] = trade
         series = self._ohlcvs.get(instrument)
         if series:

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -1,6 +1,8 @@
 import asyncio
 import concurrent.futures
 import inspect
+import threading
+import time
 import traceback
 import uuid
 from collections import defaultdict
@@ -38,6 +40,7 @@ from qubx.core.events import (
     OrderUpdateRejectedEvent,
 )
 from qubx.core.exceptions import InvalidOrderTransition, StrategyExceededMaxNumberOfRuntimeFailuresError
+from qubx.core.fit_executor import FIT_COMMIT_EVENT, FitCommitData, FitCycleState, FitExecutor
 from qubx.core.helpers import BasicScheduler, process_schedule_spec
 from qubx.core.interfaces import (
     IHealthMonitor,
@@ -132,7 +135,16 @@ class ProcessingManager(IProcessingManager):
     # Same-thread re-entrancy guards: on_fit/on_warmup_finished run inline on the processing
     # thread and may pump events that re-enter the trigger tail before is_on_fit_called /
     # is_on_warmup_finished_called flip (set only after the callback returns).
+    # With fit_executor="thread" the fit gate extends from re-entrancy guard to concurrency
+    # guard: it stays True from submission until the FitCommit is applied.
     _fit_is_running: bool = False
+    # - B.2 threaded fit executor state. Class-level defaults keep half-constructed test
+    #   objects (ProcessingManager.__new__) on the inline path; __init__ always overrides
+    #   _fit_state with a per-instance token.
+    _fit_state: FitCycleState = FitCycleState()
+    _fit_executor: FitExecutor | None = None
+    _fit_executor_mode: str = "inline"
+    _fit_soft_deadline_s: float = 120.0
     _warmup_finished_is_running: bool = False
     _fails_counter: int = 0
     _is_simulation: bool
@@ -174,6 +186,9 @@ class ProcessingManager(IProcessingManager):
         delisting_detector: DelistingDetector,
         exporter: ITradeDataExport | None = None,
         data_throttler: InstrumentThrottler | None = None,
+        fit_executor: str = "inline",
+        fit_soft_deadline_s: float = 120.0,
+        fit_state: FitCycleState | None = None,
     ):
         validate_account_callback_signatures(strategy)
         self._context = context
@@ -225,16 +240,32 @@ class ProcessingManager(IProcessingManager):
         self._custom_scheduled_methods = {}
         self._pending_no_quote_signals = {}
 
+        # - B.2 threaded fit executor: live-only and dark by default (fit_executor="inline").
+        #   Simulation ALWAYS stays inline regardless of config — the executor is never
+        #   constructed there (backtests keep today's path exactly).
+        self._fit_state = fit_state if fit_state is not None else FitCycleState()
+        self._fit_executor_mode = "thread" if (not is_simulation and fit_executor == "thread") else "inline"
+        self._fit_executor = FitExecutor() if self._fit_executor_mode == "thread" else None
+        self._fit_soft_deadline_s = fit_soft_deadline_s
+
         # - schedule daily delisting check at 23:30 (end of day)
         self._scheduler.schedule_event("30 23 * * *", "delisting_check")
 
     def set_fit_schedule(self, schedule: str) -> None:
-        logger.info(f"Setting fit schedule to {schedule}")
         rule = process_schedule_spec(schedule)
         if rule.get("type") != "cron":
             raise ValueError("Only cron type is supported for fit schedule")
+        if self._fit_state.is_fit_thread():
+            # - threaded fit: scheduler mutations are deferred to the FitCommit
+            #   (validated eagerly above so bad input still raises into on_fit).
+            self._fit_state.record(lambda: self._apply_fit_schedule(rule["schedule"], schedule))
+            return
+        self._apply_fit_schedule(rule["schedule"], schedule)
+
+    def _apply_fit_schedule(self, cron_schedule: str, original_spec: str) -> None:
+        logger.info(f"Setting fit schedule to {original_spec}")
         self._scheduler.unschedule_event("fit")
-        self._scheduler.schedule_event(rule["schedule"], "fit")
+        self._scheduler.schedule_event(cron_schedule, "fit")
 
     def set_event_schedule(self, schedule: str) -> None:
         logger.info(f"Setting event schedule to {schedule}")
@@ -269,13 +300,21 @@ class ProcessingManager(IProcessingManager):
         # Generate unique event ID for this custom schedule
         event_id = f"custom_schedule_{str(uuid.uuid4()).replace('-', '_')}"
 
+        if self._fit_state.is_fit_thread():
+            # - threaded fit: scheduler/dispatch-table mutations are deferred to the
+            #   FitCommit; the pre-generated event id stays valid for the caller.
+            self._fit_state.record(lambda: self._register_schedule(event_id, rule["schedule"], method))
+            return event_id
+
+        self._register_schedule(event_id, rule["schedule"], method)
+        return event_id
+
+    def _register_schedule(self, event_id: str, cron_schedule: str, method: Callable) -> None:
         # Store the method reference
         self._custom_scheduled_methods[event_id] = method
 
         # Schedule the event
-        self._scheduler.schedule_event(rule["schedule"], event_id)
-
-        return event_id
+        self._scheduler.schedule_event(cron_schedule, event_id)
 
     def unschedule(self, event_id: str) -> bool:
         return self._scheduler.unschedule_event(event_id)
@@ -1112,6 +1151,11 @@ class ProcessingManager(IProcessingManager):
         """
         if not self._is_ready():
             return
+        # B.2: live thread mode hands the fit body to the StrategyFitThread. Simulation
+        # (and inline mode, the default) takes today's path below, unchanged.
+        if not self._is_simulation and self._fit_executor_mode == "thread":
+            self._submit_threaded_fit(data)
+            return
         # The flag reset lives in an outer finally so no raise (finalize_ohlc or the health
         # monitor) can strand it True — a stranded flag silently disables the strategy
         # forever; on a raise is_on_fit_called stays False, so the next tick retries the fit.
@@ -1123,6 +1167,113 @@ class ProcessingManager(IProcessingManager):
             # blocks event processing until it returns.
             self.__invoke_on_fit()
         finally:
+            self._fit_is_running = False
+
+    def _submit_threaded_fit(self, data: tuple[dt_64 | None, dt_64]) -> None:
+        """Thread-mode fit (live only): submit the fit body to the single-thread
+        FitExecutor and return immediately, so the ProcessorThread keeps draining the
+        channel (order/account applies, market-cache updates, AM ticks, schedules)
+        while the fit computes.
+
+        ``_fit_is_running`` extends from re-entrancy guard to concurrency guard: it stays
+        True from submission until the FitCommit is applied, dropping overlapping fit
+        triggers and gating strategy callbacks exactly as the inline path does.
+        """
+        if self._fit_is_running:
+            logger.warning(f"[{self._strategy_name}] :: on_fit trigger dropped — previous fit is still running")
+            return
+        assert self._fit_executor is not None  # constructed with the "thread" mode
+        # - the commit rides the same channel the ProcessorThread drains
+        channel = self._context._data_providers[0].channel
+        self._fit_is_running = True
+        try:
+            # - cache finalization mutates ctx state: keep it on the ProcessorThread (fast)
+            self._cache.finalize_ohlc_for_instruments(data[1], self._context.instruments)
+            self._fit_executor.submit(lambda: self._run_fit_off_thread(channel))
+        except Exception:
+            # - nothing was submitted, so no commit will ever clear the gate — mirror the
+            #   inline outer-finally discipline here
+            self._fit_is_running = False
+            raise
+
+    def _run_fit_off_thread(self, channel: Any) -> None:
+        """Fit body on the StrategyFitThread: computes and RECORDS, never mutates ctx.
+
+        Intercepted ctx calls (set_universe/subscribe/schedule/emit_signal) land on the
+        fit-cycle state; universe additions are pre-warmed here against the bulk REST
+        loop. The FitCommit is posted in the finally on EVERY path (success, strategy
+        raise, framework raise) so the ``_fit_is_running`` gate can never be stranded —
+        mirrors the inline path's outer-finally discipline.
+        """
+        self._fit_state.begin(threading.get_ident())
+        _t_start = time.monotonic()
+        _deadline_timer = threading.Timer(self._fit_soft_deadline_s, self._warn_fit_soft_deadline)
+        _deadline_timer.daemon = True
+        _deadline_timer.start()
+        try:
+            with self._health_monitor("ctx.on_fit"):
+                try:
+                    # - same pre-fit blacklist enforcement as the inline path; its
+                    #   force-close (remove_instruments) is intercepted and committed
+                    #   with everything else.
+                    self._context._instrument_service_manager.enforce_at_fit()
+                    logger.debug(
+                        f"[<y>{self.__class__.__name__}</y>] :: Invoking <g>{self._strategy_name}</g> on_fit (threaded)"
+                    )
+                    self._strategy.on_fit(self._context)
+                    logger.debug(f"[<y>{self.__class__.__name__}</y>] :: <g>{self._strategy_name}</g> is fitted")
+                except Exception as strat_error:
+                    logger.error(
+                        f"[{self.__class__.__name__}] :: Strategy {self._strategy_name} on_fit raised an exception: {strat_error}"
+                    )
+                    logger.opt(colors=False).error(traceback.format_exc())
+        finally:
+            _deadline_timer.cancel()
+            _duration_s = time.monotonic() - _t_start
+            try:
+                self._health_monitor.record_gauge("fit_duration_s", _duration_s)
+            except Exception:
+                logger.exception("failed to record fit_duration_s gauge")
+            _ops, _signals = self._fit_state.end()
+            channel.send((None, FIT_COMMIT_EVENT, FitCommitData(ops=_ops, signals=_signals, duration_s=_duration_s), False))
+
+    def _warn_fit_soft_deadline(self) -> None:
+        logger.warning(
+            f"[{self._strategy_name}] :: on_fit still running after {self._fit_soft_deadline_s:.0f}s soft deadline — "
+            "event processing continues; universe/signal changes apply when the fit returns"
+        )
+
+    def _handle_fit_commit(self, instrument: Instrument | None, event_type: str, commit: FitCommitData) -> None:
+        """ProcessorThread-side atomic application of a threaded fit's outcome
+        (single-mutator invariant: the fit thread only recorded; every ctx mutation
+        happens here).
+
+        Order: replay the deferred ops (the universe swap is pre-warmed so apply is
+        fast; on_universe_change fires inside the replay, on this thread, exactly like
+        the inline path), commit any deferred subscriptions, then — in a finally so no
+        replay failure can strand the gate — drain fit-emitted signals into the normal
+        pipeline, set is_on_fit_called and clear _fit_is_running. Returning None hands
+        control to _run_strategy_pipeline, which processes the drained signals
+        immediately.
+        """
+        try:
+            for op in commit.ops:
+                try:
+                    op()
+                except Exception as op_error:
+                    logger.error(f"[{self.__class__.__name__}] :: deferred fit operation failed: {op_error}")
+                    logger.opt(colors=False).error(traceback.format_exc())
+            try:
+                self._subscription_manager.commit()  # apply pending operations (mirrors __invoke_on_fit)
+            except Exception as commit_error:
+                logger.error(f"[{self.__class__.__name__}] :: post-fit subscription commit failed: {commit_error}")
+                logger.opt(colors=False).error(traceback.format_exc())
+            # - any pre-warmed entries not consumed by the replay are stale now
+            self._subscription_manager.discard_prewarmed()
+        finally:
+            if commit.signals:
+                self._emitted_signals.extend(commit.signals)
+            self._context._strategy_state.is_on_fit_called = True
             self._fit_is_running = False
 
     def _handle_delisting_check(
@@ -1511,9 +1662,18 @@ class ProcessingManager(IProcessingManager):
             )
 
     def get_active_targets(self) -> dict[Instrument, TargetPosition]:
+        if self._fit_state.is_fit_thread():
+            # - threaded fit: shallow copy so the fit's iteration can't race
+            #   ProcessorThread mutations (dict-size-changed guard)
+            return dict(self._active_targets)
         return self._active_targets
 
     def emit_signal(self, signal: Signal | list[Signal]) -> None:
+        if self._fit_state.is_fit_thread():
+            # - threaded fit: buffer in the locked fit-cycle state; drained into the
+            #   normal pipeline (in emission order) when the FitCommit is applied
+            self._fit_state.buffer_signals(signal if isinstance(signal, list) else [signal])
+            return
         # - add signal to the queue. it will be processed in the data processing loop
         if isinstance(signal, list):
             self._emitted_signals.extend(signal)

--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -2,11 +2,13 @@ import pprint
 import threading
 import time
 from collections import defaultdict
+from functools import partial
 from typing import Any
 
 from qubx import logger
 from qubx.core.basics import DataType, Instrument
 from qubx.core.exceptions import NotSupported
+from qubx.core.fit_executor import FitCycleState
 from qubx.core.interfaces import IDataProvider, IHealthMonitor, ISubscriptionManager, ITimeProvider, StrategyState
 from qubx.utils.misc import synchronized
 
@@ -49,6 +51,7 @@ class SubscriptionManager(ISubscriptionManager):
         default_base_subscription: str = DataType.NONE,
         monitor_interval_seconds: float = 30.0,
         resub_backlog_threshold: int = 1000,
+        fit_state: FitCycleState | None = None,
     ) -> None:
         self._time_provider = time_provider
         self._data_providers = data_providers
@@ -67,26 +70,82 @@ class SubscriptionManager(ISubscriptionManager):
         # A.4: a busy/blocked ProcessorThread must not trigger resub churn on top of an already
         # overloaded loop — guard the [1/4]..[4/4] flow on the shared channel's backlog.
         self._resub_backlog_threshold = resub_backlog_threshold
+        # B.2 threaded fit: fit-thread calls are recorded for ProcessorThread replay
+        # instead of touching the (ProcessorThread-owned) pending-operation queues.
+        self._fit_state = fit_state
+        # (subscription_type, instrument) warmup pairs already prefetched on the fit
+        # thread via prepare(); consumed (skipped) by the commit-time _run_warmup so the
+        # FitCommit apply stays fast. Guarded by a lock: written by the fit thread, read
+        # by the ProcessorThread.
+        self._prewarmed: set[tuple[str, Instrument]] = set()
+        self._prewarmed_lock = threading.Lock()
         self._init_connection_status_callbacks()
         self._init_subscription_monitoring()
 
     @synchronized
     def subscribe(self, subscription_type: str, instruments: list[Instrument] | Instrument | None = None) -> None:
+        if self._fit_state is not None and self._fit_state.is_fit_thread():
+            # - threaded fit: pending-op queues are ProcessorThread-owned — record for
+            #   replay at the FitCommit (replay re-enters here off the fit thread)
+            self._fit_state.record(partial(self.subscribe, subscription_type, instruments))
+            return
         self._subscribe(subscription_type, instruments)
 
     @synchronized
     def unsubscribe(self, subscription_type: str, instruments: list[Instrument] | Instrument | None = None) -> None:
+        if self._fit_state is not None and self._fit_state.is_fit_thread():
+            self._fit_state.record(partial(self.unsubscribe, subscription_type, instruments))
+            return
         self._unsubscribe(subscription_type, instruments)
+
+    def prepare(self, instruments: list[Instrument]) -> None:
+        """Warmup prefetch for instruments about to be added by a deferred (fit-thread)
+        universe change — the slow half of commit(), run on the fit thread against the
+        bulk REST loop while the ProcessorThread keeps draining events.
+
+        Pure fetching: warmed history rides the channel as historical events exactly as
+        in commit-time warmup; the only manager state touched is the pre-warmed ledger,
+        which the commit-time _run_warmup consults to skip refetching (making the
+        FitCommit apply fast).
+        """
+        pairs: dict[tuple[str, Instrument], str] = {}
+        for instr in instruments:
+            try:
+                _dp = self._get_data_provider(instr.exchange)
+            except ValueError:
+                continue
+            for sub, period in self._sub_to_warmup.items():
+                if instr not in set(_dp.get_subscribed_instruments(sub)):
+                    pairs[(sub, instr)] = period
+        if not pairs:
+            return
+        for _data_provider in self._data_providers:
+            _configs = {
+                (sub, instr): period
+                for (sub, instr), period in pairs.items()
+                if instr.exchange == _data_provider.exchange()
+            }
+            if _configs:
+                _data_provider.warmup(_configs)
+        with self._prewarmed_lock:
+            self._prewarmed.update(pairs.keys())
+
+    def discard_prewarmed(self) -> None:
+        """Drop pre-warmed entries not consumed by the commit-time warmup (e.g. the
+        replayed universe change filtered an instrument out) so they can never
+        suppress a legitimate future warmup for the same pair."""
+        with self._prewarmed_lock:
+            self._prewarmed.clear()
 
     @synchronized
     def commit(self) -> None:
         if not self._has_operations_to_commit():
             return
 
-        # - warm up subscriptions
+        # - warm up subscriptions (prepare: slow, pure fetching)
         self._run_warmup()
 
-        # - update subscriptions
+        # - apply: the subscribe/unsubscribe swap (fast)
         for _sub in self._get_updated_subs():
             _current_sub_instruments = set(self.get_subscribed_instruments(_sub))
             _removed_instruments = self._pending_stream_unsubscriptions.get(_sub, set())
@@ -285,6 +344,13 @@ class SubscriptionManager(ISubscriptionManager):
 
             # TODO: think about appropriate handling of timeouts
             _warmup_configs = self._get_pending_warmups_for_exchange(_data_provider.exchange())
+            # - skip (and consume) pairs already prefetched on the fit thread (prepare())
+            with self._prewarmed_lock:
+                if self._prewarmed:
+                    _consumed = self._prewarmed.intersection(_warmup_configs.keys())
+                    if _consumed:
+                        _warmup_configs = {k: v for k, v in _warmup_configs.items() if k not in _consumed}
+                        self._prewarmed.difference_update(_consumed)
             _data_provider.warmup(_warmup_configs)
 
         self._pending_warmups.clear()

--- a/src/qubx/core/mixins/universe.py
+++ b/src/qubx/core/mixins/universe.py
@@ -1,6 +1,11 @@
+import traceback
+from functools import partial
+from typing import Callable
+
 from qubx import logger
 from qubx.core.basics import DataType, Instrument
 from qubx.core.detectors import DelistingDetector
+from qubx.core.fit_executor import FitCycleState
 from qubx.core.instrument_service import IInstrumentService, NullInstrumentService
 from qubx.core.interfaces import (
     IAccountViewer,
@@ -46,6 +51,7 @@ class UniverseManager(IUniverseManager):
         position_gathering: IPositionGathering,
         delisting_detector: DelistingDetector,
         instrument_service: IInstrumentService | None = None,
+        fit_state: FitCycleState | None = None,
     ):
         self._context = context
         self._strategy = strategy
@@ -61,6 +67,9 @@ class UniverseManager(IUniverseManager):
         self._removal_in_progress = set()
         self._delisting_detector = delisting_detector
         self._instrument_service = instrument_service if instrument_service is not None else NullInstrumentService()
+        # B.2 threaded fit: universe changes called from the fit thread are recorded as
+        # intents (replayed by the ProcessorThread at the FitCommit) instead of applied.
+        self._fit_state = fit_state
 
     def _has_position(self, instrument: Instrument) -> bool:
         return (
@@ -164,6 +173,14 @@ class UniverseManager(IUniverseManager):
             "wait_for_change",
         ), "Invalid if_has_position_then policy"
 
+        if self._fit_state is not None and self._fit_state.is_fit_thread():
+            # - threaded fit: record the intent for ProcessorThread replay at the
+            #   FitCommit and pre-warm the additions here (bulk REST loop)
+            self._defer_universe_change(
+                partial(self.set_universe, instruments, skip_callback, if_has_position_then), instruments
+            )
+            return
+
         # Settle & exclude instruments whose market is already gone (state B) FIRST,
         # so a gone instrument that also carries a delist_date is settled in place
         # before the delisting filter (state A) would otherwise strip it from the list.
@@ -226,7 +243,31 @@ class UniverseManager(IUniverseManager):
             if instr in self._removal_queue:
                 self._removal_queue.pop(instr)
 
+    def _defer_universe_change(self, op: Callable[[], None], candidates: list[Instrument]) -> None:
+        """Threaded-fit interception (single-mutator invariant): record the universe
+        change for ProcessorThread replay at the FitCommit, and prefetch warmup history
+        for the would-be additions here on the fit thread (against the bulk REST loop)
+        so the commit-time apply is fast.
+
+        The additions diff reads a snapshot of the live universe — best-effort by
+        design: a concurrent ProcessorThread removal at worst prefetches an extra
+        instrument or leaves one to be warmed at commit time.
+        """
+        assert self._fit_state is not None
+        self._fit_state.record(op)
+        _additions = sorted(set(candidates) - set(self._instruments))
+        if _additions:
+            try:
+                self._subscription_manager.prepare(_additions)
+            except Exception as e:
+                logger.error(f"[UniverseManager] :: fit-thread warmup prefetch failed: {e}")
+                logger.opt(colors=False).error(traceback.format_exc())
+
     def add_instruments(self, instruments: list[Instrument]):
+        if self._fit_state is not None and self._fit_state.is_fit_thread():
+            self._defer_universe_change(partial(self.add_instruments, instruments), instruments)
+            return
+
         # Settle & exclude already-gone markets (same gone-filter as set_universe).
         # Only _drop_gone (already-gone), NOT filter_delistings (future/scheduled),
         # so an explicitly-added still-listed instrument with a future delist_date
@@ -252,6 +293,11 @@ class UniverseManager(IUniverseManager):
             "wait_for_close",
             "wait_for_change",
         ), "Invalid if_has_position_then policy"
+
+        if self._fit_state is not None and self._fit_state.is_fit_thread():
+            # - removals need no warmup prefetch: record the intent only
+            self._fit_state.record(partial(self.remove_instruments, instruments, if_has_position_then))
+            return
 
         # - split instruments into removable and keepable
         to_remove, to_keep = self._get_what_can_be_removed_or_kept(instruments, False, if_has_position_then)

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -219,6 +219,14 @@ class LiveConfig(StrictBaseModel):
     state: StatePersistenceConfig | None = None
     rate_limiting: RateLimitingConfig | None = None
     account_manager: AccountManagerConfig = Field(default_factory=AccountManagerConfig)
+    # B.2: where strategy.on_fit runs in live mode. "inline" (default) is today's
+    # behavior — the fit blocks the ProcessorThread. "thread" hands the fit body to a
+    # dedicated StrategyFitThread so event processing continues during a slow fit;
+    # deferred ctx mutations are applied atomically on the ProcessorThread at fit end.
+    # Simulation always runs inline regardless of this setting.
+    fit_executor: Literal["inline", "thread"] = "inline"
+    # WARNING logged when a fit runs longer than this (no abort — visibility only).
+    fit_soft_deadline_s: float = 120.0
 
 
 class SimulationConfig(StrictBaseModel):

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -703,6 +703,8 @@ def create_strategy_context(
         rate_limiting_config=_rate_limiting_config,
         event_loop=loop,
         read_only=config.live.read_only,
+        fit_executor=config.live.fit_executor,
+        fit_soft_deadline_s=config.live.fit_soft_deadline_s,
     )
 
     # Set context for metric emitters to enable is_live tag and time access

--- a/tests/qubx/core/mixins/fit_executor_test.py
+++ b/tests/qubx/core/mixins/fit_executor_test.py
@@ -1,0 +1,563 @@
+"""Tests for the threaded fit executor (B.2): on_fit off the ProcessorThread.
+
+The calling test thread plays the ProcessorThread role: it submits the fit via
+``_handle_fit`` and drains the CtrlChannel (processing events and finally the
+FitCommit) exactly like ``StrategyContext.__process_incoming_data_loop`` does.
+"""
+
+import threading
+import time
+from unittest.mock import ANY, MagicMock
+
+import numpy as np
+import pytest
+
+from qubx.core.basics import CtrlChannel, DataType, Instrument, Signal
+from qubx.core.exceptions import QueueTimeout
+from qubx.core.fit_executor import FitCycleState
+from qubx.core.interfaces import StrategyState
+from qubx.core.mixins.market import CachedMarketDataHolder
+from qubx.core.mixins.processing import ProcessingManager
+from qubx.core.mixins.subscription import SubscriptionManager
+from qubx.core.mixins.universe import UniverseManager
+from qubx.core.series import Bar, Quote
+from qubx.utils.runner.configs import LiveConfig
+
+T0 = np.datetime64("2025-01-01T00:00:00", "ns")
+
+
+def _mock_instrument(symbol: str = "BTCUSDT") -> MagicMock:
+    instrument = MagicMock(spec=Instrument)
+    instrument.symbol = symbol
+    instrument.min_size = 0.001
+    instrument.exchange = "BINANCE"
+    instrument.delist_date = None
+    return instrument
+
+
+def _mock_signal(instrument: MagicMock) -> MagicMock:
+    signal = MagicMock(spec=Signal)
+    signal.instrument = instrument
+    signal.is_service = False
+    signal.group = None
+    signal.reference_price = None
+    return signal
+
+
+def make_thread_pm(fit_executor: str = "thread", is_simulation: bool = False, **kwargs):
+    """ProcessingManager with mocked collaborators, wired for the threaded-fit tests."""
+    channel = CtrlChannel("test-databus")
+
+    context = MagicMock()
+    context.is_simulation = is_simulation
+    context.is_paper_trading = False
+    context.instruments = []
+    context._strategy_state = StrategyState(
+        is_on_init_called=True,
+        is_on_start_called=True,
+        is_on_warmup_finished_called=True,
+        is_on_fit_called=False,
+        is_warmup_in_progress=False,
+    )
+    context._data_providers = [MagicMock(channel=channel)]
+    context.emitter = None
+
+    strategy = MagicMock()
+    strategy.__class__.__name__ = "TestStrategy"
+
+    cache = MagicMock()
+    cache.default_timeframe = "1h"
+    market_data = MagicMock()
+    market_data.get_market_data_cache.return_value = cache
+
+    subscription_manager = MagicMock()
+    subscription_manager.get_base_subscription.return_value = "quote"
+
+    time_provider = MagicMock()
+    time_provider.time.return_value = T0
+
+    position_tracker = MagicMock()
+    position_tracker.process_signals.return_value = []
+    position_tracker.update.return_value = []
+
+    universe_manager = MagicMock()
+    universe_manager.is_trading_allowed.return_value = True
+
+    health_monitor = MagicMock()
+    health_monitor.return_value.__enter__ = MagicMock(return_value=None)
+    health_monitor.return_value.__exit__ = MagicMock(return_value=False)
+
+    pm = ProcessingManager(
+        context=context,
+        strategy=strategy,
+        logging=MagicMock(),
+        market_data=market_data,
+        subscription_manager=subscription_manager,
+        time_provider=time_provider,
+        account_manager=MagicMock(),
+        connectors={},
+        position_tracker=position_tracker,
+        position_gathering=MagicMock(),
+        universe_manager=universe_manager,
+        scheduler=MagicMock(),
+        is_simulation=is_simulation,
+        health_monitor=health_monitor,
+        delisting_detector=MagicMock(),
+        fit_executor=fit_executor,
+        **kwargs,
+    )
+    pm._is_ready = lambda: True  # type: ignore[method-assign]
+    pm._init_stage_position_tracker = MagicMock()
+    pm._init_stage_position_tracker.process_signals.return_value = []
+    pm._init_stage_position_tracker.update.return_value = []
+    return pm, context, channel
+
+
+def drain_until_committed(pm: ProcessingManager, channel: CtrlChannel, timeout: float = 5.0) -> None:
+    """Play the ProcessorThread: drain the channel until the FitCommit clears the gate."""
+    deadline = time.monotonic() + timeout
+    while pm._fit_is_running:
+        if time.monotonic() > deadline:
+            raise TimeoutError("FitCommit was not applied within the timeout")
+        try:
+            msg = channel.receive(timeout=1)
+        except QueueTimeout:
+            continue
+        instrument, d_type, data, hist = msg
+        pm.process_data(instrument, d_type, data, hist)
+
+
+class TestThreadedFitExecution:
+    def test_fit_runs_on_strategy_fit_thread_and_commit_clears_flags(self):
+        pm, context, channel = make_thread_pm()
+        seen: dict[str, str] = {}
+
+        def on_fit(ctx):
+            seen["thread"] = threading.current_thread().name
+
+        pm._strategy.on_fit.side_effect = on_fit
+
+        pm._handle_fit(None, "fit", (None, T0))
+        # - submission returns immediately; the gate stays up until the commit is applied
+        assert pm._fit_is_running is True
+        assert context._strategy_state.is_on_fit_called is False
+
+        drain_until_committed(pm, channel)
+
+        assert seen["thread"] == "StrategyFitThread"
+        assert context._strategy_state.is_on_fit_called is True
+        assert pm._fit_is_running is False
+
+    def test_fit_duration_gauge_recorded(self):
+        pm, _, channel = make_thread_pm()
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+        pm._health_monitor.record_gauge.assert_any_call("fit_duration_s", ANY)
+
+    def test_events_processed_during_slow_fit(self):
+        """The incident scenario: a slow fit must not stop the ProcessorThread from
+        applying market/account events; the strategy itself stays gated (same as today)."""
+        pm, _, channel = make_thread_pm()
+        started, release = threading.Event(), threading.Event()
+
+        def slow_fit(ctx):
+            started.set()
+            assert release.wait(5.0), "fit was never released"
+
+        pm._strategy.on_fit.side_effect = slow_fit
+        pm._handle_fit(None, "fit", (None, T0))
+        assert started.wait(5.0)
+
+        try:
+            # - ProcessorThread (this thread) applies a quote WHILE the fit computes
+            instrument = _mock_instrument()
+            quote = MagicMock(spec=Quote)
+            quote.time = T0
+            pm.process_data(instrument, "quote", quote, False)
+
+            assert pm._fit_is_running is True  # fit is still computing
+            pm._cache.update.assert_called_once()  # market cache updated mid-fit
+            pm._account_manager.on_market_quote.assert_called_once()  # mark-to-market mid-fit
+            pm._strategy.on_market_data.assert_not_called()  # strategy stays gated (as today)
+        finally:
+            release.set()
+
+        drain_until_committed(pm, channel)
+        assert pm._context._strategy_state.is_on_fit_called is True
+
+    def test_overlapping_fit_trigger_dropped(self):
+        pm, _, channel = make_thread_pm()
+        started, release = threading.Event(), threading.Event()
+
+        def slow_fit(ctx):
+            started.set()
+            assert release.wait(5.0)
+
+        pm._strategy.on_fit.side_effect = slow_fit
+        pm._handle_fit(None, "fit", (None, T0))
+        assert started.wait(5.0)
+        try:
+            pm._handle_fit(None, "fit", (None, T0))  # overlapping trigger — dropped
+        finally:
+            release.set()
+        drain_until_committed(pm, channel)
+
+        assert pm._strategy.on_fit.call_count == 1
+
+    def test_exception_in_fit_still_posts_commit_and_clears_flags(self):
+        pm, context, channel = make_thread_pm()
+        applied: list[str] = []
+
+        def failing_fit(ctx):
+            pm._fit_state.record(lambda: applied.append("op"))
+            raise RuntimeError("fit blew up")
+
+        pm._strategy.on_fit.side_effect = failing_fit
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+
+        assert context._strategy_state.is_on_fit_called is True
+        assert pm._fit_is_running is False
+        # - ops recorded before the raise are applied, mirroring inline semantics
+        #   (mutations before an inline raise stay applied)
+        assert applied == ["op"]
+
+    def test_soft_deadline_warning_fires_for_slow_fit(self):
+        pm, _, channel = make_thread_pm(fit_soft_deadline_s=0.05)
+        pm._warn_fit_soft_deadline = MagicMock()  # type: ignore[method-assign]
+        pm._strategy.on_fit.side_effect = lambda ctx: time.sleep(0.3)
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+        pm._warn_fit_soft_deadline.assert_called_once()
+
+    def test_soft_deadline_warning_not_fired_for_fast_fit(self):
+        pm, _, channel = make_thread_pm(fit_soft_deadline_s=5.0)
+        pm._warn_fit_soft_deadline = MagicMock()  # type: ignore[method-assign]
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+        time.sleep(0.05)  # give a mis-armed timer a chance to fire
+        pm._warn_fit_soft_deadline.assert_not_called()
+
+
+class TestDeferredMutationsAndSignals:
+    def test_emitted_signals_drain_in_order_at_commit(self):
+        pm, _, channel = make_thread_pm()
+        instrument = _mock_instrument()
+        sig1, sig2 = _mock_signal(instrument), _mock_signal(instrument)
+
+        def emitting_fit(ctx):
+            pm.emit_signal(sig1)
+            pm.emit_signal([sig2])
+            # - buffered on the fit-cycle state, NOT in the live pipeline list
+            assert pm._emitted_signals == []
+
+        pm._strategy.on_fit.side_effect = emitting_fit
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+
+        # - the commit handed both signals to the normal pipeline in emission order
+        pm._logging.save_signals.assert_called_once()
+        assert list(pm._logging.save_signals.call_args[0][0]) == [sig1, sig2]
+
+    def test_schedule_from_fit_thread_is_deferred_and_keeps_event_id(self):
+        pm, _, channel = make_thread_pm()
+        scheduler = pm._scheduler
+        returned: dict[str, str] = {}
+
+        def scheduling_fit(ctx):
+            returned["event_id"] = pm.schedule("0 0 * * *", lambda c: None)
+            # - scheduler untouched while the fit runs (mutation deferred to commit)
+            scheduler.schedule_event.assert_not_called()
+
+        scheduler.schedule_event.reset_mock()  # drop registrations from __init__
+        pm._strategy.on_fit.side_effect = scheduling_fit
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+
+        event_id = returned["event_id"]
+        assert event_id.startswith("custom_schedule_")
+        assert event_id in pm._custom_scheduled_methods
+        scheduler.schedule_event.assert_called_once_with("0 0 * * *", event_id)
+
+    def test_set_fit_schedule_from_fit_thread_is_deferred(self):
+        pm, _, channel = make_thread_pm()
+        scheduler = pm._scheduler
+
+        def scheduling_fit(ctx):
+            pm.set_fit_schedule("0 0 * * *")
+            scheduler.unschedule_event.assert_not_called()
+
+        scheduler.unschedule_event.reset_mock()
+        pm._strategy.on_fit.side_effect = scheduling_fit
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+
+        scheduler.unschedule_event.assert_called_once_with("fit")
+        scheduler.schedule_event.assert_any_call("0 0 * * *", "fit")
+
+    def test_deferred_set_universe_applies_atomically_at_commit(self):
+        """End-to-end through a REAL UniverseManager: set_universe from the fit thread is
+        recorded (universe untouched mid-fit), prepared (warmup prefetch on the fit
+        thread), and applied at the commit — with on_universe_change fired on the
+        ProcessorThread."""
+        pm, context, channel = make_thread_pm()
+        instrument = _mock_instrument()
+
+        mkt = MagicMock()
+        mkt.is_instrument_listed.return_value = True
+        delisting = MagicMock()
+        delisting.filter_delistings.side_effect = lambda instruments: list(instruments)
+        account = MagicMock()
+        account.positions = {}
+        subscription_manager = MagicMock()
+
+        um = UniverseManager(
+            context=context,
+            strategy=pm._strategy,
+            market_data_manager=mkt,
+            logging=MagicMock(),
+            subscription_manager=subscription_manager,
+            trading_manager=MagicMock(),
+            time_provider=MagicMock(),
+            account=account,
+            position_gathering=MagicMock(),
+            delisting_detector=delisting,
+            fit_state=pm._fit_state,
+        )
+
+        prepare_thread: list[str] = []
+        subscription_manager.prepare.side_effect = lambda instruments: prepare_thread.append(
+            threading.current_thread().name
+        )
+        callback_thread: list[int] = []
+        pm._strategy.on_universe_change.side_effect = lambda ctx, added, removed: callback_thread.append(
+            threading.get_ident()
+        )
+
+        started, release = threading.Event(), threading.Event()
+
+        def universe_fit(ctx):
+            um.set_universe([instrument])
+            started.set()
+            assert release.wait(5.0)
+
+        pm._strategy.on_fit.side_effect = universe_fit
+        pm._handle_fit(None, "fit", (None, T0))
+        assert started.wait(5.0)
+
+        try:
+            # - mid-fit: intent recorded + prefetched, but NOTHING applied yet
+            assert um.instruments == []
+            pm._strategy.on_universe_change.assert_not_called()
+            subscription_manager.prepare.assert_called_once_with([instrument])
+            assert prepare_thread == ["StrategyFitThread"]
+        finally:
+            release.set()
+
+        drain_until_committed(pm, channel)
+
+        # - the commit (on this thread, the ProcessorThread) applied the swap and fired
+        #   the callback here
+        assert um.instruments == [instrument]
+        pm._strategy.on_universe_change.assert_called_once()
+        assert callback_thread == [threading.get_ident()]
+
+    def test_remove_instruments_from_fit_thread_is_deferred(self):
+        pm, context, _ = make_thread_pm()
+        instrument = _mock_instrument()
+
+        um = UniverseManager(
+            context=context,
+            strategy=pm._strategy,
+            market_data_manager=MagicMock(),
+            logging=MagicMock(),
+            subscription_manager=MagicMock(),
+            trading_manager=MagicMock(),
+            time_provider=MagicMock(),
+            account=MagicMock(),
+            position_gathering=MagicMock(),
+            delisting_detector=MagicMock(),
+            fit_state=pm._fit_state,
+        )
+
+        pm._fit_state.begin(threading.get_ident())
+        um.remove_instruments([instrument])
+        pm._strategy.on_universe_change.assert_not_called()  # nothing applied mid-fit
+        ops, _ = pm._fit_state.end()
+        assert len(ops) == 1
+
+
+class TestSubscriptionManagerFitPath:
+    def _make_sm(self, fit_state: FitCycleState) -> tuple[SubscriptionManager, MagicMock]:
+        dp = MagicMock()
+        dp.exchange.return_value = "BINANCE"
+        dp.get_subscribed_instruments.return_value = []
+        dp.is_simulation = True  # keeps the monitoring thread off
+        sm = SubscriptionManager(
+            time_provider=MagicMock(),
+            data_providers=[dp],
+            health_monitor=MagicMock(),
+            strategy_state=StrategyState(),
+            fit_state=fit_state,
+        )
+        return sm, dp
+
+    def test_subscribe_from_fit_thread_is_recorded_not_queued(self):
+        fit_state = FitCycleState()
+        sm, _ = self._make_sm(fit_state)
+        instrument = _mock_instrument()
+
+        fit_state.begin(threading.get_ident())
+        sm.subscribe(DataType.TRADE, [instrument])
+        assert not sm._pending_stream_subscriptions  # nothing queued from the fit thread
+        ops, _ = fit_state.end()
+        assert len(ops) == 1
+
+        ops[0]()  # ProcessorThread replay takes the normal path
+        assert instrument in sm._pending_stream_subscriptions[DataType.TRADE]
+
+    def test_prepare_prefetches_and_commit_skips_prewarmed(self):
+        fit_state = FitCycleState()
+        sm, dp = self._make_sm(fit_state)
+        instrument = _mock_instrument()
+        sub = str(DataType.OHLC["1h"])
+        sm.set_warmup({sub: "30d"})
+
+        # - fit thread: prepare() fetches the warmup for the addition
+        fit_state.begin(threading.get_ident())
+        sm.prepare([instrument])
+        fit_state.end()
+        dp.warmup.assert_called_once_with({(sub, instrument): "30d"})
+
+        # - ProcessorThread: the replayed subscribe + commit must NOT refetch
+        sm.subscribe(sub, [instrument])
+        sm.commit()
+        assert dp.warmup.call_count == 2
+        assert dp.warmup.call_args[0][0] == {}  # pre-warmed pair was skipped
+        assert not sm._prewarmed  # consumed
+
+    def test_discard_prewarmed_clears_ledger(self):
+        fit_state = FitCycleState()
+        sm, _ = self._make_sm(fit_state)
+        instrument = _mock_instrument()
+        sm.set_warmup({str(DataType.OHLC["1h"]): "30d"})
+        fit_state.begin(threading.get_ident())
+        sm.prepare([instrument])
+        fit_state.end()
+        assert sm._prewarmed
+        sm.discard_prewarmed()
+        assert not sm._prewarmed
+
+
+class TestCacheConcurrentReads:
+    def test_concurrent_append_and_fit_read_is_consistent(self):
+        """Race test: ProcessorThread appends while the fit thread snapshots — no
+        exception, and every snapshot is internally consistent."""
+        holder = CachedMarketDataHolder("1Min")
+        fit_state = FitCycleState()
+        holder.enable_concurrent_fit_reads(fit_state)
+        instrument = _mock_instrument()
+        holder.init_ohlcv(instrument)
+
+        t0 = T0.astype("datetime64[ns]").astype(int)
+        one_min = 60_000_000_000
+        errors: list[Exception] = []
+        stop_writer = threading.Event()
+
+        def writer():
+            try:
+                for i in range(20_000):
+                    if stop_writer.is_set():
+                        return
+                    holder.update_by_bar(
+                        instrument,
+                        Bar(t0 + i * one_min, 1.0 + i, 2.0 + i, 0.5 + i, 1.5 + i, volume=1.0, bought_volume=0.5),
+                    )
+            except Exception as e:  # pragma: no cover - failure path
+                errors.append(e)
+
+        def reader():
+            try:
+                fit_state.begin(threading.get_ident())
+                for _ in range(300):
+                    snapshot = holder.get_ohlcv(instrument)
+                    n = len(snapshot)
+                    # - internal consistency of the snapshot across all sub-series
+                    assert len(snapshot.close) == n
+                    assert len(snapshot.open) == n
+                    assert len(snapshot.times) == n
+                    if n:
+                        _ = snapshot.pd()
+            except Exception as e:
+                errors.append(e)
+            finally:
+                fit_state.end()
+
+        w = threading.Thread(target=writer)
+        r = threading.Thread(target=reader)
+        w.start(), r.start()
+        r.join(30.0)
+        stop_writer.set()
+        w.join(30.0)
+
+        assert not errors, f"concurrent access raised: {errors}"
+
+    def test_fit_thread_read_returns_snapshot_not_live_series(self):
+        holder = CachedMarketDataHolder("1Min")
+        fit_state = FitCycleState()
+        holder.enable_concurrent_fit_reads(fit_state)
+        instrument = _mock_instrument()
+        holder.init_ohlcv(instrument)
+        t0 = T0.astype("datetime64[ns]").astype(int)
+        holder.update_by_bar(instrument, Bar(t0, 1.0, 2.0, 0.5, 1.5, volume=1.0, bought_volume=0.5))
+
+        live = holder._get_ohlcv_series(instrument)
+        # - on-thread (no armed fit): the live series, same as today
+        assert holder.get_ohlcv(instrument) is live
+
+        fit_state.begin(threading.get_ident())
+        try:
+            snapshot = holder.get_ohlcv(instrument)
+            assert snapshot is not live
+            assert len(snapshot) == len(live)
+        finally:
+            fit_state.end()
+
+    def test_lock_free_path_when_not_enabled(self):
+        holder = CachedMarketDataHolder("1Min")
+        instrument = _mock_instrument()
+        holder.init_ohlcv(instrument)
+        live = holder._get_ohlcv_series(instrument)
+        assert holder.get_ohlcv(instrument) is live  # identical semantics to today
+
+
+class TestSimulationPurity:
+    def test_simulation_never_creates_executor_even_when_configured(self):
+        pm, _, _ = make_thread_pm(fit_executor="thread", is_simulation=True)
+        assert pm._fit_executor is None
+        assert pm._fit_executor_mode == "inline"
+
+    def test_live_inline_default_creates_no_executor(self):
+        pm, _, _ = make_thread_pm(fit_executor="inline")
+        assert pm._fit_executor is None
+        assert pm._fit_executor_mode == "inline"
+
+    def test_simulation_fit_runs_inline_on_caller_thread(self):
+        pm, context, _ = make_thread_pm(fit_executor="thread", is_simulation=True)
+        seen: dict[str, int] = {}
+        pm._strategy.on_fit.side_effect = lambda ctx: seen.setdefault("ident", threading.get_ident())
+
+        pm._handle_fit(None, "fit", (None, T0))
+
+        assert seen["ident"] == threading.get_ident()  # ran synchronously, right here
+        assert context._strategy_state.is_on_fit_called is True
+        assert pm._fit_is_running is False
+
+    def test_live_thread_mode_creates_executor(self):
+        pm, _, _ = make_thread_pm(fit_executor="thread")
+        assert pm._fit_executor is not None
+        assert pm._fit_executor_mode == "thread"
+
+    def test_config_default_is_inline(self):
+        assert LiveConfig.model_fields["fit_executor"].default == "inline"
+        assert LiveConfig.model_fields["fit_soft_deadline_s"].default == pytest.approx(120.0)


### PR DESCRIPTION
PR 6/7 (stacked on #355). Spec §B.2, quantkit#106. **DRAFT — do not merge.** Lands DARK: `live.fit_executor: inline` default; `thread` is opt-in per bot after burn-in.

- `FitExecutor` daemon worker; `_handle_fit` submits when mode=thread — the ProcessorThread keeps draining events during a fit (the incident's 7-minute freeze becomes a non-event; proven by a mid-fit-event test)
- Single-mutator preserved: fit thread only records — set_universe/add/remove/subscribe/unsubscribe/schedule intents + a locked signal buffer; one atomic `FitCommit` applies on the ProcessorThread (prepare()/apply() split of SubscriptionManager.commit; warmup prefetch on the fit thread against PR5's bulk loop)
- Off-thread reads: positions/orders/balances/leverages/targets shallow-copied; OHLCV reads return locked clones (on-thread path zero-cost)
- Sim byte-identical by construction (inline body untouched; executor never created in sim — asserted by test)
- `fit_duration_s` gauge + 120s soft-deadline WARNING

Tests: new 23-test suite; full fast suite **2333 passed / 0 failed × 2 runs**; core 859, backtester 111. Reviewer notes (from the implementation report): `unsubscribe` also intercepted (shared pending-op dicts); `enforce_at_fit` blacklist force-close timing shifts to commit in thread mode; `ctx.get_data` GenericSeries off-thread reads not copy-guarded (documented limitation); doc note needed before the flip: indicators attached to `ctx.ohlc` inside a threaded on_fit bind to snapshot clones.

https://claude.ai/code/session_017fBtVL9NcmHosCbkZmYBXg