### PR TITLE
fix(core): warmup scope — new instruments no longer re-warm the whole universe

### DIFF
--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -366,26 +366,31 @@ class SubscriptionManager(ISubscriptionManager):
     def _collect_warmups(self, plan: _CommitPlan) -> dict[IDataProvider, dict[tuple[str, Instrument], str]]:
         """Resolve this commit's full warmup set (pending pairs from subscribe() plus the
         global-subscription expansion), partitioned per data provider. Consumes and clears
-        _pending_warmups; providers with nothing to warm are omitted."""
+        _pending_warmups; providers with nothing to warm are omitted.
+
+        Scope depends on WHY a warmup-configured sub is armed this commit (#371):
+        - armed via plan.global_subscriptions (a new/renewed global sub): warm the whole
+          current universe -- correct, a global sub must cover every instrument.
+        - armed only because _new_instruments is non-empty (some OTHER sub got new
+          instruments and this sub shares a warmup config, e.g. a warmup-only ohlc(1h)
+          riding a live quote(100ms) base sub): warm just _new_instruments. Widening this
+          to the whole universe re-fetches warmup for every already-subscribed instrument
+          on every commit that adds so much as one instrument.
+        Initial boot stays correct under the narrow scope: at the first commit ALL
+        instruments are in plan.stream_subscriptions (hence in _new_instruments), so
+        everything still warms once at start.
+        """
         # - handle warmup for global subscriptions
         for _data_provider in self._data_providers:
             _subscribed_instruments = set(_data_provider.get_subscribed_instruments())
-            _new_instruments = (
-                set.union(*plan.stream_subscriptions.values()) if plan.stream_subscriptions else set()
-            )
+            _new_instruments = set.union(*plan.stream_subscriptions.values()) if plan.stream_subscriptions else set()
 
-            _subs_to_warm = set(plan.global_subscriptions)
+            for sub in plan.global_subscriptions:
+                self._record_pending_warmup(_data_provider, sub, _subscribed_instruments.union(_new_instruments))
+
             if _new_instruments:
-                _subs_to_warm.update(self._sub_to_warmup.keys())
-
-            for sub in _subs_to_warm:
-                _warmup_period = self._sub_to_warmup.get(sub)
-                if _warmup_period is None:
-                    continue
-                _sub_instruments = _data_provider.get_subscribed_instruments(sub)
-                _add_instruments = _subscribed_instruments.union(_new_instruments).difference(_sub_instruments)
-                for instr in _add_instruments:
-                    self._pending_warmups[(sub, instr)] = _warmup_period
+                for sub in set(self._sub_to_warmup.keys()) - plan.global_subscriptions:
+                    self._record_pending_warmup(_data_provider, sub, _new_instruments)
 
         # TODO: think about appropriate handling of timeouts
         _warmups: dict[IDataProvider, dict[tuple[str, Instrument], str]] = {}
@@ -395,6 +400,18 @@ class SubscriptionManager(ISubscriptionManager):
                 _warmups[_data_provider] = _warmup_configs
         self._pending_warmups.clear()
         return _warmups
+
+    def _record_pending_warmup(
+        self, data_provider: IDataProvider, sub: str, candidate_instruments: set[Instrument]
+    ) -> None:
+        """Queue warmup for `sub` x (candidate_instruments - already subscribed to `sub`),
+        skipping subs with no warmup period configured."""
+        _warmup_period = self._sub_to_warmup.get(sub)
+        if _warmup_period is None:
+            return
+        _sub_instruments = data_provider.get_subscribed_instruments(sub)
+        for instr in candidate_instruments.difference(_sub_instruments):
+            self._pending_warmups[(sub, instr)] = _warmup_period
 
     def _get_pending_warmups_for_exchange(self, exchange: str) -> dict[tuple[str, Instrument], str]:
         return {

--- a/tests/qubx/core/subscription_test.py
+++ b/tests/qubx/core/subscription_test.py
@@ -157,6 +157,67 @@ class TestSubscriptionStuff:
         assert result_a == expected
         assert result_b == expected
 
+    def test_new_instrument_does_not_rewarm_whole_universe(self):
+        """Regression for #371: a warmup-only sub (has a warmup spec but is never itself
+        a live subscription -- e.g. ohlc(1h) riding a live trade base sub) must warm only
+        the newly-added instrument when one more instrument joins an already-subscribed
+        base sub, not the whole existing universe."""
+        btc = self._get_instrument("BTCUSDT")
+        eth = self._get_instrument("ETHUSDT")
+        sol = self._get_instrument("SOLUSDT")
+
+        self.manager.set_base_subscription(DataType.TRADE)
+        self.manager.set_warmup({DataType.OHLC["1h"]: "3d"})
+        self.mock_broker.get_subscribed_instruments.side_effect = (
+            lambda sub=None: {btc, eth} if sub is None or sub == DataType.TRADE else set()
+        )
+
+        # - btc/eth already subscribed to the live base sub from an earlier commit
+        self.manager.subscribe(DataType.TRADE, [btc, eth])
+        self.manager.commit()
+        self.mock_broker.warmup.reset_mock()
+
+        # - one new instrument joins
+        self.manager.subscribe(DataType.TRADE, sol)
+        self.manager.commit()
+
+        expected_warmup = {(DataType.OHLC["1h"], sol): "3d"}
+        self.mock_broker.warmup.assert_called_once_with(expected_warmup)
+
+    def test_new_global_subscription_warms_full_universe(self):
+        """A genuinely NEW global subscription (armed via plan.global_subscriptions) must
+        still warm the whole current universe -- the #371 fix only narrows the scope for
+        subs armed solely because _new_instruments is non-empty."""
+        btc = self._get_instrument("BTCUSDT")
+        eth = self._get_instrument("ETHUSDT")
+        sol = self._get_instrument("SOLUSDT")
+        instruments = {btc, eth, sol}
+        self.mock_broker.get_subscribed_instruments.side_effect = lambda sub=None: instruments if sub is None else set()
+
+        self.manager.set_warmup({DataType.FUNDING_PAYMENT: "1d"})
+        self.manager.subscribe(DataType.FUNDING_PAYMENT)
+        self.manager.commit()
+
+        expected_warmup = {(DataType.FUNDING_PAYMENT, i): "1d" for i in instruments}
+        self.mock_broker.warmup.assert_called_once_with(expected_warmup)
+
+    def test_initial_boot_warms_all_instruments(self):
+        """First-ever commit: every instrument is 'new' (all land in
+        plan.stream_subscriptions), so the #371 fix's narrow _new_instruments-only scope
+        still warms everyone -- there is no already-subscribed instrument to exclude."""
+        btc = self._get_instrument("BTCUSDT")
+        eth = self._get_instrument("ETHUSDT")
+        sol = self._get_instrument("SOLUSDT")
+        instruments = {btc, eth, sol}
+
+        self.manager.set_base_subscription(DataType.TRADE)
+        self.manager.set_warmup({DataType.OHLC["1h"]: "3d"})
+        self.manager.subscribe(DataType.TRADE, list(instruments))
+        self.manager.commit()
+
+        expected_warmup = {(DataType.OHLC["1h"], i): "3d" for i in instruments}
+        self.mock_broker.warmup.assert_called_once_with(expected_warmup)
+
     def test_ohlc_warmup(self):
         instruments = {self._get_instrument("BTCUSDT"), self._get_instrument("ETHUSDT")}
         self.mock_broker.get_subscribed_instruments.return_value = set()


### PR DESCRIPTION
## The defect

In `core/mixins/subscription.py::_collect_warmups` (~line 377), the global-warmup expansion did:

```python
_subs_to_warm = set(plan.global_subscriptions)
if _new_instruments:
    _subs_to_warm.update(self._sub_to_warmup.keys())   # any added instrument arms ALL warmup-configured subs
for sub in _subs_to_warm:
    _sub_instruments = _data_provider.get_subscribed_instruments(sub)
    _add_instruments = _subscribed_instruments.union(_new_instruments).difference(_sub_instruments)
```

For a warmup-only sub type (e.g. `ohlc(1h)` with a warmup spec but no live subscription — the standard frab setup where the live base sub is `quote(100ms)`), `get_subscribed_instruments(sub)` is always empty, so `_add_instruments` = ALL subscribed instruments ∪ the new one — the whole universe gets its OHLC warmup re-fetched on every commit that adds so much as one instrument.

**Observed impact** (#371): on a live paper run (frab v11 dynamic, ~52 instruments/venue), a fit that added ONE instrument correctly produced a delta-correct `subscribed 1 instruments` on the wire, but was preceded by ~50 `xdata: warming up <SYM> ohlc_1h — limit 72 (3d)` REST fetches per venue — ~100 redundant fetches per hourly fit against the xdata service. No correctness issue (warmup data is just re-delivered), but wasted REST load and log noise, worse with bigger universes / shorter fit schedules.

## The fix

Scope the warmup set per *why* a sub is armed this commit, not just whether it has a warmup config:

- A sub armed via `plan.global_subscriptions` (a genuinely new/renewed global subscription) keeps the broad scope: `_subscribed_instruments ∪ _new_instruments − _sub_instruments`. A new global sub must warm everyone.
- A sub armed *only* because `_new_instruments` is non-empty now warms `_new_instruments − _sub_instruments` only.

Initial boot stays correct under the narrow scope: at the first commit ALL instruments are in `plan.stream_subscriptions` (hence in `_new_instruments`), so everything still warms once at start.

Extracted the shared "warm candidate instruments not already on this sub" logic into `_record_pending_warmup` to avoid duplicating it across the two branches.

## Behavior delta

Instruments subscribed in an *earlier* commit that somehow never warmed for a given sub are no longer re-caught by later, unrelated commits — they were only being "caught" today by the very over-expansion this PR removes. A mid-run `set_warmup` addition still only takes effect for subsequently-added instruments, same as today for the pending-warmup path.

## Tests

Added to `tests/qubx/core/subscription_test.py`:
- `test_new_instrument_does_not_rewarm_whole_universe` — the regression pin: existing multi-instrument subscription with a warmup-only `ohlc(1h)` spec, adding ONE more instrument + commit → `provider.warmup` receives configs for only the new instrument. Verified this fails against pre-fix code (extra warmup entries for the already-subscribed instruments).
- `test_new_global_subscription_warms_full_universe` — a NEW global subscription with a warmup spec still warms every subscribed instrument (broad path preserved).
- `test_initial_boot_warms_all_instruments` — first commit with N instruments still warms all N (narrow path covers it via `_new_instruments`).

`tests/qubx/core` (`-n 2`) and the full `just test` suite pass (2339 passed, 5 skipped). `ruff check` / `ruff format --check` clean on touched files.

Closes #371
