### PR TITLE
feat(account): order-replace orchestration — truthful update_order for partially-filled orders

### DIFF
--- a/docs/account-management/design.md
+++ b/docs/account-management/design.md
@@ -396,12 +396,15 @@ working order. Rather than adding a per-venue amend adapter to paper over the di
 `update_order` routes a partially-filled order through a framework-side cancel+replace: arm a
 `ReplaceIntent`, transition to `PENDING_UPDATE`, call `connector.cancel_order`. The connector
 never sees an amend call in this case — only the `cancel_order`/`submit_order` primitives every
-venue already has. The replacement resubmits under the **same client_order_id**, so a caller
+venue already has. The `filled == 0` check is inherently racy: a fill can land between the local
+check and the venue applying the amend, and the dialects then diverge on that one order after
+all. The window is bounded (one round trip) and self-corrects — the venue's amend ack carries
+the figures the next reconcile compares against. The replacement resubmits under the **same client_order_id**, so a caller
 watching one cid (e.g. a quantkit maker-taker slot) sees one continuously-live order, not a
 cancel+accept pair.
 
 **The intent lifecycle** (`ReplaceIntent` in `AccountState`, keyed by cid — `desired_remaining`,
-`price`, `filled_at_request`, `armed_at`, `filled_at_cancel`):
+`price`, `filled_at_request`, `armed_at`, `filled_at_cancel`, `canceled_venue_oid`):
 
 1. `update_order` arms the intent and fires `cancel_order`. A synchronous failure here (the
    cancel never reached the venue) clears the intent immediately and reverts via a synthetic
@@ -417,7 +420,12 @@ cancel+accept pair.
      pre-pending status with `OrderChange.UPDATE_REJECTED` — the order is still alive under the
      old terms.
    - A `FILLED` beats the cancel (order settles for real before the ack) and clears the intent
-     unconditionally — the fill is the truth now, no replacement is submitted.
+     unconditionally — the fill is the truth now, no replacement is submitted. Every other
+     terminal (`EXPIRED`/`REJECTED`/`LOST`) clears it the same way.
+   - A strategy `cancel_order` during the window is legal and wins: it clears the intent up front
+     and moves the order to `PENDING_CANCEL`. Suppression is gated on the order being
+     `PENDING_UPDATE`, not merely on an armed intent, so an explicit cancel can never be
+     swallowed and turned into a resurrection.
 3. The reconciler (`on_event`) turns a suppressed cancel into a decision. Residual (all
    magnitudes): `residual = desired_remaining − max(0, filled_at_cancel − filled_at_request)` —
    the "raced" term backs out fills that landed between the request and the cancel ack, since
@@ -428,15 +436,34 @@ cancel+accept pair.
    submits the residual under the same cid (order fields mirrored from the original —
    `TradingManager.trade`'s `OrderRequest` construction, not reinvented), then routes an
    `OrderUpdatedEvent` so the reducer splices `quantity = filled + residual` and the strategy's
-   `UPDATED` callback observes the intent already cleared. `AbandonReplace` clears the intent and
-   routes an `OrderCanceledEvent` — the truthful terminal the suppressed cancel deferred.
-5. **Expiry.** A suppressed cancel whose ack never determined `filled_at_cancel` within
-   `REPLACE_INTENT_MAX_AGE` (30s) has an unknown venue outcome — the periodic sweep clears the
-   intent and issues `RequestStatus` to refetch truth. It never fabricates `AbandonReplace` here:
-   an unconfirmed cancel is not a confirmed cancel, and routing a terminal nobody observed would
-   trade one fiction for another. The existing `_is_superseded_oid_cancel` guard still applies
-   underneath this flow — a late `OrderCanceledEvent` for the pre-replace venue id is dropped
-   whether or not a replace is in flight.
+   `UPDATED` callback observes the intent already cleared. The routed `new_quantity` is
+   lag-compensated (`residual + max(0, filled_at_cancel − order.filled_quantity)`): the reducer
+   splices against *local* `filled_quantity`, so when the cancel ack counted raced fills whose
+   deals haven't booked yet, the uncompensated splice would understate remaining permanently once
+   they do. The venue still receives the plain `residual`, and the lagging deal dedupes by trade
+   id when it lands. `AbandonReplace` clears the intent and routes an `OrderCanceledEvent` — the
+   truthful terminal the suppressed cancel deferred.
+5. **Expiry.** An intent still armed `REPLACE_INTENT_MAX_AGE` (30s) after arming — cancel never
+   acked, or acked but never decided — has an undecidable outcome. The periodic sweep clears it,
+   routes a synthetic `OrderUpdateRejectedEvent` (so the order reverts out of `PENDING_UPDATE`
+   via `pre_pending`, i.e. presumed alive under the old terms) and issues `RequestStatus` to
+   refetch truth. The revert is not optional bookkeeping: a live order's status reply is an
+   `OrderAcceptedEvent`, which deliberately refuses to wipe `PENDING_*`, and `_reconcile_order`
+   skips pending orders — without the synthetic reject the order sits in `PENDING_UPDATE`
+   forever and every later `update_order` silently no-ops on the re-entrancy guard. If the cancel
+   *did* go through, the `RequestStatus` reply's terminal now terminalizes truthfully, since no
+   intent is left to suppress it. The sweep never fabricates `AbandonReplace`: an unconfirmed
+   cancel is not a confirmed cancel, and routing a terminal nobody observed would trade one
+   fiction for another.
+6. **Duplicate cancel terminals.** A connector may emit two terminals per cancel (the ccxt one
+   does: REST ack + WS stream). The first is consumed by the suppression above; the second
+   arrives once the replacement is already live under the same cid and — until the replacement's
+   accept re-keys the venue id — resolves onto an order still carrying the *old* id, where
+   `_is_superseded_oid_cancel` cannot tell it is stale. On a successful replacement submit
+   `_execute` therefore records the killed id as a per-cid superseded-oid marker in
+   `AccountState`; a `CANCELED` matching that marker is dropped. The marker is cleared when the
+   venue id re-keys past it (`_is_superseded_oid_cancel` covers it from there) and on any
+   terminal transition.
 
 **Failure contract — truth over fiction.** Every branch below degrades to a state the venue would
 recognize; none reports an order alive that isn't, or dead that isn't.
@@ -448,8 +475,10 @@ recognize; none reports an order alive that isn't, or dead that isn't.
 | Fill races the cancel to FILLED | Intent cleared, order FILLED (no replacement) |
 | Post-cancel residual below min size | `AbandonReplace` → truthful `OrderCanceledEvent` |
 | Replacement `submit_order` raises | Truthful `OrderCanceledEvent` (the old order is already gone at the venue; nothing live to report otherwise) |
-| Cancel ack never arrives within 30s | Intent cleared, `RequestStatus` refetch — never a fabricated terminal |
+| Strategy cancels during the replace window | Intent cleared, cancel ack terminalizes truthfully, no replacement |
+| Intent unresolved for 30s (no ack, or acked-but-undecided) | Intent cleared, synthetic `OrderUpdateRejectedEvent` reverts to pre-pending, `RequestStatus` refetch — never a fabricated terminal |
 | Stale cancel for a superseded venue id | Dropped by `_is_superseded_oid_cancel`, independent of any intent |
+| Second cancel terminal for the id the replacement superseded | Dropped by the per-cid superseded-oid marker (fires before the venue id re-keys) |
 
 **Sim.** The backtester connector exercises the same account-manager path — the `filled == 0`
 native-amend leg is pinned by an integration test through the real OME (book state, not the

--- a/docs/account-management/design.md
+++ b/docs/account-management/design.md
@@ -369,6 +369,96 @@ contract.
 Read-only connectors keep the read surface alive (account events + snapshots flow);
 write methods raise.
 
+## Order updates and the replace orchestration
+
+`TradingManager.update_order(price, amount)`'s `amount` is the desired **signed remaining**
+quantity to keep working — not a delta, not the original order size (its sign must match
+`order.side`; a mismatch raises `ValueError`). This is the one existing caller's contract
+(quantkit passes `signed_remaining`) and it is what makes the routing rule below possible: the
+handler always knows "how much should still be working" independent of how much has already
+filled.
+
+**The `Order.quantity` invariant.** `quantity` (unsigned, side carried separately) always means
+**total including everything ever filled on this client order id** — at every status, on every
+venue. An amend ack's `new_quantity` is the remaining figure, so the reducer (`_handle_updated`)
+splices it back onto the cumulative fill rather than overwriting: `order.quantity =
+order.filled_quantity + event.new_quantity`. Overwriting instead of splicing is the class of bug
+this exists to close off: `remaining = quantity − filled` goes negative the moment a second fill
+lands after an amend, and every consumer reading `remaining` (position sizing, replacement slots)
+inherits the fiction. `order.quantity =` has exactly two legal assignment sites in the codebase:
+initial construction and this splice.
+
+**The routing rule.** Native venue amend is used only when `filled_quantity == 0` — the one case
+where every venue dialect agrees on what a resize means. Once any fill exists, dialects diverge:
+Hyperliquid's modify takes the new *remaining* size, Binance/Gate's amend takes the new *total*
+with `executedQty` preserved — sending "remaining" to the latter silently double-shrinks the
+working order. Rather than adding a per-venue amend adapter to paper over the difference,
+`update_order` routes a partially-filled order through a framework-side cancel+replace: arm a
+`ReplaceIntent`, transition to `PENDING_UPDATE`, call `connector.cancel_order`. The connector
+never sees an amend call in this case — only the `cancel_order`/`submit_order` primitives every
+venue already has. The replacement resubmits under the **same client_order_id**, so a caller
+watching one cid (e.g. a quantkit maker-taker slot) sees one continuously-live order, not a
+cancel+accept pair.
+
+**The intent lifecycle** (`ReplaceIntent` in `AccountState`, keyed by cid — `desired_remaining`,
+`price`, `filled_at_request`, `armed_at`, `filled_at_cancel`):
+
+1. `update_order` arms the intent and fires `cancel_order`. A synchronous failure here (the
+   cancel never reached the venue) clears the intent immediately and reverts via a synthetic
+   `OrderUpdateRejectedEvent` — the same pre-pending revert the plain cancel/update rejection
+   path uses — then re-raises.
+2. The venue's cancel ack arrives as the normal `OrderCanceledEvent`. With an intent armed, the
+   reducer **suppresses** it: no terminal transition, no strategy callback (`ApplyResult()`
+   empty), order stays `PENDING_UPDATE`. It stamps `intent.filled_at_cancel` from the event's
+   `venue_filled_quantity` when the venue reports one on the cancel response (ccxt: Binance
+   futures `executedQty` → unified `filled`), else falls back to the locally-tracked
+   `filled_quantity` — fills that raced the cancel must count either way.
+   - A cancel *rejection* instead (the venue won't cancel) clears the intent and reverts to the
+     pre-pending status with `OrderChange.UPDATE_REJECTED` — the order is still alive under the
+     old terms.
+   - A `FILLED` beats the cancel (order settles for real before the ack) and clears the intent
+     unconditionally — the fill is the truth now, no replacement is submitted.
+3. The reconciler (`on_event`) turns a suppressed cancel into a decision. Residual (all
+   magnitudes): `residual = desired_remaining − max(0, filled_at_cancel − filled_at_request)` —
+   the "raced" term backs out fills that landed between the request and the cancel ack, since
+   `desired_remaining` was computed against the *request-time* fill level. `residual` executable
+   (positive, ≥ instrument min size) → `SubmitReplacement(cid)`; otherwise → `AbandonReplace(cid,
+   reason)`.
+4. `_execute` performs the I/O, **submit before route**: `SubmitReplacement` clears the intent,
+   submits the residual under the same cid (order fields mirrored from the original —
+   `TradingManager.trade`'s `OrderRequest` construction, not reinvented), then routes an
+   `OrderUpdatedEvent` so the reducer splices `quantity = filled + residual` and the strategy's
+   `UPDATED` callback observes the intent already cleared. `AbandonReplace` clears the intent and
+   routes an `OrderCanceledEvent` — the truthful terminal the suppressed cancel deferred.
+5. **Expiry.** A suppressed cancel whose ack never determined `filled_at_cancel` within
+   `REPLACE_INTENT_MAX_AGE` (30s) has an unknown venue outcome — the periodic sweep clears the
+   intent and issues `RequestStatus` to refetch truth. It never fabricates `AbandonReplace` here:
+   an unconfirmed cancel is not a confirmed cancel, and routing a terminal nobody observed would
+   trade one fiction for another. The existing `_is_superseded_oid_cancel` guard still applies
+   underneath this flow — a late `OrderCanceledEvent` for the pre-replace venue id is dropped
+   whether or not a replace is in flight.
+
+**Failure contract — truth over fiction.** Every branch below degrades to a state the venue would
+recognize; none reports an order alive that isn't, or dead that isn't.
+
+| Failure point | Outcome |
+|---|---|
+| Sync `cancel_order` raise (never reached venue) | Intent cleared, synthetic `OrderUpdateRejectedEvent`, pre-pending revert, re-raise |
+| Async cancel rejected by venue | Intent cleared, pre-pending revert, `UPDATE_REJECTED` |
+| Fill races the cancel to FILLED | Intent cleared, order FILLED (no replacement) |
+| Post-cancel residual below min size | `AbandonReplace` → truthful `OrderCanceledEvent` |
+| Replacement `submit_order` raises | Truthful `OrderCanceledEvent` (the old order is already gone at the venue; nothing live to report otherwise) |
+| Cancel ack never arrives within 30s | Intent cleared, `RequestStatus` refetch — never a fabricated terminal |
+| Stale cancel for a superseded venue id | Dropped by `_is_superseded_oid_cancel`, independent of any intent |
+
+**Sim.** The backtester connector exercises the same account-manager path — the `filled == 0`
+native-amend leg is pinned by an integration test through the real OME (book state, not the
+request echo). The `filled > 0` replace leg is covered at the account-manager level (the
+reconciler/`_execute` chain, intent table) but not through a genuine partial fill in sim: the
+OME's matching model fills an order's full remaining quantity atomically in one `Deal`, so a
+resting order can't be left partially filled by a market move. Partial-fill replace realism is
+therefore a venue e2e concern, not a sim one, until the OME gains size-aware matching.
+
 ## Runtimes & wiring
 
 - **Live:** runner builds connectors via the registry, the AM (with per-exchange base

--- a/docs/superpowers/plans/2026-08-05-order-replace-orchestration.md
+++ b/docs/superpowers/plans/2026-08-05-order-replace-orchestration.md
@@ -1,0 +1,462 @@
+# Order Replace Orchestration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ctx.update_order` correct for partially-filled orders on every venue by (a) fixing the `Order.quantity` bookkeeping invariant and (b) routing quantity updates of partially-filled orders through a framework-side cancel+replace orchestration instead of venue-native amend.
+
+**Architecture:** The orchestration lives entirely **above the `IConnector` boundary** — in the TradingManager (initiation), the account reducer (terminal-event interception), and the account Reconciler/manager `_execute` action pattern (decision + I/O). Connectors contribute only two things: their existing `cancel_order`/`submit_order` primitives, and an optional enrichment of the terminal cancel event with the venue's final fill figure. The replacement reuses the **same client_order_id** (the same-cid splice HL's native modify already performs), so callers like quantkit's maker-taker slots see one continuous non-terminal order — no API change for strategies.
+
+**Tech Stack:** Python 3.12, qubx core (`src/qubx/core/`), pytest (`tests/qubx/core/account_manager/`).
+
+## Global Constraints
+
+- `Order.quantity` is ABSOLUTE (unsigned); side is carried separately. This plan makes it mean **total including everything ever filled on this client order id** — at all times, on every venue.
+- `update_order(price, amount)` contract: **`amount` = desired signed REMAINING to keep working** (sign must match order side). This matches the only existing caller (quantkit passes `signed_remaining`).
+- Native venue amend is used **only when `filled_quantity == 0`** — the one case where every venue dialect (HL replace-size, Binance/Gate new-total) coincides.
+- No per-venue amend adapters. No changes to the `IConnector` Protocol beyond an optional event field.
+- Connectors are stateless adapters (see `src/qubx/core/connector.py` docstring) — no replace state may live in a connector.
+- Failure contract: when a replace cannot complete, degrade to **truth** (order reported CANCELED / UPDATE_REJECTED as appropriate), never to fiction ("order alive" when it is dead).
+
+## Background (why — read before implementing)
+
+Incident 2026-08-05 (dev frab bot, pair ACE): repricing a partially-filled HL maker order poisoned the qubx Order record. HL modify = cancel+replace under the same client id; `_handle_updated` (reducer.py:472-473) overwrote `order.quantity` with the amended (remaining) size while `record_fill` (basics.py:865-880) kept `filled_quantity` cumulative → `remaining = quantity − filled` went **negative** (log-verified: −183.08, −580.92, −475.86). Downstream, quantkit's `effective_position` read a fictional maker position, trimmed the wrong leg, and livelocked for 2.5 minutes. On Binance/Gate the same call pattern is wrong differently: their amend-quantity means *new total* with executedQty preserved, so sending "remaining" silently double-shrinks the working order. Design discussion: frab session "refactor", 2026-08-05.
+
+## Event flow (target design)
+
+```
+strategy thread                     connector event loop            AM (reducer/reconciler/_execute)
+---------------                     --------------------            --------------------------------
+update_order(price, amount)
+  filled == 0 ──────────────────►   native editOrder ──ack──►       _handle_updated: splice quantity
+  filled > 0:
+    arm ReplaceIntent(cid)
+    order → PENDING_UPDATE
+    connector.cancel_order ─────►   REST cancel ──ack/WS──►         _handle_canceled: intent armed →
+                                                                      suppress terminal, stash final fills
+                                                                    reconciler.on_event → SubmitReplacement
+                                                                      or AbandonReplace (residual < min)
+                                                                    _execute:
+                                                                      SubmitReplacement: splice via routed
+                                                                        OrderUpdatedEvent + connector.submit_order
+                                                                        (same cid, residual qty)
+                                                                      AbandonReplace: clear intent + route
+                                                                        OrderCanceledEvent (truth)
+```
+
+Existing machinery reused (do NOT reimplement): `PENDING_UPDATE` re-entrancy no-op (trading.py:387), `pre_pending` status capture, `set_venue_id` re-keying, `_is_superseded_oid_cancel` stale-cancel guard (reducer.py:230-246), the `RequestStatus`/`RouteEvent` action pattern (account_manager/reconciler.py:55-90, manager.py:276-312).
+
+---
+
+### Task 1: Reducer splice invariant — `quantity = filled + new_quantity`
+
+The one-line root fix. Ships value even without the rest of the plan (it fixes HL native-modify poisoning immediately).
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/reducer.py:463-479` (`_handle_updated`)
+- Test: `tests/qubx/core/account_manager/reducer_test.py`
+
+**Interfaces:**
+- Produces: `_handle_updated` semantics — `event.new_quantity` is the desired REMAINING; the handler maintains `order.quantity = order.filled_quantity + event.new_quantity`.
+
+- [ ] **Step 1: Write the failing regression test** (mirror existing reducer_test.py fixtures for building a state with one active order — copy the setup pattern from the nearest `_handle_updated` test in that file):
+
+```python
+def test_updated_after_partial_fill_keeps_remaining_positive(state_with_order):
+    """ACE 2026-08-05 regression: amend of a partially-filled order must not
+    produce quantity < filled_quantity (negative remaining)."""
+    state, order = state_with_order  # BUY 1344.92, ACCEPTED
+    order.record_fill(764.0, 0.0719)
+
+    apply_event(state, OrderUpdatedEvent(
+        instrument=None, client_order_id=order.client_order_id,
+        venue_order_id="new-vid", new_price=0.072, new_quantity=580.92,
+    ))
+
+    assert order.quantity == pytest.approx(764.0 + 580.92)          # total incl. filled
+    assert order.quantity - order.filled_quantity == pytest.approx(580.92)  # remaining = what was sent
+
+    # more fills arrive on the replacement — remaining must NEVER go negative
+    order.record_fill(292.78, 0.0722)
+    assert order.quantity - order.filled_quantity >= 0
+```
+
+- [ ] **Step 2: Run to verify it fails** — `uv run pytest tests/qubx/core/account_manager/reducer_test.py -k remaining_positive -v` → FAIL (quantity == 580.92, remaining negative after second fill).
+
+- [ ] **Step 3: Implement.** In `_handle_updated`, replace `order.quantity = event.new_quantity` with:
+
+```python
+    if event.new_quantity is not None:
+        # new_quantity is the desired REMAINING. quantity's invariant is
+        # total-including-filled, so splice the cumulative fills back in —
+        # otherwise remaining (quantity - filled) goes negative after the
+        # first amend of a partially-filled order (ACE incident 2026-08-05).
+        order.quantity = order.filled_quantity + event.new_quantity
+```
+
+- [ ] **Step 4: Run the reducer suite** — `uv run pytest tests/qubx/core/account_manager/reducer_test.py -v` → all PASS. If an existing test asserts the old overwrite semantics, update that test's expectation to the splice (its old expectation is the bug).
+
+- [ ] **Step 5: Commit** — `git commit -m "fix(account): amend ack splices quantity as filled + remaining, never overwrites"`
+
+---
+
+### Task 2: `update_order` contract — sign validation + routing rule
+
+**Files:**
+- Modify: `src/qubx/core/mixins/trading.py:363-411` (`update_order`)
+- Test: `tests/qubx/core/` — find the trading-mixin test module via `grep -rn "def test.*update_order" tests/`; add there (create `tests/qubx/core/trading_update_order_test.py` if none exists, reusing whatever context/mock fixtures the nearest trading test uses).
+
+**Interfaces:**
+- Consumes: `AccountManagerFacade.arm_replace_intent(exchange, client_order_id, desired_remaining, price, filled_at_request)` — defined in Task 3. Until Task 3 lands, guard the new branch behind the intent-arm call and implement Tasks 2+3 on one branch, committing after both suites pass (they are one reviewable unit with Task 3; split shown here for readability).
+- Produces: routing behavior — `filled == 0` → native `connector.update_order` (unchanged); `filled > 0` → replace path (no native amend call).
+
+- [ ] **Step 1: Write failing tests:**
+
+```python
+def test_update_order_rejects_sign_mismatch(trading_ctx):
+    ctx, order = trading_ctx  # BUY order, ACCEPTED, filled 0
+    with pytest.raises(ValueError, match="sign"):
+        ctx.update_order(price=1.0, amount=-5.0, client_order_id=order.client_order_id)
+
+def test_update_order_partially_filled_routes_to_cancel(trading_ctx):
+    ctx, order = trading_ctx
+    order.record_fill(3.0, 1.0)
+    ctx.update_order(price=1.01, amount=7.0, client_order_id=order.client_order_id)
+    connector = ctx._connector_mock
+    connector.update_order.assert_not_called()          # NO native amend
+    connector.cancel_order.assert_called_once()          # replace path starts with cancel
+    assert order.status is OrderStatus.PENDING_UPDATE
+
+def test_update_order_unfilled_uses_native_amend(trading_ctx):
+    ctx, order = trading_ctx  # filled == 0
+    ctx.update_order(price=1.01, amount=10.0, client_order_id=order.client_order_id)
+    ctx._connector_mock.update_order.assert_called_once()
+    ctx._connector_mock.cancel_order.assert_not_called()
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement.** In `update_order`, after the existing resolve/terminal/PENDING_UPDATE checks and `_adjust_size`/`_adjust_price`:
+
+```python
+        if amount == 0 or (amount > 0) != (order.side == OrderSide.BUY):
+            raise ValueError(
+                f"update_order amount {amount} sign does not match order side {order.side} "
+                f"for {order.client_order_id} — amount is the desired signed remaining"
+            )
+
+        cid = order.client_order_id
+        if order.filled_quantity > 0:
+            # Venue amend dialects disagree once fills exist (HL: replace-size;
+            # Binance/Gate: new-total with executedQty kept). Route through the
+            # framework cancel+replace orchestration instead.
+            self._account_manager.arm_replace_intent(
+                instrument.exchange, cid,
+                desired_remaining=abs(amount), price=adjusted_price,
+                filled_at_request=order.filled_quantity,
+            )
+            self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
+            self._get_connector(instrument.exchange).cancel_order(order)
+            return
+```
+
+Keep the existing native path (PENDING_UPDATE transition + `connector.update_order(...)` + synchronous-failure revert) for the `filled == 0` case, unchanged except it now runs only in that case.
+
+- [ ] **Step 4: Run the tests** → PASS. **Step 5: Commit** with Task 3.
+
+---
+
+### Task 3: `ReplaceIntent` table in `AccountState` + manager facade
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/state.py` (fields at :48-70, methods nearby)
+- Modify: `src/qubx/core/account_manager/manager.py` (facade methods next to `transition_order` — locate via `grep -n "def transition_order" src/qubx/core/account_manager/manager.py`)
+- Test: `tests/qubx/core/account_manager/state_test.py`
+
+**Interfaces:**
+- Produces:
+  - `@dataclass ReplaceIntent: desired_remaining: float; price: float | None; filled_at_request: float; armed_at: np.datetime64; filled_at_cancel: float | None = None`
+  - `AccountState.arm_replace_intent(cid, intent)`, `AccountState.get_replace_intent(cid) -> ReplaceIntent | None`, `AccountState.clear_replace_intent(cid) -> ReplaceIntent | None`, `AccountState.replace_intents() -> dict[str, ReplaceIntent]` (read-only view for expiry sweep)
+  - `AccountManager.arm_replace_intent(exchange, cid, *, desired_remaining, price, filled_at_request)` — resolves the state and stamps `armed_at` from `self._time.time()`.
+
+- [ ] **Step 1: Failing tests** in `state_test.py`:
+
+```python
+def test_replace_intent_arm_get_clear():
+    state = AccountState("TEST", "USDT")
+    intent = ReplaceIntent(desired_remaining=7.0, price=1.01, filled_at_request=3.0,
+                           armed_at=np.datetime64("2026-08-05T16:05:20", "ns"))
+    state.arm_replace_intent("cid-1", intent)
+    assert state.get_replace_intent("cid-1") is intent
+    assert state.clear_replace_intent("cid-1") is intent
+    assert state.get_replace_intent("cid-1") is None
+    assert state.clear_replace_intent("cid-1") is None  # idempotent
+```
+
+- [ ] **Step 2: verify fail. Step 3: implement** — `self._replace_intents: dict[str, ReplaceIntent] = {}` in `__init__`, plus the four trivial methods and the manager facade. **Step 4: run state_test.py + the Task 2 tests → PASS. Step 5: Commit** — `git commit -m "feat(account): replace-intent table + partially-filled update_order routes to cancel+replace"`
+
+---
+
+### Task 4: Reducer interception — suppress the internal cancel, record final fills
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/reducer.py:248-255` (`_handle_canceled`), the FILLED terminal handler (`grep -n "_handle_fill" reducer.py`), and `_handle_cancel_rejected` (reducer.py:500-506)
+- Test: `tests/qubx/core/account_manager/reducer_test.py`
+
+**Interfaces:**
+- Consumes: Task 3's intent table; Task 5's `OrderCanceledEvent.venue_filled_quantity`.
+- Produces: an armed intent makes the CANCELED terminal **suppressed** (order stays PENDING_UPDATE, `intent.filled_at_cancel` populated, `ApplyResult()` empty); FILLED clears the intent and flows normally; a cancel-reject with an armed intent clears it and reverts via `pre_pending` with `OrderChange.UPDATE_REJECTED`.
+
+- [ ] **Step 1: Failing tests:**
+
+```python
+def test_canceled_with_armed_intent_is_suppressed(state_with_order):
+    state, order = state_with_order
+    order.record_fill(3.0, 1.0)
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW))
+    transition(state, order.client_order_id, OrderStatus.PENDING_UPDATE, NOW)
+
+    result = apply_event(state, OrderCanceledEvent(
+        instrument=None, client_order_id=order.client_order_id,
+        venue_order_id=order.venue_order_id, venue_filled_quantity=3.5))
+
+    assert result.is_empty()                                   # no strategy callback
+    assert order.status is OrderStatus.PENDING_UPDATE          # NOT terminal
+    assert state.get_replace_intent(order.client_order_id).filled_at_cancel == 3.5
+
+def test_canceled_without_venue_fill_figure_falls_back_to_record(state_with_order):
+    ...  # same, venue_filled_quantity=None → filled_at_cancel == order.filled_quantity
+
+def test_filled_terminal_clears_intent_and_flows(state_with_order):
+    ...  # armed intent + OrderFilledEvent → intent cleared, order FILLED, result not empty
+
+def test_cancel_rejected_with_intent_reverts_to_truth(state_with_order):
+    ...  # armed intent, PENDING_UPDATE + OrderCancelRejectedEvent →
+    ...  # intent cleared, status reverted via pre_pending, change == UPDATE_REJECTED
+```
+
+- [ ] **Step 2: verify fail. Step 3: implement.** In `_handle_canceled`, after the superseded-oid guard (keep it FIRST — it must still drop stale cancels of replaced venue ids):
+
+```python
+    intent = state.get_replace_intent(order.client_order_id)
+    if intent is not None:
+        # Internal cancel of a replace orchestration: not a terminal for the
+        # strategy — the same-cid replacement is about to be submitted. Record
+        # the venue's authoritative final fill so the residual is computed from
+        # truth (fills that raced the cancel are included).
+        intent.filled_at_cancel = (
+            event.venue_filled_quantity
+            if event.venue_filled_quantity is not None
+            else order.filled_quantity
+        )
+        return ApplyResult()
+```
+
+In the FILLED terminal handler add `state.clear_replace_intent(order.client_order_id)` before normal processing. In `_handle_cancel_rejected` add the PENDING_UPDATE + intent branch (clear intent, `_revert_from_pending(..., OrderChange.UPDATE_REJECTED, ...)`).
+
+- [ ] **Step 4: run reducer_test.py → PASS. Step 5: Commit** — `git commit -m "feat(account): replace-intent intercepts internal cancel; filled/reject paths degrade to truth"`
+
+---
+
+### Task 5: `OrderCanceledEvent.venue_filled_quantity` + ccxt enrichment
+
+**Files:**
+- Modify: `src/qubx/core/events.py:110-112` (`OrderCanceledEvent`)
+- Modify: `src/qubx/connectors/ccxt/connector.py` (`_emit_canceled_from_response` — locate via `grep -n "_emit_canceled_from_response"`)
+- Test: `tests/qubx/core/account_manager/reducer_test.py` (event field), connector unit tests (`grep -rn "emit_canceled" tests/` for the module that tests cancel emission; add there)
+
+**Interfaces:**
+- Produces: `OrderCanceledEvent(..., venue_filled_quantity: float | None = None)`; the ccxt cancel-ack emitter populates it from the response's unified `filled` field when the venue returns one (Binance futures cancel response carries `executedQty` → ccxt unified `filled`).
+
+- [ ] **Step 1: failing test** — build a fake ccxt cancel response dict with `{"filled": 3.5}`, call `_emit_canceled_from_response`, assert the sent event has `venue_filled_quantity == 3.5`; and a response without `filled` → `None`.
+- [ ] **Step 2: verify fail. Step 3: implement** — add the field with default `None` (keeps every existing constructor call site valid); in the emitter: `venue_filled_quantity=response.get("filled") if isinstance(response, dict) else None` (coerce via `float()` when present).
+- [ ] **Step 4: run both suites → PASS. Step 5: Commit** — `git commit -m "feat(events): terminal cancel carries the venue's final fill figure when reported"`
+
+---
+
+### Task 6: Reconciler decision — `SubmitReplacement` / `AbandonReplace`
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/reconciler.py` (action dataclasses next to `RequestStatus` at :55; decision in `on_event` — locate via `grep -n "def on_event" reconciler.py`)
+- Test: `tests/qubx/core/account_manager/reconciler_test.py`
+
+**Interfaces:**
+- Produces:
+
+```python
+@dataclass(frozen=True)
+class SubmitReplacement:
+    cid: str
+
+@dataclass(frozen=True)
+class AbandonReplace:
+    cid: str
+    reason: str = ""
+```
+
+  `on_event` returns `[SubmitReplacement(cid)]` when a suppressed cancel's residual is executable, `[AbandonReplace(cid, reason)]` when not. Residual formula (all magnitudes): `residual = intent.desired_remaining - max(0.0, (intent.filled_at_cancel or 0.0) - intent.filled_at_request)`.
+
+- [ ] **Step 1: failing tests:**
+
+```python
+def test_on_event_canceled_with_intent_submits_replacement(...):
+    # intent: desired 7.0, filled_at_request 3.0, filled_at_cancel 3.5 → residual 6.5
+    actions = rec.on_event(state, canceled_event, NOW)
+    assert actions == [SubmitReplacement(cid)]
+
+def test_on_event_residual_below_min_abandons(...):
+    # desired 7.0, filled_at_request 3.0, filled_at_cancel 9.9 → residual 0.1 < min_size
+    actions = rec.on_event(state, canceled_event, NOW)
+    assert isinstance(actions[0], AbandonReplace)
+
+def test_on_event_canceled_without_intent_unchanged(...):
+    # no intent → whatever on_event returned before this task (assert no new action types)
+```
+
+- [ ] **Step 2: verify fail. Step 3: implement** — in `on_event`, before existing logic:
+
+```python
+        if isinstance(event, OrderCanceledEvent):
+            cid = event.client_order_id
+            intent = state.get_replace_intent(cid) if cid else None
+            if intent is not None and intent.filled_at_cancel is not None:
+                order = state.get_order(cid)
+                raced = max(0.0, intent.filled_at_cancel - intent.filled_at_request)
+                residual = intent.desired_remaining - raced
+                min_size = order.instrument.min_size if order and order.instrument else 0.0
+                if order is None or residual < max(min_size, 0.0) or residual <= 0.0:
+                    return [AbandonReplace(cid, reason=f"residual {residual} below min")]
+                return [SubmitReplacement(cid)]
+```
+
+- [ ] **Step 4: run reconciler_test.py → PASS. Step 5: Commit** — `git commit -m "feat(account): reconciler decides replacement vs abandon from post-cancel residual"`
+
+---
+
+### Task 7: `_execute` performs the replacement (or the truthful abandon)
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/manager.py:276-312` (`_execute` match)
+- Test: `tests/qubx/core/account_manager/manager_test.py`
+
+**Interfaces:**
+- Consumes: Tasks 3-6. Mirror `TradingManager.trade`'s `OrderRequest` construction (trading.py:158-176) for field names — reduce_only/post_only travel exactly as `trade()` sends them; copy that construction, do not invent field names.
+- Produces: two new `_execute` cases.
+
+- [ ] **Step 1: failing tests** (fixture pattern: `manager_test.py` already builds a manager with a mock connector — reuse):
+
+```python
+def test_execute_submit_replacement_splices_and_submits(manager_with_order):
+    mgr, state, order, connector = manager_with_order   # BUY 10, filled 3.5, PENDING_UPDATE
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=3.5))
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])
+
+    req = connector.submit_order.call_args.args[0]
+    assert req.client_id == order.client_order_id            # same-cid splice
+    assert req.quantity == pytest.approx(6.5)                # residual 7.0 - 0.5, signed BUY
+    assert req.price == 1.01
+    assert order.quantity == pytest.approx(3.5 + 6.5)        # invariant restored
+    assert state.get_replace_intent(order.client_order_id) is None
+    assert order.status is not None and not order.status.is_terminal
+
+def test_execute_abandon_replace_reports_canceled_truth(manager_with_order):
+    mgr, state, order, connector = manager_with_order
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 3.0, 3.0, NOW, filled_at_cancel=9.9))
+    mgr._execute(state, [AbandonReplace(order.client_order_id, "residual below min")])
+    assert state.get_replace_intent(order.client_order_id) is None
+    assert order.status is OrderStatus.CANCELED              # truth surfaced via routed event
+```
+
+- [ ] **Step 2: verify fail. Step 3: implement** — new match arms in `_execute`:
+
+```python
+                    case SubmitReplacement(cid=cid):
+                        order = state.get_order(cid)
+                        intent = state.clear_replace_intent(cid)
+                        if order is None or intent is None or connector is None:
+                            logger.warning(f"[{state.exchange}] SubmitReplacement dropped: {cid}")
+                            continue
+                        raced = max(0.0, (intent.filled_at_cancel or 0.0) - intent.filled_at_request)
+                        residual = intent.desired_remaining - raced
+                        signed = residual if order.side == OrderSide.BUY else -residual
+                        request = ...  # build exactly as TradingManager.trade (trading.py:158-176),
+                                       # with client_id=cid, quantity=signed, price=intent.price,
+                                       # order_type/side/time_in_force/reduce_only/post_only from `order`
+                        connector.submit_order(request)
+                        # Splice + strategy notification via the normal reducer path (idempotent
+                        # with Task 1's rule: quantity = filled + residual).
+                        if self._pm is not None:
+                            self._pm.process_event(OrderUpdatedEvent(
+                                instrument=None, client_order_id=cid,
+                                venue_order_id=None, new_price=intent.price,
+                                new_quantity=residual))
+
+                    case AbandonReplace(cid=cid, reason=reason):
+                        order = state.get_order(cid)
+                        state.clear_replace_intent(cid)
+                        logger.warning(f"[{state.exchange}] replace abandoned for {cid}: {reason}")
+                        if self._pm is not None and order is not None:
+                            self._pm.process_event(OrderCanceledEvent(
+                                instrument=None, client_order_id=cid,
+                                venue_order_id=order.venue_order_id))
+```
+
+Note the `RouteEvent` reentrancy comment at manager.py:296-301 — `process_event` is the same synchronous re-entry pattern; keep the ordering **submit first, then route** so the strategy's UPDATED callback observes the intent already cleared.
+
+- [ ] **Step 4: run manager_test.py → PASS. Step 5: verify end-to-end at unit level** — add one test driving the full chain: `apply(OrderCanceledEvent with intent)` → assert connector.submit_order called and order non-terminal with spliced quantity (this exercises `_apply_to_state` → reducer suppress → `rec.on_event` → `_execute`). **Step 6: Commit** — `git commit -m "feat(account): _execute submits same-cid replacement or surfaces the truthful cancel"`
+
+---
+
+### Task 8: Stale-intent expiry + superseded-oid regression
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/reconciler.py` (periodic tick — locate the reconcile-tick entry via `grep -n "def on_tick\|reconcile_tick" reconciler.py manager.py`)
+- Test: `tests/qubx/core/account_manager/reconciler_test.py`
+
+- [ ] **Step 1: failing tests** — (a) an intent with `armed_at` 30s+ ago and `filled_at_cancel is None` (cancel outcome unknown) → tick returns `[AbandonReplace(cid, "intent expired"), RequestStatus(cid)]`; (b) regression: after a replacement is live (order venue id "B"), a late `OrderCanceledEvent(venue_order_id="A")` is dropped by `_is_superseded_oid_cancel` — order stays non-terminal.
+- [ ] **Step 2: verify (b) already passes** (the guard exists — this pins it for the replace flow); (a) fails.
+- [ ] **Step 3: implement** the expiry sweep in the periodic tick: `REPLACE_INTENT_MAX_AGE = np.timedelta64(30, "s")` module constant; iterate `state.replace_intents()`, emit the two actions per expired entry.
+- [ ] **Step 4: run → PASS. Step 5: Commit** — `git commit -m "feat(account): stale replace intents expire to truth + status refetch"`
+
+---
+
+### Task 9: Sim parity — integration test through the backtester OME
+
+**Files:**
+- Test: locate the sim execution-integration tests via `grep -rln "update_order" tests/qubx/backtester/` and add alongside; if none exists, create `tests/qubx/backtester/update_partially_filled_test.py` reusing the simulator setup from the nearest OME/limit-order test.
+
+- [ ] **Step 1: write the scenario test** (this is the ACE replay, in sim):
+
+```python
+def test_reprice_partially_filled_limit_keeps_remaining_correct(sim_ctx):
+    # 1. place BUY limit 1000 below touch; 2. move market so ~300 fills;
+    # 3. ctx.update_order(price=new, amount=700); 4. fill the rest.
+    order = ...  # after step 3, read via ctx.find_order_by_client_id
+    assert order.quantity - order.filled_quantity == pytest.approx(700)   # never negative
+    # after step 4:
+    assert ctx.get_position(instrument).quantity == pytest.approx(300 + 700)
+```
+
+- [ ] **Step 2: run — if the sim connector's `update_order` (backtester/connector.py:108) semantics diverge (e.g., it resets filled), fix the SIM to mirror the live contract (amount = desired remaining), not vice versa.** The sim goes through the same AM path, so Tasks 1-7 apply automatically; this test pins it.
+- [ ] **Step 3: PASS → Commit** — `git commit -m "test(backtester): partially-filled reprice keeps remaining truthful through the sim"`
+
+---
+
+### Task 10: Docs
+
+- [ ] Update `docs/account-management/design.md`: new subsection "Order updates and the replace orchestration" — the contract (amount = desired remaining), the invariant (quantity = total incl. filled), the routing rule, the intent lifecycle, the failure contract table. One page, follow the doc's existing voice.
+- [ ] Commit — `git commit -m "docs(account): order-replace orchestration design"`
+
+---
+
+## Self-review checklist (run after writing code)
+
+- Spec coverage: Tasks 1-9 map to: splice invariant ✓, sign validation ✓, routing ✓, intent table ✓, suppress/truth paths ✓, venue fill figure ✓, decision ✓, I/O ✓, expiry ✓, superseded-oid ✓, sim parity ✓.
+- The Binance/Gate double-shrink is fixed by *never native-amending at filled > 0* — verify no code path can reach `connector.update_order` with `order.filled_quantity > 0`.
+- Grep the final diff for `order.quantity =` — the ONLY assignments must be initial construction and the Task 1 splice.
+
+## Non-goals (explicitly out of scope)
+
+- Per-venue amend translation (eliminated by the routing rule).
+- The BINANCE.PM missing order-stream / `AwaitOrderConfirm LOST` re-fire defect (KAITO over-fill facet) — separate connector work.
+- Conformance/e2e coverage — see `exchanges:docs/superpowers/plans/2026-08-05-cancel-fill-reporting-conformance.md`.
+- quantkit consumer hardening — see `quantkit:docs/superpowers/plans/2026-08-05-maker-taker-venue-truth.md`.

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -513,7 +513,10 @@ class CcxtConnector(ChannelEmitter):
                 cid = cid or response.get("clientOrderId")
             filled = response.get("filled")
             if filled is not None:
-                venue_filled_quantity = float(filled)
+                try:
+                    venue_filled_quantity = float(filled)
+                except (TypeError, ValueError):
+                    venue_filled_quantity = None
         self.send(
             OrderCanceledEvent(
                 instrument=instrument,

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -505,15 +505,21 @@ class CcxtConnector(ChannelEmitter):
         instrument: Instrument | None = None
         cid = client_order_id
         vid = venue_order_id
-        if isinstance(response, dict) and response.get("id") is not None:
-            # ccxt echoes the order; recover ids from it when we lack them.
-            vid = vid or str(response.get("id"))
-            cid = cid or response.get("clientOrderId")
+        venue_filled_quantity: float | None = None
+        if isinstance(response, dict):
+            if response.get("id") is not None:
+                # ccxt echoes the order; recover ids from it when we lack them.
+                vid = vid or str(response.get("id"))
+                cid = cid or response.get("clientOrderId")
+            filled = response.get("filled")
+            if filled is not None:
+                venue_filled_quantity = float(filled)
         self.send(
             OrderCanceledEvent(
                 instrument=instrument,
                 client_order_id=cid,
                 venue_order_id=vid,
+                venue_filled_quantity=venue_filled_quantity,
             )
         )
 

--- a/src/qubx/core/account_manager/__init__.py
+++ b/src/qubx/core/account_manager/__init__.py
@@ -18,7 +18,7 @@ surface as the event-typed apply path it implements.
 from qubx.core.account_manager.config import AccountManagerConfig
 from qubx.core.account_manager.manager import AccountManager, SimulatedAccountManager
 from qubx.core.account_manager.reducer import ApplyResult
-from qubx.core.account_manager.state import AccountState, VenueAccountFigures
+from qubx.core.account_manager.state import AccountState, ReplaceIntent, VenueAccountFigures
 from qubx.core.account_manager.state_machine import (
     TRANSITIONS,
     can_transition,
@@ -65,6 +65,7 @@ __all__ = [
     "SimulatedAccountManager",
     "AccountManagerConfig",
     "ApplyResult",
+    "ReplaceIntent",
     "VenueAccountFigures",
     "TRANSITIONS",
     "can_transition",

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -16,11 +16,13 @@ from qubx.core.account_manager import reducer
 from qubx.core.account_manager.config import AccountManagerConfig
 from qubx.core.account_manager.diffs import Differ
 from qubx.core.account_manager.reconciler import (
+    AbandonReplace,
     Reconciler,
     RequestHistDeals,
     RequestSnapshot,
     RequestStatus,
     RouteEvent,
+    SubmitReplacement,
 )
 from qubx.core.account_manager.reducer import ApplyResult
 from qubx.core.account_manager.state import AccountState, ReplaceIntent
@@ -32,6 +34,7 @@ from qubx.core.basics import (
     ITimeProvider,
     Order,
     OrderOrigin,
+    OrderRequest,
     OrderStatus,
     Position,
     TransactionCostsCalculator,
@@ -42,7 +45,9 @@ from qubx.core.events import (
     AccountSnapshotEvent,
     BalanceUpdateEvent,
     FundingPaymentEvent,
+    OrderCanceledEvent,
     OrderEvent,
+    OrderUpdatedEvent,
 )
 from qubx.core.interfaces import IAccountConfigurator, IAccountViewer, IProcessingManager
 from qubx.utils.time import timedelta_to_crontab
@@ -320,6 +325,80 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
                                 f"<y>{instrument.symbol}</y> since {since} -> connector.request_hist_deals"
                             )
                             connector.request_hist_deals(instrument, since)
+
+                    case SubmitReplacement(cid=cid):
+                        order = state.get_order(cid)
+                        intent = state.clear_replace_intent(cid)
+                        if order is None or intent is None or connector is None:
+                            logger.warning(
+                                f"[{state.exchange}] SubmitReplacement dropped "
+                                f"(order/intent/connector missing): {cid}"
+                            )
+                            continue
+                        raced = max(0.0, (intent.filled_at_cancel or 0.0) - intent.filled_at_request)
+                        # residual is unsigned (desired_remaining is already abs, per
+                        # TradingManager._adjust_size) and > 0 — the reconciler's
+                        # _decide_replace only emits SubmitReplacement past that gate.
+                        # Mirror TradingManager.trade's OrderRequest construction (trading.py
+                        # ~158-176): quantity is UNSIGNED (side carries direction, exactly like
+                        # ccxt's create_order(amount, side)) — do not sign it here. Same-cid
+                        # resubmit; options carried forward but reduce_only/post_only re-stamped
+                        # from the order record (the source of truth).
+                        residual = intent.desired_remaining - raced
+                        options = dict(order.options)
+                        options.pop("reduce_only", None)
+                        options["reduceOnly"] = order.reduce_only
+                        options["post_only"] = order.post_only
+                        request = OrderRequest(
+                            instrument=order.instrument,
+                            quantity=residual,
+                            price=intent.price,
+                            order_type=order.type,
+                            side=order.side,
+                            time_in_force=order.time_in_force,
+                            client_id=cid,
+                            options=options,
+                        )
+                        connector.submit_order(request)
+                        # Splice + strategy notification via the normal reducer path (idempotent
+                        # with Task 1's rule: quantity = filled + residual). Submit FIRST, then
+                        # route — the strategy's UPDATED callback must observe the intent already
+                        # cleared (see RouteEvent above: process_event is a synchronous re-entry
+                        # into apply()).
+                        if self._pm is not None:
+                            self._pm.process_event(
+                                OrderUpdatedEvent(
+                                    instrument=None,
+                                    client_order_id=cid,
+                                    venue_order_id=None,
+                                    new_price=intent.price,
+                                    new_quantity=residual,
+                                )
+                            )
+                        else:
+                            logger.warning(
+                                f"[{state.exchange}] no processing manager wired; {cid} "
+                                "replacement submitted but not routed"
+                            )
+
+                    case AbandonReplace(cid=cid, reason=reason):
+                        order = state.get_order(cid)
+                        state.clear_replace_intent(cid)
+                        logger.warning(f"[{state.exchange}] replace abandoned for {cid}: {reason}")
+                        if order is None:
+                            continue
+                        if self._pm is not None:
+                            self._pm.process_event(
+                                OrderCanceledEvent(
+                                    instrument=None,
+                                    client_order_id=cid,
+                                    venue_order_id=order.venue_order_id,
+                                )
+                            )
+                        else:
+                            logger.warning(
+                                f"[{state.exchange}] no processing manager wired; {cid} abandon not routed"
+                            )
 
                     case _:
                         logger.warning(f"[{state.exchange}] unknown reconcile action: {action!r}")

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -359,7 +359,27 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
                             client_id=cid,
                             options=options,
                         )
-                        connector.submit_order(request)
+                        try:
+                            connector.submit_order(request)
+                        except Exception:
+                            # By this point the venue-side cancel of the OLD order already
+                            # succeeded (that's the precondition for this decision to fire) —
+                            # so a failed resubmit leaves nothing live at the venue. Surface
+                            # that truth (mirrors trade()'s remove_order-and-reraise and
+                            # update_order's clear+route on a synchronous submit failure)
+                            # instead of leaving the order stuck at a false PENDING_UPDATE.
+                            logger.exception(
+                                f"[{state.exchange}] SubmitReplacement submit failed for {cid}; surfacing cancel"
+                            )
+                            if self._pm is not None:
+                                self._pm.process_event(
+                                    OrderCanceledEvent(
+                                        instrument=None,
+                                        client_order_id=cid,
+                                        venue_order_id=order.venue_order_id,
+                                    )
+                                )
+                            continue
                         # Splice + strategy notification via the normal reducer path (idempotent
                         # with Task 1's rule: quantity = filled + residual). Submit FIRST, then
                         # route — the strategy's UPDATED callback must observe the intent already

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -199,6 +199,9 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
         )
         self._states[exchange].arm_replace_intent(cid, intent)
 
+    def clear_replace_intent(self, exchange: str, cid: str) -> ReplaceIntent | None:
+        return self._states[exchange].clear_replace_intent(cid)
+
     def remove_order(self, exchange: str, cid: str) -> None:
         self._states[exchange].remove_order(cid)
 

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -23,7 +23,7 @@ from qubx.core.account_manager.reconciler import (
     RouteEvent,
 )
 from qubx.core.account_manager.reducer import ApplyResult
-from qubx.core.account_manager.state import AccountState
+from qubx.core.account_manager.state import AccountState, ReplaceIntent
 from qubx.core.basics import (
     ZERO_COSTS,
     Balance,
@@ -185,6 +185,19 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
 
     def transition_order(self, exchange: str, cid: str, new_status: OrderStatus) -> None:
         reducer.transition(self._states[exchange], cid, new_status, self._time.time())
+
+    def arm_replace_intent(
+        self, exchange: str, cid: str, *, desired_remaining: float, price: float | None, filled_at_request: float
+    ) -> None:
+        """Arm the cancel+replace orchestration for a partially-filled `update_order`
+        (TradingManager routing) — stamps `armed_at` from the AM clock."""
+        intent = ReplaceIntent(
+            desired_remaining=desired_remaining,
+            price=price,
+            filled_at_request=filled_at_request,
+            armed_at=self._time.time(),
+        )
+        self._states[exchange].arm_replace_intent(cid, intent)
 
     def remove_order(self, exchange: str, cid: str) -> None:
         self._states[exchange].remove_order(cid)

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -380,11 +380,21 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
                                     )
                                 )
                             continue
+                        if intent.canceled_venue_oid is not None:
+                            # The replacement is live under the same cid: the id the cancel killed
+                            # is dead news. Marked only after a successful submit — the failure
+                            # branch above still has to surface a cancel for that very id.
+                            state.mark_superseded_oid(cid, intent.canceled_venue_oid)
                         # Splice + strategy notification via the normal reducer path (idempotent
                         # with Task 1's rule: quantity = filled + residual). Submit FIRST, then
                         # route — the strategy's UPDATED callback must observe the intent already
                         # cleared (see RouteEvent above: process_event is a synchronous re-entry
                         # into apply()).
+                        # The reducer splices against LOCAL filled_quantity, which lags when the
+                        # cancel ack counted fills whose deals haven't booked yet — compensate so
+                        # the splice lands on filled_at_cancel + residual either way (the lagging
+                        # deal still dedupes by trade id when it arrives).
+                        route_quantity = residual + max(0.0, (intent.filled_at_cancel or 0.0) - order.filled_quantity)
                         if self._pm is not None:
                             self._pm.process_event(
                                 OrderUpdatedEvent(
@@ -392,7 +402,7 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
                                     client_order_id=cid,
                                     venue_order_id=None,
                                     new_price=intent.price,
-                                    new_quantity=residual,
+                                    new_quantity=route_quantity,
                                 )
                             )
                         else:

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -29,12 +29,13 @@ from qubx.core.account_manager.diffs import (
     PositionFieldMismatch,
     PositionSizeMismatch,
 )
-from qubx.core.account_manager.state import AccountState, VenueAccountFigures
+from qubx.core.account_manager.state import AccountState, ReplaceIntent, VenueAccountFigures
 from qubx.core.account_manager.state_machine import can_transition
 from qubx.core.basics import EXTERNAL_CID_PREFIX, Instrument, Order, OrderOrigin, OrderStatus, Position
 from qubx.core.events import (
     AccountSnapshot,
     DealEvent,
+    OrderCanceledEvent,
     OrderLostEvent,
     OrderPartiallyFilledEvent,
 )
@@ -57,6 +58,19 @@ class RequestStatus:
     cid: str
     venue_id: str | None
     instrument: Instrument
+
+
+@dataclass(frozen=True)
+class SubmitReplacement:
+    # - the post-cancel residual of an armed replace intent is still executable: submit it
+    cid: str
+
+
+@dataclass(frozen=True)
+class AbandonReplace:
+    # - the post-cancel residual is not executable (too small/negative) or the order is gone
+    cid: str
+    reason: str = ""
 
 
 @dataclass(frozen=True)
@@ -83,7 +97,15 @@ class RouteEvent:
     event: object
 
 
-Action = RequestStatus | RequestSnapshot | RequestHistDeals | RouteEvent | OrderPartiallyFilledEvent
+Action = (
+    RequestStatus
+    | RequestSnapshot
+    | RequestHistDeals
+    | RouteEvent
+    | OrderPartiallyFilledEvent
+    | SubmitReplacement
+    | AbandonReplace
+)
 
 
 class Tick:
@@ -639,8 +661,27 @@ class Reconciler:
         return None
 
     def on_event(self, state: AccountState, event: object, now: np.datetime64) -> list[Action]:
+        if isinstance(event, OrderCanceledEvent) and event.client_order_id is not None:
+            intent = state.get_replace_intent(event.client_order_id)
+            # filled_at_cancel is only stamped by the reducer's suppressed-cancel branch — a
+            # None here means this cancel was NOT suppressed (superseded-oid drop / already
+            # terminal), so the replace decision must not fire.
+            if intent is not None and intent.filled_at_cancel is not None:
+                return self._decide_replace(state, event.client_order_id, intent)
+
         inp = DealIn(event) if isinstance(event, DealEvent) else OrderIn(event)
         return self._dispatch(inp, state, now, only=self._keys_of(event))
+
+    @staticmethod
+    def _decide_replace(state: AccountState, cid: str, intent: ReplaceIntent) -> list[Action]:
+        # Read-only: the intent stays ARMED here — clearing it is the executing side's job.
+        order = state.get_order(cid)
+        raced = max(0.0, intent.filled_at_cancel - intent.filled_at_request)  # type: ignore[operator]
+        residual = intent.desired_remaining - raced
+        min_size = order.instrument.min_size if order is not None else 0.0
+        if order is None or residual <= 0.0 or residual < min_size:
+            return [AbandonReplace(cid, reason=f"residual {residual} below min {min_size}")]
+        return [SubmitReplacement(cid)]
 
     def _spawn(self, task: Task) -> None:
         if task.key in self._tasks:  # one task per key — duplicate ignored

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -38,6 +38,7 @@ from qubx.core.events import (
     OrderCanceledEvent,
     OrderLostEvent,
     OrderPartiallyFilledEvent,
+    OrderUpdateRejectedEvent,
 )
 from qubx.utils.time import to_timedelta
 
@@ -51,9 +52,9 @@ _log = area_logger("reconciler")
 # re-fetched deals are deduped by trade_id and realize-only-guarded anyway.
 HIST_DEALS_LOOKBACK = np.timedelta64(2, "s")
 
-# A replace intent whose internal cancel never acked (filled_at_cancel unset) this long after
-# arming: the cancel's venue outcome is unknown, so the periodic sweep clears it and refetches
-# status rather than assuming either side.
+# A replace intent still armed this long after arming (cancel never acked, or acked but never
+# decided): the outcome is unknown, so the periodic sweep clears it, reverts the order out of
+# PENDING_UPDATE and refetches status rather than assuming either side.
 REPLACE_INTENT_MAX_AGE = np.timedelta64(30, "s")
 
 
@@ -428,25 +429,38 @@ class Reconciler:
         return actions + self._dispatch(Tick(), state, now)
 
     def _sweep_expired_replace_intents(self, state: AccountState, now: np.datetime64) -> list[Action]:
-        # - a replace intent's internal cancel that never acked (filled_at_cancel unset — an
-        #   acked one is consumed synchronously by _decide_replace/_execute in the same apply
-        #   call, so it can't persist to a later tick). Its venue outcome is unknown: clear +
-        #   refetch status rather than assume it. Never AbandonReplace here — that would route a
-        #   terminal cancel and fabricate an outcome nobody confirmed; RequestStatus lets venue
-        #   truth resolve it (order still live -> reverts out of PENDING_UPDATE via the normal
-        #   accepted/updated path; order gone -> a real terminal event lands and, with no intent
-        #   armed anymore, terminalizes truthfully).
+        # - a replace intent still armed a max-age after arming is stale whichever field it holds:
+        #   an unacked cancel (filled_at_cancel unset) has an unknown venue outcome, and a stamped
+        #   one whose decision never fired is equally undecidable. Never AbandonReplace here —
+        #   that would route a terminal cancel and fabricate an outcome nobody confirmed.
+        # - clearing the intent alone would strand the order: a live order's status reply is an
+        #   OrderAcceptedEvent, which deliberately refuses to wipe PENDING_*, and _reconcile_order
+        #   skips pending orders — so it would sit in PENDING_UPDATE forever and every later
+        #   update_order would silently no-op on the re-entrancy guard. The synthetic reject
+        #   reverts it to the pre-pending truth (alive under the old terms), and RequestStatus
+        #   then resolves the venue's actual verdict: if the cancel did go through, the reply's
+        #   terminal now terminalizes truthfully with no intent left to suppress it.
         actions: list[Action] = []
         for cid, intent in state.replace_intents().items():
-            if intent.filled_at_cancel is not None or now - intent.armed_at < REPLACE_INTENT_MAX_AGE:  # type: ignore
+            if now - intent.armed_at < REPLACE_INTENT_MAX_AGE:  # type: ignore
                 continue
             state.clear_replace_intent(cid)
             _log.warning(
                 f"[{state.exchange}] replace intent <y>{cid}</y> expired after "
-                f"{REPLACE_INTENT_MAX_AGE} with no cancel ack -> cleared, refetching status"
+                f"{REPLACE_INTENT_MAX_AGE} unresolved -> cleared, reverting and refetching status"
             )
             order = state.get_order(cid)
             if order is not None:
+                actions.append(
+                    RouteEvent(
+                        OrderUpdateRejectedEvent(
+                            instrument=None,
+                            client_order_id=cid,
+                            venue_order_id=order.venue_order_id,
+                            reason="replace intent expired; outcome unknown",
+                        )
+                    )
+                )
                 actions.append(RequestStatus(cid=cid, venue_id=order.venue_order_id, instrument=order.instrument))
         return actions
 
@@ -690,20 +704,35 @@ class Reconciler:
         return None
 
     def on_event(self, state: AccountState, event: object, now: np.datetime64) -> list[Action]:
-        if isinstance(event, OrderCanceledEvent) and event.client_order_id is not None:
-            intent = state.get_replace_intent(event.client_order_id)
+        if isinstance(event, OrderCanceledEvent) and (cid := self._resolved_cid(state, event)) is not None:
+            intent = state.get_replace_intent(cid)
             # filled_at_cancel is only stamped by the reducer's suppressed-cancel branch — a
             # None here means this cancel was NOT suppressed (superseded-oid drop / already
             # terminal), so the replace decision must not fire.
             if intent is not None and intent.filled_at_cancel is not None:
-                return self._decide_replace(state, event.client_order_id, intent)
+                return self._decide_replace(state, cid, intent)
 
         inp = DealIn(event) if isinstance(event, DealEvent) else OrderIn(event)
         return self._dispatch(inp, state, now, only=self._keys_of(event))
 
     @staticmethod
+    def _resolved_cid(state: AccountState, event: OrderCanceledEvent) -> str | None:
+        # Mirrors the reducer's _resolve (cid first, then venue id) so the decision keys off the
+        # SAME order the reducer stamped — a venue-id-only cancel must decide, not leak. Falls
+        # back to the event's own cid when nothing resolves, so an intent for a vanished order
+        # still reaches _decide_replace's defensive abandon.
+        if (order := state.get_order(event.client_order_id)) is None and event.venue_order_id is not None:
+            order = state.get_order_by_venue_id(event.venue_order_id)
+        return order.client_order_id if order is not None else event.client_order_id
+
+    @staticmethod
     def _decide_replace(state: AccountState, cid: str, intent: ReplaceIntent) -> list[Action]:
         # Read-only: the intent stays ARMED here — clearing it is the executing side's job.
+        # The gate is min_size only, not TradingManager._get_min_size (no min_notional / lot
+        # rules): a residual that clears min_size but not min_notional is submitted and the venue
+        # rejects it (order terminalizes REJECTED — truth), while one this gate abandons routes
+        # the cancel the suppression deferred (also truth). Both failure modes degrade truthfully,
+        # so the cheaper gate stays here rather than duplicating the sizing rules.
         order = state.get_order(cid)
         raced = max(0.0, intent.filled_at_cancel - intent.filled_at_request)  # type: ignore[operator]
         residual = intent.desired_remaining - raced

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -51,6 +51,11 @@ _log = area_logger("reconciler")
 # re-fetched deals are deduped by trade_id and realize-only-guarded anyway.
 HIST_DEALS_LOOKBACK = np.timedelta64(2, "s")
 
+# A replace intent whose internal cancel never acked (filled_at_cancel unset) this long after
+# arming: the cancel's venue outcome is unknown, so the periodic sweep clears it and refetches
+# status rather than assuming either side.
+REPLACE_INTENT_MAX_AGE = np.timedelta64(30, "s")
+
 
 @dataclass(frozen=True)
 class RequestStatus:
@@ -419,7 +424,31 @@ class Reconciler:
                 self._last_full_snapshot[state.exchange] = now
             _log.debug(f"[{state.exchange}] reconcile: snapshot due -> RequestSnapshot(include_orders={full_sweep})")
             actions.append(RequestSnapshot(state.exchange, include_orders=full_sweep))
+        actions += self._sweep_expired_replace_intents(state, now)
         return actions + self._dispatch(Tick(), state, now)
+
+    def _sweep_expired_replace_intents(self, state: AccountState, now: np.datetime64) -> list[Action]:
+        # - a replace intent's internal cancel that never acked (filled_at_cancel unset — an
+        #   acked one is consumed synchronously by _decide_replace/_execute in the same apply
+        #   call, so it can't persist to a later tick). Its venue outcome is unknown: clear +
+        #   refetch status rather than assume it. Never AbandonReplace here — that would route a
+        #   terminal cancel and fabricate an outcome nobody confirmed; RequestStatus lets venue
+        #   truth resolve it (order still live -> reverts out of PENDING_UPDATE via the normal
+        #   accepted/updated path; order gone -> a real terminal event lands and, with no intent
+        #   armed anymore, terminalizes truthfully).
+        actions: list[Action] = []
+        for cid, intent in state.replace_intents().items():
+            if intent.filled_at_cancel is not None or now - intent.armed_at < REPLACE_INTENT_MAX_AGE:  # type: ignore
+                continue
+            state.clear_replace_intent(cid)
+            _log.warning(
+                f"[{state.exchange}] replace intent <y>{cid}</y> expired after "
+                f"{REPLACE_INTENT_MAX_AGE} with no cancel ack -> cleared, refetching status"
+            )
+            order = state.get_order(cid)
+            if order is not None:
+                actions.append(RequestStatus(cid=cid, venue_id=order.venue_order_id, instrument=order.instrument))
+        return actions
 
     def on_snapshot(
         self,

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -250,16 +250,29 @@ def _handle_canceled(state: AccountState, event: OrderCanceledEvent, now: np.dat
     if order is None or order.status.is_terminal or _is_superseded_oid_cancel(order, event):
         return ApplyResult()
 
+    if event.venue_order_id is not None and state.is_superseded_oid(order.client_order_id, event.venue_order_id):
+        # A replacement already superseded this venue id, but the order still carries it (the
+        # replacement's accept hasn't re-keyed yet) so _is_superseded_oid_cancel can't see it.
+        # Connectors emitting two terminals per cancel (REST ack + WS) land the second one here.
+        return ApplyResult()
+
     intent = state.get_replace_intent(order.client_order_id)
-    if intent is not None:
+    if intent is not None and order.status is OrderStatus.PENDING_UPDATE:
         # Internal cancel of a replace orchestration: not a terminal for the strategy —
         # the same-cid replacement is about to be submitted. Record the venue's
         # authoritative final fill so the residual is computed from truth (fills that
-        # raced the cancel are included).
+        # raced the cancel are included), and the id it killed so a duplicate terminal
+        # for that id can be dropped once the replacement is live.
         intent.filled_at_cancel = (
             event.venue_filled_quantity if event.venue_filled_quantity is not None else order.filled_quantity
         )
+        intent.canceled_venue_oid = event.venue_order_id or order.venue_order_id
         return ApplyResult()
+    if intent is not None:
+        # An intent is armed but the order is no longer PENDING_UPDATE — a strategy cancel
+        # (PENDING_CANCEL) won the window. That cancel is the truth; suppressing it would
+        # resurrect an order the caller explicitly killed.
+        state.clear_replace_intent(order.client_order_id)
 
     order = transition(state, order.client_order_id, OrderStatus.CANCELED, now, update_time=event.last_update_time)
     return ApplyResult(order=order, order_change=OrderChange.CANCELED)
@@ -271,6 +284,7 @@ def _handle_lost(state: AccountState, event: OrderLostEvent, now: np.datetime64)
     order = _resolve(state, event)
     if order is None or order.status.is_terminal:
         return ApplyResult()
+    state.clear_replace_intent(order.client_order_id)  # terminal ends the orchestration
     order = transition(state, order.client_order_id, OrderStatus.LOST, now, update_time=event.last_update_time)
     return ApplyResult(order=order, order_change=OrderChange.LOST)
 
@@ -279,6 +293,7 @@ def _handle_expired(state: AccountState, event: OrderExpiredEvent, now: np.datet
     order = _resolve(state, event)
     if order is None or order.status.is_terminal:
         return ApplyResult()
+    state.clear_replace_intent(order.client_order_id)  # terminal ends the orchestration
     order = transition(state, order.client_order_id, OrderStatus.EXPIRED, now, update_time=event.last_update_time)
     return ApplyResult(order=order, order_change=OrderChange.EXPIRED)
 
@@ -287,6 +302,7 @@ def _handle_rejected(state: AccountState, event: OrderRejectedEvent, now: np.dat
     order = _active_order_for(state, event)
     if order is None or order.status.is_terminal:
         return ApplyResult()
+    state.clear_replace_intent(order.client_order_id)  # terminal ends the orchestration
     order.rejected_reason = event.reason
     order.error_code = event.code
     order = transition(state, order.client_order_id, OrderStatus.REJECTED, now, update_time=event.last_update_time)

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -250,6 +250,17 @@ def _handle_canceled(state: AccountState, event: OrderCanceledEvent, now: np.dat
     if order is None or order.status.is_terminal or _is_superseded_oid_cancel(order, event):
         return ApplyResult()
 
+    intent = state.get_replace_intent(order.client_order_id)
+    if intent is not None:
+        # Internal cancel of a replace orchestration: not a terminal for the strategy —
+        # the same-cid replacement is about to be submitted. Record the venue's
+        # authoritative final fill so the residual is computed from truth (fills that
+        # raced the cancel are included).
+        intent.filled_at_cancel = (
+            event.venue_filled_quantity if event.venue_filled_quantity is not None else order.filled_quantity
+        )
+        return ApplyResult()
+
     order = transition(state, order.client_order_id, OrderStatus.CANCELED, now, update_time=event.last_update_time)
     return ApplyResult(order=order, order_change=OrderChange.CANCELED)
 
@@ -375,6 +386,10 @@ def _handle_fill(state: AccountState, event: OrderFilledEvent, now: np.datetime6
     order = _resolve_or_materialize(state, event, now)
     if order is None or order.status.is_terminal:
         return ApplyResult()
+    # A fill wins the race against an in-flight replace's internal cancel: the order
+    # settles for real, so the armed intent (which would otherwise suppress a later
+    # CANCELED) no longer applies. No-op if none is armed.
+    state.clear_replace_intent(order.client_order_id)
     if event.venue_order_id is not None:
         state.set_venue_id(order.client_order_id, event.venue_order_id)
     # fill is None on split-stream venues (the deal arrives separately via DealEvent):
@@ -501,7 +516,16 @@ def _revert_from_pending(
 
 def _handle_cancel_rejected(state: AccountState, event: OrderCancelRejectedEvent, now: np.datetime64) -> ApplyResult:
     order = _active_order_for(state, event)
-    if order is None or order.status != OrderStatus.PENDING_CANCEL:
+    if order is None:
+        return ApplyResult()
+    if order.status is OrderStatus.PENDING_UPDATE and state.get_replace_intent(order.client_order_id) is not None:
+        # The venue rejected the replace orchestration's internal cancel, arriving
+        # asynchronously as an event (the synchronous failure-to-submit path is handled
+        # in trading.py before this ever reaches the venue). The order is still alive
+        # under the old terms — clear the intent and revert to truth.
+        state.clear_replace_intent(order.client_order_id)
+        return _revert_from_pending(state, order, OrderChange.UPDATE_REJECTED, now, update_time=event.last_update_time)
+    if order.status != OrderStatus.PENDING_CANCEL:
         return ApplyResult()
     return _revert_from_pending(state, order, OrderChange.CANCEL_REJECTED, now, update_time=event.last_update_time)
 

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -470,7 +470,11 @@ def _handle_updated(state: AccountState, event: OrderUpdatedEvent, now: np.datet
     if event.new_price is not None:
         order.price = event.new_price
     if event.new_quantity is not None:
-        order.quantity = event.new_quantity
+        # new_quantity is the desired REMAINING. quantity's invariant is
+        # total-including-filled, so splice the cumulative fills back in —
+        # otherwise remaining (quantity - filled) goes negative after the
+        # first amend of a partially-filled order.
+        order.quantity = order.filled_quantity + event.new_quantity
     order.last_update_time = event.last_update_time if event.last_update_time is not None else now
     if order.status == OrderStatus.PENDING_UPDATE:
         target = state.get_pre_pending(order.client_order_id) or OrderStatus.ACCEPTED

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -39,6 +39,20 @@ class VenueAccountFigures:
     withdrawable: float | None = None
 
 
+@dataclass
+class ReplaceIntent:
+    """Armed when a partially-filled order's update is routed through cancel+replace
+    instead of native amend. Tracks what the replacement should submit, and — once the
+    internal cancel acks — how much filled while the cancel was in flight, so the
+    residual sent to the venue reflects reality rather than a stale request-time figure."""
+
+    desired_remaining: float
+    price: float | None
+    filled_at_request: float
+    armed_at: np.datetime64
+    filled_at_cancel: float | None = None
+
+
 def _notional(position: Position) -> float:
     # NaN for an unmarked position -> 0.0, so one unmarked position can't poison aggregates
     n = position.notional_value
@@ -64,6 +78,7 @@ class AccountState:
         "_applied_funding_buckets",
         "_balance_push_as_of",
         "_position_reconcile_as_of",
+        "_replace_intents",
     )
 
     def __init__(self, exchange: str, base_currency: str, *, terminal_history_size: int = 10_000):
@@ -109,6 +124,9 @@ class AccountState:
         # - watermark: snapshot reconciled the size up to this venue time; a deal at/under it is
         #   already in that size → reducer records but doesn't re-book it
         self._position_reconcile_as_of: dict[Instrument, np.datetime64] = {}
+        # cid -> armed ReplaceIntent while a partially-filled update_order is routed
+        # through cancel+replace; absent otherwise. See ReplaceIntent for the lifecycle.
+        self._replace_intents: dict[str, ReplaceIntent] = {}
 
     def __repr__(self) -> str:
         return (
@@ -161,6 +179,13 @@ class AccountState:
 
     def get_pre_pending(self, cid: str) -> OrderStatus | None:
         return self._pre_pending_status.get(cid)
+
+    def get_replace_intent(self, cid: str) -> ReplaceIntent | None:
+        return self._replace_intents.get(cid)
+
+    def replace_intents(self) -> dict[str, ReplaceIntent]:
+        """Read-only view for the expiry sweep — a defensive copy, like get_orders."""
+        return dict(self._replace_intents)
 
     def get_last_snapshot_as_of(self) -> np.datetime64 | None:
         return self._last_snapshot_as_of
@@ -330,6 +355,12 @@ class AccountState:
         calls this when a snapshot already counted the execution, so any later
         re-delivery on any path dedups via apply_fill."""
         self._seen_trade_ids.setdefault(cid, set()).add(trade_id)
+
+    def arm_replace_intent(self, cid: str, intent: ReplaceIntent) -> None:
+        self._replace_intents[cid] = intent
+
+    def clear_replace_intent(self, cid: str) -> ReplaceIntent | None:
+        return self._replace_intents.pop(cid, None)
 
     def remove_order(self, cid: str) -> None:
         # Drop an order from state entirely (e.g. a submit that raised before reaching the

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -51,6 +51,9 @@ class ReplaceIntent:
     filled_at_request: float
     armed_at: np.datetime64
     filled_at_cancel: float | None = None
+    # venue id the suppressed cancel killed — carried to the superseded-oid marker so the
+    # connector's SECOND cancel terminal (REST ack + WS stream) can't kill the replacement
+    canceled_venue_oid: str | None = None
 
 
 def _notional(position: Position) -> float:
@@ -79,6 +82,7 @@ class AccountState:
         "_balance_push_as_of",
         "_position_reconcile_as_of",
         "_replace_intents",
+        "_superseded_oids",
     )
 
     def __init__(self, exchange: str, base_currency: str, *, terminal_history_size: int = 10_000):
@@ -127,6 +131,10 @@ class AccountState:
         # cid -> armed ReplaceIntent while a partially-filled update_order is routed
         # through cancel+replace; absent otherwise. See ReplaceIntent for the lifecycle.
         self._replace_intents: dict[str, ReplaceIntent] = {}
+        # cid -> venue id a submitted replacement superseded. A cancel terminal addressed to
+        # that id is dead news, even while the order still carries it (the replacement's accept
+        # hasn't re-keyed yet) — which is exactly when _is_superseded_oid_cancel can't tell.
+        self._superseded_oids: dict[str, str] = {}
 
     def __repr__(self) -> str:
         return (
@@ -313,6 +321,7 @@ class AccountState:
 
         if new_status.is_terminal:
             self._pending_evict_index[cid] = now
+            self._superseded_oids.pop(cid, None)
         else:
             self._pending_evict_index.pop(cid, None)
 
@@ -332,6 +341,10 @@ class AccountState:
             self._venue_id_index.pop(order.venue_order_id, None)
         order.venue_order_id = venue_order_id
         self._venue_id_index[venue_order_id] = cid
+        if self._superseded_oids.get(cid) not in (None, venue_order_id):
+            # re-keyed past the superseded id: _is_superseded_oid_cancel covers it from here.
+            # A re-key BACK to the superseded id (a late deal for the dead order) keeps the marker.
+            self._superseded_oids.pop(cid, None)
 
     def apply_fill(self, cid: str, fill: Deal, now: np.datetime64, *, update_time: np.datetime64 | None = None) -> bool:
         """Apply a fill, deduped by trade id. Returns True if newly applied, False if duplicate."""
@@ -362,6 +375,12 @@ class AccountState:
     def clear_replace_intent(self, cid: str) -> ReplaceIntent | None:
         return self._replace_intents.pop(cid, None)
 
+    def mark_superseded_oid(self, cid: str, venue_order_id: str) -> None:
+        self._superseded_oids[cid] = venue_order_id
+
+    def is_superseded_oid(self, cid: str, venue_order_id: str) -> bool:
+        return self._superseded_oids.get(cid) == venue_order_id
+
     def remove_order(self, cid: str) -> None:
         # Drop an order from state entirely (e.g. a submit that raised before reaching the
         # venue) — distinct from evict_to_history, which retains it in the ring buffer.
@@ -374,6 +393,7 @@ class AccountState:
         self._pending_evict_index.pop(cid, None)
         self._seen_trade_ids.pop(cid, None)
         self._pre_pending_status.pop(cid, None)
+        self._superseded_oids.pop(cid, None)
 
     def evict_to_history(self, cid: str) -> None:
         """Evict a terminal order from active state into the history ring buffer,
@@ -389,6 +409,7 @@ class AccountState:
         self._pending_evict_index.pop(cid, None)
         self._seen_trade_ids.pop(cid, None)
         self._pre_pending_status.pop(cid, None)
+        self._superseded_oids.pop(cid, None)
         self._terminal_history.append(order)
 
     def prune_terminal_orders(self, now: np.datetime64, retention: np.timedelta64) -> None:

--- a/src/qubx/core/events.py
+++ b/src/qubx/core/events.py
@@ -109,7 +109,10 @@ class DealEvent(OrderEvent):
 
 @msg
 class OrderCanceledEvent(OrderEvent):
-    pass
+    # The venue's final fill figure on the terminal cancel report, when reported (e.g.
+    # Binance futures cancel responses carry executedQty -> ccxt unified 'filled'). The
+    # replace orchestration uses this as the authoritative post-cancel residual input.
+    venue_filled_quantity: float | None = None
 
 
 @msg

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -418,7 +418,23 @@ class TradingManager(ITradingManager):
                 filled_at_request=order.filled_quantity,
             )
             self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
-            self._get_connector(instrument.exchange).cancel_order(order)
+            try:
+                self._get_connector(instrument.exchange).cancel_order(order)
+            except Exception as e:
+                # Same contract as the native amend path: revert to truth — the cancel
+                # never reached the venue, the order is still alive, so the just-armed
+                # intent must not survive (else the order is stuck PENDING_UPDATE, and
+                # the re-entrancy no-op above silently swallows every later update_order).
+                self._account_manager.clear_replace_intent(instrument.exchange, cid)
+                self._context.process_event(
+                    OrderUpdateRejectedEvent(
+                        instrument=instrument,
+                        client_order_id=cid,
+                        venue_order_id=order.venue_order_id,
+                        reason=f"replace cancel failed before reaching venue: {e}",
+                    )
+                )
+                raise
             return
 
         self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -335,6 +335,10 @@ class TradingManager(ITradingManager):
             client_id=cid,
             event_time=self._context.time(),
         )
+        # An explicit cancel of a mid-replace order wins over the orchestration: the reducer
+        # gates suppression on PENDING_UPDATE, this drops the intent outright so nothing can
+        # resurrect the order as a replacement.
+        self._account_manager.clear_replace_intent(order.instrument.exchange, cid)
         self._account_manager.transition_order(order.instrument.exchange, cid, OrderStatus.PENDING_CANCEL)
         try:
             self._get_connector(order.instrument.exchange).cancel_order(order)
@@ -410,6 +414,9 @@ class TradingManager(ITradingManager):
 
         cid = order.client_order_id
         if order.filled_quantity > 0:
+            # Arm only once the transition holds — a raise here (illegal source status) would
+            # otherwise leak an intent no cancel will ever clear.
+            self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
             self._account_manager.arm_replace_intent(
                 instrument.exchange,
                 cid,
@@ -417,7 +424,6 @@ class TradingManager(ITradingManager):
                 price=adjusted_price,
                 filled_at_request=order.filled_quantity,
             )
-            self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
             try:
                 self._get_connector(instrument.exchange).cancel_order(order)
             except Exception as e:

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -370,10 +370,18 @@ class TradingManager(ITradingManager):
     ) -> None:
         """Update an existing limit order with new price and amount.
 
+        `amount` is the desired signed REMAINING quantity to keep working (its sign
+        must match the order's side) — not a delta and not the original order size.
+
         Raises OrderAlreadyTerminal on a settled order (updating a settled order is
         meaningful misuse); a no-op while a previous update is still in flight.
         A synchronous connector failure reverts the order to its pre-pending status
         (via a synthetic OrderUpdateRejectedEvent) and re-raises to the caller.
+
+        Once the order has any fill, venue amend dialects disagree on what a resize
+        means (HL: replace-size; Binance/Gate: new-total with executedQty kept), so
+        this routes through the framework's cancel+replace orchestration instead of
+        a native amend — the connector only ever sees `cancel_order` in that case.
         """
         self._ensure_writable()
         order_id, client_order_id = self._normalize_order_ids(order_id, client_order_id)
@@ -386,16 +394,36 @@ class TradingManager(ITradingManager):
         if order.status is OrderStatus.PENDING_UPDATE:
             return
 
+        if amount == 0 or (amount > 0) != (order.side == OrderSide.BUY):
+            raise ValueError(
+                f"update_order amount {amount} sign does not match order side {order.side} "
+                f"for {order.client_order_id} — amount is the desired signed remaining"
+            )
+
         instrument = order.instrument
-        amount = self._adjust_size(instrument, amount)
+        # amount keeps its sign (needed by _adjust_price's rounding direction below) —
+        # size_adj is the rounded absolute magnitude to send.
+        size_adj = self._adjust_size(instrument, amount)
         adjusted_price = self._adjust_price(instrument, price, amount)
         if adjusted_price is None:
             raise ValueError(f"Price adjustment failed for {instrument.symbol}")
 
         cid = order.client_order_id
+        if order.filled_quantity > 0:
+            self._account_manager.arm_replace_intent(
+                instrument.exchange,
+                cid,
+                desired_remaining=size_adj,
+                price=adjusted_price,
+                filled_at_request=order.filled_quantity,
+            )
+            self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
+            self._get_connector(instrument.exchange).cancel_order(order)
+            return
+
         self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
         try:
-            self._get_connector(instrument.exchange).update_order(order, price=adjusted_price, quantity=abs(amount))
+            self._get_connector(instrument.exchange).update_order(order, price=adjusted_price, quantity=size_adj)
         except Exception as e:
             # Same contract as cancel_order: synthetic reject through the PM reverts
             # PENDING_UPDATE via pre_pending, then the original exception re-raises.

--- a/tests/qubx/backtester/reprice_unfilled_limit_test.py
+++ b/tests/qubx/backtester/reprice_unfilled_limit_test.py
@@ -106,17 +106,37 @@ def test_reprice_unfilled_limit_keeps_remaining_truthful_through_sim(sim):
     assert order is not None
     assert order.price == pytest.approx(30800.0)
     remaining = order.quantity - order.filled_quantity
-    assert remaining == pytest.approx(0.3)
+    assert remaining == 0.3
     assert remaining >= 0.0
 
-    # 3. Move the market down through the new price -> the REAL OME fills the BUY.
+    # OME book truth, not the AM's request-echo (OrderUpdatedEvent carries the local
+    # price param verbatim — connector.py:159-167 — so a venue-side reprice that
+    # silently no-ops would still leave the AM order reporting the requested price).
+    # The resting order must actually have moved price levels in the book.
+    book = conn._ome._ome[instr].bids
+    assert 30800.0 in book, book
+    assert 31000.0 not in book, book
+
+    # 3. Intermediate quote sitting BETWEEN the old (31000) and new (30800) levels:
+    # crosses the old level but not the new one. A reprice that updated the AM's
+    # local copy but left the OME order resting at 31000 would fill here; a real
+    # venue-side reprice must not.
+    conn.process_market_data(instr, time.feed(Q("2020-01-01 10:00:30", 30900.0, 30901.0)))
+    order = am.find_order_by_client_id(order.client_order_id)
+    assert order is not None
+    assert order.filled_quantity == 0.0
+    position = am.get_position(instr)
+    assert position is not None
+    assert position.quantity == 0.0
+
+    # 4. Move the market down through the new price -> the REAL OME fills the BUY.
     conn.process_market_data(instr, time.feed(Q("2020-01-01 10:01", 30700.0, 30701.0)))
 
     order = am.find_order_by_client_id(order.client_order_id)
     assert order is not None
-    assert order.filled_quantity == pytest.approx(0.3)
-    assert order.quantity - order.filled_quantity == pytest.approx(0.0)
+    assert order.filled_quantity == 0.3
+    assert order.quantity - order.filled_quantity == 0.0
 
     position = am.get_position(instr)
     assert position is not None
-    assert position.quantity == pytest.approx(0.3)
+    assert position.quantity == 0.3

--- a/tests/qubx/backtester/reprice_unfilled_limit_test.py
+++ b/tests/qubx/backtester/reprice_unfilled_limit_test.py
@@ -1,0 +1,122 @@
+"""Sim integration test pinning `TradingManager.update_order`'s native-amend semantics
+(amount = desired remaining) through the REAL backtester OME: SimulatedConnector + real
+AccountManager + real TradingManager, with fills driven by actual OME executions.
+
+The OME fills orders atomically (no partial fills) — there is no depth/size-aware matching
+in `qubx.backtester.ome`, so a resting order can never end up partially filled while still
+open. That means this test only covers the `filled == 0` reprice (native amend) path; the
+`filled > 0` cancel+replace chain is covered at the account-manager integration level and by
+a planned real-venue end-to-end test.
+"""
+
+import numpy as np
+import pytest
+
+from qubx.backtester.connector import SimulatedConnector
+from qubx.backtester.utils import SimulatedCtrlChannel
+from qubx.core.account_manager import SimulatedAccountManager
+from qubx.core.basics import ZERO_COSTS, ITimeProvider
+from qubx.core.interfaces import IStrategyContext
+from qubx.core.lookups import lookup
+from qubx.core.mixins.trading import TradingManager
+from qubx.core.series import Quote
+from qubx.core.utils import recognize_time
+from qubx.health.dummy import DummyHealthMonitor
+
+
+class _TimeService(ITimeProvider):
+    """Shared clock for the OME and the AM/TradingManager stack, advanced by feeding quotes."""
+
+    _time: np.datetime64 = np.datetime64(0, "ns")
+
+    def feed(self, quote: Quote) -> Quote:
+        self._time = np.datetime64(quote.time, "ns")
+        return quote
+
+    def time(self) -> np.datetime64:
+        return self._time
+
+
+def Q(when: str, bid: float, ask: float) -> Quote:
+    return Quote(recognize_time(when), bid, ask, 0, 0)
+
+
+class _RoutingContext(IStrategyContext):
+    """process_event applies straight to the AM — the PM dispatch leg
+    (ProcessingManager._dispatch_account) minus strategy callbacks.
+    Mirrors tests/qubx/core/mixins/trading_test.py::_AccountRoutingContext."""
+
+    def __init__(self, account_manager: SimulatedAccountManager, time_provider: _TimeService):
+        self._am = account_manager
+        self._time = time_provider
+
+    def time(self) -> np.datetime64:
+        return self._time.time()
+
+    def process_event(self, event) -> None:
+        self._am.apply(event)
+
+    def is_blacklisted(self, instrument) -> bool:
+        return False
+
+
+@pytest.fixture
+def sim():
+    """SimulatedConnector (real OME) + real SimulatedAccountManager + real TradingManager,
+    all sharing one clock, wired the same way ProcessingManager wires the live stack minus
+    strategy callbacks."""
+    instr = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+    assert instr is not None
+    time = _TimeService()
+    channel = SimulatedCtrlChannel("sim", sentinel=(None, None, None, None))
+    conn = SimulatedConnector(channel=channel, exchange_name="BINANCE.UM", time_provider=time, tcc=ZERO_COSTS)
+
+    am = SimulatedAccountManager(
+        connectors={"BINANCE.UM": conn}, base_currencies={"BINANCE.UM": "USDT"}, time=time
+    )
+    ctx = _RoutingContext(am, time)
+    channel.register(ctx)  # connector.send() -> channel.send() -> ctx.process_event() -> am.apply()
+    tm = TradingManager(
+        context=ctx,
+        connectors={"BINANCE.UM": conn},
+        account_manager=am,
+        strategy_name="test_strategy",
+        health_monitor=DummyHealthMonitor(),
+    )
+
+    # Prime the OME's book so it's ready to accept orders.
+    exchange = conn._ome
+    list(exchange.process_market_data(instr, time.feed(Q("2020-01-01 10:00", 32000.0, 32001.0))))
+    return tm, am, conn, instr, time
+
+
+def test_reprice_unfilled_limit_keeps_remaining_truthful_through_sim(sim):
+    tm, am, conn, instr, time = sim
+
+    # 1. BUY limit well below touch (32000/32001) -> rests unfilled.
+    order = tm.trade(instr, amount=0.5, price=31000.0)
+    assert order is not None
+    live = am.find_order_by_client_id(order.client_order_id)
+    assert live is not None
+    assert live.filled_quantity == 0.0
+
+    # 2. Reprice AND shrink in one native amend: still below touch, so it keeps resting.
+    tm.update_order(price=30800.0, amount=0.3, client_order_id=order.client_order_id)
+    order = am.find_order_by_client_id(order.client_order_id)
+    assert order is not None
+    assert order.price == pytest.approx(30800.0)
+    remaining = order.quantity - order.filled_quantity
+    assert remaining == pytest.approx(0.3)
+    assert remaining >= 0.0
+
+    # 3. Move the market down through the new price -> the REAL OME fills the BUY.
+    conn.process_market_data(instr, time.feed(Q("2020-01-01 10:01", 30700.0, 30701.0)))
+
+    order = am.find_order_by_client_id(order.client_order_id)
+    assert order is not None
+    assert order.filled_quantity == pytest.approx(0.3)
+    assert order.quantity - order.filled_quantity == pytest.approx(0.0)
+
+    position = am.get_position(instr)
+    assert position is not None
+    assert position.quantity == pytest.approx(0.3)

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -384,6 +384,25 @@ async def test_cancel_by_venue_id_emits_canceled() -> None:
     exchange.cancel_order.assert_awaited_once_with("VENUE123", "BTC/USDT:USDT")
     assert isinstance(sent[0], OrderCanceledEvent)
     assert sent[0].venue_order_id == "VENUE123"
+    assert sent[0].venue_filled_quantity is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_response_with_filled_sets_venue_filled_quantity() -> None:
+    # Binance futures cancel responses carry executedQty -> ccxt unified 'filled'; the
+    # replace orchestration needs this as the authoritative post-cancel fill figure.
+    exchange = Mock()
+    exchange.cancel_order = AsyncMock(
+        return_value={"id": "VENUE123", "clientOrderId": "qubx_BTCUSDT_1", "filled": 3.5}
+    )
+    exchange.has = {"editOrder": True}
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.cancel_order(_order(venue_order_id="VENUE123"))
+    await _drive(conn)
+
+    assert isinstance(sent[0], OrderCanceledEvent)
+    assert sent[0].venue_filled_quantity == 3.5
 
 
 @pytest.mark.asyncio

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -406,6 +406,25 @@ async def test_cancel_response_with_filled_sets_venue_filled_quantity() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancel_response_with_non_numeric_filled_still_emits_canceled() -> None:
+    # A present-but-non-numeric 'filled' must not blow up float() inside the _spawn-fired
+    # coroutine (that would silently drop the whole OrderCanceledEvent send) -- it degrades
+    # to None instead.
+    exchange = Mock()
+    exchange.cancel_order = AsyncMock(
+        return_value={"id": "VENUE123", "clientOrderId": "qubx_BTCUSDT_1", "filled": "garbage"}
+    )
+    exchange.has = {"editOrder": True}
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.cancel_order(_order(venue_order_id="VENUE123"))
+    await _drive(conn)
+
+    assert isinstance(sent[0], OrderCanceledEvent)
+    assert sent[0].venue_filled_quantity is None
+
+
+@pytest.mark.asyncio
 async def test_cancel_stop_order_uses_trigger_surface() -> None:
     # A STOP order lives on the venue's conditional/algo surface; the cancel must pass
     # params={'trigger': True} (driven by order.type), else Binance answers -2011 and the

--- a/tests/qubx/core/account_manager/manager_test.py
+++ b/tests/qubx/core/account_manager/manager_test.py
@@ -414,3 +414,77 @@ def test_apply_order_canceled_with_armed_intent_submits_replacement_end_to_end(m
     assert order.quantity == pytest.approx(3.5 + 6.5)
     assert order.status is not None and not order.status.is_terminal
     assert state.get_replace_intent(order.client_order_id) is None
+
+
+def test_duplicate_cancel_terminal_does_not_terminalize_live_replacement(manager_with_order):
+    # The ccxt connector emits TWO cancel terminals per cancel (REST ack + WS stream). The first
+    # is consumed by the intent's suppression; the second resolves by cid onto an order whose
+    # venue id has not re-keyed yet, so the superseded-oid guard alone cannot see it is stale —
+    # without the per-cid superseded-oid marker it terminalizes an order that is LIVE at the venue.
+    mgr, state, order, connector = manager_with_order
+    cid = order.client_order_id
+    state.set_venue_id(cid, "v_old")
+    state.arm_replace_intent(cid, ReplaceIntent(6.5, 1.02, 3.5, NOW))
+    cancel = OrderCanceledEvent(instrument=None, client_order_id=cid, venue_order_id="v_old", venue_filled_quantity=3.5)
+
+    mgr.apply(cancel)  # REST ack: suppressed -> replacement submitted under the same cid
+    connector.submit_order.assert_called_once()
+    assert not _present(order.status).is_terminal
+
+    mgr.apply(cancel)  # WS duplicate of the SAME terminal, replacement's accept not landed yet
+    assert not _present(order.status).is_terminal
+    connector.submit_order.assert_called_once()  # no second submit either
+
+    # the replacement's accept lands under a NEW venue id -> re-key
+    mgr.apply(OrderAcceptedEvent(instrument=None, client_order_id=cid, venue_order_id="v_new", accepted_at=T1))
+    assert order.venue_order_id == "v_new"
+
+    mgr.apply(cancel)  # third stale cancel for the superseded id
+    assert not _present(order.status).is_terminal
+
+
+def test_strategy_cancel_during_replace_window_terminalizes_truthfully(manager_with_order):
+    # cancel_order on a PENDING_UPDATE order is legal (-> PENDING_CANCEL). The suppression must
+    # key off the status, not merely the armed intent: otherwise the strategy's explicit cancel
+    # is swallowed and the replacement resurrects an order the strategy killed.
+    mgr, state, order, connector = manager_with_order
+    cid = order.client_order_id
+    state.arm_replace_intent(cid, ReplaceIntent(6.5, 1.02, 3.5, NOW))
+    mgr.transition_order(EX, cid, OrderStatus.PENDING_CANCEL)  # strategy cancel during the window
+
+    mgr.apply(OrderCanceledEvent(instrument=None, client_order_id=cid, venue_filled_quantity=3.5))
+
+    assert order.status is OrderStatus.CANCELED  # truth, not a suppressed resurrection
+    assert state.get_replace_intent(cid) is None
+    connector.submit_order.assert_not_called()
+
+
+def test_execute_submit_replacement_routes_lag_compensated_quantity(manager_with_order):
+    # The venue's cancel ack counted fills whose WS deals have not booked locally yet. The
+    # submit is the residual, but the ROUTED quantity must compensate for the local lag so the
+    # reducer's splice lands on filled_at_cancel + residual — otherwise remaining stays
+    # permanently understated once the raced deal books.
+    mgr, state, order, connector = manager_with_order  # local filled 3.5
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=4.5))
+
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])
+
+    req = connector.submit_order.call_args.args[0]
+    assert req.quantity == pytest.approx(5.5)  # residual 7.0 - raced 1.5 — what the venue gets
+    assert order.quantity == pytest.approx(4.5 + 5.5)  # splice lands on filled_at_cancel + residual
+
+
+def test_reconcile_tick_expiry_reverts_the_stuck_pending_update_order(manager_with_order):
+    # Clearing the intent alone leaves the order in PENDING_UPDATE with no event able to move
+    # it (an accepted status reply refuses to wipe pending, _reconcile_order skips pending), so
+    # every later update_order silently no-ops. The sweep must revert it to venue-recognisable
+    # truth: alive under the old terms.
+    mgr, state, order, connector = manager_with_order
+    cid = order.client_order_id
+    state.arm_replace_intent(cid, ReplaceIntent(6.5, 1.02, 3.5, T0))  # armed 60s before the AM clock
+
+    mgr._execute(state, mgr._reconcilers[EX].on_tick(state, T1))
+
+    assert state.get_replace_intent(cid) is None
+    assert order.status is OrderStatus.PARTIALLY_FILLED  # pre-pending truth, not stuck pending
+    connector.request_order_status.assert_called_once()

--- a/tests/qubx/core/account_manager/manager_test.py
+++ b/tests/qubx/core/account_manager/manager_test.py
@@ -329,6 +329,40 @@ def test_execute_submit_replacement_sends_unsigned_quantity_for_sell(manager_wit
     assert req.side == OrderSide.SELL
 
 
+def test_execute_submit_replacement_restamps_reduce_only_and_post_only(manager_with_order):
+    # Pin manager.py's options re-stamping: reduceOnly/post_only come from the order record
+    # (the source of truth), not blindly copied — a stale "reduce_only" alias in order.options
+    # must not survive, but unrelated options do.
+    mgr, state, order, connector = manager_with_order
+    order.reduce_only = True
+    order.post_only = True
+    order.options = {"reduce_only": False, "some_venue_key": "keep-me"}
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=3.5))
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])
+
+    req = connector.submit_order.call_args.args[0]
+    assert req.options["reduceOnly"] is True
+    assert req.options["post_only"] is True
+    assert "reduce_only" not in req.options  # stale alias dropped, not the stale value
+    assert req.options["some_venue_key"] == "keep-me"  # unrelated options carried forward
+
+
+def test_execute_submit_replacement_submit_failure_surfaces_cancel(manager_with_order):
+    # A synchronous connector.submit_order raise means nothing is live at the venue (the OLD
+    # order's cancel already succeeded — precondition for this decision to fire), so the truth
+    # is CANCELED, not a stuck PENDING_UPDATE. No OrderUpdatedEvent must be routed, and the
+    # exception must not escape _execute.
+    mgr, state, order, connector = manager_with_order
+    connector.submit_order.side_effect = RuntimeError("boom")
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=3.5))
+
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])  # must not raise
+
+    assert state.get_replace_intent(order.client_order_id) is None  # cleared exactly once
+    assert order.status is OrderStatus.CANCELED  # truth surfaced, not a false PENDING_UPDATE
+    assert order.quantity == 10.0  # unspliced: the failed submit never routed UPDATED
+
+
 def test_execute_abandon_replace_reports_canceled_truth(manager_with_order):
     mgr, state, order, connector = manager_with_order
     state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 3.0, 3.0, NOW, filled_at_cancel=9.9))

--- a/tests/qubx/core/account_manager/manager_test.py
+++ b/tests/qubx/core/account_manager/manager_test.py
@@ -9,9 +9,11 @@ from typing import TypeVar
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 from qubx.core.account_manager.manager import AccountManager
-from qubx.core.account_manager.state import AccountState
+from qubx.core.account_manager.reconciler import AbandonReplace, ResolveMissingOrder, SubmitReplacement
+from qubx.core.account_manager.state import AccountState, ReplaceIntent
 from qubx.core.basics import (
     Balance,
     Deal,
@@ -36,6 +38,7 @@ from qubx.core.series import Quote
 
 T0 = np.datetime64("2026-05-28T00:00:00", "ns")
 T1 = np.datetime64("2026-05-28T00:01:00", "ns")
+NOW = np.datetime64("2026-05-28T00:02:00", "ns")
 
 _btc = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
 assert _btc is not None
@@ -262,3 +265,118 @@ def test_execute_request_status_for_unknown_order_is_noop():
     am = _am()
     am._execute(am.get_state(EX), [RequestStatus(cid="nope", venue_id=None, instrument=BTC)])
     am._connectors[EX].request_order_status.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Task 7 — _execute performs the same-cid replacement or the truthful abandon
+# --------------------------------------------------------------------------- #
+
+
+class _SyncPM:
+    """Routes process_event straight back into AM.apply — mirrors ProcessingManager's
+    _dispatch_account without pulling in the whole processing stack, so tests can drive
+    the real re-entrant apply()->_execute()->process_event()->apply() chain."""
+
+    def __init__(self, am: AccountManager):
+        self._am = am
+
+    def process_event(self, event) -> None:
+        self._am.apply(event)
+
+
+@pytest.fixture
+def manager_with_order():
+    """A manager with a real (non-mock) routing PM and one BUY 10, filled 3.5,
+    PENDING_UPDATE order — mirrors the state trading.py's update_order leaves behind
+    after arming a replace intent and sending the internal cancel."""
+    am = _am()
+    state = am.get_state(EX)
+    order = _order(status=OrderStatus.PARTIALLY_FILLED)
+    order.quantity = 10.0
+    order.filled_quantity = 3.5
+    state.add_order(order)
+    am.transition_order(EX, order.client_order_id, OrderStatus.PENDING_UPDATE)
+    am._pm = _SyncPM(am)
+    connector = am._connectors[EX]
+    return am, state, order, connector
+
+
+def test_execute_submit_replacement_splices_and_submits(manager_with_order):
+    mgr, state, order, connector = manager_with_order  # BUY 10, filled 3.5, PENDING_UPDATE
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=3.5))
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])
+
+    req = connector.submit_order.call_args.args[0]
+    assert req.client_id == order.client_order_id  # same-cid splice
+    assert req.quantity == pytest.approx(6.5)  # residual 7.0 - 0.5, signed BUY
+    assert req.price == 1.01
+    assert order.quantity == pytest.approx(3.5 + 6.5)  # invariant restored
+    assert state.get_replace_intent(order.client_order_id) is None
+    assert order.status is not None and not order.status.is_terminal
+
+
+def test_execute_submit_replacement_sends_unsigned_quantity_for_sell(manager_with_order):
+    # OrderRequest.quantity must stay UNSIGNED (side conveys direction, exactly like
+    # ccxt's create_order(amount, side) and TradingManager.trade's size_adj) — a signed
+    # negative amount for a SELL replacement would misdirect or be rejected at the venue.
+    mgr, state, order, connector = manager_with_order
+    order.side = OrderSide.SELL
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=3.5))
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])
+
+    req = connector.submit_order.call_args.args[0]
+    assert req.quantity == pytest.approx(6.5)  # unsigned, never negative
+    assert req.side == OrderSide.SELL
+
+
+def test_execute_abandon_replace_reports_canceled_truth(manager_with_order):
+    mgr, state, order, connector = manager_with_order
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 3.0, 3.0, NOW, filled_at_cancel=9.9))
+    mgr._execute(state, [AbandonReplace(order.client_order_id, "residual below min")])
+    assert state.get_replace_intent(order.client_order_id) is None
+    assert order.status is OrderStatus.CANCELED  # truth surfaced via routed event
+
+
+def test_execute_submit_replacement_without_pm_still_submits_and_clears(manager_with_order):
+    # No processing manager wired: submit + clear must still happen, only the route is skipped.
+    mgr, state, order, connector = manager_with_order
+    mgr._pm = None
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=3.5))
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])
+
+    connector.submit_order.assert_called_once()
+    assert state.get_replace_intent(order.client_order_id) is None
+    assert order.quantity == 10.0  # unspliced: no routed UPDATED without a pm
+
+
+def test_execute_submit_replacement_resolves_pending_missing_order_watcher(manager_with_order):
+    # MANDATORY EXTRA (Task 6 review note): a REST snapshot landing during the internal-cancel
+    # window can spawn a ResolveMissingOrder watcher for the mid-replace cid. The routed
+    # OrderUpdatedEvent must resolve it via rec.on_event's normal OrderIn fallthrough, or the
+    # watcher would retry to a spurious OrderLostEvent later.
+    mgr, state, order, connector = manager_with_order
+    rec = mgr._reconcilers[EX]
+    rec._spawn(ResolveMissingOrder(order, NOW, wait=np.timedelta64(2, "s"), max_retries=3))
+    assert rec.active_keys() == {order.client_order_id}
+
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(7.0, 1.01, 3.0, NOW, filled_at_cancel=3.5))
+    mgr._execute(state, [SubmitReplacement(order.client_order_id)])
+
+    assert rec.active_keys() == set()  # watcher resolved — no spurious retries/LOST
+
+
+def test_apply_order_canceled_with_armed_intent_submits_replacement_end_to_end(manager_with_order):
+    # End-to-end: drive apply() with a real suppressed-cancel event and let the reducer ->
+    # reconciler -> _execute chain run for real (no direct _execute call).
+    mgr, state, order, connector = manager_with_order
+    state.arm_replace_intent(order.client_order_id, ReplaceIntent(6.5, 1.02, 3.5, NOW))
+
+    mgr.apply(OrderCanceledEvent(instrument=None, client_order_id=order.client_order_id, venue_order_id=None))
+
+    req = connector.submit_order.call_args.args[0]
+    assert req.client_id == order.client_order_id
+    assert req.quantity == pytest.approx(6.5)
+    # splice happens via the routed OrderUpdatedEvent hitting _handle_updated
+    assert order.quantity == pytest.approx(3.5 + 6.5)
+    assert order.status is not None and not order.status.is_terminal
+    assert state.get_replace_intent(order.client_order_id) is None

--- a/tests/qubx/core/account_manager/reconciler_test.py
+++ b/tests/qubx/core/account_manager/reconciler_test.py
@@ -34,6 +34,7 @@ from qubx.core.events import (
     OrderCanceledEvent,
     OrderLostEvent,
     OrderPartiallyFilledEvent,
+    OrderUpdateRejectedEvent,
 )
 from qubx.core.lookups import lookup
 
@@ -887,15 +888,49 @@ def test_on_tick_leaves_fresh_replace_intent_armed():
     assert not any(isinstance(a, RequestStatus) for a in actions)
 
 
-def test_on_tick_does_not_expire_intent_with_acked_cancel():
-    # filled_at_cancel set means the cancel ack DID arrive; the decide+_execute path
-    # consumes such intents synchronously within the same apply call, so this should
-    # never persist across a tick in practice — the sweep only targets the unacked case
-    # and must leave an acked one alone regardless.
+def test_on_tick_expires_stamped_but_undecided_intent():
+    # filled_at_cancel set means the cancel ack arrived; the decide+_execute path normally
+    # consumes such an intent synchronously in the same apply call. If it is still armed a
+    # max-age later the decision never fired (e.g. a venue-id-only cancel that failed to
+    # resolve), and a stamped-but-undecided intent is exactly as stale as an unacked one.
     st = _armed_state(filled_at_cancel=3.5)
     rec = _reconciler()
 
     actions = rec.on_tick(st, _passed_seconds(T0, 30))
 
-    assert st.get_replace_intent("c1") is not None
-    assert not any(isinstance(a, RequestStatus) for a in actions)
+    assert st.get_replace_intent("c1") is None
+    assert RequestStatus(cid="c1", venue_id="v_c1", instrument=_inst()) in actions
+
+
+def test_on_tick_expiry_routes_synthetic_reject_to_recover_the_order():
+    # A live order's status reply is an OrderAcceptedEvent, which refuses to wipe PENDING_*,
+    # and _reconcile_order skips pending orders — so clearing the intent alone leaves the order
+    # stuck in PENDING_UPDATE forever (every later update_order silently no-ops). The sweep must
+    # also revert it via the synthetic-reject path.
+    st = _armed_state(filled_at_cancel=None)
+    rec = _reconciler()
+
+    actions = rec.on_tick(st, _passed_seconds(T0, 30))
+
+    routed = [a.event for a in actions if isinstance(a, RouteEvent)]
+    assert len(routed) == 1
+    reject = routed[0]
+    assert isinstance(reject, OrderUpdateRejectedEvent)
+    assert reject.client_order_id == "c1"
+    assert reject.venue_order_id == "v_c1"
+    # the revert must precede the status refetch so a late terminal lands on a settled status
+    assert actions.index(RouteEvent(reject)) < actions.index(
+        RequestStatus(cid="c1", venue_id="v_c1", instrument=_inst())
+    )
+
+
+def test_on_event_venue_id_only_cancel_still_decides():
+    # The reducer stamps the intent via _resolve (cid OR venue id), so a cancel carrying only a
+    # venue id arms the decision — the gate must resolve the order the same way, or the intent
+    # is stamped but never decided and leaks until the sweep.
+    st = _armed_state(desired_remaining=7.0, filled_at_request=3.0, filled_at_cancel=3.5)
+    rec = _reconciler()
+
+    actions = rec.on_event(st, OrderCanceledEvent(instrument=_inst(), client_order_id=None, venue_order_id="v_c1"), T0)
+
+    assert actions == [SubmitReplacement(cid="c1")]

--- a/tests/qubx/core/account_manager/reconciler_test.py
+++ b/tests/qubx/core/account_manager/reconciler_test.py
@@ -17,13 +17,15 @@ from qubx.core.account_manager import reducer
 from qubx.core.account_manager.diffs import Differ
 from qubx.core.account_manager.reconciler import (
     HIST_DEALS_LOOKBACK,
+    AbandonReplace,
     Reconciler,
     RequestHistDeals,
     RequestSnapshot,
     RequestStatus,
     RouteEvent,
+    SubmitReplacement,
 )
-from qubx.core.account_manager.state import AccountState
+from qubx.core.account_manager.state import AccountState, ReplaceIntent
 from qubx.core.basics import Balance, Deal, Instrument, Order, OrderOrigin, OrderSide, OrderStatus, OrderType, Position
 from qubx.core.events import (
     AccountSnapshot,
@@ -731,3 +733,124 @@ def test_first_snapshot_is_full_then_light_then_full_after_sweep():
 
     # once the full-sweep interval elapses, the next due request is FULL again (WS-drop backstop)
     assert RequestSnapshot(ex, include_orders=True) in rec.on_tick(st, _passed_seconds(T0, 300))
+
+
+# --------------------------------------------------------------------------- #
+# Replace decision — SubmitReplacement / AbandonReplace on a suppressed cancel.
+#
+# The reducer suppresses a canceled event that arrives for an armed replace intent: it
+# stamps intent.filled_at_cancel and leaves the intent ARMED (order stays PENDING_UPDATE,
+# not terminalized) — then the SAME event is routed to on_event, which is where the
+# residual-vs-abandon decision under test here happens.
+# --------------------------------------------------------------------------- #
+
+
+def _armed_state(
+    cid: str = "c1",
+    *,
+    desired_remaining: float = 7.0,
+    filled_at_request: float = 3.0,
+    filled_at_cancel: float | None = 3.5,
+    status: OrderStatus = OrderStatus.PENDING_UPDATE,
+) -> AccountState:
+    st = _local(_order(cid, status=status, filled=filled_at_request))
+    st.arm_replace_intent(
+        cid,
+        ReplaceIntent(
+            desired_remaining=desired_remaining,
+            price=None,
+            filled_at_request=filled_at_request,
+            armed_at=T0,
+            filled_at_cancel=filled_at_cancel,
+        ),
+    )
+    return st
+
+
+def _canceled(cid: str = "c1") -> OrderCanceledEvent:
+    return OrderCanceledEvent(instrument=_inst(), client_order_id=cid, venue_order_id=f"v_{cid}")
+
+
+def test_on_event_canceled_with_intent_submits_replacement():
+    # desired 7.0, filled_at_request 3.0, filled_at_cancel 3.5 -> raced 0.5 -> residual 6.5
+    st = _armed_state(desired_remaining=7.0, filled_at_request=3.0, filled_at_cancel=3.5)
+    rec = _reconciler()
+
+    actions = rec.on_event(st, _canceled(), T0)
+
+    assert actions == [SubmitReplacement(cid="c1")]
+
+
+def test_on_event_residual_below_min_abandons():
+    # desired 1.0005, filled_at_request 3.0, filled_at_cancel 4.0 -> raced 1.0 -> residual 0.0005,
+    # positive but below BTCUSDT's min_size (0.001)
+    st = _armed_state(desired_remaining=1.0005, filled_at_request=3.0, filled_at_cancel=4.0)
+    rec = _reconciler()
+
+    actions = rec.on_event(st, _canceled(), T0)
+
+    assert len(actions) == 1
+    assert isinstance(actions[0], AbandonReplace)
+    assert actions[0].cid == "c1"
+
+
+def test_on_event_residual_non_positive_abandons():
+    # desired 1.0, filled_at_request 3.0, filled_at_cancel 4.5 -> raced 1.5 -> residual -0.5
+    st = _armed_state(desired_remaining=1.0, filled_at_request=3.0, filled_at_cancel=4.5)
+    rec = _reconciler()
+
+    actions = rec.on_event(st, _canceled(), T0)
+
+    assert len(actions) == 1
+    assert isinstance(actions[0], AbandonReplace)
+    assert actions[0].cid == "c1"
+
+
+def test_on_event_replace_decision_with_missing_order_abandons():
+    # armed intent for a cid with no local order (defensive: order can't be resolved)
+    st = _local()
+    st.arm_replace_intent(
+        "c1",
+        ReplaceIntent(desired_remaining=7.0, price=None, filled_at_request=3.0, armed_at=T0, filled_at_cancel=3.5),
+    )
+    rec = _reconciler()
+
+    actions = rec.on_event(st, _canceled(), T0)
+
+    assert len(actions) == 1
+    assert isinstance(actions[0], AbandonReplace)
+
+
+def test_on_event_canceled_without_intent_unchanged():
+    # no armed intent -> falls through to pre-existing OrderCanceledEvent dispatch (no tasks
+    # registered here, so no actions) -> SubmitReplacement/AbandonReplace must never appear
+    st = _local(_order("c1"))
+    rec = _reconciler()
+
+    actions = rec.on_event(st, _canceled(), T0)
+
+    assert actions == []
+
+
+def test_on_event_canceled_with_unsuppressed_intent_does_not_decide():
+    # intent armed but filled_at_cancel is None -> the reducer did NOT suppress this cancel
+    # (superseded-oid drop / already-terminal order) -> the decision branch must not fire
+    st = _armed_state(filled_at_cancel=None)
+    rec = _reconciler()
+
+    actions = rec.on_event(st, _canceled(), T0)
+
+    assert not any(isinstance(a, (SubmitReplacement, AbandonReplace)) for a in actions)
+
+
+def test_on_event_decision_does_not_mutate_state():
+    st = _armed_state(desired_remaining=7.0, filled_at_request=3.0, filled_at_cancel=3.5)
+    rec = _reconciler()
+
+    rec.on_event(st, _canceled(), T0)
+
+    # the decision reads the intent but leaves it armed — clearing is a later task's job
+    intent = st.get_replace_intent("c1")
+    assert intent is not None
+    assert intent.filled_at_cancel == 3.5
+    assert st.get_order("c1").status == OrderStatus.PENDING_UPDATE  # untouched

--- a/tests/qubx/core/account_manager/reconciler_test.py
+++ b/tests/qubx/core/account_manager/reconciler_test.py
@@ -854,3 +854,48 @@ def test_on_event_decision_does_not_mutate_state():
     assert intent is not None
     assert intent.filled_at_cancel == 3.5
     assert st.get_order("c1").status == OrderStatus.PENDING_UPDATE  # untouched
+
+
+# --------------------------------------------------------------------------- #
+# Stale replace-intent expiry — an intent whose internal cancel never acked
+# (filled_at_cancel unset) ages past REPLACE_INTENT_MAX_AGE: clear + warn + RequestStatus
+# only. The cancel's venue outcome is unknown at that point, so expiry must never
+# terminalize the order itself — RequestStatus resolves it to venue truth.
+# --------------------------------------------------------------------------- #
+
+
+def test_on_tick_expires_stale_unacked_replace_intent():
+    st = _armed_state(filled_at_cancel=None)  # cancel ack never arrived
+    rec = _reconciler()
+
+    actions = rec.on_tick(st, _passed_seconds(T0, 30))
+
+    assert st.get_replace_intent("c1") is None  # cleared
+    status_actions = [a for a in actions if isinstance(a, RequestStatus)]
+    assert status_actions == [RequestStatus(cid="c1", venue_id="v_c1", instrument=_inst())]
+    # expiry itself must not terminalize — only a subsequent status/event resolves it
+    assert st.get_active_order("c1").status is OrderStatus.PENDING_UPDATE
+
+
+def test_on_tick_leaves_fresh_replace_intent_armed():
+    st = _armed_state(filled_at_cancel=None)
+    rec = _reconciler()
+
+    actions = rec.on_tick(st, _passed_seconds(T0, 29))  # just under the 30s bar
+
+    assert st.get_replace_intent("c1") is not None
+    assert not any(isinstance(a, RequestStatus) for a in actions)
+
+
+def test_on_tick_does_not_expire_intent_with_acked_cancel():
+    # filled_at_cancel set means the cancel ack DID arrive; the decide+_execute path
+    # consumes such intents synchronously within the same apply call, so this should
+    # never persist across a tick in practice — the sweep only targets the unacked case
+    # and must leave an acked one alone regardless.
+    st = _armed_state(filled_at_cancel=3.5)
+    rec = _reconciler()
+
+    actions = rec.on_tick(st, _passed_seconds(T0, 30))
+
+    assert st.get_replace_intent("c1") is not None
+    assert not any(isinstance(a, RequestStatus) for a in actions)

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -898,3 +898,45 @@ def test_canceled_superseded_oid_ignored_even_with_armed_intent():
     assert r.is_empty()
     assert state.get_active_order("c1").status is OrderStatus.PENDING_UPDATE
     assert state.get_replace_intent("c1").filled_at_cancel is None  # untouched — guard fired first
+
+
+def test_canceled_superseded_oid_ignored_after_replacement_is_live():
+    # Full replace-flow regression (distinct from the HL cancel+recreate-modify scenario
+    # above, which never involves a ReplaceIntent): the internal cancel of oid A acks and
+    # is suppressed, _execute clears the intent and resubmits under the same cloid — its
+    # synthetic OrderUpdatedEvent carries no venue id, so the order still reads oid A at
+    # that point — then the venue's accept for the NEW order lands, moving it to oid B. A
+    # late CANCELED for the now-superseded oid A must still be dropped and must not
+    # terminalize the now-live replacement.
+    state = _state()
+    order = _order(state, status=OrderStatus.PARTIALLY_FILLED, venue_id="A")
+    order.record_fill(3.0, 1.0)
+    state.arm_replace_intent(
+        "c1", ReplaceIntent(desired_remaining=7.0, price=1.01, filled_at_request=3.0, armed_at=T0)
+    )
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+
+    # internal cancel of oid A acks -> suppressed (order stays PENDING_UPDATE, intent stamped)
+    apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1", venue_order_id="A"), T1)
+    assert state.get_replace_intent("c1").filled_at_cancel == 3.0
+
+    # _execute: clear the intent, then the resubmit's synthetic update (no venue id yet)
+    state.clear_replace_intent("c1")
+    apply(
+        state,
+        OrderUpdatedEvent(instrument=None, client_order_id="c1", venue_order_id=None, new_price=1.01, new_quantity=6.5),
+        T1,
+    )
+    assert state.get_order("c1").status is OrderStatus.PARTIALLY_FILLED  # reverted out of PENDING_UPDATE
+    assert state.get_order("c1").venue_order_id == "A"  # not yet moved — awaiting the new order's ack
+
+    # the venue confirms the resubmitted order under a NEW oid B
+    apply(state, OrderAcceptedEvent(instrument=None, client_order_id="c1", venue_order_id="B", accepted_at=T1), T1)
+    assert state.get_order("c1").venue_order_id == "B"
+
+    # the OLD order's late CANCELED (oid A) must not touch the now-live replacement
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1", venue_order_id="A"), T1)
+
+    assert r.is_empty()
+    assert state.get_order("c1").status is OrderStatus.PARTIALLY_FILLED
+    assert state.get_order("c1").venue_order_id == "B"

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -940,3 +940,26 @@ def test_canceled_superseded_oid_ignored_after_replacement_is_live():
     assert r.is_empty()
     assert state.get_order("c1").status is OrderStatus.PARTIALLY_FILLED
     assert state.get_order("c1").venue_order_id == "B"
+
+
+@pytest.mark.parametrize(
+    "event, terminal",
+    [
+        (OrderExpiredEvent(instrument=BTC, client_order_id="c1"), OrderStatus.EXPIRED),
+        (OrderRejectedEvent(instrument=BTC, client_order_id="c1", reason="nope"), OrderStatus.REJECTED),
+        (OrderLostEvent(instrument=BTC, client_order_id="c1"), OrderStatus.LOST),
+    ],
+    ids=["expired", "rejected", "lost"],
+)
+def test_terminal_event_clears_armed_replace_intent(event, terminal):
+    # Any terminal ends the replace orchestration: a surviving intent would suppress a later
+    # cancel for a dead order and keep a stale entry in the table forever.
+    state = _state()
+    _order(state, status=OrderStatus.PARTIALLY_FILLED)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+    state.arm_replace_intent("c1", ReplaceIntent(0.5, 100.0, 0.5, T0))
+
+    apply(state, event, T1)
+
+    assert _present(state.get_order("c1")).status is terminal
+    assert state.get_replace_intent("c1") is None

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -163,8 +163,8 @@ def test_cancel_event_venue_filled_quantity_defaults_to_none():
 
 
 def test_cancel_event_accepts_venue_filled_quantity_without_breaking_reducer():
-    # The reducer doesn't consume this field until Task 4's terminal interception; here it
-    # only has to accept the new kwarg and cancel as before.
+    # The reducer does not consume this field yet; here it only has to accept the new
+    # kwarg and cancel as before.
     state = _state()
     _order(state, status=OrderStatus.ACCEPTED, venue_id="B")
     r = apply(

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 from qubx.core.account_manager import reducer
-from qubx.core.account_manager.state import AccountState
+from qubx.core.account_manager.state import AccountState, ReplaceIntent
 from qubx.core.basics import (
     Balance,
     Deal,
@@ -800,3 +800,101 @@ def test_event_venue_ts_stamps_order_last_update_time():
     )
     assert r.order is not None
     assert r.order.last_update_time == venue_ts  # venue ts, not T1
+
+
+# --------------------------------------------------------------------------- #
+# 4.6 — replace-intent interception (internal cancel of a cancel+replace)
+# --------------------------------------------------------------------------- #
+
+
+def _armed_pending_update(desired_remaining: float = 7.0, filled_at_request: float = 3.0) -> tuple[AccountState, Order]:
+    state = _state()
+    order = _order(state, status=OrderStatus.PARTIALLY_FILLED, venue_id="V1")
+    order.record_fill(filled_at_request, 1.0)
+    state.arm_replace_intent(
+        "c1", ReplaceIntent(desired_remaining=desired_remaining, price=1.01, filled_at_request=filled_at_request, armed_at=T0)
+    )
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+    return state, order
+
+
+def test_canceled_with_armed_intent_is_suppressed():
+    state, order = _armed_pending_update()
+
+    r = apply(
+        state,
+        OrderCanceledEvent(
+            instrument=None, client_order_id="c1", venue_order_id="V1", venue_filled_quantity=3.5
+        ),
+        T1,
+    )
+
+    assert r.is_empty()  # no strategy callback
+    assert state.get_active_order("c1").status is OrderStatus.PENDING_UPDATE  # NOT terminal
+    assert state.get_replace_intent("c1").filled_at_cancel == 3.5
+
+
+def test_canceled_without_venue_fill_figure_falls_back_to_record():
+    state, order = _armed_pending_update()
+
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1", venue_order_id="V1"), T1)
+
+    assert r.is_empty()
+    assert state.get_active_order("c1").status is OrderStatus.PENDING_UPDATE
+    assert state.get_replace_intent("c1").filled_at_cancel == order.filled_quantity == 3.0
+
+
+def test_filled_terminal_clears_intent_and_flows():
+    state, order = _armed_pending_update()
+
+    r = apply(
+        state,
+        OrderFilledEvent(instrument=BTC, client_order_id="c1", venue_order_id="V1", fill=_fill("t1", 4.0, 1.01)),
+        T1,
+    )
+
+    assert state.get_replace_intent("c1") is None
+    assert not r.is_empty()
+    assert r.order is not None and r.order.status is OrderStatus.FILLED
+    assert r.order_change is OrderChange.FILLED
+
+
+def test_cancel_rejected_with_intent_reverts_to_truth():
+    state, order = _armed_pending_update()
+
+    r = apply(state, OrderCancelRejectedEvent(instrument=None, client_order_id="c1", reason="too late"), T1)
+
+    assert state.get_replace_intent("c1") is None
+    assert r.order is not None and r.order.status is OrderStatus.PARTIALLY_FILLED  # reverted to pre-pending
+    assert r.order_change is OrderChange.UPDATE_REJECTED
+
+
+def test_cancel_rejected_without_intent_still_needs_pending_cancel():
+    # No armed intent: the PENDING_UPDATE branch must not swallow this — falls through
+    # to the existing PENDING_CANCEL-only gate, which then no-ops.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+    r = apply(state, OrderCancelRejectedEvent(instrument=None, client_order_id="c1", reason="x"), T1)
+    assert r.is_empty()
+    assert state.get_active_order("c1").status is OrderStatus.PENDING_UPDATE  # untouched
+
+
+def test_canceled_superseded_oid_ignored_even_with_armed_intent():
+    # The superseded-oid guard must still win FIRST: a stale cancel for a replaced venue
+    # id is dropped even while an intent is armed for this cid.
+    state = _state()
+    order = _order(state, status=OrderStatus.PARTIALLY_FILLED, venue_id="A")
+    order.record_fill(3.0, 1.0)
+    state.arm_replace_intent(
+        "c1", ReplaceIntent(desired_remaining=7.0, price=1.01, filled_at_request=3.0, armed_at=T0)
+    )
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+    # the order moves to a new venue id (e.g. HL-style cancel+recreate ack) while pending
+    state.set_venue_id("c1", "B")
+
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1", venue_order_id="A"), T1)
+
+    assert r.is_empty()
+    assert state.get_active_order("c1").status is OrderStatus.PENDING_UPDATE
+    assert state.get_replace_intent("c1").filled_at_cancel is None  # untouched — guard fired first

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -9,6 +9,7 @@ a kw-only snapshot_grace (threaded once via the local apply wrapper below).
 from typing import TypeVar
 
 import numpy as np
+import pytest
 
 from qubx.core.account_manager import reducer
 from qubx.core.account_manager.state import AccountState
@@ -70,12 +71,18 @@ def _fill(trade_id: str = "t1", amount: float = 0.5, price: float = 100.0) -> De
     return Deal(trade_id=trade_id, order_id="v1", time=T0, amount=amount, price=price, aggressive=True)
 
 
-def _order(state: AccountState, cid: str = "c1", status: OrderStatus = OrderStatus.SUBMITTED, venue_id=None) -> Order:
+def _order(
+    state: AccountState,
+    cid: str = "c1",
+    status: OrderStatus = OrderStatus.SUBMITTED,
+    venue_id=None,
+    quantity: float = 1.0,
+) -> Order:
     order = Order(
         client_order_id=cid,
         type=OrderType.LIMIT,
         instrument=BTC,
-        quantity=1.0,
+        quantity=quantity,
         side=OrderSide.BUY,
         time_in_force="gtc",
         status=status,
@@ -638,6 +645,34 @@ def test_update_on_non_pending_applies_params_without_status_change():
     assert r.order.status is OrderStatus.ACCEPTED  # unchanged
     assert r.order.price == 120.0
     assert r.order_change is OrderChange.UPDATED  # fires on_order despite no status change
+
+
+def test_updated_after_partial_fill_keeps_remaining_positive():
+    # ACE 2026-08-05 regression: amend of a partially-filled order must not produce
+    # quantity < filled_quantity (negative remaining). new_quantity is the desired
+    # REMAINING; quantity's invariant is total-including-filled.
+    state = _state()
+    order = _order(state, status=OrderStatus.ACCEPTED, quantity=1344.92)
+    order.record_fill(764.0, 0.0719)
+
+    apply(
+        state,
+        OrderUpdatedEvent(
+            instrument=None,
+            client_order_id="c1",
+            venue_order_id="new-vid",
+            new_price=0.072,
+            new_quantity=580.92,
+        ),
+        T1,
+    )
+
+    assert order.quantity == pytest.approx(764.0 + 580.92)  # total incl. filled
+    assert order.quantity - order.filled_quantity == pytest.approx(580.92)  # remaining = what was sent
+
+    # more fills arrive on the replacement — remaining must NEVER go negative
+    order.record_fill(292.78, 0.0722)
+    assert order.quantity - order.filled_quantity >= 0
 
 
 def test_cancel_rejected_reverts_to_pre_pending():

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -157,6 +157,24 @@ def test_cancel_with_matching_venue_id_transitions_to_terminal():
     assert r.order is not None and r.order.status is OrderStatus.CANCELED
 
 
+def test_cancel_event_venue_filled_quantity_defaults_to_none():
+    event = OrderCanceledEvent(instrument=None, client_order_id="c1")
+    assert event.venue_filled_quantity is None
+
+
+def test_cancel_event_accepts_venue_filled_quantity_without_breaking_reducer():
+    # The reducer doesn't consume this field until Task 4's terminal interception; here it
+    # only has to accept the new kwarg and cancel as before.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED, venue_id="B")
+    r = apply(
+        state,
+        OrderCanceledEvent(instrument=None, client_order_id="c1", venue_order_id="B", venue_filled_quantity=3.5),
+        T1,
+    )
+    assert r.order is not None and r.order.status is OrderStatus.CANCELED
+
+
 def test_cancel_of_superseded_oid_after_modify_is_ignored():
     # A cancel-and-replace modify (HL): the modify cancels the OLD oid A but emits its CANCELED
     # carrying the SAME cloid as the now-live replacement, which already moved to a NEW oid B.

--- a/tests/qubx/core/account_manager/state_test.py
+++ b/tests/qubx/core/account_manager/state_test.py
@@ -13,7 +13,7 @@ from typing import TypeVar
 import numpy as np
 import pytest
 
-from qubx.core.account_manager.state import AccountState
+from qubx.core.account_manager.state import AccountState, ReplaceIntent
 from qubx.core.basics import (
     Balance,
     Deal,
@@ -489,3 +489,41 @@ def test_snapshot_balance_no_push_uses_as_of_without_ratchet():
     # identical balance at a later poll -> NOT ratcheted forward
     state.apply_balance_snapshot(Balance(exchange="binance", currency="USDT", total=50.0, free=50.0), T2)
     assert state.get_balance("USDT").last_update_time == T1
+
+
+# --------------------------------------------------------------------------- #
+# replace-intent table
+# --------------------------------------------------------------------------- #
+
+
+def test_replace_intent_arm_get_clear():
+    state = AccountState("TEST", "USDT")
+    intent = ReplaceIntent(
+        desired_remaining=7.0, price=1.01, filled_at_request=3.0, armed_at=np.datetime64("2026-08-05T16:05:20", "ns")
+    )
+    state.arm_replace_intent("cid-1", intent)
+    assert state.get_replace_intent("cid-1") is intent
+    assert state.clear_replace_intent("cid-1") is intent
+    assert state.get_replace_intent("cid-1") is None
+    assert state.clear_replace_intent("cid-1") is None  # idempotent
+
+
+def test_replace_intent_get_and_clear_unknown_cid_is_none():
+    state = AccountState("TEST", "USDT")
+    assert state.get_replace_intent("no-such-cid") is None
+    assert state.clear_replace_intent("no-such-cid") is None
+
+
+def test_replace_intents_returns_readonly_view():
+    state = AccountState("TEST", "USDT")
+    intent = ReplaceIntent(desired_remaining=7.0, price=1.01, filled_at_request=3.0, armed_at=T1)
+    state.arm_replace_intent("cid-1", intent)
+    view = state.replace_intents()
+    assert view == {"cid-1": intent}
+    view.clear()
+    assert state.get_replace_intent("cid-1") is intent  # mutating the view didn't touch internal state
+
+
+def test_replace_intent_filled_at_cancel_defaults_none():
+    intent = ReplaceIntent(desired_remaining=7.0, price=1.01, filled_at_request=3.0, armed_at=T1)
+    assert intent.filled_at_cancel is None

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -679,6 +679,27 @@ class TestTradingManagerCancelUpdateFailure:
         assert event.client_order_id == order.client_order_id
         assert "venue unreachable" in event.reason
 
+    def test_replace_cancel_sync_raise_reverts_order_and_clears_intent(self, failure_setup, mock_connector):
+        """A partially-filled update_order routes to cancel+replace (order.filled_quantity >
+        0). If the internal cancel_order raises synchronously (never reached the venue), the
+        just-armed ReplaceIntent must not survive — otherwise the order is stuck PENDING_UPDATE
+        forever (the re-entrancy guard silently no-ops every later update_order call)."""
+        tm, am, context, order = failure_setup
+        order.record_fill(0.03, 50_000.0)  # filled > 0 -> replace routing
+        mock_connector.cancel_order.side_effect = ConnectionError("venue unreachable")
+
+        with pytest.raises(ConnectionError):
+            tm.update_order(price=51_000.0, amount=0.1, client_order_id=order.client_order_id)
+
+        assert am.get_order(order.client_order_id).status is OrderStatus.ACCEPTED  # reverted, not stuck PENDING_UPDATE
+        assert am._states[order.instrument.exchange].get_replace_intent(order.client_order_id) is None
+        mock_connector.update_order.assert_not_called()  # never falls back to native amend
+
+        (event,) = context.routed_events
+        assert isinstance(event, OrderUpdateRejectedEvent)
+        assert event.client_order_id == order.client_order_id
+        assert "venue unreachable" in event.reason
+
 
 class TestTradingManagerUpdateOrderGuards:
     """update_order pre-connector guards: terminal misuse raises, in-flight update no-ops."""

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -6,7 +6,13 @@ import pytest
 from qubx.core.account_manager import SimulatedAccountManager
 from qubx.core.basics import Instrument, MarketType, Order, OrderOrigin, OrderStatus, Position
 from qubx.core.events import OrderCancelRejectedEvent, OrderUpdateRejectedEvent
-from qubx.core.exceptions import InvalidOrderSize, OrderAlreadyTerminal, OrderNotFound, ReadOnlyConnector
+from qubx.core.exceptions import (
+    InvalidOrderSize,
+    InvalidOrderTransition,
+    OrderAlreadyTerminal,
+    OrderNotFound,
+    ReadOnlyConnector,
+)
 from qubx.core.interfaces import IStrategyContext, ITimeProvider
 from qubx.core.lookups import lookup
 from qubx.core.mixins.trading import ClientIdStore, TradingManager
@@ -699,6 +705,34 @@ class TestTradingManagerCancelUpdateFailure:
         assert isinstance(event, OrderUpdateRejectedEvent)
         assert event.client_order_id == order.client_order_id
         assert "venue unreachable" in event.reason
+
+    def test_cancel_order_during_the_replace_window_clears_the_intent(self, failure_setup, mock_connector):
+        """An explicit strategy cancel of a mid-replace order is legal and must win: leaving the
+        intent armed would suppress the cancel's ack and resurrect the order as a replacement."""
+        tm, am, context, order = failure_setup
+        state = am._states[order.instrument.exchange]
+        order.record_fill(0.03, 50_000.0)  # filled > 0 -> replace routing
+        tm.update_order(price=51_000.0, amount=0.1, client_order_id=order.client_order_id)
+        assert state.get_replace_intent(order.client_order_id) is not None
+
+        assert tm.cancel_order(client_order_id=order.client_order_id) is True
+
+        assert state.get_replace_intent(order.client_order_id) is None
+        assert am.get_order(order.client_order_id).status is OrderStatus.PENDING_CANCEL
+
+    def test_replace_intent_not_armed_when_the_pending_transition_raises(self, failure_setup, mock_connector):
+        """Arming before the PENDING_UPDATE transition leaks the intent when the transition is
+        illegal (PENDING_CANCEL -> PENDING_UPDATE): no cancel is ever sent, so nothing clears it."""
+        tm, am, context, order = failure_setup
+        state = am._states[order.instrument.exchange]
+        order.record_fill(0.03, 50_000.0)
+        am.transition_order(order.instrument.exchange, order.client_order_id, OrderStatus.PENDING_CANCEL)
+
+        with pytest.raises(InvalidOrderTransition):
+            tm.update_order(price=51_000.0, amount=0.1, client_order_id=order.client_order_id)
+
+        assert state.get_replace_intent(order.client_order_id) is None
+        mock_connector.cancel_order.assert_not_called()
 
 
 class TestTradingManagerUpdateOrderGuards:

--- a/tests/qubx/core/test_order_identifier_routing.py
+++ b/tests/qubx/core/test_order_identifier_routing.py
@@ -137,6 +137,9 @@ def test_update_order_rejects_zero_amount(trading_manager):
     with pytest.raises(ValueError, match="sign"):
         trading_manager.update_order(price=1.0, amount=0.0, client_order_id="cid_1", exchange="BINANCE.UM")
 
+    trading_manager._exchange_to_connector["BINANCE.UM"].update_order.assert_not_called()
+    trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_not_called()
+
 
 def test_update_order_partially_filled_routes_to_cancel(trading_manager):
     # BUY order with a partial fill — must route through cancel+replace, never native amend.

--- a/tests/qubx/core/test_order_identifier_routing.py
+++ b/tests/qubx/core/test_order_identifier_routing.py
@@ -3,12 +3,18 @@ from unittest.mock import Mock
 import pandas as pd
 import pytest
 
-from qubx.core.basics import OrderStatus, Position
+from qubx.core.basics import OrderSide, OrderStatus, Position
 from qubx.core.mixins.trading import TradingManager
 from qubx.health.dummy import DummyHealthMonitor
 
 
-def _order(order_id="exchange_order_1", client_order_id="cid_1", status=OrderStatus.ACCEPTED):
+def _order(
+    order_id="exchange_order_1",
+    client_order_id="cid_1",
+    status=OrderStatus.ACCEPTED,
+    side=OrderSide.BUY,
+    filled_quantity=0.0,
+):
     instrument = Mock()
     instrument.exchange = "BINANCE.UM"
     instrument.symbol = "BTCUSDT"
@@ -24,6 +30,8 @@ def _order(order_id="exchange_order_1", client_order_id="cid_1", status=OrderSta
     order.venue_order_id = order_id
     order.instrument = instrument
     order.status = status
+    order.side = side
+    order.filled_quantity = filled_quantity
     return order
 
 
@@ -106,3 +114,62 @@ def test_update_order_requires_exactly_one_identifier(trading_manager):
         trading_manager.update_order(
             order_id="o1", client_order_id="c1", price=123.0, amount=1.0, exchange="BINANCE.UM"
         )
+
+
+def test_update_order_rejects_sign_mismatch(trading_manager):
+    # BUY order, filled 0 — a negative amount doesn't match the order side.
+    order = _order(client_order_id="cid_1", side=OrderSide.BUY, filled_quantity=0.0)
+    trading_manager._account_manager.find_order_by_client_id.return_value = order
+    trading_manager._account_manager.find_order_by_id.return_value = None
+
+    with pytest.raises(ValueError, match="sign"):
+        trading_manager.update_order(price=1.0, amount=-5.0, client_order_id="cid_1", exchange="BINANCE.UM")
+
+    trading_manager._exchange_to_connector["BINANCE.UM"].update_order.assert_not_called()
+    trading_manager._exchange_to_connector["BINANCE.UM"].cancel_order.assert_not_called()
+
+
+def test_update_order_rejects_zero_amount(trading_manager):
+    order = _order(client_order_id="cid_1", side=OrderSide.BUY, filled_quantity=0.0)
+    trading_manager._account_manager.find_order_by_client_id.return_value = order
+    trading_manager._account_manager.find_order_by_id.return_value = None
+
+    with pytest.raises(ValueError, match="sign"):
+        trading_manager.update_order(price=1.0, amount=0.0, client_order_id="cid_1", exchange="BINANCE.UM")
+
+
+def test_update_order_partially_filled_routes_to_cancel(trading_manager):
+    # BUY order with a partial fill — must route through cancel+replace, never native amend.
+    order = _order(client_order_id="cid_1", side=OrderSide.BUY, filled_quantity=3.0)
+    trading_manager._account_manager.find_order_by_client_id.return_value = order
+    trading_manager._account_manager.find_order_by_id.return_value = None
+    trading_manager._account_manager.transition_order.side_effect = lambda exchange, cid, status: setattr(
+        order, "status", status
+    )
+
+    trading_manager.update_order(price=1.01, amount=7.0, client_order_id="cid_1", exchange="BINANCE.UM")
+
+    connector = trading_manager._exchange_to_connector["BINANCE.UM"]
+    connector.update_order.assert_not_called()  # NO native amend
+    connector.cancel_order.assert_called_once_with(order)  # replace path starts with cancel
+
+    trading_manager._account_manager.arm_replace_intent.assert_called_once_with(
+        "BINANCE.UM", "cid_1", desired_remaining=7.0, price=1.01, filled_at_request=3.0
+    )
+    trading_manager._account_manager.transition_order.assert_called_once_with(
+        "BINANCE.UM", "cid_1", OrderStatus.PENDING_UPDATE
+    )
+    assert order.status is OrderStatus.PENDING_UPDATE
+
+
+def test_update_order_unfilled_uses_native_amend(trading_manager):
+    order = _order(client_order_id="cid_1", side=OrderSide.BUY, filled_quantity=0.0)
+    trading_manager._account_manager.find_order_by_client_id.return_value = order
+    trading_manager._account_manager.find_order_by_id.return_value = None
+
+    trading_manager.update_order(price=1.01, amount=10.0, client_order_id="cid_1", exchange="BINANCE.UM")
+
+    connector = trading_manager._exchange_to_connector["BINANCE.UM"]
+    connector.update_order.assert_called_once_with(order, price=1.01, quantity=10.0)
+    connector.cancel_order.assert_not_called()
+    trading_manager._account_manager.arm_replace_intent.assert_not_called()


### PR DESCRIPTION
## What

Makes `ctx.update_order` correct for partially-filled orders on every venue, by fixing the `Order.quantity` bookkeeping invariant and routing quantity updates of partially-filled orders through a framework-side cancel+replace orchestration instead of venue-native amend.

**Contract change:** `update_order(price, amount)` — `amount` is the desired **signed remaining** to keep working (sign must match order side; zero/mismatch raises instead of the old silent `abs()`). `Order.quantity` now always means **total including everything ever filled** on the client order id; the amend-ack reducer splices `quantity = filled_quantity + new_quantity`.

**Routing rule:** `filled == 0` → native venue amend (the one case where every venue dialect agrees). `filled > 0` → framework cancel+replace above the `IConnector` boundary, same client order id: arm a `ReplaceIntent` → internal cancel (suppressed by the reducer; the venue's final fill figure rides the new `OrderCanceledEvent.venue_filled_quantity`, populated by the ccxt connector from the cancel ack) → account-reconciler decision (`SubmitReplacement`/`AbandonReplace` from the post-cancel residual) → `_execute` submits the replacement and routes the splice event.

**Failure contract — truth over fiction, every path:** sync cancel failure → intent cleared + synthetic update-reject (order alive); sync submit failure → truthful CANCELED (order is dead at the venue); residual below min → truthful CANCELED; duplicate REST/WS cancel terminals and stale cancels of superseded venue ids → dropped (per-cid superseded-oid marker); strategy cancel during the replace window wins (no resurrection); unknown-outcome intent expiry (30s) → revert + status refetch, never a fabricated terminal.

## Why

Live incident 2026-08-05 (dev frab bot, pair ACE): repricing a partially-filled Hyperliquid maker order corrupted the Order record — HL's modify is a cancel+replace under the same client id, the amend ack overwrote `quantity` with the remaining while `filled_quantity` stayed cumulative, and `remaining = quantity − filled` went negative. Downstream execution logic then trimmed the wrong leg and livelocked. On Binance/Gate the same call pattern is wrong differently (their amend-quantity means *new total* with executedQty preserved → silent double-shrink). Full analysis: `docs/account-management/design.md` § "Order updates and the replace orchestration" and `docs/superpowers/plans/2026-08-05-order-replace-orchestration.md`.

## Testing

- ~50 new/changed tests: reducer splice + suppression + duplicate/stale-cancel regressions, routing + sign validation, intent lifecycle (arm/clear on every path), decision math (incl. below-min + venue-id-only cancels), `_execute` end-to-end through real reducer+reconciler (incl. sync-failure truth paths, raced-fill lag compensation, ResolveMissingOrder watcher resolution), expiry recovery, and a backtester integration test pinning the `filled == 0` amend path against real OME book state (with an intermediate no-fill quote so a venue-side reprice failure cannot pass).
- Branch suite: `tests/qubx/core` + `tests/qubx/backtester` green (1030 passed). Note: `tests/qubx/connectors/ccxt/test_ohlc_pagination.py` shows 5 **pre-existing** ordering-dependent failures when the connectors suite runs together — verified identical on `main` (event-loop test-isolation issue, unrelated; all pass standalone).

## Known deferrals (ledgered during review, need follow-up issues)

1. **Snapshot reconcile vs the same-cid splice**: after a replacement, the venue's order reports fills counted from zero; a snapshot that wins the venue-newer race can clobber the cumulative `filled_quantity` (pre-existing today for HL native modify). Needs a `filled_base` offset or venue-id-aware adoption — deliberately not attempted here (snapshot-semantics design pass).
2. **No confirm watcher for the replacement submit**: an async-lost replacement submit is only recovered by the periodic snapshot (`LocalOrderMissing → ResolveMissingOrder`). A meaningful watcher needs a new reconciler task type (the existing `AwaitOrderConfirm` would self-resolve on our own routed event).
3. **Backtester OME has no partial-fill matching** (fills are atomic), so the partial-fill replace race can't be simulated — covered by AM-level integration tests here and by a planned testnet e2e in the exchanges repo (`exchanges:docs/superpowers/plans/2026-08-05-cancel-fill-reporting-conformance.md`, includes the `venue_filled_quantity` conformance contract).

## Companion work (not in this PR)

- exchanges repo: conformance capability `cancel_reports_fills` + e2e partial-fill update scenario (spec committed there).
- quantkit: consumer-side hardening (corrupt-remaining guard, effective-position clamp, booked-ratio watchdog, CLOSED-state fixes) — `quantkit:docs/superpowers/plans/2026-08-05-maker-taker-venue-truth.md`.
