### PR TITLE
feat: per-dtype market-cache retention caps + FundingRate slots

### DIFF
--- a/docs/superpowers/plans/2026-08-11-market-cache-retention.md
+++ b/docs/superpowers/plans/2026-08-11-market-cache-retention.md
@@ -1,0 +1,224 @@
+# Market-Cache Retention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Per-data-type retention caps for qubx's market-data buffers (config-exposed), frab's spread-series cut to 600, `MALLOC_ARENA_MAX=2` for bot pods — PRs prepared, NOT merged; validated by a local A/B paper run measuring RSS.
+
+**Architecture:** `MarketCacheConfig {default_length, per_type}` in the live config schema, threaded runner → `StrategyContext` → `MarketManager` → `CachedMarketDataHolder`, which resolves a cap by base dtype name at series creation. frab and platform changes are one-liners with tests. Validation runs two frab paper bots side by side in tmux from the dev xrelease config — baseline (main + released qubx) vs fixed (worktree source deps + caps configured) — comparing RSS slopes.
+
+**Tech Stack:** Python/pydantic (qubx), Cython-adjacent series (read-only touch), Go (platform deployer), uv path-dependency overrides, tmux.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-market-cache-retention-design.md` (this worktree)
+
+## Global Constraints
+
+- qubx defaults must reproduce today's behavior exactly: `default_length: int = 10_000`, empty `per_type` — no opinionated caps ship in qubx.
+- `per_type` values validated `>= 1` (pydantic); a configured key logs once at startup: `market cache retention: <name>=<n>, ...`.
+- Resolution by **base dtype name** via `DataType.from_str(...)` — `orderbook(0,1)` must match key `orderbook`; unmatched dtypes use the default; the `ohlc` key applies to OHLC series creation.
+- Backtester/sim/warmup construction paths untouched.
+- `FundingRate` becomes `@dataclass(slots=True)`; no other field changes.
+- frab: `MAX_SPREAD_LENGTH = 600`; nothing else in frab's PR (config/lock bumps happen post-merge per spec §Rollout).
+- **PRs are prepared and pushed; NOTHING is merged** in any repo.
+- Worktrees: qubx work in `~/devs/Qubx/.worktrees/market-cache-retention` (branch `feat/market-cache-retention`, exists); frab work in `~/projects/frab/.worktrees/mem-retention` (branch `fix/spread-series-retention`, create). Never touch the main checkouts.
+- Subagents: sonnet or better. Conventional commits, no Co-Authored-By.
+- Gates: qubx `uv run pytest tests/qubx/core tests/qubx/utils -q` minimum + full build import; frab `uv run pytest -q`; platform `cd control-api && go build ./... && go test ./internal/k8s/...`.
+
+## File Map
+
+| Repo/worktree | File | Change |
+|---|---|---|
+| qubx wt | `src/qubx/utils/runner/configs.py` | `MarketCacheConfig`; `LiveConfig.market_cache` |
+| qubx wt | `src/qubx/core/mixins/market.py` | `CachedMarketDataHolder(per_type_lengths=...)` + resolution + log; `MarketManager` forwards |
+| qubx wt | `src/qubx/core/context.py:251` | pass market-cache values into `MarketManager` |
+| qubx wt | `src/qubx/utils/runner/runner.py:654` | pass `config.live.market_cache` into `StrategyContext` |
+| qubx wt | `src/qubx/core/basics.py:79` | `@dataclass(slots=True)` on `FundingRate` |
+| qubx wt | `tests/qubx/utils/test_market_cache_config.py` | new |
+| qubx wt | `tests/qubx/core/test_market_cache_retention.py` | new |
+| frab wt | `src/frab/domain/spread.py:15` | `MAX_SPREAD_LENGTH = 600` |
+| frab wt | `tests/test_spread_tracker.py` | length-rationale assertion |
+| platform | `control-api/internal/k8s/deployer.go` (`baseBotEnv`) | `MALLOC_ARENA_MAX=2` |
+
+---
+
+### Task 1: qubx — MarketCacheConfig schema
+
+**Files:** Modify `src/qubx/utils/runner/configs.py`; Test `tests/qubx/utils/test_market_cache_config.py` (new). Work in the qubx worktree.
+
+**Interfaces — Produces:** `MarketCacheConfig(StrictBaseModel)` with `default_length: int = 10_000` and `per_type: dict[str, int] = Field(default_factory=dict)`, validator rejecting values `< 1`; `LiveConfig.market_cache: MarketCacheConfig = Field(default_factory=MarketCacheConfig)`.
+
+- [ ] **Step 1: Failing tests** — new file:
+
+```python
+import pytest
+from pydantic import ValidationError
+from qubx.utils.runner.configs import LiveConfig, MarketCacheConfig
+
+
+def _live(**over):
+    base = dict(exchanges={}, logging={"logger": "InMemoryLogsWriter"})
+    base.update(over)
+    return LiveConfig(**base)
+
+
+def test_defaults_reproduce_current_behavior():
+    cfg = _live()
+    assert cfg.market_cache.default_length == 10_000
+    assert cfg.market_cache.per_type == {}
+
+
+def test_per_type_parses():
+    cfg = _live(market_cache={"per_type": {"orderbook": 4, "funding_rate": 64}})
+    assert cfg.market_cache.per_type == {"orderbook": 4, "funding_rate": 64}
+    assert cfg.market_cache.default_length == 10_000
+
+
+def test_zero_cap_rejected():
+    with pytest.raises(ValidationError):
+        MarketCacheConfig(per_type={"orderbook": 0})
+    with pytest.raises(ValidationError):
+        MarketCacheConfig(default_length=0)
+```
+
+- [ ] **Step 2: Run to fail** — `uv run pytest tests/qubx/utils/test_market_cache_config.py -q` → import error / missing attr.
+- [ ] **Step 3: Implement** in `configs.py` (near the other small config models):
+
+```python
+class MarketCacheConfig(StrictBaseModel):
+    """Retention caps for per-instrument market-data buffers (spec 2026-08-11)."""
+
+    default_length: int = 10_000
+    per_type: dict[str, int] = Field(default_factory=dict)
+
+    @field_validator("default_length")
+    @classmethod
+    def _default_positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("default_length must be >= 1")
+        return v
+
+    @field_validator("per_type")
+    @classmethod
+    def _caps_positive(cls, v: dict[str, int]) -> dict[str, int]:
+        for k, n in v.items():
+            if n < 1:
+                raise ValueError(f"per_type[{k!r}] must be >= 1")
+        return v
+```
+
+and on `LiveConfig`: `market_cache: MarketCacheConfig = Field(default_factory=MarketCacheConfig)`.
+
+- [ ] **Step 4: Run to pass**, then the utils suite: `uv run pytest tests/qubx/utils -q`.
+- [ ] **Step 5: Commit** — `feat(config): MarketCacheConfig — per-dtype retention caps in LiveConfig`
+
+### Task 2: qubx — resolution + threading
+
+**Files:** Modify `src/qubx/core/mixins/market.py` (`CachedMarketDataHolder.__init__` line ~51, `get_data` line ~204, the OHLC series creation path that uses `_max_series_length`; `MarketManager.__init__` line ~408 and its `CachedMarketDataHolder()` call), `src/qubx/core/context.py` (~251), `src/qubx/utils/runner/runner.py` (~654 + StrategyContext signature). Test `tests/qubx/core/test_market_cache_retention.py` (new).
+
+**Interfaces — Consumes:** Task 1's `MarketCacheConfig`. **Produces:** `CachedMarketDataHolder(default_timeframe=None, max_buffer_size=10_000, per_type_lengths: dict[str, int] | None = None)`; `MarketManager(..., max_buffer_size=..., per_type_lengths=...)`; `StrategyContext(..., market_cache_config: MarketCacheConfig | None = None)` (None → defaults; mirrors the `rate_limiting_config` passing pattern visible at runner.py:650-675).
+
+- [ ] **Step 1: Failing tests** — construct a `CachedMarketDataHolder` directly (no full context needed):
+
+```python
+from qubx.core.mixins.market import CachedMarketDataHolder
+
+
+def test_per_type_cap_applies_to_generic_series():
+    h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={"orderbook": 4, "funding_rate": 64})
+    assert h._resolve_series_length("orderbook") == 4
+    assert h._resolve_series_length("orderbook(0,1)") == 4      # parameterized form matches base name
+    assert h._resolve_series_length("funding_rate") == 64
+    assert h._resolve_series_length("quote") == 10_000          # unmatched -> default
+    assert h._resolve_series_length("ohlc(1h)") == 10_000       # ohlc key unset -> default
+
+
+def test_ohlc_key_honored():
+    h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={"ohlc": 500})
+    assert h._resolve_series_length("ohlc(1h)") == 500
+```
+
+- [ ] **Step 2: Run to fail.**
+- [ ] **Step 3: Implement.** In `CachedMarketDataHolder`: store `self._per_type_lengths = dict(per_type_lengths or {})`; add
+
+```python
+def _resolve_series_length(self, event_type: str) -> int:
+    try:
+        base = str(DataType.from_str(event_type)[0] if isinstance(DataType.from_str(event_type), tuple) else DataType.from_str(event_type))
+    except Exception:
+        base = event_type
+    base = base.split("(")[0]
+    n = self._per_type_lengths.get(base, self._max_series_length)
+    if base in self._per_type_lengths and base not in self._logged_caps:
+        self._logged_caps.add(base)
+        logger.info(f"market cache retention: {base}={n}")
+    return n
+```
+
+(implementer: check `DataType.from_str`'s actual return shape in `core/basics.py` and simplify the base-name extraction accordingly — the test's parameterized case is the contract; a plain `event_type.split("(")[0]` fallback must hold either way; `self._logged_caps: set[str]` initialized in `__init__`). Use `self._resolve_series_length(event_type)` at the `GenericSeries(...)` creation in `get_data` (replacing the bare `self._max_series_length`) and at the OHLC series creation site that currently passes `self._max_series_length`. `MarketManager.__init__` gains and forwards both values into its `CachedMarketDataHolder(...)` call. `StrategyContext` gains `market_cache_config` (default None) and passes the two values to `MarketManager`. `runner.py` passes `market_cache_config=config.live.market_cache`.
+
+- [ ] **Step 4: Run to pass**, then `uv run pytest tests/qubx/core -q` and an import smoke `uv run python -c "import qubx.utils.runner.runner"`.
+- [ ] **Step 5: Commit** — `feat(core): per-dtype market-cache retention, threaded from live config`
+
+### Task 3: qubx — FundingRate slots + PR prep
+
+**Files:** Modify `src/qubx/core/basics.py:79`; Test appended to `tests/qubx/core/test_market_cache_retention.py`.
+
+- [ ] **Step 1: Failing test:**
+
+```python
+def test_funding_rate_has_slots():
+    import numpy as np
+    from qubx.core.basics import FundingRate
+    fr = FundingRate(time=np.datetime64(0, "ns"), rate=0.0001, interval="1h", next_funding_time=np.datetime64(3600_000_000_000, "ns"))
+    assert not hasattr(fr, "__dict__")
+    with pytest.raises(AttributeError):
+        fr.extra = 1  # type: ignore[attr-defined]
+```
+
+- [ ] **Step 2: fail → Step 3:** change decorator to `@dataclass(slots=True)`. Grep the worktree for `FundingRate` attribute writes outside the constructor to confirm none (`grep -rn "\.rate = \|\.next_funding_time = " src/`) — report findings.
+- [ ] **Step 4:** targeted tests + `uv run pytest tests/qubx -q` (full unit sweep; skip integration markers per repo convention).
+- [ ] **Step 5: Commit** `perf(core): FundingRate slots — 3x smaller per tick`; push branch `feat/market-cache-retention`; open PR to `dev` titled `feat: per-dtype market-cache retention caps + FundingRate slots` referencing frab#85 and the spec, stating defaults are behavior-preserving. **Do not merge.**
+
+### Task 4: frab — spread-series length
+
+**Files:** worktree `~/projects/frab/.worktrees/mem-retention` (create: `cd ~/projects/frab && git worktree add .worktrees/mem-retention -b fix/spread-series-retention origin/main`). Modify `src/frab/domain/spread.py:15`; Test `tests/test_spread_tracker.py`.
+
+- [ ] **Step 1: Failing test** (append):
+
+```python
+def test_spread_retention_covers_ema_window_twice():
+    # 5-min EMA on 1s bars needs 300 bars; retention is 2x that window, not 10k
+    # (frab#85: 1,144 series x 10k bars held ~841MB on the dev bot).
+    from frab.domain.spread import MAX_SPREAD_LENGTH
+    assert MAX_SPREAD_LENGTH == 600
+```
+
+- [ ] **Step 2: fail → Step 3:** `MAX_SPREAD_LENGTH = 600` → **Step 4:** `uv run pytest -q` full suite green (existing tests use « 600 bars).
+- [ ] **Step 5: Commit** `perf(spread): cap 1s spread series at 600 bars (frab#85)`; push; PR to main referencing frab#85 + the qubx spec, noting the config/lock rollout lands after the qubx release. **Do not merge.**
+
+### Task 5: platform — MALLOC_ARENA_MAX
+
+**Files:** `~/devs/xlydian-platform` branch `perf/bot-malloc-arena` from origin/main. Modify `control-api/internal/k8s/deployer.go` (`baseBotEnv()`); Test alongside existing deployer tests if a `baseBotEnv` test exists, else assert via the deployment-spec builder test pattern in `internal/k8s`.
+
+- [ ] **Step 1:** locate `baseBotEnv()` (deployer.go ~line 109) and any test constructing the bot Deployment env; write the failing assertion that env contains `MALLOC_ARENA_MAX=2`.
+- [ ] **Step 2: fail → Step 3:** append `corev1.EnvVar{Name: "MALLOC_ARENA_MAX", Value: "2"}` to `baseBotEnv()` with a one-line comment: `// glibc arena cap — GIL-bound bots gain nothing from per-core arenas; frab#85`.
+- [ ] **Step 4:** `cd control-api && go build ./... && go test ./internal/k8s/...`.
+- [ ] **Step 5: Commit** `perf(deployer): MALLOC_ARENA_MAX=2 on bot pods (frab#85)`; push; PR. **Do not merge.**
+
+### Task 6: local A/B paper validation (controller-run, not subagent)
+
+Run two frab paper bots locally in tmux from the dev xrelease config; measure RSS over ≥45 min.
+
+- [ ] **Step 1: Baseline env** — `~/projects/frab` main checkout as-is (`uv sync` current lock = released qubx). **Fixed env** — the `mem-retention` worktree with `[tool.uv.sources] qubx = {path = "~/devs/Qubx/.worktrees/market-cache-retention", editable = true}` added LOCALLY (uncommitted — validation harness only, must not enter the PR) + `uv sync`.
+- [ ] **Step 2: Local config** — copy `~/devs/xrelease/dev/binance/v11-dynamic-bhpl.yaml` to scratch twice (baseline/fixed): strip `notifiers`; keep aux `xdata::quantlab` + warmup (resolve reachability the way the frab research kernels do — check `~/.qubx/accounts.toml`/env conventions; if quantlab is unreachable locally, disable warmup AND note that pair discovery still needs aux — in that case port-forward or tailnet is required, not optional); `xstream_url` → `http://localhost:18001` via `kubectl -n data-service port-forward svc/xstream-service 18001:80` (dev cluster), `api_url` → `http://localhost:18002` via control-api port-forward. Fixed config additionally gets `live.market_cache.per_type: {orderbook: 4, funding_rate: 64}`.
+- [ ] **Step 3: Run the allocator × retention matrix** — tmux session `mem-ab`, four windows, all `uv run qubx run <cfg> --paper`, launched together so every variant sees identical market data:
+
+| Window | Code | Config caps | Allocator env |
+|---|---|---|---|
+| A baseline | frab main + released qubx | none | none |
+| B caps | worktree deps | orderbook=4, funding_rate=64 | none |
+| C caps+arena | worktree deps | same as B | `MALLOC_ARENA_MAX=2` |
+| D caps+jemalloc | worktree deps | same as B | `LD_PRELOAD=libjemalloc.so.2` (install `libjemalloc2` if absent; verify preload took via `grep jemalloc /proc/<pid>/maps`) |
+
+  A↔B isolates the retention caps; B↔C isolates the glibc arena cap; B↔D tests whether jemalloc beats capped glibc. If local RAM can't carry four bots (~1–2 GB each plus warmup spikes), run (A,B) concurrently then (C,D) concurrently and compare within pairs only. Confirm B/C/D log `market cache retention: orderbook=4, funding_rate=64` at startup and all variants discover pairs and arm the funding monitor.
+- [ ] **Step 4: Measure** — sample every PID every 30s for ≥45 min: `ps -o rss= -p <pid>` appended to per-variant CSVs in the scratchpad. Success criteria: B's RSS slope after warm-up visibly flatter than A with ≥ ~100 MB divergence by minute 45 (spread series stop growing at 600 bars ≈ minute 10; FundingRate buffers cap at 64×~118); C and D quantify allocator effects on top of B — report their deltas as data, no pass/fail threshold (45 min undersells fragmentation effects that accrue over days; note this in the report).
+- [ ] **Step 5: Report** — RSS curves per variant (numbers, not adjectives), startup-log proof of caps, allocator verdict (does `MALLOC_ARENA_MAX=2` measurably help; does jemalloc beat it enough to justify a base-image/deployer change — if yes, file a follow-up issue rather than expanding scope here), functional parity checks (pair counts and armed legs must match across variants); attach the summary to the PRs and frab#85. Kill tmux, drop port-forwards, leave worktrees for PR review.

--- a/docs/superpowers/specs/2026-08-11-market-cache-retention-design.md
+++ b/docs/superpowers/specs/2026-08-11-market-cache-retention-design.md
@@ -1,0 +1,131 @@
+# Market-Cache Retention Config Design
+
+**Date:** 2026-08-11
+**Status:** Approved for planning
+**Driver:** [frab#85](https://github.com/xLydianSoftware/frab/issues/85) — live frab bots hold
+2.6–3.3 GB RSS, of which ~1.2 GB is dead history retained by one hardcoded default.
+**Repos:** qubx (this spec's implementation) + consumer rollout in frab, xrelease,
+xlydian-platform (small coordinated changes, listed in §Rollout).
+
+## Problem
+
+`CachedMarketDataHolder` buffers every event stream 10,000 items deep per instrument
+(`max_buffer_size=10_000`, threaded from nowhere — no caller overrides it). Measured on the
+dev frab bot (26h uptime, RSS 3,325 MB):
+
+- **1,078,188 `FundingRate` ticks** (118 instruments × full 10k `Indexed` buffers) ≈ 373 MB —
+  consumers read only the latest tick;
+- **460k `OrderBook` snapshots** on the prod live bot (~46 instruments × 10k) — consumers read
+  only the current book;
+- (frab-side, same pattern, fixed in rollout: 1,144 one-second spread series × 10k bars ≈ 841 MB
+  feeding a 300-bar EMA.)
+
+There is no leak — only retention nobody asked for. Profiling method and full budget:
+quantkit `docs/live-bot-memory-profiling.md`.
+
+## Design (qubx)
+
+### Config schema
+
+New model in `utils/runner/configs.py`, wired into `LiveConfig`:
+
+```python
+class MarketCacheConfig(StrictBaseModel):
+    """Retention caps for the per-instrument market-data buffers."""
+    default_length: int = 10_000              # unchanged qubx default
+    per_type: dict[str, int] = Field(default_factory=dict)
+```
+
+```python
+class LiveConfig(StrictBaseModel):
+    ...
+    market_cache: MarketCacheConfig = Field(default_factory=MarketCacheConfig)
+```
+
+YAML shape (values live in deployment configs, not in qubx — qubx ships no opinionated caps;
+defaults reproduce today's behavior exactly):
+
+```yaml
+live:
+  market_cache:
+    per_type:
+      orderbook: 4
+      funding_rate: 64
+```
+
+Validation: every value must be `>= 1` (pydantic validator; a zero/negative cap is a config
+error, not a disable switch). Keys are **base dtype names**; unknown keys are permitted and
+simply never match (forward compatibility), but each configured key is logged once at startup
+(`market cache retention: orderbook=4, funding_rate=64`) so typos are visible.
+
+### Threading
+
+`runner.py` passes the config through to the context, which passes it to the market manager:
+
+- `MarketManager.__init__(..., max_buffer_size: int = 10_000, per_type_lengths: dict[str, int] | None = None)`
+- `StrategyContext` ctor gains the same two values, sourced from `config.live.market_cache`
+  (`default_length` → `max_buffer_size`, `per_type` → `per_type_lengths`).
+- Backtester/simulation paths are untouched: they construct their own holders and `LiveConfig`
+  does not apply. (Warmup runs inside the live process but through the sim construction path —
+  also untouched.)
+
+### Resolution
+
+Applied **at series creation time** in the market manager:
+
+- Generic series (`get_data` — the path that buffers `FundingRate`, `OrderBook`, trades, …):
+  resolve the cap by the event type's **base name** via `DataType.from_str(event_type)`
+  stripping parameters, so `orderbook(0,1)` matches the `orderbook` key. Cap =
+  `per_type_lengths.get(base_name, max_buffer_size)`.
+- OHLC series: same lookup under the `ohlc` key (no deployment sets it today; default applies).
+
+Series already created keep their length for the life of the process — caps apply from process
+start, which is how bots deploy anyway (restart per release). No runtime mutation API (YAGNI).
+
+### Rider: `FundingRate` slots
+
+`qubx.core.basics.FundingRate` becomes `@dataclass(slots=True)` (~363 B → ~120 B per object).
+Grep shows no dynamic attribute assignment on instances anywhere in qubx, quantkit, frab, or
+the connector plugins. Risk: third-party pickling of old instances — none exists (objects are
+transient stream events).
+
+## Rollout (consumer repos, in order)
+
+1. **qubx**: this spec → PR → dev-push release → note the released version `X`.
+2. **xrelease**: bump the qubx pin its config validation uses to `X` **before** any frab config
+   mentions `market_cache` — unknown fields fail builds with `extra_forbidden` (the pin-lag trap
+   is already documented inline in the dev yaml's `health:` block comment).
+3. **frab**:
+   - `domain/spread.py`: `MAX_SPREAD_LENGTH` 10_000 → **600** (5-min EMA on 1s bars needs 300;
+     2× headroom). One constant; series already thread it.
+   - lock bump to qubx `X`; deploy configs (`xrelease dev/binance/v11-dynamic-bhpl.yaml`,
+     `prod/binance/frab-olereon-bin-hpl.yaml`) and the paper twin's platform overrides gain
+     `live.market_cache.per_type: {orderbook: 4, funding_rate: 64}` (64 ticks ≈ 10 min of rate
+     history; the funding monitor's staleness guard compares only against the last tick).
+   - tag `v0.11.8`, release train, restart dev + both prod bots.
+4. **xlydian-platform**: `MALLOC_ARENA_MAX=2` added to `baseBotEnv()` in
+   `control-api/internal/k8s/deployer.go` (same value as the xrust workloads; glibc arena cap —
+   near-free for GIL-bound processes, recovers arena fragmentation). Applies per bot at next
+   restart. Independent of 1–3; can land any time.
+
+## Testing
+
+- **qubx unit tests**: config parse (defaults = today's values; per_type validation rejects 0);
+  resolution (parameterized dtype `orderbook(0,1)` hits the `orderbook` cap; unmatched dtype
+  falls back to default; `ohlc` key honored); threading (MarketManager receives the values from
+  a constructed context); `FundingRate` slots (no `__dict__`, fields intact, repr unchanged).
+- **frab**: existing spread-tracker tests must stay green with the shorter buffer (they use far
+  fewer than 600 bars); one assertion added that `MAX_SPREAD_LENGTH == 600` with the EMA-window
+  rationale in the test name.
+- **Field verification** (dev bot, `debug-prof` census still standing): 24h after deploy expect
+  FundingRates ≈ 7.5k (from 1.08M), 1s bars ≈ 690k (from 9.36M), RSS trending toward
+  1.3–1.6 GB; prod live additionally sheds the 460k OrderBook snapshots (cap works regardless
+  of the still-unidentified subscriber).
+
+## Out of scope
+
+- Opinionated qubx defaults for any dtype (deployment configs own the values — explicit choice).
+- Runtime retention mutation, per-instrument caps, prefetch `cache_size_mb` shrink (optional
+  belt-and-braces a deployment can set today; not part of this change).
+- Naming the prod orderbook subscriber (tracked in frab#85; cap neutralizes it).
+- jemalloc or allocator swaps (arena cap only).

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -76,7 +76,7 @@ class AggregatedLiquidations:
         return f"[{time_to_str(self.time, 'ns')}]\t B:{self.buy_amount} @ {self.avg_buy_price} | S:{self.sell_amount} @ {self.avg_sell_price}"  # type: ignore
 
 
-@dataclass
+@dataclass(slots=True)
 class FundingRate:
     time: dt_64
     rate: float

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -172,6 +172,7 @@ class StrategyContext(IStrategyContext):
         state_persistence: IStatePersistence | None = None,
         state_snapshot_interval: str | None = None,
         rate_limiting_config: Any | None = None,
+        market_cache_config: Any | None = None,
         event_loop: asyncio.AbstractEventLoop | None = None,
         read_only: bool = False,
         fit_executor: FitExecutorMode = FitExecutorMode.THREAD,
@@ -248,11 +249,17 @@ class StrategyContext(IStrategyContext):
             else DataType.NONE,
         )
 
+        # - market_cache_config is untyped (Any) to avoid a core -> utils.runner.configs
+        #   import cycle; None (sim/backtester/warmup callers) preserves today's defaults.
+        _mc_default_length = market_cache_config.default_length if market_cache_config else 10_000
+        _mc_per_type = market_cache_config.per_type if market_cache_config else None
         self._market_data_provider = MarketManager(
             time_provider=self._time_provider,
             data_providers=self._data_providers,
             universe_manager=self,
             aux_data_storage=aux_data_storage,
+            max_buffer_size=_mc_default_length,
+            per_type_lengths=_mc_per_type,
         )
 
         # Create delisting detector to be shared between universe and processing managers

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -251,8 +251,8 @@ class StrategyContext(IStrategyContext):
 
         # - market_cache_config is untyped (Any) to avoid a core -> utils.runner.configs
         #   import cycle; None (sim/backtester/warmup callers) preserves today's defaults.
-        _mc_default_length = market_cache_config.default_length if market_cache_config else 10_000
-        _mc_per_type = market_cache_config.per_type if market_cache_config else None
+        _mc_default_length = market_cache_config.default_length if market_cache_config is not None else 10_000
+        _mc_per_type = market_cache_config.per_type if market_cache_config is not None else None
         self._market_data_provider = MarketManager(
             time_provider=self._time_provider,
             data_providers=self._data_providers,

--- a/src/qubx/core/mixins/market.py
+++ b/src/qubx/core/mixins/market.py
@@ -41,6 +41,8 @@ class CachedMarketDataHolder(IMarketDataCache):
     _updates: dict[Instrument, Bar | Quote | Trade]
     _generic_series: dict[Instrument, dict[str, GenericSeries]]
     _max_series_length: int
+    _per_type_lengths: dict[str, int]
+    _logged_caps: set[str]
 
     # Appends and the *_snapshot reads (FitContext on the StrategyFitThread)
     # serialize on this lock so a threaded fit never sees a torn series. An
@@ -48,12 +50,19 @@ class CachedMarketDataHolder(IMarketDataCache):
     # taken unconditionally — simulation just never contends on it.
     _series_lock: RLock
 
-    def __init__(self, default_timeframe: str | None = None, max_buffer_size: int = 10_000) -> None:
+    def __init__(
+        self,
+        default_timeframe: str | None = None,
+        max_buffer_size: int = 10_000,
+        per_type_lengths: dict[str, int] | None = None,
+    ) -> None:
         self._ohlcvs = dict()
         self._last_bar = defaultdict(lambda: None)
         self._updates = dict()
         self._generic_series = defaultdict(dict)
         self._max_series_length = max_buffer_size
+        self._per_type_lengths = dict(per_type_lengths or {})
+        self._logged_caps = set()
         self._series_lock = RLock()
         if default_timeframe:
             self.update_default_timeframe(default_timeframe)
@@ -61,10 +70,41 @@ class CachedMarketDataHolder(IMarketDataCache):
     def update_default_timeframe(self, default_timeframe: str):
         self.default_timeframe = convert_tf_str_td64(default_timeframe)
 
+    def _resolve_series_length(self, event_type: str) -> int:
+        """
+        Resolve the retention cap for a subscription/event type by its base dtype
+        name (e.g. "orderbook(0,1)" -> "orderbook"), falling back to the default
+        buffer size when the base name has no configured cap.
+        """
+        try:
+            base = DataType.from_str(event_type)[0].value
+            if base == DataType.NONE.value:
+                base = event_type.split("(")[0]
+        except Exception:
+            base = event_type.split("(")[0]
+
+        n = self._per_type_lengths.get(base, self._max_series_length)
+        if base in self._per_type_lengths and base not in self._logged_caps:
+            self._logged_caps.add(base)
+            logger.info(f"market cache retention: {base}={n}")
+        return n
+
+    def _resolve_ohlc_length(self, max_size: float | int) -> float | int:
+        # OHLC series default to unbounded (today's behavior, relied on by long
+        # backtests/warmups reading full history) unless an explicit "ohlc" cap
+        # is configured -- unlike generic series, which have always defaulted
+        # to max_buffer_size. Only overrides the caller's own default sentinel.
+        if max_size != np.inf:
+            return max_size
+        if DataType.OHLC.value in self._per_type_lengths:
+            return self._resolve_series_length(DataType.OHLC.value)
+        return max_size
+
     def init_ohlcv(self, instrument: Instrument, max_size=np.inf):
         if instrument not in self._ohlcvs:
+            _length = self._resolve_ohlc_length(max_size)
             self._ohlcvs[instrument] = {
-                self.default_timeframe: OHLCV(instrument.symbol, self.default_timeframe, max_size),
+                self.default_timeframe: OHLCV(instrument.symbol, self.default_timeframe, _length),
             }
         # - Clear updates to prevent stale data when re-adding instruments
         self._updates.pop(instrument, None)
@@ -155,7 +195,8 @@ class CachedMarketDataHolder(IMarketDataCache):
 
         if tf not in self._ohlcvs[instrument]:
             # - check requested timeframe
-            new_ohlc = OHLCV(instrument.symbol, tf, max_size)
+            _length = self._resolve_ohlc_length(max_size)
+            new_ohlc = OHLCV(instrument.symbol, tf, _length)
             if tf < self.default_timeframe:
                 logger.warning(
                     f"[{instrument.symbol}] Request for timeframe {timeframe} that is smaller then minimal {self.default_timeframe}"
@@ -204,7 +245,7 @@ class CachedMarketDataHolder(IMarketDataCache):
             _instr_series[event_type] = GenericSeries(
                 f"{instrument.symbol}.{event_type}",
                 1,
-                self._max_series_length,
+                self._resolve_series_length(event_type),
             )
         return _instr_series[event_type]
 
@@ -411,9 +452,11 @@ class MarketManager(IMarketManager):
         data_providers: list[IDataProvider],
         universe_manager: IUniverseManager,
         aux_data_storage: IStorage,
+        max_buffer_size: int = 10_000,
+        per_type_lengths: dict[str, int] | None = None,
     ):
         self._time_provider = time_provider
-        self._cache = CachedMarketDataHolder()
+        self._cache = CachedMarketDataHolder(max_buffer_size=max_buffer_size, per_type_lengths=per_type_lengths)
         self._data_providers = data_providers
         self._universe_manager = universe_manager
         self._aux_data_storage = aux_data_storage

--- a/src/qubx/core/mixins/market.py
+++ b/src/qubx/core/mixins/market.py
@@ -78,9 +78,10 @@ class CachedMarketDataHolder(IMarketDataCache):
         """
         try:
             base = DataType.from_str(event_type)[0].value
-            if base == DataType.NONE.value:
-                base = event_type.split("(")[0]
         except Exception:
+            base = DataType.NONE.value
+        if base == DataType.NONE.value:
+            # unrecognized/malformed dtype string -- fall back to the plain prefix
             base = event_type.split("(")[0]
 
         n = self._per_type_lengths.get(base, self._max_series_length)
@@ -314,7 +315,7 @@ class CachedMarketDataHolder(IMarketDataCache):
             ohlc.update_by_bars(bars)
         else:
             # Create a new OHLCV and add the bars
-            ohlc = OHLCV(instrument.symbol, tf)
+            ohlc = OHLCV(instrument.symbol, tf, self._resolve_ohlc_length(np.inf))
             ohlc.update_by_bars(bars)
             self._ohlcvs[instrument][tf] = ohlc
 

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -210,6 +210,28 @@ class AccountManagerConfig(StrictBaseModel):
     terminal_order_history_size: int = 10_000
 
 
+class MarketCacheConfig(StrictBaseModel):
+    """Retention caps for per-instrument market-data buffers (spec 2026-08-11)."""
+
+    default_length: int = 10_000
+    per_type: dict[str, int] = Field(default_factory=dict)
+
+    @field_validator("default_length")
+    @classmethod
+    def _default_positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("default_length must be >= 1")
+        return v
+
+    @field_validator("per_type")
+    @classmethod
+    def _caps_positive(cls, v: dict[str, int]) -> dict[str, int]:
+        for k, n in v.items():
+            if n < 1:
+                raise ValueError(f"per_type[{k!r}] must be >= 1")
+        return v
+
+
 class LiveConfig(StrictBaseModel):
     read_only: bool = False
     base_currency: str | None = None
@@ -226,6 +248,7 @@ class LiveConfig(StrictBaseModel):
     state: StatePersistenceConfig | None = None
     rate_limiting: RateLimitingConfig | None = None
     account_manager: AccountManagerConfig = Field(default_factory=AccountManagerConfig)
+    market_cache: MarketCacheConfig = Field(default_factory=MarketCacheConfig)
     # Where strategy.on_fit runs in live mode. "thread" (default) hands the fit body
     # to a dedicated StrategyFitThread; deferred ctx mutations are applied atomically
     # on the ProcessorThread at fit end. "inline" is the legacy behavior — the fit

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -673,6 +673,7 @@ def create_strategy_context(
         state_persistence=_state_persistence,
         state_snapshot_interval=_state_snapshot_interval,
         rate_limiting_config=_rate_limiting_config,
+        market_cache_config=config.live.market_cache,
         event_loop=loop,
         read_only=config.live.read_only,
         fit_executor=config.live.fit_executor,

--- a/tests/qubx/core/test_market_cache_retention.py
+++ b/tests/qubx/core/test_market_cache_retention.py
@@ -1,4 +1,25 @@
+import numpy as np
+import pytest
+
+from qubx.core.basics import Instrument, MarketType
 from qubx.core.mixins.market import CachedMarketDataHolder
+from qubx.core.series import Bar, OHLCV
+
+
+@pytest.fixture
+def mock_instrument():
+    return Instrument(
+        symbol="BTCUSDT",
+        market_type=MarketType.SPOT,
+        exchange="BINANCE",
+        base="BTC",
+        quote="USDT",
+        settle="USDT",
+        exchange_symbol="BTCUSDT",
+        tick_size=0.01,
+        lot_size=0.001,
+        min_size=0.001,
+    )
 
 
 def test_per_type_cap_applies_to_generic_series():
@@ -7,9 +28,67 @@ def test_per_type_cap_applies_to_generic_series():
     assert h._resolve_series_length("orderbook(0,1)") == 4  # parameterized form matches base name
     assert h._resolve_series_length("funding_rate") == 64
     assert h._resolve_series_length("quote") == 10_000  # unmatched -> default
+    # _resolve_series_length is a pure lookup; production OHLC creation goes through
+    # the separately-guarded _resolve_ohlc_length and stays unbounded here.
     assert h._resolve_series_length("ohlc(1h)") == 10_000  # ohlc key unset -> default
 
 
 def test_ohlc_key_honored():
     h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={"ohlc": 500})
     assert h._resolve_series_length("ohlc(1h)") == 500
+
+
+def test_resolve_ohlc_length_unconfigured_stays_unbounded():
+    h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={})
+    assert h._resolve_ohlc_length(np.inf) == np.inf
+
+
+def test_resolve_ohlc_length_configured_caps_default_sentinel():
+    h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={"ohlc": 500})
+    assert h._resolve_ohlc_length(np.inf) == 500
+
+
+def test_resolve_ohlc_length_never_overrides_callers_explicit_cap():
+    # Caller-supplied max_size (not the np.inf default sentinel) always passes
+    # through untouched, even when an "ohlc" cap is configured.
+    h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={"ohlc": 500})
+    assert h._resolve_ohlc_length(50) == 50
+
+
+def test_update_by_bars_creates_capped_series_when_ohlc_configured(mock_instrument):
+    # Subscription warmup for a non-default timeframe reaches OHLC creation via
+    # update_by_bars before init_ohlcv/get_ohlcv ever touches that (instrument,
+    # timeframe) pair -- must honor a configured "ohlc" cap too.
+    h = CachedMarketDataHolder(default_timeframe="1h", per_type_lengths={"ohlc": 500})
+    bars = [
+        Bar(
+            time=np.datetime64("2023-01-01T10:00:00", "ns"),
+            open=100.0,
+            high=110.0,
+            low=90.0,
+            close=105.0,
+            volume=1000.0,
+            bought_volume=600,
+        ),
+    ]
+    ohlcv = h.update_by_bars(mock_instrument, "5m", bars)
+    assert isinstance(ohlcv, OHLCV)
+    assert ohlcv.max_series_length == 500
+
+
+def test_update_by_bars_creates_unbounded_series_when_ohlc_unconfigured(mock_instrument):
+    h = CachedMarketDataHolder(default_timeframe="1h", per_type_lengths={})
+    bars = [
+        Bar(
+            time=np.datetime64("2023-01-01T10:00:00", "ns"),
+            open=100.0,
+            high=110.0,
+            low=90.0,
+            close=105.0,
+            volume=1000.0,
+            bought_volume=600,
+        ),
+    ]
+    ohlcv = h.update_by_bars(mock_instrument, "5m", bars)
+    assert isinstance(ohlcv, OHLCV)
+    assert ohlcv.max_series_length == np.inf

--- a/tests/qubx/core/test_market_cache_retention.py
+++ b/tests/qubx/core/test_market_cache_retention.py
@@ -1,0 +1,15 @@
+from qubx.core.mixins.market import CachedMarketDataHolder
+
+
+def test_per_type_cap_applies_to_generic_series():
+    h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={"orderbook": 4, "funding_rate": 64})
+    assert h._resolve_series_length("orderbook") == 4
+    assert h._resolve_series_length("orderbook(0,1)") == 4  # parameterized form matches base name
+    assert h._resolve_series_length("funding_rate") == 64
+    assert h._resolve_series_length("quote") == 10_000  # unmatched -> default
+    assert h._resolve_series_length("ohlc(1h)") == 10_000  # ohlc key unset -> default
+
+
+def test_ohlc_key_honored():
+    h = CachedMarketDataHolder(max_buffer_size=10_000, per_type_lengths={"ohlc": 500})
+    assert h._resolve_series_length("ohlc(1h)") == 500

--- a/tests/qubx/core/test_market_cache_retention.py
+++ b/tests/qubx/core/test_market_cache_retention.py
@@ -92,3 +92,13 @@ def test_update_by_bars_creates_unbounded_series_when_ohlc_unconfigured(mock_ins
     ohlcv = h.update_by_bars(mock_instrument, "5m", bars)
     assert isinstance(ohlcv, OHLCV)
     assert ohlcv.max_series_length == np.inf
+
+
+def test_funding_rate_has_slots():
+    import numpy as np
+    from qubx.core.basics import FundingRate
+
+    fr = FundingRate(time=np.datetime64(0, "ns"), rate=0.0001, interval="1h", next_funding_time=np.datetime64(3600_000_000_000, "ns"))
+    assert not hasattr(fr, "__dict__")
+    with pytest.raises(AttributeError):
+        fr.extra = 1  # type: ignore[attr-defined]

--- a/tests/qubx/utils/test_market_cache_config.py
+++ b/tests/qubx/utils/test_market_cache_config.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import ValidationError
+
+from qubx.utils.runner.configs import LiveConfig, MarketCacheConfig
+
+
+def _live(**over):
+    base = dict(exchanges={}, logging={"logger": "InMemoryLogsWriter"})
+    base.update(over)
+    return LiveConfig(**base)
+
+
+def test_defaults_reproduce_current_behavior():
+    cfg = _live()
+    assert cfg.market_cache.default_length == 10_000
+    assert cfg.market_cache.per_type == {}
+
+
+def test_per_type_parses():
+    cfg = _live(market_cache={"per_type": {"orderbook": 4, "funding_rate": 64}})
+    assert cfg.market_cache.per_type == {"orderbook": 4, "funding_rate": 64}
+    assert cfg.market_cache.default_length == 10_000
+
+
+def test_zero_cap_rejected():
+    with pytest.raises(ValidationError):
+        MarketCacheConfig(per_type={"orderbook": 0})
+    with pytest.raises(ValidationError):
+        MarketCacheConfig(default_length=0)


### PR DESCRIPTION
## Motivation

Driven by [frab#85](https://github.com/xLydianSoftware/frab/issues/85): live frab bots hold
2.6–3.3 GB RSS, most of it dead history retained by a single hardcoded default. Measured on
the dev frab bot (26h uptime, RSS 3,325 MB):

- **1,078,188 `FundingRate` ticks retained** (118 instruments × full 10k `Indexed` buffers)
  ≈ 373 MB — consumers only ever read the latest tick.
- **460k `OrderBook` snapshots** on the prod live bot (~46 instruments × 10k) — consumers only
  read the current book.

`CachedMarketDataHolder` buffers every event stream 10,000 items deep per instrument
(`max_buffer_size=10_000`), and nothing overrides it. This PR adds an opt-in per-dtype
retention cap, threaded from `LiveConfig`, plus a `FundingRate` slots rider that shrinks each
retained tick ~3x. Full spec: `docs/superpowers/specs/2026-08-11-market-cache-retention-design.md`.

## `MarketCacheConfig` schema

New model in `utils/runner/configs.py`, wired into `LiveConfig.market_cache`:

```python
class MarketCacheConfig(StrictBaseModel):
    """Retention caps for the per-instrument market-data buffers."""
    default_length: int = 10_000              # unchanged qubx default
    per_type: dict[str, int] = Field(default_factory=dict)
```

YAML example (values live in deployment configs — qubx itself ships no opinionated caps):

```yaml
live:
  market_cache:
    per_type:
      orderbook: 4
      funding_rate: 64
```

Validation: every value (`default_length`, each `per_type` entry) must be `>= 1` — a
zero/negative cap is a config error, not a disable switch. `per_type` keys are **base dtype
names**; unknown keys are permitted (forward compatibility) and each configured key is logged
once at startup so typos are visible.

## Behavior-preserving defaults

- Untouched deployments get identical behavior: `default_length=10_000`, empty `per_type` ->
  every series resolves to the same 10k cap as today.
- Resolution happens **at series creation time** in `CachedMarketDataHolder`. Generic series
  (the path buffering `FundingRate`, `OrderBook`, trades, …) resolve the cap by the event
  type's base name (`DataType.from_str`, stripping params) so `orderbook(0,1)` matches an
  `orderbook` key.
- **OHLC series stay unbounded unless an explicit `"ohlc"` cap is configured** — this preserves
  today's behavior for sim/backtester/warmup, which share `StrategyContext` construction with
  live and would otherwise silently truncate long-running histories.
- Series already created keep their length for the life of the process; caps only apply at
  process start (bots restart per release anyway) — no runtime mutation API.

## `update_by_bars` cap fix

`update_by_bars`'s create-new branch built a fresh `OHLCV` with no `max_size` at all, bypassing
a configured `ohlc` cap on a live-reachable path: subscription warmup for a non-default
timeframe reaches OHLC creation via `update_by_bars` *before* `init_ohlcv`/`get_ohlcv` ever
touches that `(instrument, timeframe)` pair. Routed through the same `_resolve_ohlc_length`
guard as the other two OHLC creation sites, with direct tests for `_resolve_ohlc_length`'s three
cases and for `update_by_bars` honoring/ignoring a configured cap on fresh creation.

## `FundingRate` slots rider

`qubx.core.basics.FundingRate` becomes `@dataclass(slots=True)` (no other field changes) —
roughly 3x smaller per retained tick. Grepped the qubx worktree and consumer repos (quantkit,
frab, the hyperliquid connector plugin, xrust `qubx-xdata`) for dynamic attribute assignment on
`FundingRate` instances (`.rate =`, `.next_funding_time =`, etc. outside the constructor,
`copy.copy`/pickle usage) — none found anywhere. All consumer references are either
construction (`FundingRate(...)`) or read-only access.

## Consumer rollout (post-release, not in this PR)

Deployment configs adopt `market_cache.per_type` values after this release ships (pin bump in
xrelease, then frab config changes) — tracked separately per the design spec's rollout section.
This PR only ships the qubx-side mechanism with behavior-preserving defaults.

## Testing

- `tests/qubx/core/test_market_cache_retention.py` — config parse, per-type/ohlc resolution,
  `update_by_bars` cap-honoring, and the new `FundingRate` slots test.
- `tests/qubx/utils/test_market_cache_config.py` — `MarketCacheConfig` validation.
- Full unit sweep: `uv run pytest tests/qubx -q`.

Refs: frab#85, `docs/superpowers/specs/2026-08-11-market-cache-retention-design.md`,
`docs/superpowers/plans/2026-08-11-market-cache-retention.md`.
