### PR TITLE
feat!: update_order total-quantity contract; connectors own amend dialects

### DIFF
--- a/docs/account-management/design.md
+++ b/docs/account-management/design.md
@@ -467,6 +467,9 @@ the way out; on the way back, `OrderUpdatedEvent.new_quantity` always echoes the
 **requested total** (or `None`), never a venue-dialect figure — connectors never leak
 their wire dialect into the event stream. The framework isn't traded through ccxt-HL
 today, but the dialect map exists so the public path doesn't ship an oversize landmine.
+On the ccxt-HL path specifically, an amend keeps addressing the OLD venue oid — there is
+no re-key from the modify response — so ccxt-HL amend is size-correct but identity-stale;
+order identity after amend is only handled by the exchanges-repo plugin.
 
 After a successful `editOrder`, the connector inspects the response status: if the venue
 reports CANCELED (the Binance/Gate response to an in-flight fill overtaking the new
@@ -494,7 +497,12 @@ where an HL amend ack overwrote `Order.quantity` with a remaining-dialect figure
   trim self-corrects the overshoot. Eliminating it needs a framework cancel+replace that
   reads the cancel-ack's final fill before sizing — the PR #367 orchestration this design
   rejects as not worth its complexity.
-- **Pre-existing, unchanged:** after an HL modify the venue counts the replacement's
-  fills from zero, so a snapshot that wins the venue-newer race can clobber cumulative
-  `filled_quantity` (needs a `filled_base` offset / venue-id-aware adoption — separate
-  snapshot-semantics design).
+- **Pre-existing, now guarded:** after an HL modify the venue counts the replacement's
+  fills from zero, so a snapshot that wins the venue-newer race used to clobber cumulative
+  `filled_quantity` with that lower figure. Under total semantics an un-guarded clobber
+  doesn't just lose history — it OVER-states `remaining` (`total − filled`), feeding an
+  over-sized next amend. `_apply_order_snapshot` now adopts `filled_quantity`
+  monotonically (never decreases it), closing that hole. The residual is cosmetic:
+  `OrderQuantityMismatch` diff noise against the venue's own post-modify figures until
+  venue-id-aware adoption (`filled_base` offset — separate snapshot-semantics design)
+  lands; still deferred.

--- a/docs/account-management/design.md
+++ b/docs/account-management/design.md
@@ -439,3 +439,62 @@ Sanctioned departures, detailed in the sections above:
   slippage-priced market orders and order-response enrichment — was dropped in the
   cutover; HL live trading regresses to the generic ccxt path until reimplemented as a
   `CcxtConnector` subclass.
+
+## Order updates: total-quantity contract and amend dialects
+
+`update_order(price=None, quantity=None, ...)` — at least one set, else `ValueError`.
+`quantity` is unsigned and always the order's new **TOTAL, including everything already
+filled**; the old signed-remaining convention is dropped (the order already knows its
+side, so sign carried no information). `quantity <= order.filled_quantity` raises
+`ValueError`: on Binance and Gate a shrink-to-or-below-filled is a **documented silent
+cancel**, not a resize, so it must be requested as one (`quantity == filled` is
+`cancel_order`, not an update). `quantity is None` leaves size untouched — `_adjust_size`
+only runs when a quantity is given.
+
+**Dialect table** — no venue-neutral amend exists; each connector owns translating the
+framework's total to its wire dialect, in both directions:
+
+| Venue | Native amend | Wire quantity means | Below-filled behavior |
+|---|---|---|---|
+| Binance UM (`PUT /fapi/v1/order`) | atomic modify, orderId kept | new **total**, `executedQty` preserved | silent cancel (documented) |
+| Gate futures (`PUT /futures/{settle}/orders/{id}`) | atomic modify | new **total** "including filled part" (documented) | silent cancel (documented) |
+| Hyperliquid (`modify` action) | cancel+replace at the matching engine, new oid, cloid kept | size of the **replacement** (= desired remaining; fills restart at 0) | not documented |
+
+Exchanges declare their dialect via `AMEND_QUANTITY_DIALECT` on the ccxt subclass.
+Binance/Gate default to total (passed through verbatim — ccxt already sends it
+unmodified). HL-dialect subclasses get `venue_amount = total - order.filled_quantity` on
+the way out; on the way back, `OrderUpdatedEvent.new_quantity` always echoes the
+**requested total** (or `None`), never a venue-dialect figure — connectors never leak
+their wire dialect into the event stream. The framework isn't traded through ccxt-HL
+today, but the dialect map exists so the public path doesn't ship an oversize landmine.
+
+After a successful `editOrder`, the connector inspects the response status: if the venue
+reports CANCELED (the Binance/Gate response to an in-flight fill overtaking the new
+total), it emits a truthful cancel event instead of `OrderUpdatedEvent` — the silent
+cancel becomes a visible one.
+
+**Reducer clamp invariant:** on update-ack, `quantity = new_quantity if new_quantity is
+not None else unchanged`. If the result would be `< filled_quantity` (only reachable via
+a race or a buggy connector), the reducer logs an error and clamps `quantity =
+filled_quantity` (remaining 0) rather than propagating a negative remaining; the periodic
+snapshot/status refetch reconciles afterward. This closes the 2026-08-05 ACE incident,
+where an HL amend ack overwrote `Order.quantity` with a remaining-dialect figure while
+`filled_quantity` stayed cumulative, driving `remaining = quantity - filled` negative.
+`quantity >= filled` now holds unconditionally post-reduce, with a regression test.
+
+**Accepted races** (documented, not defended against):
+
+- **Total-dialect venues (Binance/Gate):** an in-flight fill shrinks the effective
+  remaining below what the caller computed → venue under-works or (fill overtakes the
+  total) silently cancels. Both outcomes are truthful: fills are fills, and the silent
+  cancel is detected and reported as a cancel. No corrupted bookkeeping is possible.
+- **Replacement-dialect venues (HL):** an in-flight fill between reading
+  `filled_quantity` and the venue processing the modify oversizes the replacement by that
+  δ. Bounded by one round trip; identical to today's live behavior; quantkit's settle
+  trim self-corrects the overshoot. Eliminating it needs a framework cancel+replace that
+  reads the cancel-ack's final fill before sizing — the PR #367 orchestration this design
+  rejects as not worth its complexity.
+- **Pre-existing, unchanged:** after an HL modify the venue counts the replacement's
+  fills from zero, so a snapshot that wins the venue-newer race can clobber cumulative
+  `filled_quantity` (needs a `filled_base` offset / venue-id-aware adoption — separate
+  snapshot-semantics design).

--- a/docs/connectors/creating-connectors.md
+++ b/docs/connectors/creating-connectors.md
@@ -179,7 +179,12 @@ class MyConnector(ChannelEmitter):
     def update_order(self, *, client_order_id: str | None = None,
                      venue_order_id: str | None = None,
                      price: float | None = None,
-                     quantity: float | None = None) -> None: ...
+                     quantity: float | None = None) -> None:
+        # `quantity` is the order's new TOTAL size including everything already filled
+        # (None = unchanged). Translate it to your venue's amend dialect on the wire, but
+        # echo the requested total (or None) back in OrderUpdatedEvent.new_quantity —
+        # never the wire figure.
+        ...
 
     def request_order_status(self, *, client_order_id: str | None = None,
                              venue_order_id: str | None = None) -> None: ...

--- a/docs/superpowers/plans/2026-08-06-update-order-total-quantity.md
+++ b/docs/superpowers/plans/2026-08-06-update-order-total-quantity.md
@@ -1,0 +1,840 @@
+# update_order Total-Quantity Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ctx.update_order` correct for partially-filled orders on every venue by switching the quantity contract to "new TOTAL including filled" and making each connector own its venue's amend-dialect translation — no framework orchestration.
+
+**Architecture:** The trading mixin validates (`quantity > filled`, at least one of price/quantity) and passes the total through. The ccxt connector resolves `None` fields from the Order, translates the total to the venue dialect (passthrough for Binance/Gate whose amend quantity *is* the new total; `total − filled` for replacement-dialect venues, declared via a class attribute on the qubx exchange subclass), detects the documented Binance/Gate silent-cancel response, and echoes the *requested* total on the ack event. The reducer applies the ack total with a never-negative-remaining clamp. Spec: `docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md` (committed on this branch).
+
+**Tech Stack:** Python 3.12, pytest (+ pytest-asyncio for connector tests), ccxt 4.5.x, ruff.
+
+## Global Constraints
+
+- Worktree: `~/devs/Qubx/.worktrees/update-order-total`, branch `feat/update-order-total-quantity` (based on `origin/main` @ `e5c9a002`). ALL commands run from this worktree root.
+- Use `uv run pytest ...` for tests; final full-suite check is `just test`.
+- Conventional commits (`feat:`, `fix:`, `test:`, `docs:`); no co-authored-by lines.
+- **NEVER run `git stash` in this worktree** (the stash list is shared across all Qubx worktrees).
+- ruff, 120-char lines; modern typing (`float | None`, no `typing.Optional`).
+- The parameter rename `amount` → `quantity` is deliberate (loud break for old callers). Do not add a compatibility alias.
+- `docs/superpowers/` is gitignored in this repo — commit files under it with `git add -f`.
+
+---
+
+### Task 1: Trading mixin contract — optional price/quantity, total semantics, shrink-below-filled guard
+
+**Files:**
+- Modify: `src/qubx/core/mixins/trading.py:363-410` (`update_order`)
+- Modify: `src/qubx/core/interfaces.py:917-930` (`ITradingManager.update_order` declaration)
+- Modify: `src/qubx/core/context.py:829-843` (`StrategyContext.update_order` delegation)
+- Modify: `tests/qubx/core/mixins/trading_test.py` (existing `amount=` call sites at lines 674, 692, 702 + new test class)
+- Modify: `tests/qubx/core/test_order_identifier_routing.py` (existing `amount=` call sites at lines 92, 104, 106-107 and the connector-call assertion near line 97)
+
+**Interfaces:**
+- Consumes: existing `_resolve_order`, `_adjust_size(instrument, amount)`, `_adjust_price(instrument, price, amount)` (sign of `amount` = rounding-direction hint), `OrderAlreadyTerminal`, `OrderNotFound`, `OrderUpdateRejectedEvent` — all already imported in `trading.py`.
+- Produces: `update_order(price: float | None = None, quantity: float | None = None, order_id: str | None = None, client_order_id: str | None = None, exchange: str | None = None) -> None`. Calls `IConnector.update_order(order, price=<adjusted or None>, quantity=<adjusted total or None>)`. **`quantity=None` means "unchanged" and is passed through as `None`** — Tasks 3/5 rely on that.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/qubx/core/mixins/trading_test.py` (reuse the module's existing `trading_manager` / `mock_connector` / `mock_account` fixtures and `_live_order()` helper, same as `TestTradingManagerUpdateOrderGuards` at line 683):
+
+```python
+class TestTradingManagerUpdateOrderContract:
+    """Total-quantity contract: quantity is the order's new TOTAL including filled,
+    unsigned; at least one of price/quantity is required; a total at or below the
+    already-filled quantity raises (Binance/Gate silently CANCEL in that case)."""
+
+    def test_both_none_raises_connector_not_called(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        with pytest.raises(ValueError, match="price and/or quantity"):
+            trading_manager.update_order(order_id="test_order_123")
+
+        mock_connector.update_order.assert_not_called()
+        mock_account.transition_order.assert_not_called()
+
+    def test_non_positive_quantity_raises(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        with pytest.raises(ValueError, match="positive"):
+            trading_manager.update_order(quantity=0.0, order_id="test_order_123")
+
+        mock_connector.update_order.assert_not_called()
+
+    def test_total_at_or_below_filled_raises(self, trading_manager, mock_connector, mock_account):
+        # Order for 0.1, already filled 0.06: a new total of 0.05 (< filled) is a
+        # silent venue cancel in disguise — must raise, never reach the connector.
+        order = _live_order()
+        order.filled_quantity = 0.06
+        mock_account.find_order_by_id.return_value = order
+
+        with pytest.raises(ValueError, match="filled"):
+            trading_manager.update_order(quantity=0.05, order_id="test_order_123")
+        with pytest.raises(ValueError, match="filled"):
+            trading_manager.update_order(quantity=0.06, order_id="test_order_123")  # == filled: that's a cancel
+
+        mock_connector.update_order.assert_not_called()
+
+    def test_price_only_passes_none_quantity(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        trading_manager.update_order(price=51_000.0, order_id="test_order_123")
+
+        mock_connector.update_order.assert_called_once()
+        _, kwargs = mock_connector.update_order.call_args
+        assert kwargs["quantity"] is None
+        assert kwargs["price"] is not None
+
+    def test_quantity_only_passes_none_price(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        trading_manager.update_order(quantity=0.2, order_id="test_order_123")
+
+        mock_connector.update_order.assert_called_once()
+        _, kwargs = mock_connector.update_order.call_args
+        assert kwargs["price"] is None
+        assert kwargs["quantity"] == pytest.approx(0.2)
+
+    def test_old_amount_kwarg_is_a_loud_typeerror(self, trading_manager, mock_account):
+        # Deployment-coupling tripwire: an old caller using amount= must fail loudly,
+        # never silently reinterpret (spec: "Deployment coupling").
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        with pytest.raises(TypeError):
+            trading_manager.update_order(price=51_000.0, amount=0.1, order_id="test_order_123")
+```
+
+Also update the three existing call sites in this file from `amount=0.1` to `quantity=0.1` (lines 674, 692, 702), and in `tests/qubx/core/test_order_identifier_routing.py` change `amount=1.0` to `quantity=1.0` (lines 92, 104, 106-107). At `test_order_identifier_routing.py:97`, the assertion on the connector call becomes:
+
+```python
+    trading_manager._exchange_to_connector["BINANCE.UM"].update_order.assert_called_once_with(
+        order, price=123.0, quantity=1.0
+    )
+```
+
+(keep whatever exact price value the current assertion uses after `_adjust_price` — run the test and read the failure if unsure).
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/mixins/trading_test.py::TestTradingManagerUpdateOrderContract -x -q`
+Expected: FAIL — `TypeError: update_order() got an unexpected keyword argument 'quantity'` (old signature still has `amount`).
+
+- [ ] **Step 3: Implement the new mixin signature**
+
+Replace `update_order` in `src/qubx/core/mixins/trading.py:363-410` with:
+
+```python
+    def update_order(
+        self,
+        price: float | None = None,
+        quantity: float | None = None,
+        order_id: str | None = None,
+        client_order_id: str | None = None,
+        exchange: str | None = None,
+    ) -> None:
+        """Update a live limit order's price and/or quantity.
+
+        ``quantity`` is the order's new TOTAL, including everything already filled
+        (unsigned). ``None`` means "leave unchanged" — at least one of ``price`` /
+        ``quantity`` must be given. ``quantity <= filled_quantity`` raises: Binance and
+        Gate silently CANCEL an order amended to a total at/below the executed quantity,
+        so a shrink below filled must be requested as a cancel, never an update.
+
+        Raises OrderAlreadyTerminal on a settled order (updating a settled order is
+        meaningful misuse); a no-op while a previous update is still in flight.
+        A synchronous connector failure reverts the order to its pre-pending status
+        (via a synthetic OrderUpdateRejectedEvent) and re-raises to the caller.
+        """
+        if price is None and quantity is None:
+            raise ValueError("update_order requires price and/or quantity")
+        self._ensure_writable()
+        order_id, client_order_id = self._normalize_order_ids(order_id, client_order_id)
+        order = self._resolve_order(order_id, client_order_id)
+        if order is None:
+            raise OrderNotFound(client_order_id or order_id or "")
+
+        if order.status.is_terminal:
+            raise OrderAlreadyTerminal(order.client_order_id, order.status)
+        if order.status is OrderStatus.PENDING_UPDATE:
+            return
+
+        instrument = order.instrument
+        if quantity is not None:
+            if quantity <= 0:
+                raise ValueError(f"update_order quantity must be positive, got {quantity}")
+            quantity = abs(self._adjust_size(instrument, quantity))
+            if quantity <= order.filled_quantity:
+                raise ValueError(
+                    f"update_order total {quantity} <= filled {order.filled_quantity} for "
+                    f"{order.client_order_id}: a total at/below filled is a silent venue "
+                    f"cancel — use cancel_order instead"
+                )
+
+        adjusted_price: float | None = None
+        if price is not None:
+            # _adjust_price uses the amount's sign as the rounding-direction hint;
+            # quantity is unsigned now, so derive the sign from the order's side.
+            side_sign = 1.0 if order.side == "BUY" else -1.0
+            adjusted_price = self._adjust_price(instrument, price, side_sign * (quantity or order.quantity))
+            if adjusted_price is None:
+                raise ValueError(f"Price adjustment failed for {instrument.symbol}")
+
+        cid = order.client_order_id
+        self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
+        try:
+            self._get_connector(instrument.exchange).update_order(order, price=adjusted_price, quantity=quantity)
+        except Exception as e:
+            # Same contract as cancel_order: synthetic reject through the PM reverts
+            # PENDING_UPDATE via pre_pending, then the original exception re-raises.
+            self._context.process_event(
+                OrderUpdateRejectedEvent(
+                    instrument=instrument,
+                    client_order_id=cid,
+                    venue_order_id=order.venue_order_id,
+                    reason=f"update request failed before reaching venue: {e}",
+                )
+            )
+            raise
+```
+
+Update `ITradingManager.update_order` in `src/qubx/core/interfaces.py:917-930` to the same signature, docstring first line: `"""Update a live limit order's price and/or total quantity (total includes filled; None = unchanged; at least one required)."""` Keep the identifier docs.
+
+Update `src/qubx/core/context.py:829-843`:
+
+```python
+    def update_order(
+        self,
+        price: float | None = None,
+        quantity: float | None = None,
+        order_id: str | None = None,
+        client_order_id: str | None = None,
+        exchange: str | None = None,
+    ) -> None:
+        """
+        Update a live limit order's price and/or total quantity (total includes filled).
+        """
+        self._assert_not_fit_thread("update_order")
+        self._trading_manager.update_order(
+            order_id=order_id, client_order_id=client_order_id, price=price, quantity=quantity, exchange=exchange
+        )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/mixins/trading_test.py tests/qubx/core/test_order_identifier_routing.py -q`
+Expected: PASS (including the pre-existing guard/failure classes — they now use `quantity=`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/mixins/trading.py src/qubx/core/interfaces.py src/qubx/core/context.py \
+        tests/qubx/core/mixins/trading_test.py tests/qubx/core/test_order_identifier_routing.py
+git commit -m "feat(core)!: update_order takes optional price/quantity; quantity is the new total incl. filled"
+```
+
+---
+
+### Task 2: Reducer — never-negative-remaining clamp on the update ack
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/reducer.py:463-478` (`_handle_updated`)
+- Modify: `tests/qubx/core/account_manager/reducer_test.py` (append tests; helpers `_state()`, `_order()`, `_fill()`, `apply`, `T0`, `T1` already exist at lines 65-89)
+
+**Interfaces:**
+- Consumes: `OrderUpdatedEvent.new_quantity` — under the new contract this is the requested **total** (or `None` = unchanged). Connectors (Task 3) guarantee they echo the requested total, never a venue-dialect figure.
+- Produces: `Order.quantity` invariant after any update ack: `quantity >= filled_quantity` (remaining never negative — the ACE 2026-08-05 poison class).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/qubx/core/account_manager/reducer_test.py` (section 4.4):
+
+```python
+def test_update_ack_total_below_filled_clamps_remaining_at_zero():
+    # ACE 2026-08-05 regression class: an ack whose total is below cumulative fills
+    # must never make remaining (= quantity - filled) negative. Clamp to filled and
+    # let the snapshot/status refetch reconcile.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED)  # quantity=1.0
+    apply(state, OrderFilledEvent(instrument=None, client_order_id="c1", fill=_fill(amount=0.6)), T0)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+
+    r = apply(state, OrderUpdatedEvent(instrument=None, client_order_id="c1", new_price=None, new_quantity=0.4), T1)
+
+    o = r.order
+    assert o is not None
+    assert o.filled_quantity == 0.6
+    assert o.quantity == 0.6                       # clamped to filled, not 0.4
+    assert o.quantity - o.filled_quantity == 0.0   # remaining never negative
+
+
+def test_update_ack_total_above_filled_applies_verbatim():
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED)  # quantity=1.0
+    apply(state, OrderFilledEvent(instrument=None, client_order_id="c1", fill=_fill(amount=0.6)), T0)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+
+    r = apply(state, OrderUpdatedEvent(instrument=None, client_order_id="c1", new_price=None, new_quantity=2.0), T1)
+
+    o = r.order
+    assert o is not None
+    assert o.quantity == 2.0
+    assert o.quantity - o.filled_quantity == pytest.approx(1.4)
+
+
+def test_canceled_during_pending_update_terminalizes_and_clears_pre_pending():
+    # Binance/Gate amend with total <= executedQty silently cancels the order; the
+    # connector surfaces that as OrderCanceledEvent while we sit in PENDING_UPDATE.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1"), T1)
+
+    assert r.order is not None
+    assert r.order.status is OrderStatus.CANCELED
+    assert state.get_pre_pending("c1") is None
+```
+
+(`OrderFilledEvent`, `OrderCanceledEvent` are already imported at the top of this test module; verify and add if missing.)
+
+- [ ] **Step 2: Run to verify the clamp test fails**
+
+Run: `uv run pytest tests/qubx/core/account_manager/reducer_test.py -k "clamps or above_filled or pending_update" -q`
+Expected: `test_update_ack_total_below_filled_clamps_remaining_at_zero` FAILS (`o.quantity == 0.4`); the other two may already pass (that's fine — they pin current behavior against regression).
+
+- [ ] **Step 3: Implement the clamp**
+
+In `src/qubx/core/account_manager/reducer.py`, `_handle_updated`, replace lines 470-473:
+
+```python
+    if event.new_price is not None:
+        order.price = event.new_price
+    if event.new_quantity is not None:
+        if event.new_quantity < order.filled_quantity:
+            # Ack total below cumulative fills would make remaining negative (the
+            # ACE 2026-08-05 poison). Clamp to filled (remaining 0); the periodic
+            # snapshot / status refetch reconciles the true figure.
+            logger.error(
+                f"[{order.client_order_id}] update-ack total {event.new_quantity} < "
+                f"filled {order.filled_quantity}; clamping quantity to filled"
+            )
+            order.quantity = order.filled_quantity
+        else:
+            order.quantity = event.new_quantity
+```
+
+- [ ] **Step 4: Run the reducer suite**
+
+Run: `uv run pytest tests/qubx/core/account_manager/reducer_test.py -q`
+Expected: PASS (all existing update tests still green — mechanics unchanged for `new_quantity >= filled`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/account_manager/reducer.py tests/qubx/core/account_manager/reducer_test.py
+git commit -m "fix(account): update-ack clamps quantity at filled — remaining can never go negative"
+```
+
+---
+
+### Task 3: ccxt connector — None-resolution, dialect translation, requested-total echo
+
+**Files:**
+- Modify: `src/qubx/connectors/ccxt/connector.py:523-619` (`update_order`, `_update_async`, `_edit_order_direct`)
+- Modify: `src/qubx/connectors/ccxt/exchanges/hyperliquid/hyperliquid.py` (dialect attribute + pre-ack guard on `HyperliquidEnhanced`)
+- Modify: `tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py` (section "(6) update_order", lines 522-592)
+
+**Interfaces:**
+- Consumes: `IConnector.update_order(order, *, price: float | None, quantity: float | None)` — `quantity` is the new TOTAL or `None` (unchanged), from Task 1.
+- Produces: venue request always carries a concrete price and amount (resolved from the Order when `None`); `OrderUpdatedEvent(new_price=<requested price or None>, new_quantity=<requested total or None>)` — the reducer (Task 2) relies on `new_quantity` being total-or-None. Dialect declared by the exchange subclass class attribute `AMEND_QUANTITY_DIALECT: str = "replacement"` (absent ⇒ `"total"` passthrough).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py`, section (6). Check the module's `_order()` helper: it builds an Order with `quantity` and `filled_quantity` defaults — if it has no `filled_quantity` parameter, set the attribute on the returned order (Order fields are mutable; the reducer itself assigns them directly).
+
+```python
+@pytest.mark.asyncio
+async def test_update_replacement_dialect_sends_total_minus_filled() -> None:
+    # Hyperliquid-style modify is a venue-side cancel+replace: the amend amount is the
+    # REPLACEMENT order's size (remaining), while the framework speaks totals. The
+    # connector must translate on the wire and still echo the requested TOTAL on the ack.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.AMEND_QUANTITY_DIALECT = "replacement"
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    order.filled_quantity = 0.4
+    conn.update_order(order, price=102.0, quantity=2.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(1.6)   # total - filled on the wire
+    ev = sent[0]
+    assert isinstance(ev, OrderUpdatedEvent)
+    assert ev.new_quantity == 2.0                   # requested TOTAL on the event
+
+
+@pytest.mark.asyncio
+async def test_update_total_dialect_passes_total_verbatim() -> None:
+    # Binance/Gate amend quantity IS the new total (executedQty preserved): passthrough.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT  # plain Mock auto-creates attrs; ensure absent
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    order.filled_quantity = 0.4
+    conn.update_order(order, price=102.0, quantity=2.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(2.0)
+    assert sent[0].new_quantity == 2.0
+
+
+@pytest.mark.asyncio
+async def test_update_price_only_resolves_quantity_from_order_and_echoes_none() -> None:
+    # Binance requires both quantity and price on modify — a price-only update sends the
+    # order's current total on the wire but the ack event says "quantity unchanged".
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    conn.update_order(order, price=102.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(2.0)   # resolved from the order
+    assert kwargs["price"] == 102.0
+    ev = sent[0]
+    assert isinstance(ev, OrderUpdatedEvent)
+    assert ev.new_price == 102.0
+    assert ev.new_quantity is None                  # unchanged — reducer keeps its total
+
+
+@pytest.mark.asyncio
+async def test_update_quantity_only_resolves_price_from_order() -> None:
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    conn.update_order(order, quantity=3.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(3.0)
+    assert kwargs["price"] == order.price           # resolved from the order
+    ev = sent[0]
+    assert ev.new_price is None
+    assert ev.new_quantity == 3.0
+```
+
+Note on the existing tests in this section: `test_update_direct_edit_emits_updated` (line 526) and `test_update_by_cloid_uses_cloid_edit_endpoint` (line 548) assert positional/kwarg shapes of the ccxt call — update their expected `amount`/event fields to the new behavior if they fail (the wire amount for a total-dialect exchange is unchanged, so most should pass as-is; `test_update_network_error_leaves_inflight_no_reject` at line 510 calls `update_order(..., price=123.0)` with no quantity, which now resolves from the order instead of sending `None` — its assertion, `sent == []`, is unaffected).
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py -k "dialect or resolves" -q`
+Expected: FAIL — replacement-dialect test sends `amount=2.0` (no translation yet); price-only test sends `amount=None`.
+
+- [ ] **Step 3: Implement translation + resolution + echo**
+
+In `src/qubx/connectors/ccxt/connector.py`, replace `update_order` (line 523) and `_update_async`/`_edit_order_direct` plumbing:
+
+```python
+    def update_order(self, order: Order, *, price: float | None = None, quantity: float | None = None) -> None:
+        # Read venue-call fields off the Order SYNCHRONOUSLY (see cancel_order); editOrder
+        # needs side/type too, so pass them straight through.
+        # The framework speaks TOTAL quantity (incl. filled); translate to the venue's
+        # amend dialect here. "replacement" (declared on the exchange subclass): the venue
+        # modify is a cancel+replace and its amount is the replacement's size = remaining.
+        wire_price = price if price is not None else order.price
+        total = quantity if quantity is not None else order.quantity
+        if getattr(self._em.exchange, "AMEND_QUANTITY_DIALECT", "total") == "replacement":
+            wire_amount = total - order.filled_quantity
+        else:
+            wire_amount = total
+        if wire_amount <= 0:
+            raise ValueError(
+                f"update_order for {order.client_order_id}: effective amend amount "
+                f"{wire_amount} <= 0 (total {total}, filled {order.filled_quantity})"
+            )
+        self._spawn(
+            self._update_async(
+                order.client_order_id,
+                order.venue_order_id,
+                instrument_to_ccxt_symbol(order.instrument),
+                order.side.lower(),
+                order.type.lower(),
+                wire_price,
+                wire_amount,
+                price,
+                quantity,
+            )
+        )
+```
+
+`_update_async` gains the two trailing parameters and emits the *requested* values (the try/except structure, venue-verdict handling, and vid recovery stay byte-identical):
+
+```python
+    async def _update_async(
+        self,
+        client_order_id: str | None,
+        venue_order_id: str | None,
+        symbol: str,
+        side: str,
+        order_type: str,
+        wire_price: float | None,
+        wire_amount: float | None,
+        requested_price: float | None,
+        requested_total: float | None,
+    ) -> None:
+        ...
+        # (inside the success path, replacing the current OrderUpdatedEvent emission)
+        self.send(
+            OrderUpdatedEvent(
+                instrument=None,
+                client_order_id=client_order_id,
+                venue_order_id=vid,  # str | None — never coerce to "" (AM would index a bogus id)
+                new_price=requested_price,
+                new_quantity=requested_total,
+            )
+        )
+```
+
+`_edit_order_direct` is called with `wire_price` / `wire_amount` (its body is unchanged — it already sends `abs(quantity)` as `amount`).
+
+In `src/qubx/connectors/ccxt/exchanges/hyperliquid/hyperliquid.py`, on `HyperliquidEnhanced` (line 18):
+
+```python
+class HyperliquidEnhanced(CcxtFuturePatchMixin, cxp.hyperliquid):
+    # HL modify is a cancel+replace at the matching engine: the amend amount is the
+    # replacement order's size (= desired remaining), NOT the new total. The qubx ccxt
+    # connector subtracts filled before hitting the wire when it sees this marker.
+    AMEND_QUANTITY_DIALECT = "replacement"
+```
+
+and add a pre-ack guard override (upstream `edit_order('')` crashes in `parse_to_int('')` before any HTTP call — turn that into a clean venue-verdict reject):
+
+```python
+    async def edit_order_with_client_order_id(self, clientOrderId, symbol, type, side, amount=None, price=None, params={}):
+        # HL modify addresses the order by venue oid; there is no cloid-amend endpoint.
+        # Upstream's base fallback would call edit_order('') and crash in parse_to_int('').
+        raise ccxt.NotSupported("hyperliquid: modify requires the venue order id (order not acked yet)")
+```
+
+(`ccxt.NotSupported` subclasses `ExchangeError`, which is in `_VENUE_VERDICT_ERRORS` — the connector emits a clean `OrderUpdateRejectedEvent`. Add a test for this in `tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py` only if an HL-exchange-class test fixture already exists; otherwise cover it in the exchange-class test file used in Task 4.)
+
+- [ ] **Step 4: Run the connector writes suite**
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/connectors/ccxt/connector.py src/qubx/connectors/ccxt/exchanges/hyperliquid/hyperliquid.py \
+        tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+git commit -m "feat(ccxt): connector owns amend-dialect translation; ack echoes the requested total"
+```
+
+---
+
+### Task 4: Silent-cancel detection + Gate cid-only edit fix
+
+**Files:**
+- Modify: `src/qubx/connectors/ccxt/connector.py` (`_update_async` success path)
+- Modify: `src/qubx/connectors/ccxt/exchanges/gateio/gateio.py` (`GateioFutures`)
+- Modify: `tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py`
+- Create or modify: `tests/qubx/connectors/ccxt/test_gateio_exchange.py` (check `ls tests/qubx/connectors/ccxt/` first — if a gateio exchange-class test module exists, append there; follow the fixture pattern of `tests/qubx/connectors/ccxt/test_binance_exchange.py:215-277`, which tests `BinanceQV.edit_contract_order_request` at the request-dict level)
+
+**Interfaces:**
+- Consumes: `_emit_canceled_from_response(client_order_id, venue_order_id, response)` — already exists in `connector.py` (used by the cancel path).
+- Produces: an edit response with ccxt-unified `status == "canceled"` emits `OrderCanceledEvent` instead of `OrderUpdatedEvent`. Gate `edit_order_request` accepts `id=''` + `params={'clientOrderId': cid}` and produces `order_id = 't-' + cid` in the path (matching how qubx-placed Gate orders carry `text = 't-<cid>'`).
+
+- [ ] **Step 1: Write the failing silent-cancel test**
+
+```python
+@pytest.mark.asyncio
+async def test_update_silent_cancel_response_emits_canceled_not_updated() -> None:
+    # Binance/Gate documented behavior: an amend whose total lands at/below executedQty
+    # CANCELS the order (no reject). Racing fills can trigger this despite the mixin
+    # pre-check — the connector must surface the truth as a cancel, not an update-ack.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123", "status": "canceled"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.update_order(_order(venue_order_id="VENUE123"), price=102.0, quantity=2.0)
+    await _drive(conn)
+
+    assert len(sent) == 1
+    assert isinstance(sent[0], OrderCanceledEvent)
+    assert sent[0].venue_order_id == "VENUE123"
+```
+
+(`OrderCanceledEvent` import: check the module's import block; add if missing.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py -k silent_cancel -q`
+Expected: FAIL — an `OrderUpdatedEvent` is emitted.
+
+- [ ] **Step 3: Implement silent-cancel detection**
+
+In `_update_async`, immediately after the vid-recovery line (`vid = vid or str(r.get("id"))`) and before the `OrderUpdatedEvent` emission:
+
+```python
+        if isinstance(r, dict) and r.get("status") == "canceled":
+            # Binance/Gate amend to a total at/below executedQty CANCELS the order
+            # (documented, no error). Surface the truth: this is a cancel, not an update.
+            logger.warning(
+                f"[{self.exchange_name}] edit of {client_order_id} was a silent venue cancel "
+                f"(amend total at/below executed) — emitting cancel"
+            )
+            self._emit_canceled_from_response(client_order_id, vid, r)
+            return
+```
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py -q` — expected PASS.
+
+- [ ] **Step 4: Write the failing Gate request-level test**
+
+Append to the existing `tests/qubx/connectors/ccxt/test_gateio_exchange.py` (it has registration tests only, no offline fixture yet — add one modeled on `offline_binance_usdm` in `test_binance_exchange.py:73-84`; reuse this file's existing `GateioFutures` import and add `pytest`/`run` imports as the binance file does):
+
+```python
+def _gate_swap_market(base: str) -> dict:
+    return {
+        "id": f"{base}_USDT",
+        "symbol": f"{base}/USDT:USDT",
+        "base": base, "quote": "USDT", "settle": "USDT",
+        "baseId": base, "quoteId": "USDT", "settleId": "usdt",
+        "type": "swap", "spot": False, "swap": True, "future": False, "option": False,
+        "contract": True, "linear": True, "inverse": False,
+        "contractSize": 1.0, "active": True,
+        "precision": {"amount": 1, "price": 0.1},
+        "limits": {"amount": {"min": 1}, "price": {}, "cost": {}},
+        "info": {},
+    }
+
+
+@pytest.fixture
+def offline_gateio_futures():
+    """GateioFutures with preseeded swap markets — no network calls."""
+    ex = GateioFutures({"options": {"defaultType": "swap"}})
+    ex.set_markets([_gate_swap_market("BTC")])
+    yield ex
+    run(ex.close())
+
+
+class TestGateioCidOnlyEdit:
+    """ccxt's base edit_order_with_client_order_id routes to edit_order_request with
+    id='' and the cid in params; upstream gate has no cid substitution for amends
+    (unlike its fetch_order/cancel_order builders): order_id='' lands in the URL path
+    and a stray ``clientOrderId`` body key rides along. The override must produce the
+    documented custom-id path form: order_id = 't-<cid>' (qubx-placed gate orders carry
+    text='t-<cid>', which the venue resolves while the order is live)."""
+
+    def test_cid_only_edit_request_substitutes_t_prefixed_order_id(self, offline_gateio_futures):
+        request = offline_gateio_futures.edit_order_request(
+            "", "BTC/USDT:USDT", "limit", "buy", 1.0, 100.0, {"clientOrderId": "myCid123"}
+        )
+        assert request["order_id"] == "t-myCid123"
+        assert "clientOrderId" not in request
+        assert request["settle"] == "usdt"
+
+    def test_venue_id_edit_request_unchanged(self, offline_gateio_futures):
+        request = offline_gateio_futures.edit_order_request(
+            "123456789", "BTC/USDT:USDT", "limit", "buy", 1.0, 100.0, {}
+        )
+        assert request["order_id"] == "123456789"
+```
+
+Run: `uv run pytest tests/qubx/connectors/ccxt/test_gateio_exchange.py -q` — expected: the cid test FAILS (`order_id == ""` and the stray key present), the venue-id test passes.
+
+- [ ] **Step 5: Implement the Gate override**
+
+In `src/qubx/connectors/ccxt/exchanges/gateio/gateio.py`, on `GateioFutures`:
+
+```python
+    def edit_order_request(self, id, symbol, type, side, amount=None, price=None, params={}):
+        """ccxt's base edit_order_with_client_order_id routes here with id='' and the
+        cid in params, but upstream gate has no cid substitution for amends (unlike its
+        fetch_order/cancel_order builders): it sends order_id='' in the URL path plus a
+        stray ``clientOrderId`` body key the amend endpoint doesn't define. Mirror
+        fetch_order_request's documented 't-' substitution.
+        """
+        clientOrderId = self.safe_string_2(params, "clientOrderId", "text")
+        if not id and clientOrderId is not None:
+            params = self.omit(params, ["clientOrderId", "text"])
+            if clientOrderId[0] != "t":
+                clientOrderId = "t-" + clientOrderId
+            id = clientOrderId
+        return super().edit_order_request(id, symbol, type, side, amount, price, params)
+```
+
+Run the Gate test — expected PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/qubx/connectors/ccxt/connector.py src/qubx/connectors/ccxt/exchanges/gateio/gateio.py \
+        tests/qubx/connectors/ccxt/
+git commit -m "fix(ccxt): surface silent venue cancel on amend; gate cid-only edit builds a valid order_id path"
+```
+
+---
+
+### Task 5: Backtester sim tests — reprice through the real OME (salvaged from PR #367, adapted)
+
+**Files:**
+- Create: `tests/qubx/backtester/reprice_unfilled_limit_test.py` — start from the PR #367 version at `~/devs/Qubx/.worktrees/order-replace/tests/qubx/backtester/reprice_unfilled_limit_test.py` (142 lines; fixture builds SimulatedConnector + real OME + SimulatedAccountManager + TradingManager on one clock), with the adaptations below.
+- No production-code changes: `src/qubx/backtester/connector.py:108-135` already resolves `None` price/quantity from the old order and re-places with the given quantity as the new order's full size — since the OME has no partial fills, a resting order always has `filled == 0` and "new total" ≡ "replacement size".
+
+**Interfaces:**
+- Consumes: `TradingManager.update_order(price=..., quantity=...)` from Task 1.
+- Produces: sim-level pins that (a) a price+quantity amend moves the actual OME book level and keeps `remaining == total - filled` truthful, (b) a price-only amend preserves quantity.
+
+- [ ] **Step 1: Copy and adapt the salvaged test**
+
+Changes to the copied file:
+1. Module docstring: replace the "amount = desired remaining" sentence with: `TradingManager.update_order's total-quantity semantics (quantity = new total incl. filled; None = unchanged) through the REAL backtester OME`. Keep the OME-has-no-partial-fills caveat sentence.
+2. Line 104: `tm.update_order(price=30800.0, amount=0.3, client_order_id=order.client_order_id)` → `tm.update_order(price=30800.0, quantity=0.3, client_order_id=order.client_order_id)` (with `filled == 0`, total 0.3 ⇒ remaining 0.3 — same book assertions hold).
+3. Append a price-only test to the same file:
+
+```python
+def test_price_only_reprice_preserves_quantity_through_sim(sim):
+    tm, am, conn, instr, time = sim
+
+    order = tm.trade(instr, amount=0.5, price=31000.0)
+    assert order is not None
+
+    # Reprice only — quantity omitted must mean "unchanged", venue-side and locally.
+    tm.update_order(price=30800.0, client_order_id=order.client_order_id)
+
+    live = am.find_order_by_client_id(order.client_order_id)
+    assert live is not None
+    assert live.price == pytest.approx(30800.0)
+    assert live.quantity == pytest.approx(0.5)      # untouched
+    assert live.filled_quantity == 0.0
+
+    book = conn._ome._ome[instr].bids
+    assert 30800.0 in book, book
+    assert 31000.0 not in book, book
+
+    # Fill through the new level: the full 0.5 executes.
+    conn.process_market_data(instr, time.feed(Q("2020-01-01 10:01", 30700.0, 30701.0)))
+    live = am.find_order_by_client_id(order.client_order_id)
+    assert live is not None
+    assert live.filled_quantity == pytest.approx(0.5)
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `uv run pytest tests/qubx/backtester/reprice_unfilled_limit_test.py -q`
+Expected: PASS (Task 1 already shipped the signature; if the price-only test fails, read `src/qubx/backtester/connector.py:108-135` — the fix belongs there, keeping `quantity if quantity is not None else old_order.quantity`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/qubx/backtester/reprice_unfilled_limit_test.py
+git commit -m "test(backtester): repricing keeps totals truthful through the real OME; price-only preserves quantity"
+```
+
+---
+
+### Task 6: Repo-wide sweep + full canonical suite
+
+**Files:**
+- Modify: whatever the sweep finds (expected: none beyond already-updated tests).
+
+- [ ] **Step 1: Sweep for stale call sites and semantics**
+
+```bash
+grep -rn "update_order(" src/ tests/ --include="*.py" | grep -v "def update_order" | grep "amount"
+grep -rn "amount=" src/qubx/core/mixins/trading.py src/qubx/core/context.py src/qubx/core/interfaces.py | grep -i update
+```
+
+Expected: zero hits. Any hit = a missed caller; convert it to `quantity=` with total semantics (if it was passing a remaining, convert the value to `filled + remaining` — but per the ecosystem sweep there are no such callers inside qubx).
+
+- [ ] **Step 2: Run the full canonical suite**
+
+Run: `just test`
+Expected: green (baseline caveat: `tests/qubx/connectors/ccxt/test_ohlc_pagination.py` has 5 pre-existing ordering-dependent failures ONLY in single-process runs; under `just test`'s xdist they don't appear — if they do, compare against `main` before assuming branch damage).
+
+- [ ] **Step 3: Lint**
+
+Run: `uv run ruff check src/qubx/core src/qubx/connectors/ccxt tests/qubx && uv run ruff format --check src/qubx/core/mixins/trading.py src/qubx/core/account_manager/reducer.py src/qubx/connectors/ccxt/connector.py`
+Expected: clean. Fix and amend if not.
+
+- [ ] **Step 4: Commit (only if the sweep changed anything)**
+
+```bash
+git add -A && git commit -m "chore: align remaining update_order call sites with the quantity contract"
+```
+
+---
+
+### Task 7: Docs + PR
+
+**Files:**
+- Modify: `docs/account-management/design.md` (new section)
+- PR via `gh`
+
+- [ ] **Step 1: Write the design-doc section**
+
+Append a section `## Order updates: total-quantity contract and amend dialects` to `docs/account-management/design.md` covering, in this order (condense from the spec `docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md`, keep it ~60 lines):
+1. The contract (total incl. filled; None = unchanged; `<= filled` raises and why — the documented Binance/Gate silent cancel).
+2. The dialect table (Binance/Gate = total; HL = replacement/remaining; declared via `AMEND_QUANTITY_DIALECT` on the exchange subclass) and the both-directions translation rule (wire out, requested-total echoed back).
+3. The reducer clamp invariant (`quantity >= filled` always; ACE reference).
+4. Accepted races verbatim from the spec's "Accepted races" section (total-dialect under-work/silent-cancel; replacement-dialect δ-oversize; pre-existing HL fills-from-zero snapshot caveat).
+
+- [ ] **Step 2: Commit docs (plan file included)**
+
+```bash
+git add docs/account-management/design.md
+git add -f docs/superpowers/plans/2026-08-06-update-order-total-quantity.md
+git commit -m "docs(account): document the update_order total-quantity contract and amend dialects"
+```
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/update-order-total-quantity
+gh pr create --repo xLydianSoftware/Qubx --base main --title "feat!: update_order total-quantity contract; connectors own amend dialects" --body-file <body written to scratchpad>
+```
+
+PR body must cover: What (contract + dialect ownership + clamp + silent-cancel + Gate cid fix), Why (ACE 2026-08-05; dialect table with the doc citations; supersedes #367 and why — link the spec file), Testing (suites run + the salvaged sim tests), Breaking (the `amount`→`quantity` rename + deployment coupling paragraph from the spec), Follow-ups (exchanges-repo HL translation PR gated on semantics verification; qubx-lighter dialect verification; quantkit price-only PR).
+
+- [ ] **Step 4: Close PR #367 with a pointer**
+
+```bash
+gh pr close 367 --repo xLydianSoftware/Qubx --comment "Superseded by <new PR url>: review concluded the replace orchestration was over-engineered relative to real usage (the only production caller repriced only). The replacement switches update_order to a total-quantity contract with connector-owned amend dialects — see docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md on the new branch. Salvaged from this branch: the reducer never-negative-remaining regression, both sim reprice tests, and the design-doc analysis."
+```
+
+- [ ] **Step 5: Report** — PR URL, test counts, and the two follow-up repos' next steps.
+
+---
+
+## Deferred to follow-up repos (NOT in this plan)
+
+- **exchanges (`qubx-hyperliquid`)**: `_build_modify_action` translation (`size = total − filled`) + **verify the HL remaining-semantics inference first** — per review discussion: read the official `hyperliquid-python-sdk` source (clone it) and HL docs for how their own client builds `modify` sizes after partial fills; then a testnet probe. Gated on this PR shipping.
+- **qubx-lighter**: verify Lighter `base_amount` dialect on `sign_modify_order`; fix the stale `update_order=False` conformance capability flag in the exchanges-monorepo copy.
+- **quantkit**: `executor.py:461` → price-only amend; update the three remaining-semantics tests; pin new qubx version (deploy coupled — see spec "Deployment coupling").

--- a/docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md
+++ b/docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md
@@ -1,0 +1,185 @@
+# update_order: total-quantity contract + connector-owned amend dialects
+
+**Date:** 2026-08-06
+**Status:** Design approved in discussion; supersedes PR #367 (`feat/order-replace`), which will be closed unmerged.
+**Repos touched:** Qubx (this spec), exchanges (`qubx-hyperliquid` plugin), qubx-lighter (verification), quantkit (consumer follow-up).
+
+## Problem
+
+`ctx.update_order(price, amount)` is broken for partially-filled orders because nobody owns the
+translation between the framework's idea of "amount" and each venue's amend dialect:
+
+| Venue | Native amend | Quantity in the request means | If new qty ≤ filled |
+|---|---|---|---|
+| Binance UM (`PUT /fapi/v1/order`) | atomic modify, orderId kept | **new TOTAL**, executedQty preserved | **silent cancel** (documented) |
+| Gate futures (`PUT /futures/{settle}/orders/{id}`) | atomic modify | **new TOTAL "including filled part"** (documented) | **silent cancel** (documented) |
+| Hyperliquid (`modify` action) | cancel+replace at the matching engine, new oid, cloid kept | **size of the replacement order** (= desired remaining; fills restart at 0). High-confidence inference from ccxt's `sz`/`origSz` mapping + schema reuse — **needs one testnet probe before merge** | not documented |
+| Lighter (signed `modify_order` tx) | atomic modify (price+size in one tx) | **unverified** | unverified |
+
+Today the trading mixin passes `abs(amount)` verbatim to the connector, and connectors pass it
+verbatim to the venue. The one production caller in the entire ecosystem (quantkit
+`maker_taker/executor.py:461`, reprice-only) passes `signed_remaining(live)` — which double-shrinks
+on Binance/Gate (total dialect) and was venue-correct on HL only by accident. On HL the amend ack
+then overwrote `Order.quantity` with the remaining while `filled_quantity` stayed cumulative, so
+`remaining = quantity − filled` went negative — the 2026-08-05 ACE incident.
+
+PR #367 fixed this with `amount = desired signed remaining` plus a framework-side cancel+replace
+orchestration (ReplaceIntent) for `filled > 0`. Review verdict: over-engineered relative to real
+usage — no caller anywhere resizes a working order; every venue we trade has a native atomic
+modify; and the orchestration turned Binance's race-free atomic amend into a two-round-trip
+cancel-gap-replace with its own failure modes (expiry, suppression, superseded-oid markers) and two
+ledgered deferrals.
+
+## Design
+
+One principle: **the framework speaks one dialect — quantity is always the order's new TOTAL,
+including everything already filled — and each connector translates to its venue's dialect in both
+directions.** No orchestration layer; the venue's own atomic modify is used everywhere.
+
+### 1. Contract (`ITradingManager.update_order` / trading mixin)
+
+```python
+def update_order(
+    self,
+    price: float | None = None,
+    quantity: float | None = None,
+    order_id: str | None = None,
+    client_order_id: str | None = None,
+    exchange: str | None = None,
+) -> None
+```
+
+- At least one of `price` / `quantity` must be set, else `ValueError`.
+- `quantity` is **unsigned, positive, the new TOTAL including filled**. The signed-amount
+  convention is dropped: the order already knows its side, so sign carries no information.
+  (`quantity <= 0` → `ValueError`.)
+- **`quantity <= order.filled_quantity` → `ValueError`** (best-effort pre-check). This guards the
+  documented Binance/Gate behavior of *silently cancelling* the order in that case — a shrink below
+  filled is a cancel in disguise and must be requested as one. `quantity == filled` (remaining 0)
+  is included: that's `cancel_order`, not an update.
+- Unchanged from main: terminal order → `OrderAlreadyTerminal`; `PENDING_UPDATE` in flight → no-op;
+  synchronous connector failure → synthetic `OrderUpdateRejectedEvent` (reverts `PENDING_UPDATE`)
+  then re-raise.
+- `_adjust_size` / `_adjust_price` run on the total when quantity is given; when `quantity is
+  None`, no size adjustment happens (price-only update).
+
+`IConnector.update_order(order, *, price=None, quantity=None)` keeps its signature; `quantity`
+now carries total semantics and either field may be `None` (meaning "unchanged").
+
+### 2. Event + reducer
+
+- `OrderUpdatedEvent.new_quantity` means **new TOTAL, or `None` = unchanged**. Connectors echo the
+  requested total (or `None`) — never a venue-dialect figure.
+- Reducer on update-ack: `quantity = new_quantity if new_quantity is not None else unchanged`.
+  Invariant guard: if the resulting `quantity < filled_quantity` (can only happen via a race or a
+  buggy connector), log an error and clamp `quantity = filled_quantity` (remaining 0), then let the
+  periodic snapshot / status refetch reconcile. Never let `remaining` go negative — that is the
+  ACE poison and gets a regression test.
+- No splice arithmetic, no ReplaceIntent table, no cancel suppression, no expiry machinery.
+
+### 3. ccxt connector (Binance, Gate — and public-framework HL correctness)
+
+- Resolve `None` fields from the Order before building the venue request (Binance requires both
+  `quantity` and `price` on modify): `price or order.price`, `quantity or order.quantity`.
+- **Dialect map** in the connector (it already holds the full `Order`, so `filled_quantity` is at
+  hand): exchanges with replacement-dialect amend (currently `hyperliquid`) get
+  `venue_amount = total − order.filled_quantity`; everything else (Binance, Gate) passes the total
+  through verbatim — which ccxt already sends unmodified. We don't trade HL through ccxt, but the
+  public framework must not ship an oversize landmine.
+- **Silent-cancel detection**: after a successful `editOrder`, inspect the response's order status;
+  if the venue reports the order CANCELED (the documented Binance/Gate response to an in-flight
+  fill overtaking the new total), emit a truthful cancel event instead of `OrderUpdatedEvent`.
+- **Fix the cid-only (pre-ack) edit path**, verified broken today:
+  - Gate: `edit_order_request` does no `t-` prefix substitution → empty order-id in the URL path
+    plus a stray `clientOrderId` body key. Fix in the qubx Gate subclass (mirror the
+    `fetch_order`/`cancel_order` substitution) **or** reject pre-ack updates framework-side the way
+    the HL plugin does (`InvalidOrderParameters`). Prefer the fix; the reject is the fallback.
+  - ccxt-HL: `parse_to_int('')` crashes locally → every pre-ack update becomes UPDATE_REJECTED.
+    Pre-ack reject with a clear message is sufficient here (we don't trade this path).
+  - Binance already works via the existing `BinanceQV` override; keep its regression test.
+
+### 4. exchanges repo — `qubx-hyperliquid` plugin (the connector we actually trade HL with)
+
+`_build_modify_action` (hyperliquid/connector.py):
+
+- `new_size = (quantity if quantity is not None else order.quantity) − order.filled_quantity`;
+  raise `InvalidOrderParameters` if `new_size <= 0` (mirror of the mixin pre-check, read at build
+  time so the window is smaller).
+- `_do_update` already emits `new_quantity=quantity` verbatim — under the new contract that is
+  exactly right (requested total, or `None`). No change.
+- Everything else stays: pre-ack reject, trigger-order reject, new-oid re-keying with the
+  WS-inside-REST race handling.
+- **Merge gate:** one testnet probe confirming the modify-size = remaining inference (place, partial
+  fill or verify sizing behavior, modify, read back `origSz`/`sz`). Lands next to the existing
+  conformance/e2e plan (`docs/superpowers/plans/2026-08-05-cancel-fill-reporting-conformance.md`).
+
+### 5. qubx-lighter (verification only, separate repo)
+
+`_modify_order` sends `base_amount` in a signed modify tx; whether Lighter reads it as total or
+remaining is unverified. Verify against Lighter docs/testnet and translate if needed. Also fix the
+stale `update_order=False` conformance capability flag in the exchanges-monorepo copy.
+
+### 6. Backtester
+
+No change. The sim connector's cancel+recreate uses `quantity or old.quantity` as the new order's
+full size, and the OME has no partial-fill matching, so a resting sim order always has
+`filled == 0` — "new total" and "replacement size" coincide for every reachable state.
+
+### 7. quantkit follow-up (separate PR, after the qubx release)
+
+`executor.py:461` becomes price-only: `ctx.update_order(price=new_price, client_order_id=...,
+exchange=...)`. Deletes the `signed_remaining` computation (the exact derived value the ACE
+bookkeeping poison flowed through) and the signed-amount min-notional hack. Tests that encode
+remaining-semantics (`test_amends_unfilled_remainder`,
+`test_amend_sell_passes_signed_negative_amount`, integration repricing tests) are updated to
+assert price-only calls.
+
+## Accepted races (documented, not defended against)
+
+- **Total-dialect venues (Binance/Gate):** an in-flight fill shrinks the effective remaining below
+  what the caller computed → venue under-works or (fill overtakes the total) silently cancels. Both
+  outcomes are truthful: fills are fills, and the silent cancel is detected (§3) and reported as a
+  cancel. No corrupted bookkeeping is possible.
+- **Replacement-dialect venues (HL):** an in-flight fill between reading `filled_quantity` and the
+  venue processing the modify oversizes the replacement by that δ. Bounded by one round trip;
+  identical to today's live behavior; quantkit's settle trim self-corrects the overshoot. The only
+  way to eliminate it is a framework cancel+replace that reads the cancel-ack's final fill before
+  sizing — exactly the PR #367 orchestration this design rejects as not worth its complexity.
+- **Pre-existing, unchanged:** after an HL modify the venue counts the replacement's fills from
+  zero, so a snapshot that wins the venue-newer race can clobber cumulative `filled_quantity`
+  (needs a `filled_base` offset / venue-id-aware adoption — separate snapshot-semantics design).
+
+## Salvaged from PR #367
+
+- The two backtester sim tests (reprice-unfilled-limit through the real OME with book-truth
+  assertions and an intermediate no-fill quote), adapted to the new signature.
+- Reducer regression tests, adapted: the never-negative-remaining invariant, update-ack semantics.
+- The `docs/account-management/design.md` section, rewritten for this design.
+- Dropped: ReplaceIntent state + reconciler decisions + `_execute` replace path + expiry recovery +
+  suppression/superseded-oid machinery + `OrderCanceledEvent.venue_filled_quantity` plumbing (that
+  enrichment only served the orchestration; re-introduce independently if ever needed).
+
+## Testing
+
+- **Unit (qubx):** mixin validation (both-None, non-positive, `<= filled`, terminal,
+  PENDING_UPDATE no-op, sync-failure revert); reducer total-ack + clamp invariant; ccxt connector
+  dialect map (HL subtraction incl. `None` defaults), silent-cancel detection, Gate cid-only fix
+  (wire-level request assertion like the existing BinanceQV test).
+- **Sim (qubx):** the two salvaged backtester tests.
+- **exchanges:** unit tests on `_build_modify_action` size math (`None` quantity → current
+  remaining; shrink-below-filled raises); testnet probe as merge gate.
+- **quantkit:** executor tests flip to price-only assertions.
+
+## Rollout order
+
+1. Qubx PR (contract + reducer + ccxt) → release via dev pipeline.
+2. exchanges `qubx-hyperliquid` PR (translation + testnet probe) — gated on the HL semantics probe.
+3. quantkit PR (price-only executor) pinned to the new qubx version.
+4. qubx-lighter verification issue.
+5. Close PR #367 with a pointer to this spec once the Qubx PR is open.
+
+**Deployment coupling:** the `amount` → `quantity` parameter rename is a deliberate loud break —
+an old quantkit calling `update_order(amount=...)` fails with `TypeError` at call time (surfaced
+as the executor's amend-failure warning, maker chase stops repricing) instead of silently sending
+the wrong dialect. Strategy deployments must therefore bump qubx and quantkit **together** (frab
+pins both; step 3's quantkit release is the pairing partner). No compatibility alias.

--- a/docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md
+++ b/docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md
@@ -145,9 +145,14 @@ assert price-only calls.
   identical to today's live behavior; quantkit's settle trim self-corrects the overshoot. The only
   way to eliminate it is a framework cancel+replace that reads the cancel-ack's final fill before
   sizing — exactly the PR #367 orchestration this design rejects as not worth its complexity.
-- **Pre-existing, unchanged:** after an HL modify the venue counts the replacement's fills from
-  zero, so a snapshot that wins the venue-newer race can clobber cumulative `filled_quantity`
-  (needs a `filled_base` offset / venue-id-aware adoption — separate snapshot-semantics design).
+- **Pre-existing, now guarded:** after an HL modify the venue counts the replacement's fills from
+  zero, so a snapshot that wins the venue-newer race used to clobber cumulative `filled_quantity`
+  with that lower figure. Under total semantics an un-guarded clobber doesn't just lose history —
+  it OVER-states `remaining` (`total − filled`), feeding an over-sized next amend. `_apply_order_snapshot`
+  now adopts `filled_quantity` monotonically (never decreases it), closing that hole. The residual is
+  cosmetic: `OrderQuantityMismatch` diff noise against the venue's own post-modify figures until
+  venue-id-aware adoption (`filled_base` offset — separate snapshot-semantics design) lands; still
+  deferred.
 
 ## Salvaged from PR #367
 

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -598,6 +598,15 @@ class CcxtConnector(ChannelEmitter):
         # resolves it from its own cached order by client_order_id (or venue id).
         if isinstance(r, dict) and r.get("id") is not None:
             vid = vid or str(r.get("id"))
+        if isinstance(r, dict) and r.get("status") == "canceled":
+            # Binance/Gate amend to a total at/below executedQty CANCELS the order
+            # (documented, no error). Surface the truth: this is a cancel, not an update.
+            logger.warning(
+                f"[{self.exchange_name}] edit of {client_order_id} was a silent venue cancel "
+                f"(amend total at/below executed) — emitting cancel"
+            )
+            self._emit_canceled_from_response(client_order_id, vid, r)
+            return
         self.send(
             OrderUpdatedEvent(
                 instrument=None,

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -656,6 +656,8 @@ class CcxtConnector(ChannelEmitter):
         # (thread the order's side/type/tif + original price/qty) is straightforward — but it's
         # deferred to the recreate follow-up. Until then, reject without touching the live order.
         # TODO(account-mgmt): wire the recreate from the passed Order.
+        # TODO(account-mgmt): this path is itself a REPLACEMENT — when wired, size the recreate
+        # at total - filled, not the total-dialect `quantity` (wire_amount) it currently receives.
         raise ccxt.NotSupported("cancel+recreate update is not yet wired for editOrder-less venues")
 
     def _emit_update_rejected(self, client_order_id: str | None, venue_order_id: str | None, error: Exception) -> None:

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -523,6 +523,20 @@ class CcxtConnector(ChannelEmitter):
     def update_order(self, order: Order, *, price: float | None = None, quantity: float | None = None) -> None:
         # Read venue-call fields off the Order SYNCHRONOUSLY (see cancel_order); editOrder
         # needs side/type too, so pass them straight through.
+        # The framework speaks TOTAL quantity (incl. filled); translate to the venue's
+        # amend dialect here. "replacement" (declared on the exchange subclass): the venue
+        # modify is a cancel+replace and its amount is the replacement's size = remaining.
+        wire_price = price if price is not None else order.price
+        total = quantity if quantity is not None else order.quantity
+        if getattr(self._em.exchange, "AMEND_QUANTITY_DIALECT", "total") == "replacement":
+            wire_amount = total - order.filled_quantity
+        else:
+            wire_amount = total
+        if wire_amount <= 0:
+            raise ValueError(
+                f"update_order for {order.client_order_id}: effective amend amount "
+                f"{wire_amount} <= 0 (total {total}, filled {order.filled_quantity})"
+            )
         self._spawn(
             self._update_async(
                 order.client_order_id,
@@ -530,6 +544,8 @@ class CcxtConnector(ChannelEmitter):
                 instrument_to_ccxt_symbol(order.instrument),
                 order.side.lower(),
                 order.type.lower(),
+                wire_price,
+                wire_amount,
                 price,
                 quantity,
             )
@@ -542,8 +558,10 @@ class CcxtConnector(ChannelEmitter):
         symbol: str,
         side: str,
         order_type: str,
-        price: float | None,
-        quantity: float | None,
+        wire_price: float | None,
+        wire_amount: float | None,
+        requested_price: float | None,
+        requested_total: float | None,
     ) -> None:
         """Direct editOrder where the venue supports it, else cancel+recreate.
 
@@ -556,9 +574,11 @@ class CcxtConnector(ChannelEmitter):
         vid = venue_order_id
         try:
             if self._em.exchange.has.get("editOrder", False):
-                r = await self._edit_order_direct(client_order_id, vid, symbol, side, order_type, price, quantity)
+                r = await self._edit_order_direct(
+                    client_order_id, vid, symbol, side, order_type, wire_price, wire_amount
+                )
             else:
-                r = await self._update_via_cancel_recreate(client_order_id, venue_order_id, price, quantity)
+                r = await self._update_via_cancel_recreate(client_order_id, venue_order_id, wire_price, wire_amount)
         except _VENUE_VERDICT_ERRORS as e:
             # Venue verdict — must precede the bare NetworkError catch (see _submit_async).
             self._emit_update_rejected(client_order_id, venue_order_id, e)
@@ -583,8 +603,8 @@ class CcxtConnector(ChannelEmitter):
                 instrument=None,
                 client_order_id=client_order_id,
                 venue_order_id=vid,  # str | None — never coerce to "" (AM would index a bogus id)
-                new_price=price,
-                new_quantity=quantity,
+                new_price=requested_price,
+                new_quantity=requested_total,
             )
         )
 

--- a/src/qubx/connectors/ccxt/exchanges/base.py
+++ b/src/qubx/connectors/ccxt/exchanges/base.py
@@ -3,17 +3,23 @@ Base classes and mixins for CCXT exchange implementations.
 """
 
 import asyncio
+from typing import Literal
 
 
 class CcxtFuturePatchMixin:
     """
     Mixin class that patches CCXT Future.race to prevent InvalidStateError race conditions.
-    
+
     This fix should be applied to all CCXT exchange classes to prevent race conditions
     that can occur when multiple futures complete simultaneously and try to set the
     result on an already-done future.
     """
-    
+
+    # Amend-quantity wire dialect for update_order; the connector's translation lives at
+    # CcxtConnector.update_order (getattr(..., "total") default). Override per exchange
+    # (see HyperliquidEnhanced) when the venue's amend size means "remaining", not "total".
+    AMEND_QUANTITY_DIALECT: Literal["total", "replacement"] = "total"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Patch the Future.race method to prevent InvalidStateError

--- a/src/qubx/connectors/ccxt/exchanges/gateio/gateio.py
+++ b/src/qubx/connectors/ccxt/exchanges/gateio/gateio.py
@@ -88,3 +88,18 @@ class GateioFutures(CcxtFuturePatchMixin, cxp.gate):
             else:
                 await self._funding_rate_adapter.stop()
                 self._funding_rate_adapter = None
+
+    def edit_order_request(self, id, symbol, type, side, amount=None, price=None, params={}):
+        """ccxt's base edit_order_with_client_order_id routes here with id='' and the
+        cid in params, but upstream gate has no cid substitution for amends (unlike its
+        fetch_order/cancel_order builders): it sends order_id='' in the URL path plus a
+        stray ``clientOrderId`` body key the amend endpoint doesn't define. Mirror
+        fetch_order_request's documented 't-' substitution.
+        """
+        clientOrderId = self.safe_string_2(params, "clientOrderId", "text")
+        if not id and clientOrderId is not None:
+            params = self.omit(params, ["clientOrderId", "text"])
+            if clientOrderId[0] != "t":
+                clientOrderId = "t-" + clientOrderId
+            id = clientOrderId
+        return super().edit_order_request(id, symbol, type, side, amount, price, params)

--- a/src/qubx/connectors/ccxt/exchanges/hyperliquid/hyperliquid.py
+++ b/src/qubx/connectors/ccxt/exchanges/hyperliquid/hyperliquid.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 import ccxt.pro as cxp
 from ccxt.async_support.base.ws.client import Client
-from ccxt.base.errors import ExchangeError, InvalidOrder
+from ccxt.base.errors import ExchangeError, InvalidOrder, NotSupported
 
 from qubx import logger
 
@@ -20,9 +20,21 @@ class HyperliquidEnhanced(CcxtFuturePatchMixin, cxp.hyperliquid):
     Mixin class to enhance Hyperliquid with OHLCV parsing and funding rate subscriptions
     """
 
+    # HL modify is a cancel+replace at the matching engine: the amend amount is the
+    # replacement order's size (= desired remaining), NOT the new total. The qubx ccxt
+    # connector subtracts filled before hitting the wire when it sees this marker.
+    AMEND_QUANTITY_DIALECT = "replacement"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._funding_rate_adapter: Optional[PollingToWebSocketAdapter] = None
+
+    async def edit_order_with_client_order_id(
+        self, clientOrderId, symbol, type, side, amount=None, price=None, params={}
+    ):
+        # HL modify addresses the order by venue oid; there is no cloid-amend endpoint.
+        # Upstream's base fallback would call edit_order('') and crash in parse_to_int('').
+        raise NotSupported("hyperliquid: modify requires the venue order id (order not acked yet)")
 
     def parse_ohlcv(self, ohlcv, market=None):
         """

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -622,8 +622,12 @@ class Reconciler:
             state.transition_order(local.client_order_id, snap.status, snap.last_update_time)
         else:
             local.last_update_time = snap.last_update_time
-        local.filled_quantity = snap.filled_quantity
-        local.avg_fill_price = snap.avg_fill_price
+        # - monotonic adoption only (mirrors Order.record_fill's contract): replacement-dialect
+        #   venues (e.g. HL modify) restart fills at 0 under the same cid — a LOWER snapshot
+        #   figure is the replacement's counter, not a rollback, and must not clobber real fills.
+        if snap.filled_quantity > local.filled_quantity:
+            local.filled_quantity = snap.filled_quantity
+            local.avg_fill_price = snap.avg_fill_price
 
     @staticmethod
     def _fill_event(order: Order) -> Action | None:

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -470,7 +470,17 @@ def _handle_updated(state: AccountState, event: OrderUpdatedEvent, now: np.datet
     if event.new_price is not None:
         order.price = event.new_price
     if event.new_quantity is not None:
-        order.quantity = event.new_quantity
+        if event.new_quantity < order.filled_quantity:
+            # Ack total below cumulative fills would make remaining negative (the
+            # ACE 2026-08-05 poison). Clamp to filled (remaining 0); the periodic
+            # snapshot / status refetch reconciles the true figure.
+            logger.error(
+                f"[{order.client_order_id}] update-ack total {event.new_quantity} < "
+                f"filled {order.filled_quantity}; clamping quantity to filled"
+            )
+            order.quantity = order.filled_quantity
+        else:
+            order.quantity = event.new_quantity
     order.last_update_time = event.last_update_time if event.last_update_time is not None else now
     if order.status == OrderStatus.PENDING_UPDATE:
         target = state.get_pre_pending(order.client_order_id) or OrderStatus.ACCEPTED

--- a/src/qubx/core/connector.py
+++ b/src/qubx/core/connector.py
@@ -49,6 +49,10 @@ class IConnector(Protocol):
     # AM routes by either.
     def cancel_order(self, order: Order) -> None: ...
 
+    # ``quantity`` is the order's new TOTAL size including everything already filled;
+    # None means unchanged. Connectors translate this to their venue's amend dialect on the
+    # wire (e.g. HL's "replacement" dialect wants total - filled), but MUST echo the
+    # requested total (or None) back in OrderUpdatedEvent.new_quantity — never the wire figure.
     def update_order(self, order: Order, *, price: float | None = None, quantity: float | None = None) -> None: ...
 
     def request_order_status(self, order: Order) -> None: ...

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -828,18 +828,18 @@ class StrategyContext(IStrategyContext):
 
     def update_order(
         self,
-        price: float,
-        amount: float,
+        price: float | None = None,
+        quantity: float | None = None,
         order_id: str | None = None,
         client_order_id: str | None = None,
         exchange: str | None = None,
     ) -> None:
         """
-        Update an existing limit order with new price and amount.
+        Update a live limit order's price and/or total quantity (total includes filled).
         """
         self._assert_not_fit_thread("update_order")
         self._trading_manager.update_order(
-            order_id=order_id, client_order_id=client_order_id, price=price, amount=amount, exchange=exchange
+            order_id=order_id, client_order_id=client_order_id, price=price, quantity=quantity, exchange=exchange
         )
 
     def get_min_size(self, instrument: Instrument, amount: float | None = None) -> float:

--- a/src/qubx/core/events.py
+++ b/src/qubx/core/events.py
@@ -129,6 +129,7 @@ class OrderLostEvent(OrderEvent):
 @msg
 class OrderUpdatedEvent(OrderEvent):
     new_price: float | None
+    # requested new TOTAL quantity incl. filled; None = unchanged. Never a venue-dialect wire figure.
     new_quantity: float | None
 
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -916,13 +916,14 @@ class ITradingManager:
 
     def update_order(
         self,
-        price: float,
-        amount: float,
+        price: float | None = None,
+        quantity: float | None = None,
         order_id: str | None = None,
         client_order_id: str | None = None,
         exchange: str | None = None,
     ) -> None:
-        """Update an existing limit order with new price and amount.
+        """Update a live limit order's price and/or total quantity (total includes filled;
+        None = unchanged; at least one required).
 
         Exactly one identifier must be provided:
         - order_id: Exchange/server order id

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -381,9 +381,9 @@ class TradingManager(ITradingManager):
         A synchronous connector failure reverts the order to its pre-pending status
         (via a synthetic OrderUpdateRejectedEvent) and re-raises to the caller.
         """
+        self._ensure_writable()
         if price is None and quantity is None:
             raise ValueError("update_order requires price and/or quantity")
-        self._ensure_writable()
         order_id, client_order_id = self._normalize_order_ids(order_id, client_order_id)
         order = self._resolve_order(order_id, client_order_id)
         if order is None:
@@ -402,7 +402,7 @@ class TradingManager(ITradingManager):
         if quantity is not None:
             if quantity <= 0:
                 raise ValueError(f"update_order quantity must be positive, got {quantity}")
-            quantity = abs(self._adjust_size(instrument, side_sign * quantity))
+            quantity = self._adjust_size(instrument, side_sign * quantity)
             if quantity <= order.filled_quantity:
                 raise ValueError(
                     f"update_order total {quantity} <= filled {order.filled_quantity} for "

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -395,10 +395,14 @@ class TradingManager(ITradingManager):
             return
 
         instrument = order.instrument
+        # _adjust_size/_adjust_price use the amount's sign as a direction hint (reducing-order
+        # detection, rounding direction); quantity is unsigned at the public API, so derive the
+        # sign from the order's side once and reuse it for both.
+        side_sign = 1.0 if order.side == "BUY" else -1.0
         if quantity is not None:
             if quantity <= 0:
                 raise ValueError(f"update_order quantity must be positive, got {quantity}")
-            quantity = abs(self._adjust_size(instrument, quantity))
+            quantity = abs(self._adjust_size(instrument, side_sign * quantity))
             if quantity <= order.filled_quantity:
                 raise ValueError(
                     f"update_order total {quantity} <= filled {order.filled_quantity} for "
@@ -408,9 +412,6 @@ class TradingManager(ITradingManager):
 
         adjusted_price: float | None = None
         if price is not None:
-            # _adjust_price uses the amount's sign as the rounding-direction hint;
-            # quantity is unsigned now, so derive the sign from the order's side.
-            side_sign = 1.0 if order.side == "BUY" else -1.0
             adjusted_price = self._adjust_price(instrument, price, side_sign * (quantity or order.quantity))
             if adjusted_price is None:
                 raise ValueError(f"Price adjustment failed for {instrument.symbol}")

--- a/src/qubx/core/mixins/trading.py
+++ b/src/qubx/core/mixins/trading.py
@@ -362,19 +362,27 @@ class TradingManager(ITradingManager):
 
     def update_order(
         self,
-        price: float,
-        amount: float,
+        price: float | None = None,
+        quantity: float | None = None,
         order_id: str | None = None,
         client_order_id: str | None = None,
         exchange: str | None = None,
     ) -> None:
-        """Update an existing limit order with new price and amount.
+        """Update a live limit order's price and/or quantity.
+
+        ``quantity`` is the order's new TOTAL, including everything already filled
+        (unsigned). ``None`` means "leave unchanged" — at least one of ``price`` /
+        ``quantity`` must be given. ``quantity <= filled_quantity`` raises: Binance and
+        Gate silently CANCEL an order amended to a total at/below the executed quantity,
+        so a shrink below filled must be requested as a cancel, never an update.
 
         Raises OrderAlreadyTerminal on a settled order (updating a settled order is
         meaningful misuse); a no-op while a previous update is still in flight.
         A synchronous connector failure reverts the order to its pre-pending status
         (via a synthetic OrderUpdateRejectedEvent) and re-raises to the caller.
         """
+        if price is None and quantity is None:
+            raise ValueError("update_order requires price and/or quantity")
         self._ensure_writable()
         order_id, client_order_id = self._normalize_order_ids(order_id, client_order_id)
         order = self._resolve_order(order_id, client_order_id)
@@ -387,15 +395,30 @@ class TradingManager(ITradingManager):
             return
 
         instrument = order.instrument
-        amount = self._adjust_size(instrument, amount)
-        adjusted_price = self._adjust_price(instrument, price, amount)
-        if adjusted_price is None:
-            raise ValueError(f"Price adjustment failed for {instrument.symbol}")
+        if quantity is not None:
+            if quantity <= 0:
+                raise ValueError(f"update_order quantity must be positive, got {quantity}")
+            quantity = abs(self._adjust_size(instrument, quantity))
+            if quantity <= order.filled_quantity:
+                raise ValueError(
+                    f"update_order total {quantity} <= filled {order.filled_quantity} for "
+                    f"{order.client_order_id}: a total at/below filled is a silent venue "
+                    f"cancel — use cancel_order instead"
+                )
+
+        adjusted_price: float | None = None
+        if price is not None:
+            # _adjust_price uses the amount's sign as the rounding-direction hint;
+            # quantity is unsigned now, so derive the sign from the order's side.
+            side_sign = 1.0 if order.side == "BUY" else -1.0
+            adjusted_price = self._adjust_price(instrument, price, side_sign * (quantity or order.quantity))
+            if adjusted_price is None:
+                raise ValueError(f"Price adjustment failed for {instrument.symbol}")
 
         cid = order.client_order_id
         self._account_manager.transition_order(instrument.exchange, cid, OrderStatus.PENDING_UPDATE)
         try:
-            self._get_connector(instrument.exchange).update_order(order, price=adjusted_price, quantity=abs(amount))
+            self._get_connector(instrument.exchange).update_order(order, price=adjusted_price, quantity=quantity)
         except Exception as e:
             # Same contract as cancel_order: synthetic reject through the PM reverts
             # PENDING_UPDATE via pre_pending, then the original exception re-raises.

--- a/tests/qubx/backtester/reprice_unfilled_limit_test.py
+++ b/tests/qubx/backtester/reprice_unfilled_limit_test.py
@@ -1,0 +1,167 @@
+"""Sim integration test pinning `TradingManager.update_order`'s total-quantity semantics
+(quantity = new total incl. filled; None = unchanged) through the REAL backtester OME:
+SimulatedConnector + real AccountManager + real TradingManager, with fills driven by actual
+OME executions.
+
+The OME fills orders atomically (no partial fills) — there is no depth/size-aware matching
+in `qubx.backtester.ome`, so a resting order can never end up partially filled while still
+open. That means this test only covers the `filled == 0` reprice path; the `filled > 0`
+cancel+replace chain is covered at the account-manager integration level and by a planned
+real-venue end-to-end test.
+"""
+
+import numpy as np
+import pytest
+
+from qubx.backtester.connector import SimulatedConnector
+from qubx.backtester.utils import SimulatedCtrlChannel
+from qubx.core.account_manager import SimulatedAccountManager
+from qubx.core.basics import ZERO_COSTS, ITimeProvider
+from qubx.core.interfaces import IStrategyContext
+from qubx.core.lookups import lookup
+from qubx.core.mixins.trading import TradingManager
+from qubx.core.series import Quote
+from qubx.core.utils import recognize_time
+from qubx.health.dummy import DummyHealthMonitor
+
+
+class _TimeService(ITimeProvider):
+    """Shared clock for the OME and the AM/TradingManager stack, advanced by feeding quotes."""
+
+    _time: np.datetime64 = np.datetime64(0, "ns")
+
+    def feed(self, quote: Quote) -> Quote:
+        self._time = np.datetime64(quote.time, "ns")
+        return quote
+
+    def time(self) -> np.datetime64:
+        return self._time
+
+
+def Q(when: str, bid: float, ask: float) -> Quote:
+    return Quote(recognize_time(when), bid, ask, 0, 0)
+
+
+class _RoutingContext(IStrategyContext):
+    """process_event applies straight to the AM — the PM dispatch leg
+    (ProcessingManager._dispatch_account) minus strategy callbacks.
+    Mirrors tests/qubx/core/mixins/trading_test.py::_AccountRoutingContext."""
+
+    def __init__(self, account_manager: SimulatedAccountManager, time_provider: _TimeService):
+        self._am = account_manager
+        self._time = time_provider
+
+    def time(self) -> np.datetime64:
+        return self._time.time()
+
+    def process_event(self, event) -> None:
+        self._am.apply(event)
+
+    def is_blacklisted(self, instrument) -> bool:
+        return False
+
+
+@pytest.fixture
+def sim():
+    """SimulatedConnector (real OME) + real SimulatedAccountManager + real TradingManager,
+    all sharing one clock, wired the same way ProcessingManager wires the live stack minus
+    strategy callbacks."""
+    instr = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+    assert instr is not None
+    time = _TimeService()
+    channel = SimulatedCtrlChannel("sim", sentinel=(None, None, None, None))
+    conn = SimulatedConnector(channel=channel, exchange_name="BINANCE.UM", time_provider=time, tcc=ZERO_COSTS)
+
+    am = SimulatedAccountManager(connectors={"BINANCE.UM": conn}, base_currencies={"BINANCE.UM": "USDT"}, time=time)
+    ctx = _RoutingContext(am, time)
+    channel.register(ctx)  # connector.send() -> channel.send() -> ctx.process_event() -> am.apply()
+    tm = TradingManager(
+        context=ctx,
+        connectors={"BINANCE.UM": conn},
+        account_manager=am,
+        strategy_name="test_strategy",
+        health_monitor=DummyHealthMonitor(),
+    )
+
+    # Prime the OME's book so it's ready to accept orders.
+    exchange = conn._ome
+    list(exchange.process_market_data(instr, time.feed(Q("2020-01-01 10:00", 32000.0, 32001.0))))
+    return tm, am, conn, instr, time
+
+
+def test_reprice_unfilled_limit_keeps_remaining_truthful_through_sim(sim):
+    tm, am, conn, instr, time = sim
+
+    # 1. BUY limit well below touch (32000/32001) -> rests unfilled.
+    order = tm.trade(instr, amount=0.5, price=31000.0)
+    assert order is not None
+    live = am.find_order_by_client_id(order.client_order_id)
+    assert live is not None
+    assert live.filled_quantity == 0.0
+
+    # 2. Reprice AND shrink the total in one amend: still below touch, so it keeps resting.
+    tm.update_order(price=30800.0, quantity=0.3, client_order_id=order.client_order_id)
+    order = am.find_order_by_client_id(order.client_order_id)
+    assert order is not None
+    assert order.price == pytest.approx(30800.0)
+    remaining = order.quantity - order.filled_quantity
+    assert remaining == 0.3
+    assert remaining >= 0.0
+
+    # OME book truth, not the AM's request-echo (OrderUpdatedEvent carries the local
+    # price param verbatim — connector.py:159-167 — so a venue-side reprice that
+    # silently no-ops would still leave the AM order reporting the requested price).
+    # The resting order must actually have moved price levels in the book.
+    book = conn._ome._ome[instr].bids
+    assert 30800.0 in book, book
+    assert 31000.0 not in book, book
+
+    # 3. Intermediate quote sitting BETWEEN the old (31000) and new (30800) levels:
+    # crosses the old level but not the new one. A reprice that updated the AM's
+    # local copy but left the OME order resting at 31000 would fill here; a real
+    # venue-side reprice must not.
+    conn.process_market_data(instr, time.feed(Q("2020-01-01 10:00:30", 30900.0, 30901.0)))
+    order = am.find_order_by_client_id(order.client_order_id)
+    assert order is not None
+    assert order.filled_quantity == 0.0
+    position = am.get_position(instr)
+    assert position is not None
+    assert position.quantity == 0.0
+
+    # 4. Move the market down through the new price -> the REAL OME fills the BUY.
+    conn.process_market_data(instr, time.feed(Q("2020-01-01 10:01", 30700.0, 30701.0)))
+
+    order = am.find_order_by_client_id(order.client_order_id)
+    assert order is not None
+    assert order.filled_quantity == 0.3
+    assert order.quantity - order.filled_quantity == 0.0
+
+    position = am.get_position(instr)
+    assert position is not None
+    assert position.quantity == 0.3
+
+
+def test_price_only_reprice_preserves_quantity_through_sim(sim):
+    tm, am, conn, instr, time = sim
+
+    order = tm.trade(instr, amount=0.5, price=31000.0)
+    assert order is not None
+
+    # Reprice only — quantity omitted must mean "unchanged", venue-side and locally.
+    tm.update_order(price=30800.0, client_order_id=order.client_order_id)
+
+    live = am.find_order_by_client_id(order.client_order_id)
+    assert live is not None
+    assert live.price == pytest.approx(30800.0)
+    assert live.quantity == pytest.approx(0.5)  # untouched
+    assert live.filled_quantity == 0.0
+
+    book = conn._ome._ome[instr].bids
+    assert 30800.0 in book, book
+    assert 31000.0 not in book, book
+
+    # Fill through the new level: the full 0.5 executes.
+    conn.process_market_data(instr, time.feed(Q("2020-01-01 10:01", 30700.0, 30701.0)))
+    live = am.find_order_by_client_id(order.client_order_id)
+    assert live is not None
+    assert live.filled_quantity == pytest.approx(0.5)

--- a/tests/qubx/connectors/ccxt/test_binance_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_binance_exchange.py
@@ -24,7 +24,13 @@ from qubx.connectors.ccxt.exchanges.binance.exchange import BinanceQVUSDM
 
 
 def run(coro):
-    return asyncio.run(coro)
+    # NOT asyncio.run: that clears the thread's current event loop on exit, breaking
+    # later tests in the same worker that rely on asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _usdm_market(base: str, amount_precision: float, price_precision: float) -> dict:

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -681,6 +681,25 @@ async def test_update_quantity_only_resolves_price_from_order() -> None:
     assert ev.new_quantity == 3.0
 
 
+@pytest.mark.asyncio
+async def test_update_silent_cancel_response_emits_canceled_not_updated() -> None:
+    # Binance/Gate documented behavior: an amend whose total lands at/below executedQty
+    # CANCELS the order (no reject). Racing fills can trigger this despite the mixin
+    # pre-check — the connector must surface the truth as a cancel, not an update-ack.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123", "status": "canceled"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.update_order(_order(venue_order_id="VENUE123"), price=102.0, quantity=2.0)
+    await _drive(conn)
+
+    assert len(sent) == 1
+    assert isinstance(sent[0], OrderCanceledEvent)
+    assert sent[0].venue_order_id == "VENUE123"
+
+
 def test_update_replacement_dialect_zero_remaining_raises_synchronously() -> None:
     # A fully-filled order under the replacement dialect translates to a <= 0 wire
     # amount, which is meaningless to send — raise synchronously (no venue call spawned)

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -592,6 +592,115 @@ async def test_update_cancel_recreate_path_rejects_without_touching_live_order()
     assert isinstance(sent[0], OrderUpdateRejectedEvent)
 
 
+@pytest.mark.asyncio
+async def test_update_replacement_dialect_sends_total_minus_filled() -> None:
+    # Hyperliquid-style modify is a venue-side cancel+replace: the amend amount is the
+    # REPLACEMENT order's size (remaining), while the framework speaks totals. The
+    # connector must translate on the wire and still echo the requested TOTAL on the ack.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.AMEND_QUANTITY_DIALECT = "replacement"
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    order.filled_quantity = 0.4
+    conn.update_order(order, price=102.0, quantity=2.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(1.6)  # total - filled on the wire
+    ev = sent[0]
+    assert isinstance(ev, OrderUpdatedEvent)
+    assert ev.new_quantity == 2.0  # requested TOTAL on the event
+
+
+@pytest.mark.asyncio
+async def test_update_total_dialect_passes_total_verbatim() -> None:
+    # Binance/Gate amend quantity IS the new total (executedQty preserved): passthrough.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT  # plain Mock auto-creates attrs; ensure absent
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    order.filled_quantity = 0.4
+    conn.update_order(order, price=102.0, quantity=2.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(2.0)
+    assert sent[0].new_quantity == 2.0
+
+
+@pytest.mark.asyncio
+async def test_update_price_only_resolves_quantity_from_order_and_echoes_none() -> None:
+    # Binance requires both quantity and price on modify — a price-only update sends the
+    # order's current total on the wire but the ack event says "quantity unchanged".
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    conn.update_order(order, price=102.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(2.0)  # resolved from the order
+    assert kwargs["price"] == 102.0
+    ev = sent[0]
+    assert isinstance(ev, OrderUpdatedEvent)
+    assert ev.new_price == 102.0
+    assert ev.new_quantity is None  # unchanged — reducer keeps its total
+
+
+@pytest.mark.asyncio
+async def test_update_quantity_only_resolves_price_from_order() -> None:
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    conn.update_order(order, quantity=3.0)
+    await _drive(conn)
+
+    _, kwargs = exchange.edit_order.await_args
+    assert kwargs["amount"] == pytest.approx(3.0)
+    assert kwargs["price"] == order.price  # resolved from the order
+    ev = sent[0]
+    assert ev.new_price is None
+    assert ev.new_quantity == 3.0
+
+
+def test_update_replacement_dialect_zero_remaining_raises_synchronously() -> None:
+    # A fully-filled order under the replacement dialect translates to a <= 0 wire
+    # amount, which is meaningless to send — raise synchronously (no venue call spawned)
+    # rather than let the venue reject it asynchronously.
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.AMEND_QUANTITY_DIALECT = "replacement"
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    order = _order(venue_order_id="VENUE123")
+    order.quantity = 2.0
+    order.filled_quantity = 2.0
+    with pytest.raises(ValueError):
+        conn.update_order(order, quantity=2.0)
+
+    exchange.edit_order.assert_not_awaited()
+    assert sent == []
+
+
 # --------------------------------------------------------------------------- #
 # (7) make_client_id prefix
 # --------------------------------------------------------------------------- #

--- a/tests/qubx/connectors/ccxt/test_gateio_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_gateio_exchange.py
@@ -1,8 +1,15 @@
 """Tests for Gate.io exchange registration and custom class."""
 
+import asyncio
+
 import ccxt.pro as cxp
+import pytest
 
 from qubx.connectors.ccxt.exchanges import EXCHANGE_ALIASES, READER_CAPABILITIES, GateioFutures
+
+
+def run(coro):
+    return asyncio.run(coro)
 
 
 class TestGateioRegistration:
@@ -38,3 +45,61 @@ class TestGateioRegistration:
         exchange = GateioFutures()
         assert exchange._funding_rate_adapter is None
         assert exchange.id == "gate"
+
+
+def _gate_swap_market(base: str) -> dict:
+    return {
+        "id": f"{base}_USDT",
+        "symbol": f"{base}/USDT:USDT",
+        "base": base,
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": base,
+        "quoteId": "USDT",
+        "settleId": "usdt",
+        "type": "swap",
+        "spot": False,
+        "swap": True,
+        "future": False,
+        "option": False,
+        "contract": True,
+        "linear": True,
+        "inverse": False,
+        "contractSize": 1.0,
+        "active": True,
+        "precision": {"amount": 1, "price": 0.1},
+        "limits": {"amount": {"min": 1}, "price": {}, "cost": {}},
+        "info": {},
+    }
+
+
+@pytest.fixture
+def offline_gateio_futures():
+    """GateioFutures with preseeded swap markets — no network calls."""
+    ex = GateioFutures({"options": {"defaultType": "swap"}})
+    ex.set_markets([_gate_swap_market("BTC")])
+    yield ex
+    run(ex.close())
+
+
+class TestGateioCidOnlyEdit:
+    """ccxt's base edit_order_with_client_order_id routes to edit_order_request with
+    id='' and the cid in params; upstream gate has no cid substitution for amends
+    (unlike its fetch_order/cancel_order builders): order_id='' lands in the URL path
+    and a stray ``clientOrderId`` body key rides along. The override must produce the
+    documented custom-id path form: order_id = 't-<cid>' (qubx-placed gate orders carry
+    text='t-<cid>', which the venue resolves while the order is live)."""
+
+    def test_cid_only_edit_request_substitutes_t_prefixed_order_id(self, offline_gateio_futures):
+        request = offline_gateio_futures.edit_order_request(
+            "", "BTC/USDT:USDT", "limit", "buy", 1.0, 100.0, {"clientOrderId": "myCid123"}
+        )
+        assert request["order_id"] == "t-myCid123"
+        assert "clientOrderId" not in request
+        assert request["settle"] == "usdt"
+
+    def test_venue_id_edit_request_unchanged(self, offline_gateio_futures):
+        request = offline_gateio_futures.edit_order_request(
+            "123456789", "BTC/USDT:USDT", "limit", "buy", 1.0, 100.0, {}
+        )
+        assert request["order_id"] == "123456789"

--- a/tests/qubx/connectors/ccxt/test_gateio_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_gateio_exchange.py
@@ -9,7 +9,13 @@ from qubx.connectors.ccxt.exchanges import EXCHANGE_ALIASES, READER_CAPABILITIES
 
 
 def run(coro):
-    return asyncio.run(coro)
+    # NOT asyncio.run: that clears the thread's current event loop on exit, breaking
+    # later tests in the same worker that rely on asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 class TestGateioRegistration:

--- a/tests/qubx/connectors/ccxt/test_hyperliquid_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_hyperliquid_exchange.py
@@ -1,0 +1,44 @@
+"""Unit tests for Qubx's Hyperliquid exchange overrides.
+
+Pins the cid-only edit guard: HL modify addresses the order by venue oid — there is
+no cloid-amend endpoint, so the base ccxt fallback (edit_order('')) would crash
+inside parse_to_int(''). HyperliquidEnhanced overrides edit_order_with_client_order_id
+to raise ccxt NotSupported before any network call, so the connector's cid-only edit
+path (used before the venue ack is seen) gets a clean reject instead of a crash.
+
+Fully offline — no markets/network needed, since the override raises immediately.
+"""
+
+import asyncio
+
+import pytest
+from ccxt.base.errors import NotSupported
+
+from qubx.connectors.ccxt.exchanges.hyperliquid.hyperliquid import HyperliquidEnhanced
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class TestHyperliquidAmendDialect:
+    def test_amend_quantity_dialect_is_replacement(self):
+        # HL modify is a venue-side cancel+replace: the amend amount is the replacement
+        # order's size (remaining), not the new total — the connector must translate.
+        assert HyperliquidEnhanced.AMEND_QUANTITY_DIALECT == "replacement"
+
+
+class TestHyperliquidCidOnlyEditRejected:
+    def test_edit_order_with_client_order_id_raises_not_supported(self):
+        exchange = HyperliquidEnhanced()
+
+        async def _attempt_edit():
+            try:
+                await exchange.edit_order_with_client_order_id(
+                    "qubx-cid-1", "BTC/USDC:USDC", "limit", "buy", 1.0, 100.0
+                )
+            finally:
+                await exchange.close()
+
+        with pytest.raises(NotSupported):
+            run(_attempt_edit())

--- a/tests/qubx/connectors/ccxt/test_hyperliquid_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_hyperliquid_exchange.py
@@ -18,7 +18,13 @@ from qubx.connectors.ccxt.exchanges.hyperliquid.hyperliquid import HyperliquidEn
 
 
 def run(coro):
-    return asyncio.run(coro)
+    # NOT asyncio.run: that clears the thread's current event loop on exit, breaking
+    # later tests in the same worker that rely on asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 class TestHyperliquidAmendDialect:

--- a/tests/qubx/connectors/ccxt/test_ohlc_pagination.py
+++ b/tests/qubx/connectors/ccxt/test_ohlc_pagination.py
@@ -15,6 +15,15 @@ from qubx.connectors.ccxt.handlers.ohlc import OhlcDataHandler
 from qubx.core.basics import Instrument, MarketType
 
 
+def run(coro):
+    # private loop — never depends on, or disturbs, the thread's current-loop slot
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
 def _make_instrument() -> Instrument:
     return Instrument(
         symbol="BTCUSDT",
@@ -78,9 +87,7 @@ class TestOhlcPagination:
 
         exchange_manager.exchange.fetch_ohlcv = AsyncMock(side_effect=mock_fetch_ohlcv)
 
-        bars = asyncio.get_event_loop().run_until_complete(
-            handler.get_historical_ohlc(instrument, "1h", requested_bars)
-        )
+        bars = run(handler.get_historical_ohlc(instrument, "1h", requested_bars))
 
         assert len(bars) >= requested_bars
         # Should have made ~5 calls (500 / 100)
@@ -105,9 +112,7 @@ class TestOhlcPagination:
 
         exchange_manager.exchange.fetch_ohlcv = AsyncMock(side_effect=mock_fetch_ohlcv)
 
-        bars = asyncio.get_event_loop().run_until_complete(
-            handler.get_historical_ohlc(instrument, "1h", requested_bars)
-        )
+        bars = run(handler.get_historical_ohlc(instrument, "1h", requested_bars))
 
         assert len(bars) >= requested_bars
         assert call_count >= 2  # 2000 / 1000
@@ -132,9 +137,7 @@ class TestOhlcPagination:
 
         exchange_manager.exchange.fetch_ohlcv = AsyncMock(side_effect=mock_fetch_ohlcv)
 
-        bars = asyncio.get_event_loop().run_until_complete(
-            handler.get_historical_ohlc(instrument, "1h", 1000)
-        )
+        bars = run(handler.get_historical_ohlc(instrument, "1h", 1000))
 
         assert len(bars) == 100  # 2 pages * 50
         assert call_count == 3  # 2 successful + 1 empty
@@ -148,9 +151,7 @@ class TestOhlcPagination:
         same_bar = [[1_000_000_000, 50000.0, 50100.0, 49900.0, 50050.0, 100.0]]
         exchange_manager.exchange.fetch_ohlcv = AsyncMock(return_value=same_bar)
 
-        bars = asyncio.get_event_loop().run_until_complete(
-            handler.get_historical_ohlc(instrument, "1h", 100)
-        )
+        bars = run(handler.get_historical_ohlc(instrument, "1h", 100))
 
         assert len(bars) == 1  # Only 1 unique bar
 
@@ -172,9 +173,7 @@ class TestOhlcPagination:
 
         exchange_manager.exchange.fetch_ohlcv = AsyncMock(side_effect=mock_fetch_ohlcv)
 
-        bars = asyncio.get_event_loop().run_until_complete(
-            handler.get_historical_ohlc(instrument, "1h", 30)
-        )
+        bars = run(handler.get_historical_ohlc(instrument, "1h", 30))
 
         # With 10 bars per page and 1 overlap, need ~4 pages for 30 unique bars
         assert len(bars) >= 30

--- a/tests/qubx/core/account_manager/reconciler_test.py
+++ b/tests/qubx/core/account_manager/reconciler_test.py
@@ -319,6 +319,61 @@ def test_status_resolved():
     assert isinstance(a[0].event, OrderPartiallyFilledEvent) and a[0].event.client_order_id == "order1"  # type: ignore
 
 
+def test_snapshot_does_not_decrease_filled_after_replacement_amend():
+    # A replacement-dialect amend (e.g. HL modify) restarts venue-side fills at 0 under the
+    # same cid. A snapshot reporting a LOWER filled figure is that restart, not a rollback —
+    # adopting it verbatim would over-state remaining and over-size the next amend (F1).
+    rec = _reconciler()
+    st = _local(_order("order1", status=OrderStatus.PARTIALLY_FILLED, quantity=2.0, filled=0.4))
+
+    rec.on_snapshot(
+        st,
+        _origin(
+            as_of=_passed_seconds(T0, 5),
+            open_orders=[
+                _order(
+                    "order1",
+                    status=OrderStatus.ACCEPTED,
+                    quantity=2.0,
+                    filled=0.0,
+                    last_update_time=_passed_seconds(T0, 4),  # newer VENUE ts than local
+                )
+            ],
+        ),
+        _passed_seconds(T0, 5),
+    )
+
+    o = st.get_order("order1")
+    assert o.filled_quantity == 0.4  # type: ignore # monotonic — the lower snapshot figure is dropped
+
+
+def test_snapshot_still_adopts_a_genuinely_higher_filled():
+    # The monotonic guard must not block real progress: a snapshot reporting MORE filled than
+    # local (a missed fill) is still adopted.
+    rec = _reconciler()
+    st = _local(_order("order1", status=OrderStatus.PARTIALLY_FILLED, quantity=2.0, filled=0.4))
+
+    rec.on_snapshot(
+        st,
+        _origin(
+            as_of=_passed_seconds(T0, 5),
+            open_orders=[
+                _order(
+                    "order1",
+                    status=OrderStatus.PARTIALLY_FILLED,
+                    quantity=2.0,
+                    filled=0.6,
+                    last_update_time=_passed_seconds(T0, 4),
+                )
+            ],
+        ),
+        _passed_seconds(T0, 5),
+    )
+
+    o = st.get_order("order1")
+    assert o.filled_quantity == 0.6  # type: ignore
+
+
 def test_snapshot_does_not_wipe_pending_cancel_marker():
     D_ON()
     # our cancel is in flight (PENDING_CANCEL). A snapshot poll still showing the order live

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -9,6 +9,7 @@ a kw-only snapshot_grace (threaded once via the local apply wrapper below).
 from typing import TypeVar
 
 import numpy as np
+import pytest
 
 from qubx.core.account_manager import reducer
 from qubx.core.account_manager.state import AccountState
@@ -693,6 +694,52 @@ def test_accept_during_pending_update_preserves_marker():
     r = apply(state, OrderUpdateRejectedEvent(instrument=None, client_order_id="c1", reason="below filled"), T1)
     assert r.order is not None and r.order.status is OrderStatus.ACCEPTED
     assert r.order_change is OrderChange.UPDATE_REJECTED
+
+
+def test_update_ack_total_below_filled_clamps_remaining_at_zero():
+    # ACE 2026-08-05 regression class: an ack whose total is below cumulative fills
+    # must never make remaining (= quantity - filled) negative. Clamp to filled and
+    # let the snapshot/status refetch reconcile.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED)  # quantity=1.0
+    apply(state, OrderFilledEvent(instrument=None, client_order_id="c1", fill=_fill(amount=0.6)), T0)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+
+    r = apply(state, OrderUpdatedEvent(instrument=None, client_order_id="c1", new_price=None, new_quantity=0.4), T1)
+
+    o = r.order
+    assert o is not None
+    assert o.filled_quantity == 0.6
+    assert o.quantity == 0.6  # clamped to filled, not 0.4
+    assert o.quantity - o.filled_quantity == 0.0  # remaining never negative
+
+
+def test_update_ack_total_above_filled_applies_verbatim():
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED)  # quantity=1.0
+    apply(state, OrderFilledEvent(instrument=None, client_order_id="c1", fill=_fill(amount=0.6)), T0)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+
+    r = apply(state, OrderUpdatedEvent(instrument=None, client_order_id="c1", new_price=None, new_quantity=2.0), T1)
+
+    o = r.order
+    assert o is not None
+    assert o.quantity == 2.0
+    assert o.quantity - o.filled_quantity == pytest.approx(1.4)
+
+
+def test_canceled_during_pending_update_terminalizes_and_clears_pre_pending():
+    # Binance/Gate amend with total <= executedQty silently cancels the order; the
+    # connector surfaces that as OrderCanceledEvent while we sit in PENDING_UPDATE.
+    state = _state()
+    _order(state, status=OrderStatus.ACCEPTED)
+    state.transition_order("c1", OrderStatus.PENDING_UPDATE, T0)
+
+    r = apply(state, OrderCanceledEvent(instrument=None, client_order_id="c1"), T1)
+
+    assert r.order is not None
+    assert r.order.status is OrderStatus.CANCELED
+    assert state.get_pre_pending("c1") is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -192,7 +192,7 @@ class TestReadOnlyGate:
 
     def test_update_order_blocked(self, read_only_trading_manager):
         with pytest.raises(ReadOnlyConnector):
-            read_only_trading_manager.update_order(price=1.0, amount=1.0, client_order_id="x")
+            read_only_trading_manager.update_order(price=1.0, quantity=1.0, client_order_id="x")
 
 
 class TestTradingManagerClosePosition:
@@ -430,15 +430,27 @@ class TestTradingManagerClosePositions:
 
 
 def _live_order(order_id="test_order_123"):
-    """A resolvable, non-terminal order living on BINANCE.UM."""
-    instrument = Mock()
-    instrument.exchange = "BINANCE.UM"
-    order = Mock()
-    order.client_order_id = "qubx_BTCUSDT_1"
-    order.venue_order_id = order_id
-    order.instrument = instrument
-    order.status = OrderStatus.ACCEPTED
-    return order
+    """A resolvable, non-terminal order living on BINANCE.UM.
+
+    Real Order + real Instrument (not Mock): the update_order contract touches
+    order.side/quantity/filled_quantity and real instrument rounding, none of which
+    a bare Mock can satisfy without raising on comparisons.
+    """
+    instrument = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+    assert instrument is not None
+    return Order(
+        client_order_id="qubx_BTCUSDT_1",
+        venue_order_id=order_id,
+        origin=OrderOrigin.FRAMEWORK,
+        type="LIMIT",
+        instrument=instrument,
+        submitted_at=pd.Timestamp("2023-01-01").asm8,
+        quantity=0.1,
+        price=50_000.0,
+        side="BUY",
+        status=OrderStatus.ACCEPTED,
+        time_in_force="gtc",
+    )
 
 
 class TestTradingManagerTradeOrderShape:
@@ -671,7 +683,7 @@ class TestTradingManagerCancelUpdateFailure:
         mock_connector.update_order.side_effect = ConnectionError("venue unreachable")
 
         with pytest.raises(ConnectionError):
-            tm.update_order(price=51_000.0, amount=0.1, client_order_id=order.client_order_id)
+            tm.update_order(price=51_000.0, quantity=0.1, client_order_id=order.client_order_id)
 
         assert am.get_order(order.client_order_id).status is OrderStatus.ACCEPTED
         (event,) = context.routed_events
@@ -689,7 +701,7 @@ class TestTradingManagerUpdateOrderGuards:
         mock_account.find_order_by_id.return_value = order
 
         with pytest.raises(OrderAlreadyTerminal):
-            trading_manager.update_order(price=51_000.0, amount=0.1, order_id="test_order_123")
+            trading_manager.update_order(price=51_000.0, quantity=0.1, order_id="test_order_123")
 
         mock_connector.update_order.assert_not_called()
         mock_account.transition_order.assert_not_called()
@@ -699,10 +711,82 @@ class TestTradingManagerUpdateOrderGuards:
         order.status = OrderStatus.PENDING_UPDATE
         mock_account.find_order_by_id.return_value = order
 
-        assert trading_manager.update_order(price=51_000.0, amount=0.1, order_id="test_order_123") is None
+        assert trading_manager.update_order(price=51_000.0, quantity=0.1, order_id="test_order_123") is None
 
         mock_connector.update_order.assert_not_called()
         mock_account.transition_order.assert_not_called()
+
+
+class TestTradingManagerUpdateOrderContract:
+    """Total-quantity contract: quantity is the order's new TOTAL including filled,
+    unsigned; at least one of price/quantity is required; a total at or below the
+    already-filled quantity raises (Binance/Gate silently CANCEL in that case)."""
+
+    def test_both_none_raises_connector_not_called(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        with pytest.raises(ValueError, match="price and/or quantity"):
+            trading_manager.update_order(order_id="test_order_123")
+
+        mock_connector.update_order.assert_not_called()
+        mock_account.transition_order.assert_not_called()
+
+    def test_non_positive_quantity_raises(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        with pytest.raises(ValueError, match="positive"):
+            trading_manager.update_order(quantity=0.0, order_id="test_order_123")
+
+        mock_connector.update_order.assert_not_called()
+
+    def test_total_at_or_below_filled_raises(self, trading_manager, mock_connector, mock_account):
+        # Order for 0.1, already filled 0.06: a new total of 0.05 (< filled) is a
+        # silent venue cancel in disguise — must raise, never reach the connector.
+        order = _live_order()
+        order.filled_quantity = 0.06
+        mock_account.find_order_by_id.return_value = order
+        mock_account.get_position.return_value = None  # flat: skip position-reducing math
+
+        with pytest.raises(ValueError, match="filled"):
+            trading_manager.update_order(quantity=0.05, order_id="test_order_123")
+        with pytest.raises(ValueError, match="filled"):
+            trading_manager.update_order(quantity=0.06, order_id="test_order_123")  # == filled: that's a cancel
+
+        mock_connector.update_order.assert_not_called()
+
+    def test_price_only_passes_none_quantity(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        trading_manager.update_order(price=51_000.0, order_id="test_order_123")
+
+        mock_connector.update_order.assert_called_once()
+        _, kwargs = mock_connector.update_order.call_args
+        assert kwargs["quantity"] is None
+        assert kwargs["price"] is not None
+
+    def test_quantity_only_passes_none_price(self, trading_manager, mock_connector, mock_account):
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+        mock_account.get_position.return_value = None  # flat: skip position-reducing math
+
+        trading_manager.update_order(quantity=0.2, order_id="test_order_123")
+
+        mock_connector.update_order.assert_called_once()
+        _, kwargs = mock_connector.update_order.call_args
+        assert kwargs["price"] is None
+        assert kwargs["quantity"] == pytest.approx(0.2)
+
+    def test_old_amount_kwarg_is_a_loud_typeerror(self, trading_manager, mock_account):
+        # Deployment-coupling tripwire: an old caller using amount= must fail loudly,
+        # never silently reinterpret (spec: "Deployment coupling").
+        order = _live_order()
+        mock_account.find_order_by_id.return_value = order
+
+        with pytest.raises(TypeError):
+            trading_manager.update_order(price=51_000.0, amount=0.1, order_id="test_order_123")
 
 
 class TestAdjustSizeMinNotional:

--- a/tests/qubx/core/mixins/trading_test.py
+++ b/tests/qubx/core/mixins/trading_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
@@ -429,7 +429,7 @@ class TestTradingManagerClosePositions:
         trading_manager.close_position.assert_any_call(ada_future, False)
 
 
-def _live_order(order_id="test_order_123"):
+def _live_order(order_id="test_order_123", side="BUY"):
     """A resolvable, non-terminal order living on BINANCE.UM.
 
     Real Order + real Instrument (not Mock): the update_order contract touches
@@ -447,7 +447,7 @@ def _live_order(order_id="test_order_123"):
         submitted_at=pd.Timestamp("2023-01-01").asm8,
         quantity=0.1,
         price=50_000.0,
-        side="BUY",
+        side=side,
         status=OrderStatus.ACCEPTED,
         time_in_force="gtc",
     )
@@ -787,6 +787,22 @@ class TestTradingManagerUpdateOrderContract:
 
         with pytest.raises(TypeError):
             trading_manager.update_order(price=51_000.0, amount=0.1, order_id="test_order_123")
+
+    def test_sell_update_derives_signed_size_adjust_hint(self, trading_manager, mock_connector, mock_account):
+        # _adjust_size's reducing-order detection (_is_position_reducing) needs a SIGNED
+        # amount matching order direction. quantity is unsigned at the public API, so the
+        # implementation must derive the sign from order.side before calling _adjust_size
+        # — same as it already does for _adjust_price.
+        order = _live_order(side="SELL")
+        mock_account.find_order_by_id.return_value = order
+        mock_account.get_position.return_value = None  # flat: skip position-reducing math
+
+        with patch.object(trading_manager, "_adjust_size", wraps=trading_manager._adjust_size) as spy:
+            trading_manager.update_order(quantity=0.2, order_id="test_order_123")
+
+        spy.assert_called_once()
+        _, called_amount = spy.call_args.args
+        assert called_amount < 0
 
 
 class TestAdjustSizeMinNotional:

--- a/tests/qubx/core/test_order_identifier_routing.py
+++ b/tests/qubx/core/test_order_identifier_routing.py
@@ -24,6 +24,9 @@ def _order(order_id="exchange_order_1", client_order_id="cid_1", status=OrderSta
     order.venue_order_id = order_id
     order.instrument = instrument
     order.status = status
+    order.filled_quantity = 0.0
+    order.side = "BUY"
+    order.quantity = 1.0
     return order
 
 
@@ -89,7 +92,7 @@ def test_update_order_routes_client_order_id(trading_manager):
     trading_manager._account_manager.find_order_by_client_id.return_value = order
     trading_manager._account_manager.find_order_by_id.return_value = None
 
-    trading_manager.update_order(client_order_id="cid_1", price=123.0, amount=1.0, exchange="BINANCE.UM")
+    trading_manager.update_order(client_order_id="cid_1", price=123.0, quantity=1.0, exchange="BINANCE.UM")
 
     trading_manager._account_manager.transition_order.assert_called_once_with(
         "BINANCE.UM", "cid_1", OrderStatus.PENDING_UPDATE
@@ -101,8 +104,8 @@ def test_update_order_routes_client_order_id(trading_manager):
 
 def test_update_order_requires_exactly_one_identifier(trading_manager):
     with pytest.raises(ValueError):
-        trading_manager.update_order(price=123.0, amount=1.0, exchange="BINANCE.UM")
+        trading_manager.update_order(price=123.0, quantity=1.0, exchange="BINANCE.UM")
     with pytest.raises(ValueError):
         trading_manager.update_order(
-            order_id="o1", client_order_id="c1", price=123.0, amount=1.0, exchange="BINANCE.UM"
+            order_id="o1", client_order_id="c1", price=123.0, quantity=1.0, exchange="BINANCE.UM"
         )


### PR DESCRIPTION
## What

Makes `ctx.update_order` correct for partially-filled orders on every venue by switching
to a **total-quantity contract with connector-owned amend dialects** — no framework-side
orchestration.

- `update_order(price=None, quantity=None, order_id=None, client_order_id=None,
  exchange=None)` — at least one of `price`/`quantity` required. `quantity` is unsigned
  and always the order's new **TOTAL, including everything already filled** (the old
  signed-remaining `amount` parameter is gone — the order already knows its side, so sign
  carried no information).
- `quantity <= order.filled_quantity` raises `ValueError`: on Binance and Gate that's a
  documented **silent cancel**, not a resize, so it must be requested as a cancel.
- Reducer clamp: on update-ack, if the resulting `quantity` would fall below
  `filled_quantity` (race or buggy connector), it's clamped to `filled_quantity`
  (remaining 0) instead of going negative, and the error is logged. `quantity >= filled`
  now holds unconditionally post-reduce.
- ccxt connector owns the wire-dialect translation both directions via
  `AMEND_QUANTITY_DIALECT` on the exchange subclass (`"total"` default, `"replacement"`
  for HL-style venues): `venue_amount = total - filled_quantity` when replacement-dialect,
  passthrough otherwise. `OrderUpdatedEvent.new_quantity` always echoes the **requested
  total** — never a venue-dialect figure — so connectors can't leak their wire dialect
  into the event stream.
- Silent-cancel detection: after a successful `editOrder`, the connector inspects the
  response status; a venue-reported CANCELED now emits a truthful `OrderCanceledEvent`
  instead of a fabricated `OrderUpdatedEvent`.
- Gate cid-only (pre-ack) edit fix: `edit_order_request` was building an empty order-id
  path plus a stray `clientOrderId` body key; fixed with the same `t-`-prefix
  substitution already used for `fetch_order`/`cancel_order`. ccxt-HL cid-only edits are
  pre-ack-rejected (framework doesn't trade this path).

Docs: `docs/account-management/design.md` § "Order updates: total-quantity contract and
amend dialects" carries the full writeup (contract, dialect table, clamp invariant,
accepted races).

## Why

Live incident 2026-08-05 (dev frab bot, pair ACE): repricing a partially-filled
Hyperliquid maker order corrupted the `Order` record — HL's `modify` is a cancel+replace
under the same client id, the amend ack overwrote `quantity` with the remaining while
`filled_quantity` stayed cumulative, and `remaining = quantity − filled` went negative.
Downstream execution logic then trimmed the wrong leg and livelocked. The same call
pattern (`signed_remaining`, quantkit `maker_taker/executor.py:461`, the only production
`update_order` caller in the ecosystem) is wrong differently on Binance/Gate: their amend
quantity means *new total* with `executedQty` preserved, so a remaining figure silently
double-shrinks the order.

Root cause: nobody owned the translation between the framework's idea of "amount" and
each venue's amend dialect:

| Venue | Native amend | Wire quantity means | Below-filled behavior |
|---|---|---|---|
| Binance UM (`PUT /fapi/v1/order`) | atomic modify, orderId kept | new **total**, `executedQty` preserved | silent cancel (documented) |
| Gate futures (`PUT /futures/{settle}/orders/{id}`) | atomic modify | new **total** "including filled part" (documented) | silent cancel (documented) |
| Hyperliquid (`modify` action) | cancel+replace at the matching engine, new oid, cloid kept | size of the **replacement** (= desired remaining; fills restart at 0) | not documented |

This supersedes #367 (`feat/order-replace`, "order-replace orchestration"), which fixed
the same incident with `amount = desired signed remaining` plus a framework-side
cancel+replace orchestration (`ReplaceIntent` table, reconciler decisions, cancel
suppression, superseded-oid markers, 30s expiry recovery) for `filled > 0`. Review
verdict: over-engineered relative to real usage — no caller anywhere resizes a working
order, every venue we trade has a native atomic modify, and the orchestration turned
Binance's race-free atomic amend into a two-round-trip cancel-gap-replace with its own
failure modes. This PR instead makes the framework speak one dialect (total, always) and
pushes translation to the venue boundary, using the venue's own atomic modify everywhere.
Full design: `docs/superpowers/specs/2026-08-06-update-order-total-quantity-design.md`
(on this branch).

Salvaged from #367: the reducer never-negative-remaining regression test, both backtester
sim reprice tests (adapted to the new signature), and the design-doc analysis.

## Testing

- `just test` (`uv run pytest -m "not integration and not e2e" --ignore=debug -v -n
  auto`): **2327 passed, 5 skipped, 2 failed**. Both failures are the pre-existing
  `test_ohlc_pagination.py::TestOhlcPagination` event-loop test-isolation flake
  (`RuntimeError: There is no current event loop in thread 'MainThread'`), verified
  byte-identical (`git diff main -- tests/qubx/connectors/ccxt/test_ohlc_pagination.py`
  → empty) on `main` — not caused by this branch.
- New/changed suites: trading-mixin contract tests (optional price/quantity validation,
  `<= filled` rejection, terminal/PENDING_UPDATE/sync-failure paths); reducer clamp
  regression (never-negative-remaining); ccxt dialect-map tests (HL subtraction incl.
  `None` defaults), silent-cancel detection, Gate cid-only-edit wire-level request
  assertions, hyperliquid cid-only edit rejection; backtester sim reprice tests through
  the real OME (repricing keeps totals truthful; price-only preserves quantity).
- `ruff check`/`ruff format --check`: no new findings — pre-existing findings on
  `main`(113 `ruff check`, 1 `connector.py` format hunk) confirmed byte-identical, none
  introduced by this branch.

## Breaking

- **`amount` → `quantity` rename, signed-remaining → total semantics.** A caller still
  using `update_order(amount=...)` fails loudly with `TypeError` at call time (not a
  silent misinterpretation). An ecosystem sweep (28 non-definition call sites across
  `src/qubx/core/mixins/trading.py`, `src/qubx/core/context.py`, and 8 test files, plus a
  grep for stray `amount=` on `update_order`) confirmed no positional `(price, amount)`
  callers exist that would silently reinterpret under the new contract — every remaining
  call site already passes `quantity=` (or matches the new positional signature) with
  total-quantity semantics.
- **Deployment coupling is three-way, not two.** qubx, the exchanges repo
  (`qubx-hyperliquid`), and quantkit must be released and pinned as a coordinated set.
  The exchanges-repo plugin currently sends `abs(order.quantity)` as the HL modify size
  when `quantity` is `None` — under the new total-quantity contract that value is the
  **total**, but HL's `modify` action wants the **remaining** (replacement-dialect: `size
  = total − filled`), so an unreleased exchanges plugin over-executes by `filled` on
  every price-only amend. The exchanges-repo `_build_modify_action` fix is a **hard
  gate**: it must ship before (or together with) any quantkit release that calls the new
  `update_order` contract against Hyperliquid. An old quantkit build calling
  `update_order(amount=...)` still breaks loudly with `TypeError` rather than silently
  sending the wrong dialect, but only once paired with this qubx version — frab pins all
  three, and the quantkit follow-up PR (below) is the pairing partner for this release.
- **Merge policy: merge commit only, do not squash.** `scripts/next-version.sh` drops the
  oldest commit subject in the range (known `while read` bug), so a squash-merge of this
  PR would collapse everything into one subject and risk a patch-bump instead of the
  minor/major this breaking change requires. Use "Create a merge commit" for this PR.

## Follow-ups

- **exchanges (`qubx-hyperliquid`)**: `_build_modify_action` translation
  (`size = total − filled`), gated on verifying the HL remaining-semantics inference
  first — reading the official `hyperliquid-python-sdk` source for how their own client
  builds `modify` sizes after partial fills, then a testnet probe (place, partial-fill,
  modify, read back `origSz`/`sz`).
- **qubx-lighter**: verify Lighter's `base_amount` dialect on `sign_modify_order`
  (total vs. remaining, currently unverified) and fix the stale `update_order=False`
  conformance capability flag in the exchanges-monorepo copy.
- **quantkit**: `executor.py:461` → price-only amend
  (`ctx.update_order(price=new_price, client_order_id=..., exchange=...)`), deleting the
  `signed_remaining` computation (the exact derived value the ACE bookkeeping poison
  flowed through); update the three remaining-semantics tests to price-only assertions;
  pin the new qubx version.