### PR TITLE
fix: multi-currency capital, converting transfers, and per-exchange equity reporting

### DIFF
--- a/docs/superpowers/plans/2026-08-10-multi-currency-capital.md
+++ b/docs/superpowers/plans/2026-08-10-multi-currency-capital.md
@@ -1,0 +1,1091 @@
+# Multi-currency capital Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a multi-exchange simulation whose venues settle in different currencies report and size against the correct account capital, and make per-exchange equity reporting reconcile with total equity.
+
+**Architecture:** Each simulated venue gets its own base currency, resolved from its instruments' settle currency with an explicit override. `AccountState.total_capital()` iterates every balance and values each through a rate lookup that returns `None` for unpriced assets, so non-base settle balances count while spot holdings do not. Cross-venue transfers debit the source in its currency and credit the destination in its own. On the reporting side, transfers align as-of onto the portfolio-log index and the per-exchange capital split survives the storage round-trip.
+
+**Tech Stack:** Python 3.12, pandas, pyarrow/parquet, pytest, uv, ruff.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md`
+
+## Global Constraints
+
+- Python `>=3.12,<4.0`. Modern types only: `list`, `dict`, `X | None`, `tuple`. Never `from __future__ import annotations`.
+- ruff, `line-length = 120`.
+- Logging via `from qubx import logger`.
+- Conventional commits, no co-authored-by lines.
+- Run tests with `uv run pytest <path> -v`. Full suite: `just test`.
+- Single PR against `Qubx:main`; each task below is one commit.
+- `tests/qubx/core/account_manager/state_metrics_test.py:61-70` (the PEPE pin) must keep passing **unedited**. If a change requires editing it, the change is wrong.
+- Comments state only the non-obvious. No section-divider banners, no rationale essays.
+
+---
+
+### Task 1: Resolve a base currency per exchange in SimulationSetup
+
+**Files:**
+- Modify: `src/qubx/backtester/utils.py:1-2` (import `field`), `:85-113` (`SimulationSetup`), `:346` (`recognize_simulation_configuration` annotation)
+- Modify: `src/qubx/backtester/simulator.py:41` (`simulate` annotation), `src/qubx/utils/runner/configs.py:249` (`SimulationConfig.base_currency` annotation)
+- Test: `tests/qubx/backtester/test_base_currency_seeding.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `SimulationSetup.base_currencies: dict[str, str]` — resolved currency per exchange, populated in `__post_init__`. `SimulationSetup.base_currency` stays a `str` after init (display/persistence) even when a dict was passed in. Module-level `_derive_settle_currency(instruments: list[Instrument], exchange: str) -> str | None`.
+
+**Why the annotations:** a YAML mapping reaches `SimulationSetup` through
+`SimulationConfig.base_currency` → `runner.py:1219` (`sim_params["base_currency"] = sim.base_currency`)
+→ `simulate(base_currency=...)` → `recognize_simulation_configuration(basic_currency=...)`. The
+values pass through untouched; only the three `str` annotations along that chain reject a dict.
+The live path already resolves per-exchange currencies (`runner.py:759-770`), so this brings
+simulation in line with it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/qubx/backtester/test_base_currency_seeding.py`:
+
+```python
+def _multi_setup(base_currency, instruments) -> SimulationSetup:
+    return SimulationSetup(
+        setup_type=SetupTypes.STRATEGY,
+        name="test",
+        generator=None,
+        tracker=None,
+        instruments=instruments,
+        exchanges=["BINANCE.UM", "HYPERLIQUID.F"],
+        capital=100_000.0,
+        base_currency=base_currency,
+    )
+
+
+def _swap(exchange: str, symbol: str, settle: str) -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange=exchange,
+        base=symbol[:3],
+        quote=settle,
+        settle=settle,
+        exchange_symbol=symbol,
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_base_currency_derived_per_exchange_from_settle():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    assert setup.base_currencies == {"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDC"}
+
+
+def test_explicit_mapping_overrides_derivation():
+    setup = _multi_setup(
+        {"HYPERLIQUID.F": "usdc"},
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    assert setup.base_currencies == {"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDC"}
+    assert isinstance(setup.base_currency, str)
+
+
+def test_mixed_settle_venue_falls_back_to_scalar():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("BINANCE.UM", "BTCUSDC", "USDC")],
+    )
+    assert setup.base_currencies["BINANCE.UM"] == "USDT"
+
+
+def test_no_instruments_keeps_scalar_for_every_exchange():
+    setup = _multi_setup("usdt", [])
+    assert setup.base_currencies == {"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDT"}
+```
+
+Add `Instrument` and `MarketType` to the existing `from qubx.core.basics import Balance` line.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/backtester/test_base_currency_seeding.py -v`
+Expected: FAIL — `AttributeError: 'SimulationSetup' object has no attribute 'base_currencies'`
+
+- [ ] **Step 3: Implement resolution**
+
+In `src/qubx/backtester/utils.py`, change the import on line 2 to `from dataclasses import dataclass, field`, add the helper above the `SimulationSetup` class:
+
+```python
+def _derive_settle_currency(instruments: list[Instrument], exchange: str) -> str | None:
+    """The one settle currency a venue's instruments agree on, or None when absent or mixed."""
+    settles = {i.settle.upper() for i in instruments if i.exchange == exchange and i.settle}
+    return settles.pop() if len(settles) == 1 else None
+```
+
+Change the field declaration (`:96`) to `base_currency: str | dict[str, str]`, add below `enable_funding` (`:100`):
+
+```python
+    base_currencies: dict[str, str] = field(init=False, default_factory=dict)
+```
+
+and replace `__post_init__` (`:102-110`) with:
+
+```python
+    def __post_init__(self) -> None:
+        # Per-exchange base currency: explicit mapping wins, else the venue's shared settle
+        # currency, else the scalar. AccountState upper-cases, so normalize here or the seeded
+        # Balance lands under a key total_capital never reads.
+        explicit = (
+            {ex: ccy.upper() for ex, ccy in self.base_currency.items()}
+            if isinstance(self.base_currency, dict)
+            else {}
+        )
+        default_ccy = (
+            self.base_currency.upper()
+            if isinstance(self.base_currency, str)
+            else (explicit.get(self.exchanges[0], "USDT") if self.exchanges else "USDT")
+        )
+        self.base_currencies = {
+            ex: explicit.get(ex) or _derive_settle_currency(self.instruments, ex) or default_ccy
+            for ex in self.exchanges
+        }
+        self.base_currency = self.base_currencies[self.exchanges[0]] if self.exchanges else default_ccy
+        # Normalize capital to a per-exchange dict: split evenly when a single float is given
+        if isinstance(self.capital, (int, float)):
+            n = len(self.exchanges)
+            per_exchange = float(self.capital) / n if n > 0 else float(self.capital)
+            self.capital = {exchange: per_exchange for exchange in self.exchanges}
+```
+
+- [ ] **Step 4: Widen the annotations along the config chain**
+
+Three annotation-only edits, no logic changes:
+
+- `src/qubx/utils/runner/configs.py:249`: `base_currency: str | dict[str, str] | None = None`
+- `src/qubx/backtester/simulator.py:41`: `base_currency: str | dict[str, str] = "USDT"`
+- `src/qubx/backtester/utils.py:346`: `basic_currency: str | dict[str, str],`
+
+Add to `tests/qubx/backtester/test_base_currency_seeding.py`:
+
+```python
+def test_simulation_config_accepts_per_exchange_mapping():
+    from qubx.utils.runner.configs import SimulationConfig
+
+    cfg = SimulationConfig(
+        capital=100_000.0,
+        instruments=["BINANCE.UM:SWAP:BTCUSDT", "HYPERLIQUID.F:SWAP:BTCUSDC"],
+        start="2026-01-01",
+        stop="2026-02-01",
+        data={"storage": "qdb::quantlab"},
+        base_currency={"HYPERLIQUID.F": "USDC"},
+    )
+    assert cfg.base_currency == {"HYPERLIQUID.F": "USDC"}
+```
+
+If `SimulationConfig` requires fields beyond these, copy them from an existing config fixture in
+`tests/qubx/utils/` rather than guessing.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/backtester/test_base_currency_seeding.py -v`
+Expected: PASS, including the two pre-existing tests in that file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/qubx/backtester/utils.py src/qubx/backtester/simulator.py src/qubx/utils/runner/configs.py tests/qubx/backtester/test_base_currency_seeding.py
+git commit -m "feat(backtester): resolve base currency per exchange in SimulationSetup"
+```
+
+---
+
+### Task 2: Seed each venue in its own currency
+
+**Files:**
+- Modify: `src/qubx/backtester/utils.py` (add `initial_balances`), `src/qubx/backtester/runner.py:609-630`
+- Test: `tests/qubx/backtester/test_base_currency_seeding.py`
+
+**Interfaces:**
+- Consumes: `SimulationSetup.base_currencies` from Task 1.
+- Produces: `initial_balances(setup: SimulationSetup) -> dict[str, Balance]` in `qubx.backtester.utils` — exchange → the `Balance` to seed. The runner calls it instead of building balances inline, so seeding is testable without constructing a runner.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/qubx/backtester/test_base_currency_seeding.py`:
+
+```python
+def test_initial_balances_seed_each_venue_in_its_own_currency():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    balances = initial_balances(setup)
+    assert balances["BINANCE.UM"].currency == "USDT"
+    assert balances["HYPERLIQUID.F"].currency == "USDC"
+    assert balances["BINANCE.UM"].total == 50_000.0
+    assert balances["HYPERLIQUID.F"].free == 50_000.0
+
+
+def test_seeded_capital_visible_per_venue():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    am = SimulatedAccountManager(
+        connectors={ex: MagicMock() for ex in setup.exchanges},
+        base_currencies=setup.base_currencies,
+        time=_Clock(),
+    )
+    for exchange, balance in initial_balances(setup).items():
+        am.seed_balance(exchange, balance)
+
+    assert am.get_total_capital("HYPERLIQUID.F") == 50_000.0
+    assert am.get_total_capital() == 100_000.0
+```
+
+Add `initial_balances` to the `from qubx.backtester.utils import ...` line.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/backtester/test_base_currency_seeding.py -v -k initial_balances`
+Expected: FAIL with `ImportError: cannot import name 'initial_balances'`
+
+- [ ] **Step 3: Implement and wire the runner**
+
+Add to `src/qubx/backtester/utils.py`, below `SimulationSetup`:
+
+```python
+def initial_balances(setup: SimulationSetup) -> dict[str, Balance]:
+    """Startup balance per exchange, each in that venue's own base currency."""
+    assert isinstance(setup.capital, dict)
+    return {
+        exchange: Balance(
+            exchange=exchange,
+            currency=setup.base_currencies[exchange],
+            total=capital,
+            free=capital,
+            locked=0.0,
+        )
+        for exchange, capital in setup.capital.items()
+    }
+```
+
+Add `Balance` to the `from qubx.core.basics import (...)` block (`:10-18`) if absent.
+
+In `src/qubx/backtester/runner.py`, replace lines 609-630 with:
+
+```python
+        am = SimulatedAccountManager(
+            connectors=self._connectors,
+            base_currencies=self.setup.base_currencies,
+            time=time_provider,
+            cfg=AccountManagerConfig(),
+            account_id=self.account_id,
+            tcc=_exchange_to_tcc,
+        )
+
+        # - seed initial capital per exchange into the account state
+        for exchange, balance in initial_balances(self.setup).items():
+            am.seed_balance(exchange, balance)
+```
+
+Add `initial_balances` to the existing `from qubx.backtester.utils import ...` in `runner.py`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/backtester/test_base_currency_seeding.py -v && uv run pytest tests/qubx/backtester -v -x`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/backtester/utils.py src/qubx/backtester/runner.py tests/qubx/backtester/test_base_currency_seeding.py
+git commit -m "feat(backtester): seed each simulated venue in its own base currency"
+```
+
+---
+
+### Task 3: Value every balance through a rate lookup that may answer "unknown"
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/state.py:49-67` (`__slots__`), `:69-80` (`__init__`), `:186-195` (`total_capital`)
+- Test: `tests/qubx/core/account_manager/state_metrics_test.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `AccountState.mark_cash_currency(currency: str) -> None` and `AccountState.conversion_rate_to_base(currency: str) -> float | None`. `total_capital()` keeps its signature and its venue-equity short-circuit.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/qubx/core/account_manager/state_metrics_test.py`:
+
+```python
+def test_total_capital_counts_marked_settle_currency():
+    state = _state(1000.0)  # base USDT
+    state.mark_cash_currency("USDC")
+    state.update_balance("USDC", Balance(exchange="binance", currency="USDC", free=250.0, locked=0.0, total=250.0))
+    assert state.total_capital() == 1250.0
+
+
+def test_marked_cash_currency_survives_position_close():
+    state = _state(1000.0)
+    state.mark_cash_currency("USDC")
+    state.update_balance("USDC", Balance(exchange="binance", currency="USDC", free=250.0, locked=0.0, total=250.0))
+    assert not state.get_positions()
+    assert state.total_capital() == 1250.0
+
+
+def test_conversion_rate_unknown_for_unpriced_asset():
+    state = _state(1000.0)
+    assert state.conversion_rate_to_base("USDT") == 1.0
+    assert state.conversion_rate_to_base("PEPE") is None
+
+
+def test_venue_equity_still_wins_over_summed_cash():
+    state = _state(1000.0)
+    state.mark_cash_currency("USDC")
+    state.update_balance("USDC", Balance(exchange="binance", currency="USDC", free=250.0, locked=0.0, total=250.0))
+    state.set_venue_figures(_venue(equity=5000.0))
+    assert state.total_capital() == 5000.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/account_manager/state_metrics_test.py -v`
+Expected: FAIL — `AttributeError: 'AccountState' object has no attribute 'mark_cash_currency'`
+
+- [ ] **Step 3: Implement**
+
+In `src/qubx/core/account_manager/state.py`, add `"_cash_currencies",` to `__slots__` after `"_balances",`, and in `__init__` after the `_balances` line:
+
+```python
+        # Currencies this venue settles cash in: base plus any settle currency actually booked.
+        # Persisted rather than derived from open positions so leftovers survive a flat book.
+        self._cash_currencies: set[str] = {self.base_currency}
+```
+
+Replace `total_capital` (`:186-195`) and add the two helpers next to it:
+
+```python
+    def mark_cash_currency(self, currency: str) -> None:
+        if currency:
+            self._cash_currencies.add(currency.upper())
+
+    def conversion_rate_to_base(self, currency: str) -> float | None:
+        """Rate from `currency` to this account's base currency, or None when unknown.
+
+        Cash currencies are stable-to-stable at 1.0; everything else is unpriced until
+        marks-based conversion lands, and unpriced balances are excluded rather than
+        counted at par — a spot base asset is not capital.
+        """
+        return 1.0 if currency.upper() in self._cash_currencies else None
+
+    def total_capital(self) -> float:
+        venue = self._venue_figures
+        if venue is not None and venue.equity is not None:
+            return venue.equity
+        cash = sum(
+            b.total * rate
+            for c, b in list(self._balances.items())
+            if (rate := self.conversion_rate_to_base(c)) is not None
+        )
+        return cash + sum(p.market_value_funds for p in list(self._positions.values()))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/account_manager -v`
+Expected: PASS, with `test_base_currency_explicit_not_inferred` passing unedited (PEPE is unpriced, so excluded).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/account_manager/state.py tests/qubx/core/account_manager/state_metrics_test.py
+git commit -m "feat(account): count every priced cash balance in total_capital"
+```
+
+---
+
+### Task 4: Book settle currencies as cash on fills and funding
+
+**Files:**
+- Modify: `src/qubx/core/account_manager/reducer.py:316-320`, `src/qubx/core/account_manager/manager.py:681-683`
+- Test: `tests/qubx/core/account_manager/reducer_test.py`
+
+**Interfaces:**
+- Consumes: `AccountState.mark_cash_currency` from Task 3.
+- Produces: no new API. After any futures fill or funding settlement, `instrument.settle` is a cash currency on that venue.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/qubx/core/account_manager/reducer_test.py`. It already has `_fill(trade_id, amount, price) -> Deal` (`:70`) and imports `reducer`, `AccountState`, and `Instrument`; add `MarketType` to the `from qubx.core.basics import (...)` block if absent. The instrument is built literally rather than via `lookup`, which has no USDC-settled fixtures:
+
+```python
+USDC_PERP = Instrument(
+    symbol="BTCUSDC",
+    market_type=MarketType.SWAP,
+    exchange="hyperliquid",
+    base="BTC",
+    quote="USDC",
+    settle="USDC",
+    exchange_symbol="BTCUSDC",
+    tick_size=0.01,
+    lot_size=0.001,
+    min_size=0.001,
+    contract_size=1.0,
+)
+
+
+def test_futures_deal_marks_settle_currency_as_cash():
+    # Round trip on a USDC-settled perp inside a USDT-based state: buy 1 @ 100, sell 1 @ 110.
+    state = AccountState("hyperliquid", "USDT")
+    reducer._book_deal(state, USDC_PERP, _fill(amount=1.0, price=100.0))
+    reducer._book_deal(state, USDC_PERP, _fill(trade_id="t2", amount=-1.0, price=110.0))
+
+    assert state.conversion_rate_to_base("USDC") == 1.0
+    assert state.get_balance("USDC").total == pytest.approx(10.0)
+    assert state.total_capital() == pytest.approx(10.0)  # flat book: cash only, no market value
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/core/account_manager/reducer_test.py -v -k marks_settle`
+Expected: FAIL — `total_capital()` returns 0.0 because USDC is unpriced on a USDT-based state.
+
+- [ ] **Step 3: Implement**
+
+In `reducer.py`, inside the `if instrument.is_futures():` branch, immediately before the existing `state.adjust_balance(instrument.settle, realized_pnl - fee)`:
+
+```python
+        state.mark_cash_currency(instrument.settle)
+```
+
+In `manager.py`, replace the funding balance block (`:681-683`) with:
+
+```python
+        # Only an existing settle balance is adjusted — funding never creates one.
+        if state.get_balance(instrument.settle) is not None:
+            state.mark_cash_currency(instrument.settle)
+            state.adjust_balance(instrument.settle, amount)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/account_manager -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/account_manager/reducer.py src/qubx/core/account_manager/manager.py tests/qubx/core/account_manager/reducer_test.py
+git commit -m "feat(account): mark settle currencies as cash on fills and funding"
+```
+
+---
+
+### Task 5: Converting cross-venue transfers
+
+**Files:**
+- Modify: `src/qubx/core/basics.py:928-960` (`Transfer` fields and `to_dict`), `src/qubx/backtester/transfers.py:21-48`, `src/qubx/backtester/utils.py:643` and `:661-673` (transfers-log columns)
+- Test: `tests/qubx/backtester/test_transfers.py`
+
+**Interfaces:**
+- Consumes: `AccountManager.get_base_currency(exchange)`, `AccountState.conversion_rate_to_base` from Task 3.
+- Produces: `Transfer.to_currency: str | None` and `Transfer.to_amount: float | None` (both default `None`, meaning "same as source"). The transfers-log frame gains `to_currency` and `to_amount` columns. `transfer_funds(from_exchange, to_exchange, currency, amount)` keeps its signature; `currency` is now explicitly the **source** currency.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/qubx/backtester/test_transfers.py`:
+
+```python
+def _am_cross_currency():
+    am = SimulatedAccountManager(
+        connectors={"BINANCE.UM": MagicMock(), "HYPERLIQUID.F": MagicMock()},
+        base_currencies={"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDC"},
+        time=_T(),
+    )
+    am.get_state("BINANCE.UM").update_balance(
+        "USDT", Balance(exchange="BINANCE.UM", currency="USDT", total=1000.0, free=1000.0)
+    )
+    am.get_state("HYPERLIQUID.F").update_balance(
+        "USDC", Balance(exchange="HYPERLIQUID.F", currency="USDC", total=1000.0, free=1000.0)
+    )
+    return am
+
+
+def test_transfer_debits_source_currency_credits_destination_currency():
+    am = _am_cross_currency()
+    mgr = SimulationTransferManager(am, _T())
+    tid = mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "USDC", 250.0)
+
+    assert am.get_balance("USDC", "HYPERLIQUID.F").free == 750.0
+    assert am.get_balance("USDT", "BINANCE.UM").free == 1250.0
+    assert am.get_balance("USDC", "BINANCE.UM").total == 0.0
+
+    t = mgr.get_transfer_status(tid)
+    assert (t.currency, t.amount) == ("USDC", 250.0)
+    assert (t.to_currency, t.to_amount) == ("USDT", 250.0)
+
+
+def test_transfer_insufficient_funds_checks_source_currency():
+    am = _am_cross_currency()
+    mgr = SimulationTransferManager(am, _T())
+    with pytest.raises(ValueError, match="Insufficient funds"):
+        mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "USDC", 5000.0)
+
+
+def test_transfer_rejects_unpriced_currency():
+    am = _am_cross_currency()
+    am.get_state("HYPERLIQUID.F").update_balance(
+        "PEPE", Balance(exchange="HYPERLIQUID.F", currency="PEPE", total=10.0, free=10.0)
+    )
+    mgr = SimulationTransferManager(am, _T())
+    with pytest.raises(ValueError, match="no conversion rate"):
+        mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "PEPE", 1.0)
+
+
+def test_transfers_log_carries_destination_columns():
+    am = _am_cross_currency()
+    mgr = SimulationTransferManager(am, _T())
+    mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "USDC", 100.0)
+    df = collect_transfers_log(mgr)
+
+    assert list(df.columns) == _TRANSFERS_LOG_COLUMNS
+    assert df.iloc[0]["to_currency"] == "USDT"
+    assert df.iloc[0]["to_amount"] == 100.0
+```
+
+Add `_TRANSFERS_LOG_COLUMNS` to the `from qubx.backtester.utils import ...` line.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/backtester/test_transfers.py -v`
+Expected: FAIL — the destination is credited in USDC, and `Transfer` has no `to_currency`.
+
+- [ ] **Step 3: Implement**
+
+In `src/qubx/core/basics.py`, add to the `Transfer` dataclass after `failure_reason`:
+
+```python
+    to_currency: str | None = None  # destination currency when it differs from `currency`
+    to_amount: float | None = None  # credited amount in `to_currency`
+```
+
+and include both in the `to_dict()` mapping alongside the existing fields.
+
+Replace `transfer_funds` in `src/qubx/backtester/transfers.py:21-48`:
+
+```python
+    def transfer_funds(self, from_exchange: str, to_exchange: str, currency: str, amount: float) -> str:
+        if amount <= 0:
+            raise ValueError(f"Transfer amount must be positive, got {amount}")
+        to_currency = self._account.get_base_currency(to_exchange)
+        # Venues settle in their own currency: a withdrawal leaves in `currency` and arrives as
+        # `to_currency`. Both legs must be priced — an unpriced asset has no transferable value.
+        from_rate = self._account.get_state(from_exchange).conversion_rate_to_base(currency)
+        to_rate = self._account.get_state(to_exchange).conversion_rate_to_base(to_currency)
+        if from_rate is None or to_rate is None:
+            raise ValueError(f"Cannot transfer {currency} to {to_exchange} {to_currency}: no conversion rate")
+        to_amount = amount * from_rate / to_rate
+
+        from_balance = self._account.get_balance(currency, exchange=from_exchange)
+        if from_balance.free < amount:
+            raise ValueError(
+                f"Insufficient funds in {from_exchange}: "
+                f"{from_balance.free:.8f} {currency} available, {amount:.8f} requested"
+            )
+
+        self._account.adjust_balance(from_exchange, currency, -amount)
+        self._account.adjust_balance(to_exchange, to_currency, to_amount)
+
+        transaction_id = f"sim_{uuid.uuid4().hex[:12]}"
+        self._transfers[transaction_id] = Transfer(
+            transaction_id=transaction_id,
+            from_exchange=from_exchange,
+            to_exchange=to_exchange,
+            currency=currency,
+            amount=amount,
+            status=TransferStatus.COMPLETED,  # transfers are instant in simulation
+            timestamp=self._time.time(),
+            to_currency=to_currency,
+            to_amount=to_amount,
+        )
+        logger.debug(
+            f"[SimTransfer] {amount:.8f} {currency} {from_exchange} -> "
+            f"{to_amount:.8f} {to_currency} {to_exchange} ({transaction_id})"
+        )
+        return transaction_id
+```
+
+In `src/qubx/backtester/utils.py`, extend the columns constant (`:643`) and the row dict (`:661-670`):
+
+```python
+_TRANSFERS_LOG_COLUMNS = [
+    "transaction_id",
+    "from_exchange",
+    "to_exchange",
+    "currency",
+    "amount",
+    "status",
+    "to_currency",
+    "to_amount",
+]
+```
+
+```python
+                "status": str(t.status),
+                "to_currency": t.to_currency or t.currency,
+                "to_amount": t.to_amount if t.to_amount is not None else t.amount,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/backtester/test_transfers.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/basics.py src/qubx/backtester/transfers.py src/qubx/backtester/utils.py tests/qubx/backtester/test_transfers.py
+git commit -m "feat(backtester): convert cross-venue transfers at the venue boundary"
+```
+
+---
+
+### Task 6: Align transfers as-of onto the portfolio-log index
+
+**Files:**
+- Modify: `src/qubx/core/metrics.py:766-837` (`get_equity_per_exchange`), plus a module-level helper above it
+- Test: `tests/qubx/core/test_session_result_equity.py` (create)
+
+**Interfaces:**
+- Consumes: the `to_amount` column from Task 5.
+- Produces: `_transfer_offsets(transfers: pd.DataFrame, exchange: str, index: pd.DatetimeIndex) -> pd.Series` in `qubx.core.metrics` — cumulative net transfer effect on one venue, aligned onto `index`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/qubx/core/test_session_result_equity.py`:
+
+```python
+import pandas as pd
+
+from qubx.core.metrics import _transfer_offsets
+
+INDEX = pd.date_range("2026-01-01", periods=4, freq="1h")
+
+
+def _transfers(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows).set_index("timestamp")
+
+
+def test_off_grid_transfer_lands_on_next_bar():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 100.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 100.0, 100.0]
+    assert list(_transfer_offsets(tl, "A", INDEX)) == [0.0, 0.0, -100.0, -100.0]
+
+
+def test_two_transfers_in_one_bar_sum():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 100.0,
+                "status": "completed",
+            },
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:30"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 50.0,
+                "to_amount": 50.0,
+                "status": "completed",
+            },
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 150.0, 150.0]
+
+
+def test_transfer_before_first_bar_counts_from_the_start():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2025-12-31 23:00"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 10.0,
+                "to_amount": 10.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [10.0, 10.0, 10.0, 10.0]
+
+
+def test_transfer_after_last_bar_is_ignored():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-02 00:00"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 10.0,
+                "to_amount": 10.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_non_completed_transfers_excluded():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 100.0,
+                "status": "pending",
+            },
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 7.0,
+                "to_amount": 7.0,
+                "status": "failed",
+            },
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_converted_transfer_credits_destination_amount():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 99.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 99.0, 99.0]
+    assert list(_transfer_offsets(tl, "A", INDEX)) == [0.0, 0.0, -100.0, -100.0]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/test_session_result_equity.py -v`
+Expected: FAIL with `ImportError: cannot import name '_transfer_offsets'`
+
+- [ ] **Step 3: Implement**
+
+Add above `TradingSessionResult` in `src/qubx/core/metrics.py`:
+
+```python
+def _transfer_offsets(transfers: pd.DataFrame, exchange: str, index: pd.DatetimeIndex) -> pd.Series:
+    """Cumulative net transfer effect on `exchange`, aligned as-of onto `index`.
+
+    Transfer timestamps come from strategy schedules and rarely coincide with portfolio-log
+    bars, so alignment is as-of (first bar at or after the transfer) rather than exact match.
+    """
+    if not {"from_exchange", "to_exchange", "amount"}.issubset(transfers.columns):
+        return pd.Series(0.0, index=index)
+    done = transfers
+    if "status" in done.columns:
+        done = done[done["status"].astype(str).str.lower() == "completed"]
+    if done.empty:
+        return pd.Series(0.0, index=index)
+
+    credited = done["to_amount"].fillna(done["amount"]) if "to_amount" in done.columns else done["amount"]
+    deltas = credited.where(done["to_exchange"] == exchange, 0.0) - done["amount"].where(
+        done["from_exchange"] == exchange, 0.0
+    )
+    cumulative = deltas.groupby(level=0).sum().sort_index().cumsum()
+    return cumulative.reindex(index, method="ffill").fillna(0.0)
+```
+
+Replace the transfer block inside `get_equity_per_exchange` (`:808-833`) with:
+
+```python
+            if with_transfers and self.transfers_log is not None and not self.transfers_log.empty:
+                equity = equity + _transfer_offsets(self.transfers_log, exchange, self.portfolio_log.index)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/test_session_result_equity.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/metrics.py tests/qubx/core/test_session_result_equity.py
+git commit -m "fix(metrics): align transfers as-of onto the portfolio-log index"
+```
+
+---
+
+### Task 7: Keep the per-exchange capital split across persistence and slicing
+
+**Files:**
+- Modify: `src/qubx/utils/results.py:234` (schema), `:630-660` (writer), `:905-925` (loader), `src/qubx/core/metrics.py:709-715` (slicing)
+- Test: `tests/qubx/core/test_session_result_equity.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: metadata column `capital_by_exchange` (JSON string, `pa.string()`), and `_capital_from_meta(meta: dict, exchanges: list[str]) -> float | dict[str, float]` in `qubx.utils.results`. The `capital` float column keeps meaning "total" so existing DuckDB queries are unaffected.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/qubx/core/test_session_result_equity.py`:
+
+```python
+from qubx.utils.results import _capital_from_meta
+
+
+def test_capital_by_exchange_round_trips():
+    meta = {"capital": 100_000.0, "capital_by_exchange": '{"BINANCE.UM": 60000.0, "HYPERLIQUID.F": 40000.0}'}
+    assert _capital_from_meta(meta, ["BINANCE.UM", "HYPERLIQUID.F"]) == {
+        "BINANCE.UM": 60_000.0,
+        "HYPERLIQUID.F": 40_000.0,
+    }
+
+
+def test_legacy_scalar_capital_splits_evenly():
+    meta = {"capital": 100_000.0}
+    assert _capital_from_meta(meta, ["BINANCE.UM", "HYPERLIQUID.F"]) == {
+        "BINANCE.UM": 50_000.0,
+        "HYPERLIQUID.F": 50_000.0,
+    }
+
+
+def test_single_exchange_capital_stays_scalar():
+    assert _capital_from_meta({"capital": 100_000.0}, ["BINANCE.UM"]) == 100_000.0
+
+
+def test_malformed_capital_by_exchange_falls_back_to_even_split():
+    meta = {"capital": 100_000.0, "capital_by_exchange": "not-json"}
+    assert _capital_from_meta(meta, ["A", "B"]) == {"A": 50_000.0, "B": 50_000.0}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/core/test_session_result_equity.py -v -k capital`
+Expected: FAIL with `ImportError: cannot import name '_capital_from_meta'`
+
+- [ ] **Step 3: Implement**
+
+In `src/qubx/utils/results.py`, add to the metadata schema right after `("capital", pa.float64()),`:
+
+```python
+            ("capital_by_exchange", pa.string()),  # - JSON string; absent on legacy results
+```
+
+In the metadata writer, beside the existing `"capital": float(_capital),`:
+
+```python
+            "capital_by_exchange": _json.dumps(result.capital) if isinstance(result.capital, dict) else "",
+```
+
+Add the module-level loader helper:
+
+```python
+def _capital_from_meta(meta: dict, exchanges: list[str]) -> float | dict[str, float]:
+    """Per-exchange capital from metadata, falling back to an even split for legacy results.
+
+    Legacy rows predate the `capital_by_exchange` column and store only the total; the sim has
+    split a scalar evenly across venues since 69ed8448, so an even split reproduces what ran.
+    """
+    import json as _json
+
+    raw = meta.get("capital_by_exchange") or ""
+    if raw:
+        try:
+            parsed = _json.loads(raw)
+            if isinstance(parsed, dict) and parsed:
+                return {str(k): float(v) for k, v in parsed.items()}
+        except (ValueError, TypeError):
+            logger.warning(f"Ignoring malformed capital_by_exchange metadata: {raw!r}")
+    total = float(meta.get("capital", 0.0))
+    return {ex: total / len(exchanges) for ex in exchanges} if len(exchanges) > 1 else total
+```
+
+In the loader, replace `capital=float(meta.get("capital", 0.0)),` with `capital=_capital_from_meta(meta, _to_list(meta.get("exchanges"))),`.
+
+In `src/qubx/core/metrics.py`, replace the slicing block (`:709-715`) with:
+
+```python
+        # Recompute capital at the cut, preserving the per-exchange split so
+        # get_equity_per_exchange keeps reconciling with get_equity after a slice.
+        if start is not None and not self.portfolio_log.empty:
+            if isinstance(self.capital, dict) and len(self.exchanges) > 1:
+                prior = self.get_equity_per_exchange().loc[:start]
+                capital = {ex: float(prior[ex].iloc[-1]) for ex in prior.columns} if not prior.empty else self.capital
+            else:
+                prior_equity = self.get_equity().loc[:start]
+                capital = float(prior_equity.iloc[-1]) if not prior_equity.empty else self.capital
+        else:
+            capital = self.capital
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/test_session_result_equity.py -v && uv run pytest tests/qubx/utils -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/utils/results.py src/qubx/core/metrics.py tests/qubx/core/test_session_result_equity.py
+git commit -m "fix(results): persist per-exchange capital and preserve it when slicing"
+```
+
+---
+
+### Task 8: Pin the sum-equals-total invariant
+
+**Files:**
+- Test: `tests/qubx/core/test_session_result_equity.py`
+
+**Interfaces:**
+- Consumes: `_transfer_offsets` (Task 6), `_capital_from_meta` (Task 7).
+- Produces: nothing consumed downstream. This is the regression gate for both reporting defects.
+
+- [ ] **Step 1: Write the failing-if-regressed tests**
+
+Append to `tests/qubx/core/test_session_result_equity.py`:
+
+```python
+from qubx.core.metrics import TradingSessionResult
+
+
+def _two_venue_result(capital, transfers: pd.DataFrame | None = None) -> TradingSessionResult:
+    idx = INDEX
+    portfolio = pd.DataFrame(
+        {
+            "BINANCE.UM:BTCUSDT_PnL": [0.0, 10.0, 10.0, 10.0],
+            "BINANCE.UM:BTCUSDT_Commissions": [0.0, 1.0, 0.0, 0.0],
+            "BINANCE.UM:BTCUSDT_Value": [1000.0, 1000.0, 1000.0, 1000.0],
+            "HYPERLIQUID.F:BTCUSDC_PnL": [0.0, -10.0, -10.0, -10.0],
+            "HYPERLIQUID.F:BTCUSDC_Commissions": [0.0, 1.0, 0.0, 0.0],
+            "HYPERLIQUID.F:BTCUSDC_Value": [-1000.0, -1000.0, -1000.0, -1000.0],
+        },
+        index=idx,
+    )
+    return TradingSessionResult(
+        id=0,
+        name="t",
+        start=idx[0],
+        stop=idx[-1],
+        exchanges=["BINANCE.UM", "HYPERLIQUID.F"],
+        instruments=[],
+        capital=capital,
+        base_currency="USDT",
+        commissions=None,
+        portfolio_log=portfolio,
+        executions_log=pd.DataFrame(),
+        signals_log=pd.DataFrame(),
+        targets_log=pd.DataFrame(),
+        strategy_class="test",
+        transfers_log=transfers,
+    )
+
+
+def _assert_reconciles(result: TradingSessionResult) -> None:
+    per_exchange = result.get_equity_per_exchange().sum(axis=1)
+    pd.testing.assert_series_equal(per_exchange, result.get_equity(), check_names=False)
+
+
+def test_per_exchange_equity_reconciles_in_memory():
+    _assert_reconciles(_two_venue_result({"BINANCE.UM": 50_000.0, "HYPERLIQUID.F": 50_000.0}))
+
+
+def test_per_exchange_equity_reconciles_after_legacy_scalar_load():
+    capital = _capital_from_meta({"capital": 100_000.0}, ["BINANCE.UM", "HYPERLIQUID.F"])
+    _assert_reconciles(_two_venue_result(capital))
+
+
+def test_per_exchange_equity_reconciles_with_transfers():
+    transfers = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "BINANCE.UM",
+                "to_exchange": "HYPERLIQUID.F",
+                "amount": 5_000.0,
+                "to_amount": 5_000.0,
+                "status": "completed",
+            }
+        ]
+    )
+    result = _two_venue_result({"BINANCE.UM": 50_000.0, "HYPERLIQUID.F": 50_000.0}, transfers)
+    _assert_reconciles(result)
+    per_exchange = result.get_equity_per_exchange()
+    assert per_exchange["HYPERLIQUID.F"].iloc[-1] - per_exchange["HYPERLIQUID.F"].iloc[0] > 4_000.0
+
+
+def test_per_exchange_equity_reconciles_after_slicing():
+    result = _two_venue_result({"BINANCE.UM": 50_000.0, "HYPERLIQUID.F": 50_000.0})
+    _assert_reconciles(result[INDEX[1] :])
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/qubx/core/test_session_result_equity.py -v`
+Expected: PASS. If `test_per_exchange_equity_reconciles_after_slicing` fails, the slicing branch in Task 7 is wrong — fix it there, not by relaxing this assertion. (`TradingSessionResult.__getitem__` at `metrics.py:685` accepts a slice, so `result[INDEX[1]:]` is the correct call.)
+
+- [ ] **Step 3: Verify the tests actually bite**
+
+Temporarily revert `_transfer_offsets` to exact-membership matching (`if ts in index`) and re-run.
+Expected: `test_per_exchange_equity_reconciles_with_transfers` FAILS on the drift assertion. Restore the implementation.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `just test`
+Expected: PASS. Pay attention to `tests/qubx/core/account_manager/state_metrics_test.py` and `tests/qubx/backtester/` — those cover the changed paths.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/qubx/core/test_session_result_equity.py
+git commit -m "test(metrics): pin per-exchange equity against total equity"
+```
+
+---
+
+## Manual verification before the PR
+
+Not automated — it needs market data and a strategy, so it belongs in the PR description rather than the suite.
+
+1. Run a short BINANCE.UM ⇄ HYPERLIQUID.F frab simulation (`configs/experiments/v11_bhpl/v11_00_baseline.yml`, one month).
+2. Confirm `ctx.get_total_capital()` at the first execution equals the configured capital, not double it.
+3. Confirm `r.gross_leverage` stays near the configured leverage rather than decaying across the run.
+4. Confirm `r.get_equity_per_exchange().sum(axis=1)` matches `r.equity`.
+5. Reload a **pre-existing** stored run (`FARB_V4/v11_00_fp1d_to05/20260716_001508`) and confirm the same reconciliation now holds via the legacy even-split path, and that its 17 transfers are visible as steps.
+
+## Follow-ups (not in this PR)
+
+- frab: `BalanceDifferenceRebalancer` stops hardcoding `target_currency = "USDT"` (`components/rebalancer.py:31`) and passes the source venue's base currency.
+- quantkit: confirm `XChangesTransferService` can bridge USDC → USDT before live rebalancing depends on it.
+- qubx: marks-based `conversion_rate_to_base` for unpriced assets (the `state.py:245` TODO).

--- a/docs/superpowers/plans/2026-08-10-multi-currency-capital.md
+++ b/docs/superpowers/plans/2026-08-10-multi-currency-capital.md
@@ -970,7 +970,12 @@ git commit -m "fix(results): persist per-exchange capital and preserve it when s
 
 **Interfaces:**
 - Consumes: `_transfer_offsets` (Task 6), `_capital_from_meta` (Task 7).
-- Produces: nothing consumed downstream. This is the regression gate for both reporting defects.
+- Produces: nothing consumed downstream. The sum-equals-total invariant is the regression gate for
+  the capital-split defect (a scalar capital leaking into a multi-exchange result doubles the
+  per-exchange sum). It does not gate the transfer defect — a transfer's two legs are exact
+  negatives landing on the same bar, so a value-preserving transfer leaves the sum unchanged
+  regardless of alignment. That defect is gated separately, by asserting the transferred amount
+  lands on the source and destination venues' own equity curves.
 
 - [ ] **Step 1: Write the failing-if-regressed tests**
 

--- a/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
+++ b/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
@@ -104,8 +104,13 @@ dict in `__post_init__`, beside the existing capital split (`backtester/utils.py
 Resolution order per venue:
 
 1. explicit mapping entry, if given
-2. otherwise, the shared `settle` of that venue's configured instruments, when they agree
+2. otherwise, the shared `settle` of that venue's configured instruments, when they agree *and*
+   that currency is a recognized stable
 3. otherwise, the scalar `base_currency`
+
+An unrecognized settle currency can't be valued at par, so a BTC-settled venue
+(`BINANCE.UM:ETHBTC`) falls through to the scalar instead of being seeded 100,000 BTC counted as
+capital.
 
 `runner.py:611` passes the resolved dict to `SimulatedAccountManager` instead of broadcasting one
 string; `runner.py:622-629` seeds each venue in its own currency.
@@ -160,8 +165,10 @@ is unpriced, not because it is special-cased.
 
 Cash currencies are tracked explicitly: a persisted `_cash_currencies: set[str]` on `AccountState`
 (added to `__slots__`, `state.py:49-67`), seeded with `base_currency` and extended wherever a
-settle balance is adjusted (`reducer.py:320`, `manager.py:683`). Persisting rather than deriving
-from open positions means a flat venue's leftover USDC keeps counting.
+settle balance is adjusted (`reducer.py:320`, `manager.py:683`), via `mark_cash_currency`, which
+only admits recognized stables — the account's own `base_currency` stays exempt since it is
+seeded in at construction. Persisting rather than deriving from open positions means a flat
+venue's leftover USDC keeps counting.
 
 This also closes the mixed-settle hole that per-exchange seeding cannot: a BINANCE.UM carrying
 both USDT-M and USDC-M perps resolves to a single base currency, and the USDC-M side's PnL is only

--- a/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
+++ b/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
@@ -1,0 +1,243 @@
+# Multi-currency capital: account state, transfers, and reporting
+
+Date: 2026-08-10
+Status: approved, ready for planning
+Target: single PR against `Qubx:main`
+
+## Problem
+
+A multi-exchange simulation whose venues settle in different currencies reports the wrong
+account capital, sizes positions off that wrong number, and then hides the error in the
+per-exchange reporting. Two independent defects, both reproducible today on `main`.
+
+### Defect 1 — capital blind to non-base currencies (behavioural)
+
+`SimulatedAccountManager` gives every venue the same base currency
+(`backtester/runner.py:611`, `base_currencies={exchange: setup.base_currency}`) and seeds each
+venue's balance in it (`runner.py:622-629`). Money, however, books to the *instrument's* settle
+currency:
+
+- realized PnL and fees — `core/account_manager/reducer.py:320`,
+  `adjust_balance(instrument.settle, realized_pnl - fee)`, which creates the balance on demand
+- funding — `core/account_manager/manager.py:683`, same settle currency, but only when that
+  balance already exists
+
+`AccountState.total_capital()` (`core/account_manager/state.py:186-195`) reads exactly one
+balance: `self._balances.get(self.base_currency)`. On a USDC-settled venue seeded in USDT, every
+dollar the venue earns lands in a USDC balance the metric cannot see. The venue's reported
+capital stays pinned near its frozen USDT seed plus unrealized `market_value_funds`.
+
+Strategies size off this number. In frab, `FundingPair.amount_for_pair_leverage` calls
+`ctx.get_total_capital()`, so the sizing base inherits the blind spot.
+
+Two existing TODOs mark the same seam: `reducer.py:315` ("revisit for instruments whose settle
+currency differs from the portfolio base currency") and `state.py:245` ("convert settle/quote ->
+base_currency via marks").
+
+### Defect 2 — per-exchange equity reporting (read-side)
+
+`TradingSessionResult.get_equity_per_exchange` (`core/metrics.py:766-837`) is wrong in two ways:
+
+1. **Transfers are silently dropped.** Lines 824 and 829 gate on `if ts in transfer_amounts.index`
+   — exact membership in the portfolio-log index. Portfolio logs are sampled on a bar boundary;
+   transfers fire on strategy schedules, so their timestamps rarely coincide. The function also
+   counts rows regardless of `status`, so a pending or failed transfer would book as settled.
+2. **Per-exchange initial capital is wrong after a storage round-trip.** Line 803 reads
+   `self.capital[exchange] if isinstance(self.capital, dict) else self.capital`, treating a scalar
+   as *each* venue's seed rather than the total.
+
+The simulator itself is correct: `SimulationSetup.__post_init__` (`backtester/utils.py:106-110`)
+normalizes a scalar into a per-exchange dict, and `backtester/simulator.py:327` passes that dict
+through. The dict is destroyed by persistence:
+
+- `utils/results.py:234` declares the metadata column as `pa.float64()`
+- `utils/results.py:656` writes `float(result.get_total_capital())`
+- `utils/results.py:918` reads back `capital=float(meta.get("capital", 0.0))`
+
+So an in-memory result plots correctly and a reloaded one does not. `core/metrics.py:713`
+flattens the same way when slicing, recomputing `capital` as `float(equity at the cut)`.
+
+## Evidence
+
+Diagnosed on frab backtest `FARB_V4/v11_00_fp1d_to05/20260716_001508` (qubx 1.11.7,
+BINANCE.UM ⇄ HYPERLIQUID.F, `capital: 100000`, 2025-11-01 → 2026-07-10).
+
+Sizing base recovered from `executions_log` and fitted against candidate quantities:
+
+| candidate | median error | correlation |
+|---|---|---|
+| `2 × BINANCE equity` | +2.2% | +0.69 |
+| `BINANCE + HYPERLIQUID` (true total) | +25.9% | **−0.76** |
+| `2 × HYPERLIQUID equity` | +51.3% | −0.75 |
+
+The base tracked the USDT venue and was *anti-correlated* with true total equity. It fell
+114k → 59k while the account grew 100k → 123k. Position count stayed flat (~9.8 legs per venue)
+while per-leg notional halved, and reported gross leverage decayed from ~400% to ~170%.
+
+For defect 2 on the same run: 17 completed transfers, every timestamp at `HH:02:00` against an
+hourly log — zero matched, so none appeared in the chart. Per-exchange equity summed to
+$223,402 against a true equity of $123,402, exactly one scalar capital too much.
+
+## Goals
+
+- `get_total_capital()` reflects all of a venue's money regardless of settle currency
+- Simulated venues hold the currency they could actually hold
+- Cross-venue transfers model the real withdraw-swap-deposit
+- Per-exchange equity reconciles with total equity, transfers visible, for both fresh and
+  already-saved results
+- Live behaviour unchanged
+
+## Non-goals
+
+- Non-stable currency conversion. `conversion_rate` stays 1.0; the seam is wired, not filled.
+- A live `ITransferManager`. Qubx ships only the simulated one; live is injected by the strategy
+  (frab supplies quantkit's `XChangesTransferService`).
+- Changing the funding guard at `manager.py:682`. See "Deliberately unchanged".
+
+## Design
+
+### 1. Per-exchange base currency
+
+`SimulationSetup.base_currency` accepts `str | dict[str, str]` and normalizes to a per-exchange
+dict in `__post_init__`, beside the existing capital split (`backtester/utils.py:106-110`).
+Resolution order per venue:
+
+1. explicit mapping entry, if given
+2. otherwise, the shared `settle` of that venue's configured instruments, when they agree
+3. otherwise, the scalar `base_currency`
+
+`runner.py:611` passes the resolved dict to `SimulatedAccountManager` instead of broadcasting one
+string; `runner.py:622-629` seeds each venue in its own currency.
+
+Existing scalar configs are unaffected. A BINANCE.UM/HYPERLIQUID.F config resolves to
+USDT/USDC from its instruments with no config change. Seeding runs once at init, before any
+dynamic universe exists, so resolution reads only the configured instrument list.
+
+YAML form for the override:
+
+```yaml
+simulation:
+  base_currency:
+    BINANCE.UM: USDT
+    HYPERLIQUID.F: USDC
+```
+
+### 2. Currency-agnostic total capital
+
+`AccountState.total_capital()` (`state.py:186`) sums every balance through `conversion_rate`
+instead of reading `self.base_currency` alone. The venue-reported-equity short-circuit stays
+ahead of it untouched, so live continues to prefer `_venue_figures.equity`.
+
+Consequence worth having: a stray foreign stable on a venue still counts, so the metric cannot
+silently lose money again if seeding or a transfer puts funds somewhere unexpected.
+
+### 3. Converting transfers (simulation)
+
+`SimulationTransferManager.transfer_funds` (`backtester/transfers.py:21-46`) resolves each side's
+base currency from the account, debits the source in its currency, credits the destination in its
+currency at `conversion_rate`, and records both currencies and both amounts on the `Transfer`.
+The `currency` argument becomes the *source* currency. The insufficient-funds check reads the
+source venue's balance in that currency.
+
+This models withdraw USDC from HPL → arrive as USDT on Binance. It is a simulation model only:
+`runner.py:634` wires this manager for backtests and paper twins, while live uses whatever the
+strategy injected (`runner.py:1058`).
+
+### 4. Reporting — transfer alignment
+
+Replace exact membership (`metrics.py:824`, `:829`) with as-of alignment: build signed per-venue
+deltas indexed by transfer timestamp, `cumsum()` in transfer-time order, then
+`reindex(portfolio_index, method="ffill").fillna(0.0)`.
+
+This resolves every failure mode at once — off-grid stamps land on the following bar, several
+transfers inside one bar sum instead of colliding, transfers before the first bar still count,
+and transfers after the last bar drop out.
+
+Two corrections ride along: filter to completed transfers, and apply the debit amount to the
+source venue and the credit amount to the destination now that the two can differ.
+
+### 5. Reporting — capital round-trip
+
+Persist the resolved split. Keep the `capital` float column as the total so existing DuckDB
+`storage.search()` queries keep working, and add a `capital_by_exchange` JSON column
+(`utils/results.py:234`, `:656`, `:918`) that the loader prefers.
+
+When the column is absent — every result saved so far — split the scalar evenly across
+`exchanges`, matching what `SimulationSetup` has done since March 2026 (`69ed8448`). Results
+already in storage then render correctly without a rerun. Multi-exchange results produced
+*before* that commit were seeded differently and the even split will misattribute them; they are
+old enough not to warrant a version-conditional path.
+
+Slicing (`metrics.py:713`) carries the shape instead of collapsing it: per-venue capital at the
+cut, taken from `get_equity_per_exchange`.
+
+### Invariant
+
+`get_equity_per_exchange().sum(axis=1) == get_equity()` at every bar. One assertion covers both
+reporting defects; on the run above it reads $223,402 against $123,402.
+
+### Deliberately unchanged
+
+The funding guard at `manager.py:682` ("only an existing settle balance is adjusted"). With
+per-exchange seeding the settle balance exists from init, so the guard is satisfied. It exists so
+funding never invents a wallet, and loosening it would mask a genuinely mis-seeded account.
+
+## Testing
+
+Account and currency:
+
+- `SimulationSetup` resolution table: scalar broadcast, explicit override, single-settle
+  derivation, mixed-settle fallback
+- `total_capital()` sums multiple balances, and the venue-figures short-circuit still wins
+  (this is what keeps live unchanged)
+- converting transfers, extending `tests/qubx/backtester/test_transfers.py`: source debited in
+  its currency, destination credited in its own, both amounts recorded, insufficient funds
+  checked against the source balance
+
+Regression that reproduces the original defect: a two-venue sim, USDT and USDC, one hedged pair,
+funding enabled, asserting `ctx.get_total_capital()` tracks total equity. The quantity is
+anti-correlated with equity before the fix, so this fails hard on `main`.
+
+Reporting, in `tests/qubx/core/metrics_test.py`:
+
+- the sum-equals-total invariant in memory, after a storage round-trip, after slicing, and with
+  transfers present
+- transfer alignment against off-grid stamps, two in one bar, before the first bar, after the
+  last bar, and non-completed statuses
+- legacy metadata with no `capital_by_exchange` splits evenly
+
+## Compatibility
+
+Summing one balance equals reading it, so same-currency venue pairs are unchanged — BINANCE⇄GATEIO
+simulations produce identical results. Only mixed-settle pairs move: today BINANCE.UM ⇄
+HYPERLIQUID.F, plus Lighter if it is simulated.
+
+Paper twins share `SimulationTransferManager` and therefore pick up converting transfers, which is
+intended — paper should mirror simulation.
+
+Live venues that report equity are unaffected: the `_venue_figures` short-circuit runs ahead of
+the sum, and no live transfer manager ships in qubx. A live venue with no reported equity falls
+back to the derived path, which now counts every balance instead of one — more complete, and the
+same correction being made for simulation.
+
+## Rollout
+
+One PR against `Qubx:main`, organized as separate commits (account/currency, transfers,
+reporting/persistence, tests) so review stays navigable. Merging `main` cuts a stable release.
+
+1. merge the PR, wait for the release pipeline
+2. bump frab's qubx pin to the released version
+3. frab PR: `BalanceDifferenceRebalancer` stops hardcoding `target_currency = "USDT"`
+   (`components/rebalancer.py:31`) and uses the source venue's base currency
+4. rerun `v11_00_fp1d_to05`
+
+Expect a genuinely different result rather than a rescaled one: gross leverage flat near the
+configured 2.0× instead of decaying 4.0 → 1.7, with Sharpe and CAGR moving accordingly. That run
+also predates frab's `e417def` leverage² fix (merged 2026-07-20), which the rerun picks up.
+
+## Open question (non-blocking)
+
+Whether quantkit's `XChangesTransferService` can bridge USDC → USDT in live. Step 3 changes what
+frab asks for in production as well as simulation. Asking to move USDT off a USDC-settled venue is
+likely already wrong today, so this is a latent live issue to confirm rather than one this design
+introduces.

--- a/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
+++ b/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
@@ -209,8 +209,13 @@ cut, taken from `get_equity_per_exchange`.
 
 ### Invariant
 
-`get_equity_per_exchange().sum(axis=1) == get_equity()` at every bar. One assertion covers both
-reporting defects; on the run above it reads $223,402 against $123,402.
+`get_equity_per_exchange().sum(axis=1) == get_equity()` at every bar. This catches the
+capital-split defect: a scalar capital leaking into a multi-exchange result doubles the
+per-exchange sum against total equity (verified; on the run above it reads $223,402 against
+$123,402). It does not catch the transfer defect — a transfer's two legs are exact negatives
+landing on the same bar, so a value-preserving transfer leaves the sum unchanged whether or not
+it is aligned correctly. That defect is caught separately, by asserting the transferred amount
+actually lands on the source and destination venues' own equity curves.
 
 ### Deliberately unchanged
 

--- a/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
+++ b/docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md
@@ -89,7 +89,8 @@ $223,402 against a true equity of $123,402, exactly one scalar capital too much.
 
 ## Non-goals
 
-- Non-stable currency conversion. `conversion_rate` stays 1.0; the seam is wired, not filled.
+- Marks-based currency conversion. `conversion_rate_to_base` answers 1.0 for cash currencies and
+  `None` elsewhere; the seam is wired and typed, not filled.
 - A live `ITransferManager`. Qubx ships only the simulated one; live is injected by the strategy
   (frab supplies quantkit's `XChangesTransferService`).
 - Changing the funding guard at `manager.py:682`. See "Deliberately unchanged".
@@ -124,12 +125,47 @@ simulation:
 
 ### 2. Currency-agnostic total capital
 
-`AccountState.total_capital()` (`state.py:186`) sums every balance through `conversion_rate`
-instead of reading `self.base_currency` alone. The venue-reported-equity short-circuit stays
-ahead of it untouched, so live continues to prefer `_venue_figures.equity`.
+`AccountState.total_capital()` (`state.py:186`) iterates **every** balance instead of reading
+`self.base_currency` alone, valuing each through a rate lookup that is allowed to answer "unknown":
 
-Consequence worth having: a stray foreign stable on a venue still counts, so the metric cannot
-silently lose money again if seeding or a transfer puts funds somewhere unexpected.
+```python
+def conversion_rate_to_base(self, currency: str) -> float | None:
+    """Rate from `currency` to this account's base currency, or None when unknown."""
+
+def total_capital(self) -> float:
+    venue = self._venue_figures
+    if venue is not None and venue.equity is not None:
+        return venue.equity
+    cash = sum(
+        b.total * rate
+        for c, b in self._balances.items()
+        if (rate := self.conversion_rate_to_base(c)) is not None
+    )
+    return cash + sum(p.market_value_funds for p in list(self._positions.values()))
+```
+
+The venue-reported-equity short-circuit stays ahead of it untouched, so live continues to prefer
+`_venue_figures.equity`.
+
+Summing *all* balances at 1.0 would be wrong, not merely imprecise: spot fills credit the base
+asset (`reducer.py:325`, `adjust_balance(instrument.base, deal.amount)`), so a flat sum values a
+million PEPE at a million dollars. Today's defect understates capital by a bounded amount; that
+would overstate it without bound. `tests/qubx/core/account_manager/state_metrics_test.py:61-70`
+already pins the correct behaviour and must keep passing unedited.
+
+The rate table therefore starts narrow and widens later without moving a call site: today it
+answers 1.0 for the venue's cash currencies and `None` for everything else; when marks-based
+conversion lands (the `state.py:245` TODO) it answers for everything. PEPE is excluded because it
+is unpriced, not because it is special-cased.
+
+Cash currencies are tracked explicitly: a persisted `_cash_currencies: set[str]` on `AccountState`
+(added to `__slots__`, `state.py:49-67`), seeded with `base_currency` and extended wherever a
+settle balance is adjusted (`reducer.py:320`, `manager.py:683`). Persisting rather than deriving
+from open positions means a flat venue's leftover USDC keeps counting.
+
+This also closes the mixed-settle hole that per-exchange seeding cannot: a BINANCE.UM carrying
+both USDT-M and USDC-M perps resolves to a single base currency, and the USDC-M side's PnL is only
+visible because USDC is a settle currency.
 
 ### 3. Converting transfers (simulation)
 
@@ -188,8 +224,11 @@ Account and currency:
 
 - `SimulationSetup` resolution table: scalar broadcast, explicit override, single-settle
   derivation, mixed-settle fallback
-- `total_capital()` sums multiple balances, and the venue-figures short-circuit still wins
+- `total_capital()` counts a non-base *settle* balance, still excludes an unpriced asset balance
+  (the existing PEPE pin passes unedited), and the venue-figures short-circuit still wins
   (this is what keeps live unchanged)
+- `_cash_currencies` grows when a settle balance is adjusted and keeps counting after the
+  position closes
 - converting transfers, extending `tests/qubx/backtester/test_transfers.py`: source debited in
   its currency, destination credited in its own, both amounts recorded, insufficient funds
   checked against the source balance

--- a/src/qubx/backtester/runner.py
+++ b/src/qubx/backtester/runner.py
@@ -11,7 +11,7 @@ from qubx.backtester.sentinels import NoDataContinue
 from qubx.backtester.simulated_data import SimulatedDataIterator
 from qubx.backtester.transfers import SimulationTransferManager
 from qubx.core.account_manager import AccountManagerConfig, SimulatedAccountManager
-from qubx.core.basics import SW, Balance, DataType, Instrument, TransactionCostsCalculator
+from qubx.core.basics import SW, DataType, Instrument, TransactionCostsCalculator
 from qubx.core.context import StrategyContext
 from qubx.core.exceptions import SimulationConfigError, SimulationError
 from qubx.core.helpers import extract_parameters_from_object, full_qualified_class_name
@@ -49,6 +49,7 @@ from .utils import (
     SimulationSetup,
     _get_default_warmup_period,
     find_open_close_time_indent_secs_from_subscription,
+    initial_balances,
 )
 
 
@@ -608,7 +609,7 @@ class SimulationRunner:
 
         am = SimulatedAccountManager(
             connectors=self._connectors,
-            base_currencies={exchange: self.setup.base_currency for exchange in self.setup.exchanges},
+            base_currencies=self.setup.base_currencies,
             time=time_provider,
             cfg=AccountManagerConfig(),
             account_id=self.account_id,
@@ -616,17 +617,7 @@ class SimulationRunner:
         )
 
         # - seed initial capital per exchange into the account state
-        assert isinstance(self.setup.capital, dict)
-        for exchange, capital in self.setup.capital.items():
-            am.seed_balance(
-                exchange,
-                Balance(
-                    exchange=exchange,
-                    currency=self.setup.base_currency,
-                    total=capital,
-                    free=capital,
-                    locked=0.0,
-                ),
-            )
+        for exchange, balance in initial_balances(self.setup).items():
+            am.seed_balance(exchange, balance)
 
         return am

--- a/src/qubx/backtester/simulator.py
+++ b/src/qubx/backtester/simulator.py
@@ -38,7 +38,7 @@ def simulate(
     instruments: list[str] | list[Instrument] | dict[ExchangeName_t, list[SymbolOrInstrument_t]] | None = None,
     commissions: str | dict[str, str | None] | None = None,
     exchange: ExchangeName_t | list[ExchangeName_t] | None = None,
-    base_currency: str = "USDT",
+    base_currency: str | dict[str, str] = "USDT",
     n_jobs: int = 1,
     silent: bool = False,
     aux_data: IStorage | None = None,

--- a/src/qubx/backtester/transfers.py
+++ b/src/qubx/backtester/transfers.py
@@ -21,6 +21,15 @@ class SimulationTransferManager(ITransferManager):
     def transfer_funds(self, from_exchange: str, to_exchange: str, currency: str, amount: float) -> str:
         if amount <= 0:
             raise ValueError(f"Transfer amount must be positive, got {amount}")
+        to_currency = self._account.get_base_currency(to_exchange)
+        # Venues settle in their own currency: a withdrawal leaves in `currency` and arrives as
+        # `to_currency`. Both legs must be priced — an unpriced asset has no transferable value.
+        from_rate = self._account.get_state(from_exchange).conversion_rate_to_base(currency)
+        to_rate = self._account.get_state(to_exchange).conversion_rate_to_base(to_currency)
+        if from_rate is None or to_rate is None:
+            raise ValueError(f"Cannot transfer {currency} to {to_exchange} {to_currency}: no conversion rate")
+        to_amount = amount * from_rate / to_rate
+
         from_balance = self._account.get_balance(currency, exchange=from_exchange)
         if from_balance.free < amount:
             raise ValueError(
@@ -28,11 +37,8 @@ class SimulationTransferManager(ITransferManager):
                 f"{from_balance.free:.8f} {currency} available, {amount:.8f} requested"
             )
 
-        # Instant transfer: debit the source and credit the destination. adjust_balance
-        # mutates the held Balance in place (holders keep a live reference) and creates
-        # the destination Balance if missing.
         self._account.adjust_balance(from_exchange, currency, -amount)
-        self._account.adjust_balance(to_exchange, currency, amount)
+        self._account.adjust_balance(to_exchange, to_currency, to_amount)
 
         transaction_id = f"sim_{uuid.uuid4().hex[:12]}"
         self._transfers[transaction_id] = Transfer(
@@ -43,8 +49,13 @@ class SimulationTransferManager(ITransferManager):
             amount=amount,
             status=TransferStatus.COMPLETED,  # transfers are instant in simulation
             timestamp=self._time.time(),
+            to_currency=to_currency,
+            to_amount=to_amount,
         )
-        logger.debug(f"[SimTransfer] {amount:.8f} {currency} {from_exchange} -> {to_exchange} ({transaction_id})")
+        logger.debug(
+            f"[SimTransfer] {amount:.8f} {currency} {from_exchange} -> "
+            f"{to_amount:.8f} {to_currency} {to_exchange} ({transaction_id})"
+        )
         return transaction_id
 
     def get_transfer_status(self, transaction_id: str) -> Transfer:

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, TypeAlias
 
@@ -80,6 +80,12 @@ def _type(obj: Any) -> SetupTypes:
     return t
 
 
+def _derive_settle_currency(instruments: list[Instrument], exchange: str) -> str | None:
+    """The one settle currency a venue's instruments agree on, or None when absent or mixed."""
+    settles = {i.settle.upper() for i in instruments if i.exchange == exchange and i.settle}
+    return settles.pop() if len(settles) == 1 else None
+
+
 @dataclass
 class SimulationSetup:
     """
@@ -93,16 +99,32 @@ class SimulationSetup:
     instruments: list[Instrument]
     exchanges: list[str]
     capital: float | dict[str, float]
-    base_currency: str
+    base_currency: str | dict[str, str]
     commissions: str | dict[str, str | None] | None = None
     signal_timeframe: str = "1Min"
     accurate_stop_orders_execution: bool = False
     enable_funding: bool = False
+    base_currencies: dict[str, str] = field(init=False, default_factory=dict)
 
     def __post_init__(self) -> None:
-        # Normalize once at the config boundary: AccountState stores base_currency upper-cased,
-        # so a lowercase value here would seed capital under a key total_capital never reads.
-        self.base_currency = self.base_currency.upper()
+        # Per-exchange base currency: explicit mapping wins, else the venue's shared settle
+        # currency, else the scalar. AccountState upper-cases, so normalize here or the seeded
+        # Balance lands under a key total_capital never reads.
+        explicit = (
+            {ex: ccy.upper() for ex, ccy in self.base_currency.items()}
+            if isinstance(self.base_currency, dict)
+            else {}
+        )
+        default_ccy = (
+            self.base_currency.upper()
+            if isinstance(self.base_currency, str)
+            else (explicit.get(self.exchanges[0], "USDT") if self.exchanges else "USDT")
+        )
+        self.base_currencies = {
+            ex: explicit.get(ex) or _derive_settle_currency(self.instruments, ex) or default_ccy
+            for ex in self.exchanges
+        }
+        self.base_currency = self.base_currencies[self.exchanges[0]] if self.exchanges else default_ccy
         # Normalize capital to a per-exchange dict: split evenly when a single float is given
         if isinstance(self.capital, (int, float)):
             n = len(self.exchanges)
@@ -345,7 +367,7 @@ def recognize_simulation_configuration(
     instruments: list[Instrument],
     exchanges: list[str],
     capital: float | dict[str, float],
-    basic_currency: str,
+    basic_currency: str | dict[str, str],
     commissions: str | dict[str, str | None] | None,
     signal_timeframe: str,
     accurate_stop_orders_execution: bool,

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from qubx import logger
 from qubx.core.basics import (
+    Balance,
     CtrlChannel,
     DataType,
     Instrument,
@@ -133,6 +134,21 @@ class SimulationSetup:
 
     def __str__(self) -> str:
         return f"{self.name} {self.setup_type} capital {self.capital} {self.base_currency} for [{','.join(map(lambda x: x.symbol, self.instruments))}] @ {self.exchanges}[{self.commissions}]"
+
+
+def initial_balances(setup: SimulationSetup) -> dict[str, Balance]:
+    """Startup balance per exchange, each in that venue's own base currency."""
+    assert isinstance(setup.capital, dict)
+    return {
+        exchange: Balance(
+            exchange=exchange,
+            currency=setup.base_currencies[exchange],
+            total=capital,
+            free=capital,
+            locked=0.0,
+        )
+        for exchange, capital in setup.capital.items()
+    }
 
 
 # fmt: off

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -678,7 +678,16 @@ def recognize_simulation_data_config(
     )
 
 
-_TRANSFERS_LOG_COLUMNS = ["transaction_id", "from_exchange", "to_exchange", "currency", "amount", "status"]
+_TRANSFERS_LOG_COLUMNS = [
+    "transaction_id",
+    "from_exchange",
+    "to_exchange",
+    "currency",
+    "amount",
+    "status",
+    "to_currency",
+    "to_amount",
+]
 
 
 def collect_transfers_log(transfer_manager: ITransferManager | None) -> pd.DataFrame | None:
@@ -705,6 +714,8 @@ def collect_transfers_log(transfer_manager: ITransferManager | None) -> pd.DataF
                 "currency": t.currency,
                 "amount": t.amount,
                 "status": str(t.status),
+                "to_currency": t.to_currency or t.currency,
+                "to_amount": t.to_amount if t.to_amount is not None else t.amount,
             }
             for t in transfers
         ]

--- a/src/qubx/backtester/utils.py
+++ b/src/qubx/backtester/utils.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from qubx import logger
 from qubx.core.basics import (
+    STABLE_CURRENCIES,
     Balance,
     CtrlChannel,
     DataType,
@@ -81,10 +82,18 @@ def _type(obj: Any) -> SetupTypes:
     return t
 
 
+def _settle_currencies(instruments: list[Instrument], exchange: str) -> set[str]:
+    return {i.settle.upper() for i in instruments if i.exchange == exchange and i.settle}
+
+
 def _derive_settle_currency(instruments: list[Instrument], exchange: str) -> str | None:
-    """The one settle currency a venue's instruments agree on, or None when absent or mixed."""
-    settles = {i.settle.upper() for i in instruments if i.exchange == exchange and i.settle}
-    return settles.pop() if len(settles) == 1 else None
+    """The one settle currency a venue's instruments agree on, or None when absent, mixed, or
+    not a recognized stable — BINANCE.UM:ETHBTC settles in BTC, and BTC is not 1.0 of capital."""
+    settles = _settle_currencies(instruments, exchange)
+    if len(settles) != 1:
+        return None
+    settle = settles.pop()
+    return settle if settle in STABLE_CURRENCIES else None
 
 
 @dataclass
@@ -121,10 +130,15 @@ class SimulationSetup:
             if isinstance(self.base_currency, str)
             else (explicit.get(self.exchanges[0], "USDT") if self.exchanges else "USDT")
         )
-        self.base_currencies = {
-            ex: explicit.get(ex) or _derive_settle_currency(self.instruments, ex) or default_ccy
-            for ex in self.exchanges
-        }
+        self.base_currencies = {}
+        for ex in self.exchanges:
+            resolved = explicit.get(ex) or _derive_settle_currency(self.instruments, ex)
+            if resolved is None and (settles := _settle_currencies(self.instruments, ex)):
+                logger.debug(
+                    f"No single stable settle currency for {ex} (saw {sorted(settles)}) "
+                    f"- using {default_ccy} as its base currency"
+                )
+            self.base_currencies[ex] = resolved or default_ccy
         self.base_currency = self.base_currencies[self.exchanges[0]] if self.exchanges else default_ccy
         # Normalize capital to a per-exchange dict: split evenly when a single float is given
         if isinstance(self.capital, (int, float)):
@@ -325,7 +339,9 @@ def find_instruments_and_exchanges(
                 _instrs.append(instrument)
                 _exchanges.append(resolved_exchange)
 
-    return _instrs, list(set(_exchanges))
+    # sorted, not list(set(...)): string hashing is per-process randomized, and exchanges[0]
+    # decides the persisted scalar base_currency of a multi-venue run.
+    return _instrs, sorted(set(_exchanges))
 
 
 class _StructureSniffer:

--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -680,5 +680,6 @@ class SimulatedAccountManager(AccountManager):
         # redeliver); live venues debit on-venue and we observe via pushes/snapshots.
         # Only an existing settle balance is adjusted — funding never creates one.
         if state.get_balance(instrument.settle) is not None:
+            state.mark_cash_currency(instrument.settle)
             state.adjust_balance(instrument.settle, amount)
         return FundingPaymentEvent(instrument=instrument, time=np.datetime64(int(payment.time), "ns"), amount=amount)

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -313,6 +313,7 @@ def _book_deal(state: AccountState, instrument: Instrument, deal: Deal) -> Posit
     realized_pnl, fee = pos.update_position_by_deal(deal, state.conversion_rate(instrument))
     logger.debug("deal {} amt={} {}->{} tid={}", instrument.symbol, deal.amount, _before, pos.quantity, deal.trade_id)
     if instrument.is_futures():
+        state.mark_cash_currency(instrument.settle)
         # TODO(account-mgmt): fee is folded into settle here (correct when
         # settle == portfolio base currency); revisit for instruments whose
         # settle currency differs from the portfolio base currency.

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from qubx import logger
-from qubx.core.basics import Balance, Deal, Instrument, Order, OrderStatus, Position
+from qubx.core.basics import STABLE_CURRENCIES, Balance, Deal, Instrument, Order, OrderStatus, Position
 
 # Bounded per-exchange funding-bucket dedup (insertion order ≈ funding-event time order):
 # old buckets evict once the cap is hit so the set can't grow unbounded over long-running
@@ -188,7 +188,13 @@ class AccountState:
     # ================================================================== #
 
     def mark_cash_currency(self, currency: str) -> None:
-        if currency:
+        """Count `currency` as cash at par from now on — recognized stables only.
+
+        A BTC-settled instrument (BINANCE.UM:ETHBTC) must not turn a BTC balance into capital.
+        The account's own base currency is exempt: it is seeded into the set at construction,
+        so a deliberately coin-margined account keeps being counted.
+        """
+        if currency and currency.upper() in STABLE_CURRENCIES:
             self._cash_currencies.add(currency.upper())
 
     def conversion_rate_to_base(self, currency: str) -> float | None:
@@ -207,11 +213,14 @@ class AccountState:
         # list() is a C-atomic snapshot: these aggregates are read from other threads
         # (fit thread, control server) while the ProcessorThread inserts positions —
         # a bare generator over the live dict can raise "dict changed size during
-        # iteration". Same pattern for every _positions iteration below.
+        # iteration". Same pattern for every _balances/_positions iteration here and below.
         cash = sum(
-            b.total * rate
-            for c, b in list(self._balances.items())
-            if (rate := self.conversion_rate_to_base(c)) is not None
+            (
+                b.total * rate
+                for c, b in list(self._balances.items())
+                if (rate := self.conversion_rate_to_base(c)) is not None
+            ),
+            0.0,
         )
         return cash + sum(p.market_value_funds for p in list(self._positions.values()))
 

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -52,6 +52,7 @@ class AccountState:
         "_active_orders",
         "_positions",
         "_balances",
+        "_cash_currencies",
         "_venue_id_index",
         "_inflight_index",
         "_pending_evict_index",
@@ -74,6 +75,9 @@ class AccountState:
         self._active_orders: dict[str, Order] = {}  # client_order_id -> Order
         self._positions: dict[Instrument, Position] = {}
         self._balances: dict[str, Balance] = {}  # currency -> Balance
+        # Currencies this venue settles cash in: base plus any settle currency actually booked.
+        # Persisted rather than derived from open positions so leftovers survive a flat book.
+        self._cash_currencies: set[str] = {self.base_currency}
 
         # ---- lookup / bookkeeping indices (mutator-maintained) -----------
         # venue_order_id -> client_order_id
@@ -183,16 +187,32 @@ class AccountState:
     # figures are preferred over the derived value, per metric.          #
     # ================================================================== #
 
+    def mark_cash_currency(self, currency: str) -> None:
+        if currency:
+            self._cash_currencies.add(currency.upper())
+
+    def conversion_rate_to_base(self, currency: str) -> float | None:
+        """Rate from `currency` to this account's base currency, or None when unknown.
+
+        Cash currencies are stable-to-stable at 1.0; everything else is unpriced until
+        marks-based conversion lands, and unpriced balances are excluded rather than
+        counted at par — a spot base asset is not capital.
+        """
+        return 1.0 if currency.upper() in self._cash_currencies else None
+
     def total_capital(self) -> float:
         venue = self._venue_figures
         if venue is not None and venue.equity is not None:
             return venue.equity
-        base = self._balances.get(self.base_currency)
-        cash = base.total if base is not None else 0.0
         # list() is a C-atomic snapshot: these aggregates are read from other threads
         # (fit thread, control server) while the ProcessorThread inserts positions —
         # a bare generator over the live dict can raise "dict changed size during
         # iteration". Same pattern for every _positions iteration below.
+        cash = sum(
+            b.total * rate
+            for c, b in list(self._balances.items())
+            if (rate := self.conversion_rate_to_base(c)) is not None
+        )
         return cash + sum(p.market_value_funds for p in list(self._positions.values()))
 
     def total_initial_margin(self) -> float:

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -40,6 +40,9 @@ OPTION_SIGNAL_PRICE = "signal_price"
 OPTION_SKIP_PRICE_CROSS_CONTROL = "skip_price_cross_control"
 OPTION_AVOID_STOP_ORDER_PRICE_VALIDATION = "avoid_stop_order_price_validation"
 
+# The only currencies the framework may value at par (1.0) until marks-based conversion lands.
+STABLE_CURRENCIES: frozenset[str] = frozenset({"USDT", "USDC", "USD", "BUSD", "DAI", "FDUSD", "TUSD", "USDE", "PYUSD"})
+
 SW = Stopwatch()
 
 

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -943,6 +943,8 @@ class Transfer:
     timestamp: dt_64
     raw_status: str | None = None  # venue-native status; None for simulation
     failure_reason: str | None = None  # populated when status is FAILED
+    to_currency: str | None = None  # destination currency when it differs from `currency`
+    to_amount: float | None = None  # credited amount in `to_currency`
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-safe mapping (datetime64 -> str, status -> its value) for wire/reporting."""
@@ -956,6 +958,8 @@ class Transfer:
             "status": str(self.status),
             "raw_status": self.raw_status,
             "failure_reason": self.failure_reason,
+            "to_currency": self.to_currency,
+            "to_amount": self.to_amount,
         }
 
 

--- a/src/qubx/core/metrics.py
+++ b/src/qubx/core/metrics.py
@@ -604,6 +604,28 @@ def monthly_returns(
     return pd.concat((100 * r_month, acc_balance), axis=1, keys=["Returns", "Balance"])
 
 
+def _transfer_offsets(transfers: pd.DataFrame, exchange: str, index: pd.DatetimeIndex) -> pd.Series:
+    """Cumulative net transfer effect on `exchange`, aligned as-of onto `index`.
+
+    Transfer timestamps come from strategy schedules and rarely coincide with portfolio-log
+    bars, so alignment is as-of (first bar at or after the transfer) rather than exact match.
+    """
+    if not {"from_exchange", "to_exchange", "amount"}.issubset(transfers.columns):
+        return pd.Series(0.0, index=index)
+    done = transfers
+    if "status" in done.columns:
+        done = done[done["status"].astype(str).str.lower() == "completed"]
+    if done.empty:
+        return pd.Series(0.0, index=index)
+
+    credited = done["to_amount"].fillna(done["amount"]) if "to_amount" in done.columns else done["amount"]
+    deltas = credited.where(done["to_exchange"] == exchange, 0.0) - done["amount"].where(
+        done["from_exchange"] == exchange, 0.0
+    )
+    cumulative = deltas.groupby(level=0).sum().sort_index().cumsum()
+    return cumulative.reindex(index, method="ffill").fillna(0.0)
+
+
 class TradingSessionResult:
     # fmt: off
     id: int
@@ -807,30 +829,7 @@ class TradingSessionResult:
 
             # Account for transfers if requested
             if with_transfers and self.transfers_log is not None and not self.transfers_log.empty:
-                if (
-                    "to_exchange" in self.transfers_log.columns
-                    and "from_exchange" in self.transfers_log.columns
-                    and "amount" in self.transfers_log.columns
-                ):
-                    # Filter transfers for this exchange
-                    inbound = self.transfers_log[self.transfers_log["to_exchange"] == exchange]["amount"]
-                    outbound = self.transfers_log[self.transfers_log["from_exchange"] == exchange]["amount"]
-
-                    # Create series of transfer amounts at each timestamp
-                    transfer_amounts = pd.Series(0.0, index=self.portfolio_log.index)
-
-                    # Add inbound transfers
-                    for ts, amount in inbound.items():
-                        if ts in transfer_amounts.index:
-                            transfer_amounts.loc[ts] += amount
-
-                    # Subtract outbound transfers
-                    for ts, amount in outbound.items():
-                        if ts in transfer_amounts.index:
-                            transfer_amounts.loc[ts] -= amount
-
-                    # Cumulative sum to apply transfers from their timestamp onwards
-                    equity += transfer_amounts.cumsum()
+                equity = equity + _transfer_offsets(self.transfers_log, exchange, self.portfolio_log.index)
 
             result[exchange] = equity
 

--- a/src/qubx/core/metrics.py
+++ b/src/qubx/core/metrics.py
@@ -728,11 +728,15 @@ class TradingSessionResult:
         start = to_timestamp(key.start) if key.start is not None else None
         stop = to_timestamp(key.stop) if key.stop is not None else None
 
-        # Recompute capital as equity value at the cut start point
+        # Recompute capital at the cut, preserving the per-exchange split so
+        # get_equity_per_exchange keeps reconciling with get_equity after a slice.
         if start is not None and not self.portfolio_log.empty:
-            equity = self.get_equity()
-            prior = equity.loc[:start]
-            capital = float(prior.iloc[-1]) if not prior.empty else self.capital
+            if isinstance(self.capital, dict) and len(self.exchanges) > 1:
+                prior = self.get_equity_per_exchange().loc[:start]
+                capital = {ex: float(prior[ex].iloc[-1]) for ex in prior.columns} if not prior.empty else self.capital
+            else:
+                prior_equity = self.get_equity().loc[:start]
+                capital = float(prior_equity.iloc[-1]) if not prior_equity.empty else self.capital
         else:
             capital = self.capital
 

--- a/src/qubx/utils/results.py
+++ b/src/qubx/utils/results.py
@@ -178,6 +178,26 @@ def write_metadata_parquet(
     write_parquet_table(table, path, storage_options)
 
 
+def _capital_from_meta(meta: dict, exchanges: list[str]) -> float | dict[str, float]:
+    """Per-exchange capital from metadata, falling back to an even split for legacy results.
+
+    Legacy rows predate the `capital_by_exchange` column and store only the total; the sim has
+    split a scalar evenly across venues since 69ed8448, so an even split reproduces what ran.
+    """
+    import json as _json
+
+    raw = meta.get("capital_by_exchange") or ""
+    if raw:
+        try:
+            parsed = _json.loads(raw)
+            if isinstance(parsed, dict) and parsed:
+                return {str(k): float(v) for k, v in parsed.items()}
+        except (ValueError, TypeError):
+            logger.warning(f"Ignoring malformed capital_by_exchange metadata: {raw!r}")
+    total = float(meta.get("capital", 0.0))
+    return {ex: total / len(exchanges) for ex in exchanges} if len(exchanges) > 1 else total
+
+
 class SimulationResultsSaver:
     """
     Manages writing simulation results and status to parquet storage.
@@ -232,6 +252,7 @@ class SimulationResultsSaver:
             ("creation_time", pa.timestamp("us", tz="UTC")),
             ("simulation_time_sec", pa.int64()),
             ("capital", pa.float64()),
+            ("capital_by_exchange", pa.string()),  # - JSON string; absent on legacy results
             ("base_currency", pa.string()),
             ("commissions", pa.string()),
             ("exchanges", pa.list_(pa.string())),
@@ -654,6 +675,7 @@ class SimulationResultsSaver:
             "creation_time": _ts_utc(result.creation_time),
             "simulation_time_sec": int(result.simulation_time_sec or 0),
             "capital": float(_capital),
+            "capital_by_exchange": _json.dumps(result.capital) if isinstance(result.capital, dict) else "",
             "base_currency": result.base_currency or "",
             "commissions": _commissions,
             "exchanges": list(result.exchanges or []),
@@ -915,7 +937,7 @@ class SimulationResultsSaver:
             stop=_strip_tz(meta.get("stop", "")),
             exchanges=_to_list(meta.get("exchanges")),
             instruments=_to_list(meta.get("symbols")),
-            capital=float(meta.get("capital", 0.0)),
+            capital=_capital_from_meta(meta, _to_list(meta.get("exchanges"))),
             base_currency=meta.get("base_currency", "USDT"),
             commissions=meta.get("commissions"),
             portfolio_log=portfolio,

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -246,7 +246,7 @@ class SimulationConfig(StrictBaseModel):
     data: StorageConfig
     custom_data: list[TypedStorageConfig] = Field(default_factory=list)
     commissions: dict | str | None = None
-    base_currency: str | None = None
+    base_currency: str | dict[str, str] | None = None
     n_jobs: int | None = None
     variate: dict = Field(default_factory=dict)
     debug: str | None = None

--- a/tests/qubx/backtester/test_base_currency_seeding.py
+++ b/tests/qubx/backtester/test_base_currency_seeding.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from qubx.backtester.utils import SetupTypes, SimulationSetup
 from qubx.core.account_manager import SimulatedAccountManager
-from qubx.core.basics import Balance
+from qubx.core.basics import Balance, Instrument, MarketType
 
 
 class _Clock:
@@ -57,3 +57,76 @@ def test_lowercase_base_currency_capital_not_ignored():
     assert am.get_base_currency("BINANCE.UM") == "USDT"
     assert am.get_balance("USDT", "BINANCE.UM").total == 10_000.0
     assert am.get_total_capital("BINANCE.UM") == 10_000.0
+
+
+def _multi_setup(base_currency, instruments) -> SimulationSetup:
+    return SimulationSetup(
+        setup_type=SetupTypes.STRATEGY,
+        name="test",
+        generator=None,
+        tracker=None,
+        instruments=instruments,
+        exchanges=["BINANCE.UM", "HYPERLIQUID.F"],
+        capital=100_000.0,
+        base_currency=base_currency,
+    )
+
+
+def _swap(exchange: str, symbol: str, settle: str) -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange=exchange,
+        base=symbol[:3],
+        quote=settle,
+        settle=settle,
+        exchange_symbol=symbol,
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+        contract_size=1.0,
+    )
+
+
+def test_base_currency_derived_per_exchange_from_settle():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    assert setup.base_currencies == {"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDC"}
+
+
+def test_explicit_mapping_overrides_derivation():
+    setup = _multi_setup(
+        {"HYPERLIQUID.F": "usdc"},
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    assert setup.base_currencies == {"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDC"}
+    assert isinstance(setup.base_currency, str)
+
+
+def test_mixed_settle_venue_falls_back_to_scalar():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("BINANCE.UM", "BTCUSDC", "USDC")],
+    )
+    assert setup.base_currencies["BINANCE.UM"] == "USDT"
+
+
+def test_no_instruments_keeps_scalar_for_every_exchange():
+    setup = _multi_setup("usdt", [])
+    assert setup.base_currencies == {"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDT"}
+
+
+def test_simulation_config_accepts_per_exchange_mapping():
+    from qubx.utils.runner.configs import SimulationConfig
+
+    cfg = SimulationConfig(
+        capital=100_000.0,
+        instruments=["BINANCE.UM:SWAP:BTCUSDT", "HYPERLIQUID.F:SWAP:BTCUSDC"],
+        start="2026-01-01",
+        stop="2026-02-01",
+        data={"storage": "qdb::quantlab"},
+        base_currency={"HYPERLIQUID.F": "USDC"},
+    )
+    assert cfg.base_currency == {"HYPERLIQUID.F": "USDC"}

--- a/tests/qubx/backtester/test_base_currency_seeding.py
+++ b/tests/qubx/backtester/test_base_currency_seeding.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
-from qubx.backtester.utils import SetupTypes, SimulationSetup, initial_balances
+from qubx.backtester.utils import SetupTypes, SimulationSetup, find_instruments_and_exchanges, initial_balances
 from qubx.core.account_manager import SimulatedAccountManager
 from qubx.core.basics import Balance, Instrument, MarketType
 
@@ -113,9 +113,35 @@ def test_mixed_settle_venue_falls_back_to_scalar():
     assert setup.base_currencies["BINANCE.UM"] == "USDT"
 
 
+def test_non_stable_settle_is_not_derived_as_base_currency():
+    # BINANCE.UM:ETHBTC is a BTC-settled linear swap: deriving BTC would seed 100k BTC at par.
+    setup = _multi_setup("USDT", [_swap("BINANCE.UM", "ETHBTC", "BTC")])
+    assert setup.base_currencies["BINANCE.UM"] == "USDT"
+
+
 def test_no_instruments_keeps_scalar_for_every_exchange():
     setup = _multi_setup("usdt", [])
     assert setup.base_currencies == {"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDT"}
+
+
+def test_scalar_base_currency_follows_deterministic_exchange_order():
+    # exchanges[0] picks the scalar base_currency persisted into _metadata.parquet, so the
+    # exchange list must not depend on per-process string hashing.
+    instruments = [_swap("HYPERLIQUID.F", "BTCUSDC", "USDC"), _swap("BINANCE.UM", "BTCUSDT", "USDT")]
+    _, exchanges = find_instruments_and_exchanges(instruments, None)
+    assert exchanges == ["BINANCE.UM", "HYPERLIQUID.F"]
+
+    setup = SimulationSetup(
+        setup_type=SetupTypes.STRATEGY,
+        name="test",
+        generator=None,
+        tracker=None,
+        instruments=instruments,
+        exchanges=exchanges,
+        capital=100_000.0,
+        base_currency="USDT",
+    )
+    assert setup.base_currency == "USDT"
 
 
 def test_simulation_config_accepts_per_exchange_mapping():

--- a/tests/qubx/backtester/test_base_currency_seeding.py
+++ b/tests/qubx/backtester/test_base_currency_seeding.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
-from qubx.backtester.utils import SetupTypes, SimulationSetup
+from qubx.backtester.utils import SetupTypes, SimulationSetup, initial_balances
 from qubx.core.account_manager import SimulatedAccountManager
 from qubx.core.basics import Balance, Instrument, MarketType
 
@@ -130,3 +130,32 @@ def test_simulation_config_accepts_per_exchange_mapping():
         base_currency={"HYPERLIQUID.F": "USDC"},
     )
     assert cfg.base_currency == {"HYPERLIQUID.F": "USDC"}
+
+
+def test_initial_balances_seed_each_venue_in_its_own_currency():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    balances = initial_balances(setup)
+    assert balances["BINANCE.UM"].currency == "USDT"
+    assert balances["HYPERLIQUID.F"].currency == "USDC"
+    assert balances["BINANCE.UM"].total == 50_000.0
+    assert balances["HYPERLIQUID.F"].free == 50_000.0
+
+
+def test_seeded_capital_visible_per_venue():
+    setup = _multi_setup(
+        "USDT",
+        [_swap("BINANCE.UM", "BTCUSDT", "USDT"), _swap("HYPERLIQUID.F", "BTCUSDC", "USDC")],
+    )
+    am = SimulatedAccountManager(
+        connectors={ex: MagicMock() for ex in setup.exchanges},
+        base_currencies=setup.base_currencies,
+        time=_Clock(),
+    )
+    for exchange, balance in initial_balances(setup).items():
+        am.seed_balance(exchange, balance)
+
+    assert am.get_total_capital("HYPERLIQUID.F") == 50_000.0
+    assert am.get_total_capital() == 100_000.0

--- a/tests/qubx/backtester/test_funding_routing.py
+++ b/tests/qubx/backtester/test_funding_routing.py
@@ -192,6 +192,35 @@ class TestSimulatedAccountFunding:
         assert event is not None  # attribution still books downstream
         assert am.get_state(instr.exchange).get_balance("USDT") is None  # no balance materialized
 
+    def test_settlement_marks_settle_currency_as_cash(self):
+        # USDC-settled swap on a USDT-based venue: process_market_funding must register
+        # instrument.settle as cash so total_capital() actually counts the settlement.
+        instr = Instrument(
+            symbol="BTCUSDC",
+            market_type=MarketType.SWAP,
+            exchange="TEST",
+            base="BTC",
+            quote="USDC",
+            settle="USDC",
+            exchange_symbol="BTCUSDC",
+            tick_size=0.01,
+            lot_size=0.001,
+            min_size=0.001,
+            contract_size=1.0,
+        )
+        am = _sim_am(instr)
+        am.seed_balance(instr.exchange, Balance(exchange=instr.exchange, currency="USDC", free=0.0, total=0.0))
+        am.seed_position(_marked_position(instr, 0.5))
+        state = am.get_state(instr.exchange)
+        assert state.conversion_rate_to_base("USDC") is None  # not cash yet
+        capital_before = state.total_capital()
+
+        event = am.process_market_funding(instr, _payment())
+
+        assert event is not None
+        assert state.conversion_rate_to_base("USDC") == 1.0
+        assert state.total_capital() == pytest.approx(capital_before + event.amount)
+
     def test_live_account_manager_never_books_market_funding(self):
         # live: the account's funding arrives via the connector's typed events only
         instr = _btc()

--- a/tests/qubx/backtester/test_transfers.py
+++ b/tests/qubx/backtester/test_transfers.py
@@ -7,6 +7,7 @@ import pytest
 from qubx.backtester.runner import SimulationRunner
 from qubx.backtester.transfers import SimulationTransferManager
 from qubx.backtester.utils import (
+    _TRANSFERS_LOG_COLUMNS,
     SetupTypes,
     SimulationSetup,
     collect_transfers_log,
@@ -100,7 +101,9 @@ def test_insufficient_funds_raises_and_leaves_balances_untouched():
 def test_unknown_currency_raises():
     am = _am()
     tm = SimulationTransferManager(am, _T())
-    with pytest.raises(ValueError, match="Insufficient funds"):
+    # DOGE is unpriced on E1: pricing is checked before balance, so this is now a
+    # conversion-rate rejection rather than an insufficient-funds one.
+    with pytest.raises(ValueError, match="no conversion rate"):
         tm.transfer_funds("E1", "E2", "DOGE", 1.0)
 
 
@@ -217,10 +220,10 @@ def test_simulation_context_has_transfer_manager():
 
     runner.ctx.transfer_funds("BINANCE.UM", "HYPERLIQUID", "USDT", 1000.0)
     assert runner.account_manager.get_balance("USDT", exchange="BINANCE.UM").total == 4000.0
-    # HYPERLIQUID is seeded in its own settle currency (USDC), not the scalar "USDT" passed
-    # to SimulationSetup, so its USDT balance starts at 0 and only holds the transferred amount.
-    assert runner.account_manager.get_balance("USDT", exchange="HYPERLIQUID").total == 1000.0
-    assert runner.account_manager.get_balance("USDC", exchange="HYPERLIQUID").total == 5000.0
+    # Transfers convert at the venue boundary: HYPERLIQUID settles in USDC, so the withdrawn
+    # USDT arrives converted into USDC, not as a foreign USDT balance.
+    assert runner.account_manager.get_balance("USDT", exchange="HYPERLIQUID").total == 0.0
+    assert runner.account_manager.get_balance("USDC", exchange="HYPERLIQUID").total == 6000.0
 
 
 def test_warmup_mode_force_assigns_sim_manager():
@@ -245,3 +248,60 @@ def test_on_init_injection_wins_in_plain_sim():
     runner = _make_runner(strategy=_InjectingStrategy())
 
     assert runner.ctx._transfer_manager is stub
+
+
+def _am_cross_currency():
+    am = SimulatedAccountManager(
+        connectors={"BINANCE.UM": MagicMock(), "HYPERLIQUID.F": MagicMock()},
+        base_currencies={"BINANCE.UM": "USDT", "HYPERLIQUID.F": "USDC"},
+        time=_T(),
+    )
+    am.get_state("BINANCE.UM").update_balance(
+        "USDT", Balance(exchange="BINANCE.UM", currency="USDT", total=1000.0, free=1000.0)
+    )
+    am.get_state("HYPERLIQUID.F").update_balance(
+        "USDC", Balance(exchange="HYPERLIQUID.F", currency="USDC", total=1000.0, free=1000.0)
+    )
+    return am
+
+
+def test_transfer_debits_source_currency_credits_destination_currency():
+    am = _am_cross_currency()
+    mgr = SimulationTransferManager(am, _T())
+    tid = mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "USDC", 250.0)
+
+    assert am.get_balance("USDC", "HYPERLIQUID.F").free == 750.0
+    assert am.get_balance("USDT", "BINANCE.UM").free == 1250.0
+    assert am.get_balance("USDC", "BINANCE.UM").total == 0.0
+
+    t = mgr.get_transfer_status(tid)
+    assert (t.currency, t.amount) == ("USDC", 250.0)
+    assert (t.to_currency, t.to_amount) == ("USDT", 250.0)
+
+
+def test_transfer_insufficient_funds_checks_source_currency():
+    am = _am_cross_currency()
+    mgr = SimulationTransferManager(am, _T())
+    with pytest.raises(ValueError, match="Insufficient funds"):
+        mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "USDC", 5000.0)
+
+
+def test_transfer_rejects_unpriced_currency():
+    am = _am_cross_currency()
+    am.get_state("HYPERLIQUID.F").update_balance(
+        "PEPE", Balance(exchange="HYPERLIQUID.F", currency="PEPE", total=10.0, free=10.0)
+    )
+    mgr = SimulationTransferManager(am, _T())
+    with pytest.raises(ValueError, match="no conversion rate"):
+        mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "PEPE", 1.0)
+
+
+def test_transfers_log_carries_destination_columns():
+    am = _am_cross_currency()
+    mgr = SimulationTransferManager(am, _T())
+    mgr.transfer_funds("HYPERLIQUID.F", "BINANCE.UM", "USDC", 100.0)
+    df = collect_transfers_log(mgr)
+
+    assert list(df.columns) == _TRANSFERS_LOG_COLUMNS
+    assert df.iloc[0]["to_currency"] == "USDT"
+    assert df.iloc[0]["to_amount"] == 100.0

--- a/tests/qubx/backtester/test_transfers.py
+++ b/tests/qubx/backtester/test_transfers.py
@@ -217,7 +217,10 @@ def test_simulation_context_has_transfer_manager():
 
     runner.ctx.transfer_funds("BINANCE.UM", "HYPERLIQUID", "USDT", 1000.0)
     assert runner.account_manager.get_balance("USDT", exchange="BINANCE.UM").total == 4000.0
-    assert runner.account_manager.get_balance("USDT", exchange="HYPERLIQUID").total == 6000.0
+    # HYPERLIQUID is seeded in its own settle currency (USDC), not the scalar "USDT" passed
+    # to SimulationSetup, so its USDT balance starts at 0 and only holds the transferred amount.
+    assert runner.account_manager.get_balance("USDT", exchange="HYPERLIQUID").total == 1000.0
+    assert runner.account_manager.get_balance("USDC", exchange="HYPERLIQUID").total == 5000.0
 
 
 def test_warmup_mode_force_assigns_sim_manager():

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -820,3 +820,29 @@ def test_futures_deal_marks_settle_currency_as_cash():
     assert state.conversion_rate_to_base("USDC") == 1.0
     assert state.get_balance("USDC").total == pytest.approx(10.0)
     assert state.total_capital() == pytest.approx(10.0)  # flat book: cash only, no market value
+
+
+BTC_PERP = Instrument(
+    symbol="ETHBTC",
+    market_type=MarketType.SWAP,
+    exchange="binance.um",
+    base="ETH",
+    quote="BTC",
+    settle="BTC",
+    exchange_symbol="ETHBTC",
+    tick_size=0.00001,
+    lot_size=0.001,
+    min_size=0.001,
+    contract_size=1.0,
+)
+
+
+def test_btc_settled_deal_does_not_become_cash():
+    # BINANCE.UM:ETHBTC is BTC-settled; 0.01 BTC of realized PnL is not 0.01 of capital.
+    state = AccountState("binance.um", "USDT")
+    reducer._book_deal(state, BTC_PERP, _fill(amount=1.0, price=0.05))
+    reducer._book_deal(state, BTC_PERP, _fill(trade_id="t2", amount=-1.0, price=0.06))
+
+    assert state.conversion_rate_to_base("BTC") is None
+    assert state.get_balance("BTC").total == pytest.approx(0.01)
+    assert state.total_capital() == 0.0

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -794,3 +794,29 @@ def test_event_venue_ts_stamps_order_last_update_time():
     )
     assert r.order is not None
     assert r.order.last_update_time == venue_ts  # venue ts, not T1
+
+
+USDC_PERP = Instrument(
+    symbol="BTCUSDC",
+    market_type=MarketType.SWAP,
+    exchange="hyperliquid",
+    base="BTC",
+    quote="USDC",
+    settle="USDC",
+    exchange_symbol="BTCUSDC",
+    tick_size=0.01,
+    lot_size=0.001,
+    min_size=0.001,
+    contract_size=1.0,
+)
+
+
+def test_futures_deal_marks_settle_currency_as_cash():
+    # Round trip on a USDC-settled perp inside a USDT-based state: buy 1 @ 100, sell 1 @ 110.
+    state = AccountState("hyperliquid", "USDT")
+    reducer._book_deal(state, USDC_PERP, _fill(amount=1.0, price=100.0))
+    reducer._book_deal(state, USDC_PERP, _fill(trade_id="t2", amount=-1.0, price=110.0))
+
+    assert state.conversion_rate_to_base("USDC") == 1.0
+    assert state.get_balance("USDC").total == pytest.approx(10.0)
+    assert state.total_capital() == pytest.approx(10.0)  # flat book: cash only, no market value

--- a/tests/qubx/core/account_manager/state_metrics_test.py
+++ b/tests/qubx/core/account_manager/state_metrics_test.py
@@ -194,12 +194,32 @@ def test_total_capital_counts_marked_settle_currency():
     assert state.total_capital() == 1250.0
 
 
-def test_marked_cash_currency_survives_position_close():
+def test_marked_cash_currency_counts_with_no_positions():
     state = _state(1000.0)
     state.mark_cash_currency("USDC")
     state.update_balance("USDC", Balance(exchange="binance", currency="USDC", free=250.0, locked=0.0, total=250.0))
     assert not state.get_positions()
     assert state.total_capital() == 1250.0
+
+
+def test_non_stable_settle_currency_is_not_marked_as_cash():
+    state = _state(1000.0)
+    state.mark_cash_currency("BTC")
+    state.update_balance("BTC", Balance(exchange="binance", currency="BTC", free=2.0, locked=0.0, total=2.0))
+    assert state.conversion_rate_to_base("BTC") is None
+    assert state.total_capital() == 1000.0
+
+
+def test_coin_margined_base_currency_still_counts():
+    # The base currency is exempt from the stable check — it is seeded at construction.
+    state = _state(2.0, base_currency="BTC")
+    assert state.total_capital() == 2.0
+
+
+def test_total_capital_is_float_on_empty_state():
+    capital = AccountState(exchange="binance", base_currency="USDT").total_capital()
+    assert isinstance(capital, float)
+    assert capital == 0.0
 
 
 def test_conversion_rate_unknown_for_unpriced_asset():

--- a/tests/qubx/core/account_manager/state_metrics_test.py
+++ b/tests/qubx/core/account_manager/state_metrics_test.py
@@ -185,3 +185,32 @@ def test_net_leverage_signed_negative_for_short():
     assert state.net_leverage() == -5_000.0 / 995_000.0
     assert state.gross_leverage() == 5_000.0 / 995_000.0
     assert state.leverage(inst) == -5_000.0 / 995_000.0
+
+
+def test_total_capital_counts_marked_settle_currency():
+    state = _state(1000.0)  # base USDT
+    state.mark_cash_currency("USDC")
+    state.update_balance("USDC", Balance(exchange="binance", currency="USDC", free=250.0, locked=0.0, total=250.0))
+    assert state.total_capital() == 1250.0
+
+
+def test_marked_cash_currency_survives_position_close():
+    state = _state(1000.0)
+    state.mark_cash_currency("USDC")
+    state.update_balance("USDC", Balance(exchange="binance", currency="USDC", free=250.0, locked=0.0, total=250.0))
+    assert not state.get_positions()
+    assert state.total_capital() == 1250.0
+
+
+def test_conversion_rate_unknown_for_unpriced_asset():
+    state = _state(1000.0)
+    assert state.conversion_rate_to_base("USDT") == 1.0
+    assert state.conversion_rate_to_base("PEPE") is None
+
+
+def test_venue_equity_still_wins_over_summed_cash():
+    state = _state(1000.0)
+    state.mark_cash_currency("USDC")
+    state.update_balance("USDC", Balance(exchange="binance", currency="USDC", free=250.0, locked=0.0, total=250.0))
+    state.set_venue_figures(_venue(equity=5000.0))
+    assert state.total_capital() == 5000.0

--- a/tests/qubx/core/test_session_result_equity.py
+++ b/tests/qubx/core/test_session_result_equity.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from qubx.core.metrics import TradingSessionResult, _transfer_offsets
 from qubx.utils.results import _capital_from_meta
@@ -195,23 +196,35 @@ def test_per_exchange_equity_reconciles_after_legacy_scalar_load():
     _assert_reconciles(_two_venue_result(capital))
 
 
-def test_per_exchange_equity_reconciles_with_transfers():
+def test_transfer_moves_capital_from_source_to_destination_venue():
+    # A transfer's two legs are exact negatives landing on the same bar, so the sum-equals-total
+    # invariant holds whether the transfer is aligned correctly, misaligned, or dropped entirely
+    # (see get_equity_per_exchange). The sum assertion below is only a no-money-created-or-
+    # destroyed cross-check. Comparing per-venue equity with and without transfers isolates the
+    # transfer's actual effect from organic PnL/commissions, and is what catches a misaligned or
+    # dropped transfer.
+    transfer_amount = 5_000.0
     transfers = _transfers(
         [
             {
                 "timestamp": pd.Timestamp("2026-01-01 01:02"),
                 "from_exchange": "BINANCE.UM",
                 "to_exchange": "HYPERLIQUID.F",
-                "amount": 5_000.0,
-                "to_amount": 5_000.0,
+                "amount": transfer_amount,
+                "to_amount": transfer_amount,
                 "status": "completed",
             }
         ]
     )
     result = _two_venue_result({"BINANCE.UM": 50_000.0, "HYPERLIQUID.F": 50_000.0}, transfers)
     _assert_reconciles(result)
-    per_exchange = result.get_equity_per_exchange()
-    assert per_exchange["HYPERLIQUID.F"].iloc[-1] - per_exchange["HYPERLIQUID.F"].iloc[0] > 4_000.0
+
+    with_transfers = result.get_equity_per_exchange()
+    without_transfers = result.get_equity_per_exchange(with_transfers=False)
+    source_effect = (with_transfers["BINANCE.UM"] - without_transfers["BINANCE.UM"]).iloc[-1]
+    dest_effect = (with_transfers["HYPERLIQUID.F"] - without_transfers["HYPERLIQUID.F"]).iloc[-1]
+    assert source_effect == pytest.approx(-transfer_amount)
+    assert dest_effect == pytest.approx(transfer_amount)
 
 
 def test_per_exchange_equity_reconciles_after_slicing():

--- a/tests/qubx/core/test_session_result_equity.py
+++ b/tests/qubx/core/test_session_result_equity.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from qubx.core.metrics import _transfer_offsets
+from qubx.utils.results import _capital_from_meta
 
 INDEX = pd.date_range("2026-01-01", periods=4, freq="1h")
 
@@ -121,3 +122,28 @@ def test_converted_transfer_credits_destination_amount():
     )
     assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 99.0, 99.0]
     assert list(_transfer_offsets(tl, "A", INDEX)) == [0.0, 0.0, -100.0, -100.0]
+
+
+def test_capital_by_exchange_round_trips():
+    meta = {"capital": 100_000.0, "capital_by_exchange": '{"BINANCE.UM": 60000.0, "HYPERLIQUID.F": 40000.0}'}
+    assert _capital_from_meta(meta, ["BINANCE.UM", "HYPERLIQUID.F"]) == {
+        "BINANCE.UM": 60_000.0,
+        "HYPERLIQUID.F": 40_000.0,
+    }
+
+
+def test_legacy_scalar_capital_splits_evenly():
+    meta = {"capital": 100_000.0}
+    assert _capital_from_meta(meta, ["BINANCE.UM", "HYPERLIQUID.F"]) == {
+        "BINANCE.UM": 50_000.0,
+        "HYPERLIQUID.F": 50_000.0,
+    }
+
+
+def test_single_exchange_capital_stays_scalar():
+    assert _capital_from_meta({"capital": 100_000.0}, ["BINANCE.UM"]) == 100_000.0
+
+
+def test_malformed_capital_by_exchange_falls_back_to_even_split():
+    meta = {"capital": 100_000.0, "capital_by_exchange": "not-json"}
+    assert _capital_from_meta(meta, ["A", "B"]) == {"A": 50_000.0, "B": 50_000.0}

--- a/tests/qubx/core/test_session_result_equity.py
+++ b/tests/qubx/core/test_session_result_equity.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from qubx.core.metrics import _transfer_offsets
+from qubx.core.metrics import TradingSessionResult, _transfer_offsets
 from qubx.utils.results import _capital_from_meta
 
 INDEX = pd.date_range("2026-01-01", periods=4, freq="1h")
@@ -147,3 +147,73 @@ def test_single_exchange_capital_stays_scalar():
 def test_malformed_capital_by_exchange_falls_back_to_even_split():
     meta = {"capital": 100_000.0, "capital_by_exchange": "not-json"}
     assert _capital_from_meta(meta, ["A", "B"]) == {"A": 50_000.0, "B": 50_000.0}
+
+
+def _two_venue_result(capital, transfers: pd.DataFrame | None = None) -> TradingSessionResult:
+    idx = INDEX
+    portfolio = pd.DataFrame(
+        {
+            "BINANCE.UM:BTCUSDT_PnL": [0.0, 10.0, 10.0, 10.0],
+            "BINANCE.UM:BTCUSDT_Commissions": [0.0, 1.0, 0.0, 0.0],
+            "BINANCE.UM:BTCUSDT_Value": [1000.0, 1000.0, 1000.0, 1000.0],
+            "HYPERLIQUID.F:BTCUSDC_PnL": [0.0, -10.0, -10.0, -10.0],
+            "HYPERLIQUID.F:BTCUSDC_Commissions": [0.0, 1.0, 0.0, 0.0],
+            "HYPERLIQUID.F:BTCUSDC_Value": [-1000.0, -1000.0, -1000.0, -1000.0],
+        },
+        index=idx,
+    )
+    return TradingSessionResult(
+        id=0,
+        name="t",
+        start=idx[0],
+        stop=idx[-1],
+        exchanges=["BINANCE.UM", "HYPERLIQUID.F"],
+        instruments=[],
+        capital=capital,
+        base_currency="USDT",
+        commissions=None,
+        portfolio_log=portfolio,
+        executions_log=pd.DataFrame(),
+        signals_log=pd.DataFrame(),
+        targets_log=pd.DataFrame(),
+        strategy_class="test",
+        transfers_log=transfers,
+    )
+
+
+def _assert_reconciles(result: TradingSessionResult) -> None:
+    per_exchange = result.get_equity_per_exchange().sum(axis=1)
+    pd.testing.assert_series_equal(per_exchange, result.get_equity(), check_names=False)
+
+
+def test_per_exchange_equity_reconciles_in_memory():
+    _assert_reconciles(_two_venue_result({"BINANCE.UM": 50_000.0, "HYPERLIQUID.F": 50_000.0}))
+
+
+def test_per_exchange_equity_reconciles_after_legacy_scalar_load():
+    capital = _capital_from_meta({"capital": 100_000.0}, ["BINANCE.UM", "HYPERLIQUID.F"])
+    _assert_reconciles(_two_venue_result(capital))
+
+
+def test_per_exchange_equity_reconciles_with_transfers():
+    transfers = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "BINANCE.UM",
+                "to_exchange": "HYPERLIQUID.F",
+                "amount": 5_000.0,
+                "to_amount": 5_000.0,
+                "status": "completed",
+            }
+        ]
+    )
+    result = _two_venue_result({"BINANCE.UM": 50_000.0, "HYPERLIQUID.F": 50_000.0}, transfers)
+    _assert_reconciles(result)
+    per_exchange = result.get_equity_per_exchange()
+    assert per_exchange["HYPERLIQUID.F"].iloc[-1] - per_exchange["HYPERLIQUID.F"].iloc[0] > 4_000.0
+
+
+def test_per_exchange_equity_reconciles_after_slicing():
+    result = _two_venue_result({"BINANCE.UM": 50_000.0, "HYPERLIQUID.F": 50_000.0})
+    _assert_reconciles(result[INDEX[1] :])

--- a/tests/qubx/core/test_session_result_equity.py
+++ b/tests/qubx/core/test_session_result_equity.py
@@ -197,12 +197,8 @@ def test_per_exchange_equity_reconciles_after_legacy_scalar_load():
 
 
 def test_transfer_moves_capital_from_source_to_destination_venue():
-    # A transfer's two legs are exact negatives landing on the same bar, so the sum-equals-total
-    # invariant holds whether the transfer is aligned correctly, misaligned, or dropped entirely
-    # (see get_equity_per_exchange). The sum assertion below is only a no-money-created-or-
-    # destroyed cross-check. Comparing per-venue equity with and without transfers isolates the
-    # transfer's actual effect from organic PnL/commissions, and is what catches a misaligned or
-    # dropped transfer.
+    # Sum-equals-total is tautological here (the two legs are exact negatives), so it holds even
+    # if the transfer is misaligned or dropped — the with/without comparison is what catches that.
     transfer_amount = 5_000.0
     transfers = _transfers(
         [

--- a/tests/qubx/core/test_session_result_equity.py
+++ b/tests/qubx/core/test_session_result_equity.py
@@ -1,0 +1,123 @@
+import pandas as pd
+
+from qubx.core.metrics import _transfer_offsets
+
+INDEX = pd.date_range("2026-01-01", periods=4, freq="1h")
+
+
+def _transfers(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows).set_index("timestamp")
+
+
+def test_off_grid_transfer_lands_on_next_bar():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 100.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 100.0, 100.0]
+    assert list(_transfer_offsets(tl, "A", INDEX)) == [0.0, 0.0, -100.0, -100.0]
+
+
+def test_two_transfers_in_one_bar_sum():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 100.0,
+                "status": "completed",
+            },
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:30"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 50.0,
+                "to_amount": 50.0,
+                "status": "completed",
+            },
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 150.0, 150.0]
+
+
+def test_transfer_before_first_bar_counts_from_the_start():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2025-12-31 23:00"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 10.0,
+                "to_amount": 10.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [10.0, 10.0, 10.0, 10.0]
+
+
+def test_transfer_after_last_bar_is_ignored():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-02 00:00"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 10.0,
+                "to_amount": 10.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_non_completed_transfers_excluded():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 100.0,
+                "status": "pending",
+            },
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 7.0,
+                "to_amount": 7.0,
+                "status": "failed",
+            },
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_converted_transfer_credits_destination_amount():
+    tl = _transfers(
+        [
+            {
+                "timestamp": pd.Timestamp("2026-01-01 01:02"),
+                "from_exchange": "A",
+                "to_exchange": "B",
+                "amount": 100.0,
+                "to_amount": 99.0,
+                "status": "completed",
+            }
+        ]
+    )
+    assert list(_transfer_offsets(tl, "B", INDEX)) == [0.0, 0.0, 99.0, 99.0]
+    assert list(_transfer_offsets(tl, "A", INDEX)) == [0.0, 0.0, -100.0, -100.0]

--- a/tests/qubx/utils/test_results_saver_roundtrip.py
+++ b/tests/qubx/utils/test_results_saver_roundtrip.py
@@ -1,0 +1,64 @@
+"""Save -> load round trip for SimulationResultsSaver.
+
+pa.Table.from_pandas(df, schema=METADATA_SCHEMA) is strict: a writer key that does not
+match the schema breaks every simulation save, so the metadata columns need a live pin.
+"""
+
+import pandas as pd
+
+from qubx.core.metrics import TradingSessionResult
+from qubx.utils.results import SimulationResultsSaver
+
+INDEX = pd.date_range("2026-01-01", periods=3, freq="1h")
+
+
+def _result(capital) -> TradingSessionResult:
+    portfolio = pd.DataFrame(
+        {
+            "BINANCE.UM:BTCUSDT_PnL": [0.0, 10.0, 10.0],
+            "BINANCE.UM:BTCUSDT_Commissions": [0.0, 1.0, 0.0],
+            "BINANCE.UM:BTCUSDT_Value": [1000.0, 1000.0, 1000.0],
+            "HYPERLIQUID.F:BTCUSDC_PnL": [0.0, -5.0, -5.0],
+            "HYPERLIQUID.F:BTCUSDC_Commissions": [0.0, 1.0, 0.0],
+            "HYPERLIQUID.F:BTCUSDC_Value": [-1000.0, -1000.0, -1000.0],
+        },
+        index=INDEX,
+    )
+    return TradingSessionResult(
+        id=0,
+        name="roundtrip",
+        start=INDEX[0],
+        stop=INDEX[-1],
+        exchanges=["BINANCE.UM", "HYPERLIQUID.F"],
+        instruments=[],
+        capital=capital,
+        base_currency="USDT",
+        commissions=None,
+        portfolio_log=portfolio,
+        executions_log=pd.DataFrame(),
+        signals_log=pd.DataFrame(),
+        targets_log=pd.DataFrame(),
+        strategy_class="tests.Dummy",
+    )
+
+
+def test_save_load_preserves_per_exchange_capital(tmp_path):
+    capital = {"BINANCE.UM": 60_000.0, "HYPERLIQUID.F": 40_000.0}
+    run_dir = SimulationResultsSaver.save(_result(capital), str(tmp_path))
+
+    loaded = SimulationResultsSaver.load(run_dir)
+
+    assert loaded.capital == capital
+    assert loaded.get_total_capital() == 100_000.0
+    assert loaded.exchanges == ["BINANCE.UM", "HYPERLIQUID.F"]
+    assert loaded.base_currency == "USDT"
+
+
+def test_save_load_keeps_single_exchange_capital_scalar(tmp_path):
+    result = _result(100_000.0)
+    result.exchanges = ["BINANCE.UM"]
+    run_dir = SimulationResultsSaver.save(result, str(tmp_path))
+
+    loaded = SimulationResultsSaver.load(run_dir)
+
+    assert loaded.capital == 100_000.0


### PR DESCRIPTION
## Why

On a multi-exchange simulation whose venues settle in different currencies, `AccountState.total_capital()` read exactly one balance — the account's `base_currency` — while money books to `instrument.settle`. On a USDC-settled venue seeded in USDT, every dollar the venue earned was invisible to the metric, and any strategy sizing off `ctx.get_total_capital()` inherited the blind spot.

Measured on a real 8-month frab backtest (`FARB_V4/v11_00_fp1d_to05`, BINANCE.UM ⇄ HYPERLIQUID.F, 100k, 2025-11-01 → 2026-07-10), the sizing base recovered from the executions log fits:

| candidate | median error | correlation with true equity |
|---|---|---|
| `2 × BINANCE equity` | +2.2% | +0.69 |
| `BINANCE + HYPERLIQUID` (true total) | +25.9% | **−0.76** |
| `2 × HYPERLIQUID equity` | +51.3% | −0.75 |

The base tracked the USDT venue and was *anti-correlated* with account equity. It fell 114k → 59k while the account grew 100k → 123k; position count stayed flat (~9.8 legs/venue) while per-leg notional halved and gross leverage decayed ~400% → ~170%.

A second, read-side defect hid it: `get_equity_per_exchange` dropped all 17 transfers (exact timestamp membership against an hourly log, transfers stamped `HH:02:00`) and, after a storage round-trip, treated the scalar total as *each* venue's seed — per-exchange equity summed to $223,402 against a true equity of $123,402.

## What changed

1. **Per-exchange base currency** — `SimulationSetup.base_currency` accepts `str | dict[str, str]` and resolves per venue: explicit mapping > the venue's shared instrument settle currency (when it is a recognized stable) > the scalar. The runner seeds each venue in its own currency. Existing scalar configs are unaffected; a BINANCE.UM/HYPERLIQUID.F config resolves to USDT/USDC with no config change. The live path already did this (`utils/runner/runner.py:759-770`); this brings simulation in line.
2. **Priced-cash capital** — `total_capital()` iterates every balance and values each through `conversion_rate_to_base(currency) -> float | None`, which answers 1.0 for the venue's cash currencies and `None` for anything unpriced. Unpriced balances are *excluded*, never counted at par: summing everything at 1.0 would value a million PEPE at $1M, trading a bounded understatement for an unbounded overstatement. The venue-reported-equity short-circuit stays first, so live is unchanged.
3. **Converting transfers** — `SimulationTransferManager` debits the source in its currency and credits the destination in its own, recording both on the `Transfer`. Simulation-only; qubx ships no live transfer manager.
4. **As-of transfer alignment** — `_transfer_offsets` replaces exact-membership matching, so off-grid stamps land on the following bar, same-bar transfers sum, and only completed transfers count.
5. **Capital survives persistence** — new `capital_by_exchange` JSON metadata column; `capital` keeps its `float64` type and "total" meaning so existing DuckDB `storage.search()` queries are untouched. Legacy results with no such column split evenly, which is what the sim has done since `69ed8448` — so already-stored runs render correctly without a rerun.

Design doc: `docs/superpowers/specs/2026-08-10-multi-currency-capital-design.md`.

## ⚠️ Rollout sequencing — read before bumping frab

`transfer_funds` now validates the requested currency against the **source** venue's cash currencies. frab hardcodes it in two places — `BalanceDifferenceRebalancer.target_currency = "USDT"` (`components/rebalancer.py:31`) and `MarginRatioRebalancer.target_currency = "USDC"` (`components/margin_risk.py:82`). Both call sites catch `Exception` and degrade gracefully, so **nothing crashes** — cross-venue rebalancing just silently stops working in mixed-currency backtests.

So frab's qubx pin bump must land **together with** the frab change that passes the source venue's base currency, not before it.

## Behaviour and compatibility

- **Live unchanged** for venues that report equity (`_venue_figures.equity` short-circuits ahead of the summation). A live venue with *no* reported equity now falls through to a summation that counts every priced cash balance — more complete, the same correction.
- **Same-currency venue pairs are bit-identical** (summing one balance equals reading it), so BINANCE⇄GATEIO sims do not move. Only mixed-settle pairs change.
- **`Transfer`'s new fields default to `None`**, so a live transfer manager in another package that constructs `Transfer` without them keeps working; the transfers-log builder falls back to the source values.
- **New:** a coin-margined or fiat-quoted venue no longer gets an implicitly derived base currency — its settle currency is not a recognized stable, so it falls back to the scalar and needs an explicit `base_currency` mapping if that is not what you want.
- Multi-exchange results saved *before* `69ed8448` (March 2026) were seeded differently and the even-split fallback will misattribute them; they are old enough that a version-conditional path was not worth it.

## Testing

Full suite: **2392 passed, 5 skipped, 0 failed** (baseline before this branch: 2384 + 8 new tests).

The regression gate is `tests/qubx/core/test_session_result_equity.py`. Note that the sum-equals-total invariant catches the capital-split defect but is *structurally blind* to the transfer defect — a value-preserving transfer leaves the sum unchanged by construction — so the transfer defect is pinned by an explicit two-sided with/without-transfers delta assertion instead. That was verified by mutation: reverting `_transfer_offsets` to exact-membership matching makes it fail on the drift assertion, not the sum.

## Known limitations / follow-ups

- `conversion_rate_to_base` answers 1.0 for cash currencies and `None` elsewhere; marks-based conversion is the `state.py` TODO and is deliberately not filled here. The `to_amount = amount * from_rate / to_rate` formula mixes two numeraires and is only correct while every rate is 1.0 — it needs revisiting when marks land.
- In live, only a local fill marks a non-base settle currency; `apply_balance_push` does not. A snapshot-restored position funded purely via balance pushes on a venue with no reported equity would stay uncounted until the next fill.
- `metrics.py` has a pre-existing `from __future__ import annotations` at line 1, left alone here to keep the diff readable.
- A venue settling in a stable that is not in `STABLE_CURRENCIES` degrades to the scalar (unchanged from pre-branch behaviour, since derivation itself is new).
