### PR TITLE
feat(health): per-event-type data latency + windowed percentiles

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1699,7 +1699,9 @@ class LatencyMetrics:
     """
     Health metrics for system performance.
 
-    All latency values are in milliseconds.
+    All latency values are in milliseconds. `data_feed` pools event types whose
+    timestamps mark emission moments; settlement-stamped types (funding payments)
+    are excluded because their age is structural, not transport latency.
     """
 
     data_feed: float

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -28,7 +28,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
     This emitter sends metrics to QuestDB with custom timestamps and tags.
     """
 
-    SYMBOL_TAGS = ["symbol", "exchange", "type", "environment", "strategy"]
+    SYMBOL_TAGS = ["symbol", "exchange", "type", "environment", "strategy", "event_type"]
     RECORD_COLUMN_TYPES = {"DOUBLE", "LONG", "STRING", "BOOLEAN", "TIMESTAMP", "SYMBOL"}
 
     def __init__(

--- a/src/qubx/health/base.py
+++ b/src/qubx/health/base.py
@@ -21,6 +21,11 @@ STALE_THRESHOLDS = {
     "trade": "30min",
 }
 
+# Event types whose timestamps mark period boundaries (funding settlement), not emission
+# moments — their age is structural, so they are excluded from the pooled data_feed figure.
+# Per-type tracking and emission still include them.
+DATA_FEED_LATENCY_EXCLUDE = frozenset({DataType.FUNDING_PAYMENT})
+
 
 @dataclass
 class TimingContext:
@@ -43,6 +48,7 @@ class BaseHealthMonitor(IHealthMonitor):
         buffer_size: int = 1000,
         emit_health: bool = True,
         queue_degrade_window: str = "5Min",
+        latency_window: str = "5Min",
     ):
         """Initialize the health metrics monitor.
 
@@ -54,6 +60,9 @@ class BaseHealthMonitor(IHealthMonitor):
             queue_monitor_interval: Interval to check queue size, e.g. "100ms", "500ms" (default: "100ms")
             buffer_size: Size of buffer for storing metrics
             emit_health: Whether to emit health metrics (default: True)
+            latency_window: Only samples that arrived within this window enter latency
+                percentiles, so a buffer that stopped rolling cannot pin the "now" stats
+                with stale readings (default: "5Min")
         """
         self.time_provider = time_provider
         self._emitter = emitter
@@ -73,6 +82,7 @@ class BaseHealthMonitor(IHealthMonitor):
         # minimum", evaluated continuously instead of in minute buckets. Floor is 0 — a
         # healthy queue empties constantly, so no level threshold is needed.
         self._queue_degrade_window = convert_tf_str_td64(queue_degrade_window) if queue_degrade_window else None
+        self._latency_window_ns = recognize_timeframe(latency_window)
         self._last_drain_time: dt_64 | None = None
         self._queue_degraded = False  # - the monitor's own edge tracker: status is written only on transitions
         self._status: ContextStatus | None = None
@@ -376,12 +386,20 @@ class BaseHealthMonitor(IHealthMonitor):
         # Calculate events per second
         return float(total_events / time_window_seconds)
 
+    def _recent_values(self, indicator) -> np.ndarray:
+        """Values of samples that arrived within the latency window, oldest first."""
+        samples = indicator.to_array()
+        cutoff = self.time_provider.time().astype("datetime64[ns]").astype(int) - self._latency_window_ns
+        return samples["value"][samples["timestamp"] > cutoff]
+
     def get_data_latency(self, exchange: str, event_type: str, percentile: float = 90) -> float:
         """Get data latency for a specific event type on an exchange."""
         key = (exchange, event_type)
         if key not in self._data_latency or self._data_latency[key].is_empty():
             return 0.0
-        latencies = self._data_latency[key].to_array()["value"]
+        latencies = self._recent_values(self._data_latency[key])
+        if len(latencies) == 0:
+            return 0.0
         return float(np.percentile(latencies, percentile))
 
     def get_data_latencies(self, exchange: str, percentile: float = 90) -> dict[str, float]:
@@ -415,10 +433,10 @@ class BaseHealthMonitor(IHealthMonitor):
 
     def get_exchange_latencies(self, exchange: str, percentile: float = 90) -> LatencyMetrics:
         data_latencies = []
-        for (ex, _), latency in self._data_latency.items():
-            if ex == exchange:
+        for (ex, event_type), latency in self._data_latency.items():
+            if ex == exchange and event_type not in DATA_FEED_LATENCY_EXCLUDE:
                 if not latency.is_empty():
-                    data_latencies.extend(latency.to_array()["value"])
+                    data_latencies.extend(self._recent_values(latency))
 
         data_feed = float(np.percentile(data_latencies, percentile)) if data_latencies else 0.0
 
@@ -624,12 +642,16 @@ class BaseHealthMonitor(IHealthMonitor):
         metrics = self.get_exchange_latencies(exchange, percentile=90)
         tags = {"type": "health", "exchange": exchange}
         assert self._emitter is not None
-        self._emitter.emit(
-            name="latency.p90.data",
-            value=metrics.data_feed,
-            tags=tags,
-            timestamp=current_time,
-        )
+        # One row per event type: types have incompatible latency semantics (a funding
+        # payment is stamped at settlement, a quote at emission), so dashboards pick the
+        # types they mean instead of receiving a pre-pooled figure.
+        for event_type, data_latency in self.get_data_latencies(exchange, percentile=90).items():
+            self._emitter.emit(
+                name="latency.p90.data",
+                value=data_latency,
+                tags={**tags, "event_type": str(event_type)},
+                timestamp=current_time,
+            )
         self._emitter.emit(
             name="latency.p90.order_submit",
             value=metrics.order_submit,

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -156,6 +156,9 @@ class HealthConfig(StrictBaseModel):
     #   1Hz samples and never went a whole minute without emptying; observed backlogs ran
     #   4-5 minutes. Empty string disables the check.
     queue_degrade_window: str = "5Min"
+    # - latency percentiles only look at samples that arrived within this window, so a
+    #   buffer that stopped rolling (sparse event types, dead feed) cannot pin the stats.
+    latency_window: str = "5Min"
 
 
 class DataTypeThrottleConfig(StrictBaseModel):

--- a/tests/qubx/health/test_base.py
+++ b/tests/qubx/health/test_base.py
@@ -676,6 +676,98 @@ class TestBaseHealthMonitor:
         assert metrics.order_submit > 0
         assert metrics.order_cancel > 0
 
+    def test_data_feed_pool_excludes_funding_payment(
+        self, monitor: BaseHealthMonitor, time_provider: MockTimeProvider
+    ) -> None:
+        """Pooled per-exchange data_feed latency must ignore funding_payment samples.
+
+        funding_payment events are timestamped at the funding settlement time, so their
+        measured age is structural (seconds to hours), not transport latency. Once enough
+        of them accumulate in the pool, the pooled p90 permanently jumps to the funding
+        cluster even though the quote feed is healthy.
+        """
+        instrument = _get_test_instrument()
+        exchange = instrument.exchange
+        monitor.subscribe(instrument, "quote")
+        monitor.subscribe(instrument, "funding_payment")
+
+        current_time = time_provider.time()
+        for _ in range(90):
+            monitor.on_data_arrival(instrument, "quote", current_time - np.timedelta64(50, "ms"))
+        # settlement-stamped events: hours old on arrival, 25% of the pool
+        for _ in range(30):
+            monitor.on_data_arrival(instrument, "funding_payment", current_time - np.timedelta64(4, "h"))
+
+        pooled = monitor.get_exchange_latencies(exchange).data_feed
+        assert 45 <= pooled <= 55
+
+        # per-type view still reports the funding age for diagnostics
+        funding = monitor.get_data_latency(exchange, "funding_payment")
+        assert funding >= 4 * 3600 * 1000 * 0.99
+
+    def test_data_latency_ignores_samples_outside_window(
+        self, monitor: BaseHealthMonitor, time_provider: MockTimeProvider
+    ) -> None:
+        """A buffer that stopped receiving samples must not pin the 'now' percentile."""
+        instrument = _get_test_instrument()
+        exchange = instrument.exchange
+        monitor.subscribe(instrument, "quote")
+
+        monitor.on_data_arrival(instrument, "quote", time_provider.time() - np.timedelta64(500, "ms"))
+        assert monitor.get_data_latency(exchange, "quote") > 0
+        assert monitor.get_exchange_latencies(exchange).data_feed > 0
+
+        time_provider.advance(timedelta(minutes=6))  # beyond the default 5Min window
+        assert monitor.get_data_latency(exchange, "quote") == 0.0
+        assert monitor.get_exchange_latencies(exchange).data_feed == 0.0
+
+    def test_data_latency_window_uses_only_recent_samples(
+        self, monitor: BaseHealthMonitor, time_provider: MockTimeProvider
+    ) -> None:
+        """Stale high-latency samples age out of the percentile once fresh ones arrive."""
+        instrument = _get_test_instrument()
+        exchange = instrument.exchange
+        monitor.subscribe(instrument, "quote")
+
+        for _ in range(50):
+            monitor.on_data_arrival(instrument, "quote", time_provider.time() - np.timedelta64(900, "ms"))
+        time_provider.advance(timedelta(minutes=6))
+        for _ in range(50):
+            monitor.on_data_arrival(instrument, "quote", time_provider.time() - np.timedelta64(50, "ms"))
+
+        latency = monitor.get_data_latency(exchange, "quote")
+        assert 45 <= latency <= 55
+        pooled = monitor.get_exchange_latencies(exchange).data_feed
+        assert 45 <= pooled <= 55
+
+    def test_latency_window_is_configurable(self, time_provider: MockTimeProvider) -> None:
+        """A custom latency_window bounds how far back the percentile looks."""
+        monitor = BaseHealthMonitor(time_provider, latency_window="1Min")
+        instrument = _get_test_instrument()
+        monitor.subscribe(instrument, "quote")
+
+        monitor.on_data_arrival(instrument, "quote", time_provider.time() - np.timedelta64(100, "ms"))
+        time_provider.advance(timedelta(seconds=90))
+        assert monitor.get_data_latency(instrument.exchange, "quote") == 0.0
+
+    def test_data_latency_emitted_per_event_type(self, time_provider: MockTimeProvider) -> None:
+        """latency.p90.data rows carry an event_type tag so dashboards choose which
+        types to plot instead of receiving one pooled figure."""
+        emitter = InMemoryMetricEmitter()
+        monitor = BaseHealthMonitor(time_provider, emitter=emitter)
+        instrument = _get_test_instrument()
+        monitor.subscribe(instrument, "quote")
+        monitor.subscribe(instrument, "funding_payment")
+
+        monitor.on_data_arrival(instrument, "quote", time_provider.time() - np.timedelta64(50, "ms"))
+        monitor.on_data_arrival(instrument, "funding_payment", time_provider.time() - np.timedelta64(4, "h"))
+        monitor._emit()
+
+        df = emitter.get_dataframe(metric_name="latency.p90.data")
+        assert set(df["event_type"]) == {"quote", "funding_payment"}
+        assert 45 <= df[df["event_type"] == "quote"].iloc[0]["value"] <= 55
+        assert df[df["event_type"] == "funding_payment"].iloc[0]["value"] >= 4 * 3600 * 1000 * 0.99
+
     def test_subscribe_adds_to_active_subscriptions(self, monitor: BaseHealthMonitor) -> None:
         """Test that subscribe adds instrument/event_type to active subscriptions."""
         instrument = _get_test_instrument()


### PR DESCRIPTION
## What

Fixes the `latency.p90.data` health metric so per-exchange dashboard latency reflects actual feed transport latency instead of pooled cross-type sample ages. Three changes:

1. **Per-event-type emission** — `latency.p90.data` is now emitted once per `(exchange, event_type)` with an `event_type` tag (QuestDB SYMBOL column), so Grafana queries choose which types they plot (`WHERE event_type = 'quote'`) instead of receiving one pre-pooled figure. Order submit/cancel metrics are unchanged.
2. **Windowed percentiles** — data-latency percentiles (`get_data_latency`, the pooled `get_exchange_latencies().data_feed`) only look at samples that **arrived** within `latency_window` (new ctor param + `HealthConfig` field, default `5Min`). A ring buffer that stopped receiving samples can no longer pin the "now" stat with hours-old readings.
3. **Pooled figure excludes `funding_payment`** — `LatencyMetrics.data_feed` (still public API, no longer feeding the dashboard) stops mixing in settlement-stamped samples, whose age is structural rather than transport latency.

## Why

Dev frab bot, 2026-08-07: the BINANCE.UM "Data feed latency p90" panel stepped from ~200ms to a **constant 1.22s at exactly 04:00:00 UTC** (a Binance funding boundary) with no deploy and no restart. The live decomposition showed quote p90 = 139ms (healthy) vs funding_payment p90 = 73 minutes. Mechanism: `get_exchange_latencies` pooled every event type's ring buffer into one percentile; `funding_payment` events are timestamped at settlement time (structurally old on arrival — up to hours when the hourly refit resubscription replays them), and once their share of the pool crossed the ~10% that owns the p90 rank, the pooled figure permanently jumped into the funding cluster. Between funding boundaries that buffer is frozen, which is why the panel was constant to 0.1ms for tens of minutes. The value was a slow fuse off the Aug 5 restart — it would recur ~2 days after every restart.

## Testing

- 5 new tests in `tests/qubx/health/test_base.py`, each RED-proofed against the pre-fix source (the pooled-exclusion test reproduces the incident shape: pre-fix pooled p90 = 14,400,000ms from a 25% funding share): pool exclusion, window expiry, window recency, configurable window, per-type tagged emission.
- Full health suite: 51 passed. Ruff clean on touched files (one pre-existing baseline F401 in the test file left untouched).

## Follow-up (separate PR, xlydian-platform)

The two `bot-health` dashboard panels currently `avg(value)` with no `event_type` filter — after this releases they must filter/group on the new tag (e.g. `event_type = 'quote'`, or group by type). I'll put that PR up next. Until both land, the panels keep showing the polluted number (rows without the tag from old releases, or averaged types from new ones).

## Open questions for review

- **OHLC bar timestamps**: `ohlc`/`ohlc_quotes`/`ohlc_trades` events carry bar-open timestamps, so their measured "latency" grows 0→timeframe across each bar — same pollution class, deliberately **not** excluded here to keep the change incident-scoped. With per-type tags the dashboard can just not plot them. Say the word if you want them added to `DATA_FEED_LATENCY_EXCLUDE` too.
- **Keep or drop the pooled `data_feed`**: it no longer feeds dashboards; kept as API (with the funding exclusion) for `get_exchange_latencies` callers. Can drop the exclusion or the field if you'd rather.
- Order submit/cancel latencies are deliberately **not** windowed — they're sparse by nature, and windowing would zero them between orders.
