### PR TITLE
fix(rate-limiting): enforce order pools, make gates loop-agnostic, charge real ccxt weights

### DIFF
--- a/docs/connectors/rate-limiting.md
+++ b/docs/connectors/rate-limiting.md
@@ -10,7 +10,7 @@ A **pool** represents one independent rate limit enforced by an exchange. Most e
 
 There are two pool types:
 
-- **Rate pool** (`pool_type="rate"`) — Time-based token bucket. Tokens refill at a constant rate. When depleted, a gate closes and reopens on a timer. Used for request weight limits, message rate limits, etc.
+- **Rate pool** (`pool_type="rate"`) — Time-based token bucket. Tokens refill at a constant rate. When the exchange reports a limit hit, a gate closes until a deadline. Used for request weight limits, message rate limits, etc.
 
 - **Quota pool** (`pool_type="quota"`) — Externally managed budget with no time-based refill. The exchange controls replenishment (e.g., Lighter's volume quota which is replenished by trading volume). When depleted, the gate closes and stays closed until the exchange reports positive remaining via `sync_from_exchange()`.
 
@@ -35,20 +35,20 @@ An **endpoint** maps an API call to one or more pool costs. A single request can
 
 ### Gates
 
-Each pool has a **gate** (an `asyncio.Event`). When open, `acquire()` proceeds immediately. When closed, all requests for that pool block until the gate reopens.
+Each pool has a **gate**, held as a monotonic deadline (`_gate_until`) rather than an `asyncio.Event`. A deadline is loop-agnostic and needs no running loop, so a gate can be closed from any thread and is observed identically from every event loop sharing the limiter. When open, `acquire()` proceeds immediately. When closed, requests for that pool wait until the deadline passes, or raise `RateLimitGateTimeout` after `gate_max_wait` seconds.
 
-- **Rate pool gates** reopen automatically after a cooldown timer.
-- **Quota pool gates** never reopen on a timer — only when the exchange reports positive remaining via `sync_from_exchange()`, or on reconnection via `reset_gates()`.
+- **Rate pool gates** close for `cooldown` seconds (or `retry_after` when the exchange supplies one) and reopen once that deadline passes. Repeated hits extend the deadline; they never shorten it.
+- **Quota pool gates** close indefinitely (`math.inf`) — they reopen only when the exchange reports positive remaining via `sync_from_exchange()`, or on reconnection via `reset_gates()`.
 
 ### Scopes
 
 Pools are scoped to what the exchange rate-limits by:
 
-- `"ip"` — Per IP address (REST API weight limits)
-- `"account"` — Per trading account
+- `"ip"` — Per IP address (REST API weight limits). Id is the discovered egress IP (`egress_ip: auto`) or the one configured explicitly.
+- `"account"` — Per trading account. Id is `acct_<sha256(api_key)[:16]>` — hashed so the raw key never reaches a Redis key, a log line or a metric tag. Two bots holding the same API key therefore share one bucket automatically.
 - `"address"` — Per L1/wallet address (Lighter sendTx limits)
 
-The scope determines the backend storage key, enabling future cross-bot coordination via a shared Redis backend.
+The scope determines the backend storage key, so under `backend: redis` — what production deployments run; the default is the in-process `local` backend — every bot resolving the same scope id shares one bucket. A scope whose id cannot be resolved — no API key configured, no egress IP discovered — falls back to a **per-process** id, not a shared literal: an unknown identity is no evidence of a shared one, and a shared literal would collapse every bot on the backend onto one bucket at 1/N of the budget each. Such a bot is limited correctly on its own, just not coordinated with its peers.
 
 ## Defining Configuration
 
@@ -138,6 +138,13 @@ async def send_order(self, order_params):
 
 The engine iterates the endpoint's pool costs in order, acquiring from each pool. If any pool's gate is closed, `acquire()` blocks (for rate pools) or raises immediately (for quota pools).
 
+### The ccxt connector
+
+`qubx.connectors.ccxt.rate_limits` declares two pools for every ccxt venue:
+
+- `ccxt_rest` (IP-scoped) — acquired by the throttle hook that `install_rate_limiter_hooks()` puts on the exchange, so every REST call ccxt makes is charged its real ccxt cost from inside `fetch2`, storage/warmup fetches included. What is charged depends on when the hook is installed: the storage path installs it before the first call, so even that storage's `load_markets()` is charged, while the live connector attaches its limiter after the exchange is built (`factory.py`), so the connector's own initial markets load is not.
+- `orders` (account-scoped) — acquired by the connector before `create_order` / `cancel_order` / `edit_order`. Those endpoints map to `[("orders", 1)]` only: the IP weight of the same request is already charged by the throttle hook, so naming `ccxt_rest` again would double-charge it.
+
 ### Syncing state from exchange responses
 
 When the exchange reports actual usage in response headers or WebSocket messages, call `sync_from_exchange()` to correct drift between the model and reality.
@@ -180,7 +187,7 @@ async def _handle_error(self, error: dict):
             )
 ```
 
-You can target a specific pool, an endpoint (closes all pools in its costs), or pass nothing to close all rate pools.
+You can target a specific pool, an endpoint (closes all pools in its costs), or pass nothing to close all rate pools. Prefer `pool_name=` — `endpoint=` closes every pool in that endpoint's cost list, so a read-path 429 reported by endpoint would also close the order pool and stall the write path.
 
 ### Resetting on reconnection
 
@@ -257,6 +264,7 @@ Available metrics (all tagged with `exchange`, `pool`, `scope`):
 | `rate_limit.hits` | Cumulative rate limit hits reported |
 | `rate_limit.wait_seconds` | Cumulative time spent waiting for budget |
 | `rate_limit.consumed` | Cumulative tokens consumed |
+| `rate_limit.gate_timeouts` | Cumulative `RateLimitGateTimeout` raised by this pool |
 
 ## Architecture
 
@@ -269,14 +277,14 @@ ExchangeRateLimiter (engine.py)
 ├── collect_metrics()          → delegates to pool.get_state()
 │
 ├── RatePool (pools.py)        — time-based token bucket
-│   ├── acquire()              waits for gate, then backend.acquire()
-│   ├── close_gate()           clears gate, schedules timed reopen
+│   ├── acquire()              waits out the gate deadline, then backend.acquire()
+│   ├── close_gate()           pushes the gate deadline out by cooldown
 │   ├── sync()                 updates backend token count
 │   └── get_state()            reads remaining from backend
 │
 └── QuotaPool (pools.py)       — externally managed
     ├── acquire()              fails fast if depleted (RateLimitGateTimeout)
-    ├── close_gate()           clears gate, NO timed reopen
+    ├── close_gate()           sets the gate deadline to math.inf
     ├── sync()                 updates remaining, reopens gate if positive
     └── get_state()            returns in-memory remaining
 ```

--- a/src/qubx/connectors/ccxt/connection_manager.py
+++ b/src/qubx/connectors/ccxt/connection_manager.py
@@ -155,7 +155,8 @@ class ConnectionManager:
                 await asyncio.sleep(1)
                 continue
             except (RateLimitExceeded, DDoSProtection) as e:
-                # Rate limit hit — report to rate limiter if available and backoff
+                # WS 429/418 are IP actions that ban REST too, and a gate close is not a token debit,
+                # so the next header sync does not erase it — hence the REST pool.
                 logger.warning(
                     f"<yellow>{self._exchange_id}</yellow> Rate limited in {stream_name}: {e}"
                 )

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -76,6 +76,7 @@ from qubx.core.events import (
 from qubx.core.exceptions import InvalidOrderParameters
 from qubx.core.interfaces import IDataProvider, ITimeProvider
 from qubx.core.utils import recognize_time
+from qubx.rate_limiting import RateLimitGateTimeout
 from qubx.utils.misc import AsyncThreadLoop
 from qubx.utils.time import to_timedelta
 
@@ -127,6 +128,11 @@ _VENUE_VERDICT_ERRORS: tuple[type[Exception], ...] = (
     ccxt.OnMaintenance,
     ccxt.ExchangeError,  # catch-all for venue-side ExchangeError subtypes (BadRequest, NotSupported, ...)
 )
+# The venue telling us we exceeded ITS order budget. Both are needed: Binance maps -1015
+# ("too many new orders") to RateLimitExceeded, Kraken maps "EOrder:Rate limit exceeded" to
+# DDoSProtection, and in ccxt the two are siblings, not parent/child.
+_ORDER_RATE_LIMIT_ERRORS: tuple[type[Exception], ...] = (ccxt.RateLimitExceeded, ccxt.DDoSProtection)
+
 # RateLimitExceeded / ExchangeNotAvailable / OnMaintenance are ccxt NetworkError
 # *subclasses* but the venue actively refused the request, so they are venue verdicts
 # and listed above. The except sites MUST match this tuple BEFORE a bare ccxt.NetworkError
@@ -241,6 +247,24 @@ class CcxtConnector(ChannelEmitter):
         """
         return self._loop.submit(coro).result(timeout=timeout)
 
+    async def _acquire_order_slot(self, endpoint: str) -> None:
+        """Charge the venue's order-count budget; this request's IP weight is charged by the throttle override."""
+        rate_limiter = self._em.rate_limiter
+        if rate_limiter is not None:
+            await rate_limiter.acquire(endpoint)
+
+    def _report_order_limit_hit(self, error: Exception) -> None:
+        """Close the orders gate when the venue itself reports an order-budget breach.
+
+        A no-op for every other error. Without it the pool is proactive-model-only, so it never
+        sees the budget another actor on the same account (manual trading, a second bot) spends.
+        """
+        rate_limiter = self._em.rate_limiter
+        if rate_limiter is None or not isinstance(error, _ORDER_RATE_LIMIT_ERRORS):
+            return
+        # pool_name, never endpoint= — the latter closes every pool in the endpoint's cost list
+        rate_limiter.report_limit_hit(pool_name="orders", reason=f"venue order rate limit: {error}")
+
     # ------------------------------------------------------------------ #
     # Write side — submit
     # ------------------------------------------------------------------ #
@@ -286,16 +310,22 @@ class CcxtConnector(ChannelEmitter):
 
     async def _submit_async(self, instrument: Instrument, client_id: str | None, payload: dict[str, Any]) -> None:
         try:
+            await self._acquire_order_slot("create_order")
             r = await self._em.exchange.create_order(**payload)
+        except RateLimitGateTimeout as e:
+            self._emit_submit_rejected(instrument, client_id, e)
+            return
         except _VENUE_VERDICT_ERRORS as e:
             # Venue verdict — must precede the bare NetworkError catch (rate-limit /
             # maintenance / unavailable are NetworkError subclasses but are verdicts).
+            self._report_order_limit_hit(e)
             self._emit_submit_rejected(instrument, client_id, e)
             return
         except ccxt.NetworkError as e:
             # Transient connectivity / timeout: the order may or may not have reached
             # the venue. Do NOT terminal-reject — leave it inflight so AM's inflight
             # check / snapshot reconcile resolves the true state from the venue.
+            self._report_order_limit_hit(e)
             logger.warning(f"[{self.exchange_name}] Network error submitting {client_id}: {e}; leaving inflight")
             return
         except Exception as e:  # noqa: BLE001 — unexpected: still a venue-side failure, must not raise across the loop
@@ -324,7 +354,7 @@ class CcxtConnector(ChannelEmitter):
         )
 
     def _emit_submit_rejected(self, instrument: Instrument, client_id: str | None, error: Exception) -> None:
-        logger.warning(f"[{self.exchange_name}] Order {client_id} rejected by venue: {error}")
+        logger.warning(f"[{self.exchange_name}] Order {client_id} rejected: {error}")
         self.send(
             OrderRejectedEvent(
                 instrument=instrument,
@@ -362,7 +392,14 @@ class CcxtConnector(ChannelEmitter):
         AM to reconcile rather than terminal-rejected.
         """
         try:
+            # Outside _cancel_with_retry: one slot per operation, and its broad handlers would eat the timeout.
+            await self._acquire_order_slot("cancel_order")
             ok, response = await self._cancel_with_retry(client_order_id, venue_order_id, symbol, is_trigger)
+        except RateLimitGateTimeout as e:
+            self._emit_cancel_rejected(
+                client_order_id, venue_order_id, reason=f"rate limited: {e}", code="RateLimitGateTimeout"
+            )
+            return
         except ccxt.NetworkError as e:
             logger.warning(
                 f"[{self.exchange_name}] Network error cancelling {client_order_id or venue_order_id}: "
@@ -379,7 +416,13 @@ class CcxtConnector(ChannelEmitter):
         else:
             self._emit_cancel_rejected(client_order_id, venue_order_id)
 
-    def _emit_cancel_rejected(self, client_order_id: str | None, venue_order_id: str | None) -> None:
+    def _emit_cancel_rejected(
+        self,
+        client_order_id: str | None,
+        venue_order_id: str | None,
+        reason: str | None = None,
+        code: str | None = None,
+    ) -> None:
         # Carry both ids: AM's reject handler resolves the order by cid first, then venue id,
         # so the order can revert out of PENDING_CANCEL regardless of which id the caller had.
         self.send(
@@ -387,7 +430,8 @@ class CcxtConnector(ChannelEmitter):
                 instrument=None,
                 client_order_id=client_order_id,
                 venue_order_id=venue_order_id,
-                reason=f"venue rejected cancel for {venue_order_id or client_order_id}",
+                reason=reason or f"venue rejected cancel for {venue_order_id or client_order_id}",
+                code=code,
             )
         )
 
@@ -420,14 +464,19 @@ class CcxtConnector(ChannelEmitter):
                     else await self._em.exchange.cancel_order_with_client_order_id(client_order_id, symbol)
                 )
                 return True, r
-            except ccxt.NetworkError:
+            except ccxt.NetworkError as e:
                 # Transient (incl. ExchangeNotAvailable / OnMaintenance / rate-limit):
                 # UNKNOWN whether the cancel landed → re-raise so the caller leaves it
                 # inflight rather than terminal-rejecting.
+                self._report_order_limit_hit(e)
                 raise
             except (ccxt.NotSupported, ccxt.BadRequest, ccxt.ExchangeError) as e:
                 logger.warning(f"[{client_order_id}] Cancel-by-client-id rejected by venue: {e}")
                 return False, None
+            except RateLimitGateTimeout:
+                # erupts from inside the venue call (the throttle hook's own gate check) — the venue
+                # was never reached, so it is not a refusal; the caller emits the rate-limited event.
+                raise
             except Exception as e:  # noqa: BLE001
                 logger.warning(f"[{client_order_id}] Cancel-by-client-id unexpected error: {e}")
                 return False, None
@@ -457,6 +506,7 @@ class CcxtConnector(ChannelEmitter):
             except ccxt.NetworkError as e:
                 # Transient connectivity (incl. ExchangeNotAvailable / rate-limit): retry,
                 # and raise on exhaustion so the UNKNOWN outcome leaves the order inflight.
+                self._report_order_limit_hit(e)
                 verdict = self._classify_cancel_error(e, acked=True)
                 if verdict == "reject":
                     logger.warning(f"[{venue_order_id}] Cancel failed (missing/invalid orderId): {e}")
@@ -479,6 +529,9 @@ class CcxtConnector(ChannelEmitter):
                     return None, None
                 last_network_error = None
                 logger.warning(f"[{venue_order_id}] Exchange error while cancelling: {e}")
+            except RateLimitGateTimeout:
+                # see the cloid-only path above: not a venue refusal, the caller emits it coded.
+                raise
             except Exception as err:  # noqa: BLE001
                 logger.error(f"Unexpected error canceling order {venue_order_id}: {err}")
                 return False, None
@@ -593,19 +646,25 @@ class CcxtConnector(ChannelEmitter):
         # orderId with -1102).
         vid = venue_order_id
         try:
+            await self._acquire_order_slot("edit_order")
             if self._em.exchange.has.get("editOrder", False):
                 r = await self._edit_order_direct(
                     client_order_id, vid, symbol, side, order_type, wire_price, wire_amount
                 )
             else:
                 r = await self._update_via_cancel_recreate(client_order_id, venue_order_id, wire_price, wire_amount)
+        except RateLimitGateTimeout as e:
+            self._emit_update_rejected(client_order_id, venue_order_id, e)
+            return
         except _VENUE_VERDICT_ERRORS as e:
             # Venue verdict — must precede the bare NetworkError catch (see _submit_async).
+            self._report_order_limit_hit(e)
             self._emit_update_rejected(client_order_id, venue_order_id, e)
             return
         except ccxt.NetworkError as e:
             # Transient: UNKNOWN whether the edit landed. Leave the order PENDING_UPDATE
             # inflight for AM to reconcile rather than emitting a terminal reject.
+            self._report_order_limit_hit(e)
             logger.warning(f"[{self.exchange_name}] Network error updating {client_order_id}: {e}; leaving inflight")
             return
         except Exception as e:  # noqa: BLE001

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -247,8 +247,8 @@ class CcxtConnector(ChannelEmitter):
         """
         return self._loop.submit(coro).result(timeout=timeout)
 
-    async def _acquire_order_slot(self, endpoint: str) -> None:
-        """Charge the venue's order-count budget; this request's IP weight is charged by the throttle override."""
+    async def _acquire_endpoint_budget(self, endpoint: str) -> None:
+        """Charge whatever budget this endpoint draws beyond IP weight, which the throttle already took."""
         rate_limiter = self._em.rate_limiter
         if rate_limiter is not None:
             await rate_limiter.acquire(endpoint)
@@ -310,7 +310,7 @@ class CcxtConnector(ChannelEmitter):
 
     async def _submit_async(self, instrument: Instrument, client_id: str | None, payload: dict[str, Any]) -> None:
         try:
-            await self._acquire_order_slot("create_order")
+            await self._acquire_endpoint_budget("create_order")
             r = await self._em.exchange.create_order(**payload)
         except RateLimitGateTimeout as e:
             self._emit_submit_rejected(instrument, client_id, e)
@@ -393,7 +393,7 @@ class CcxtConnector(ChannelEmitter):
         """
         try:
             # Outside _cancel_with_retry: one slot per operation, and its broad handlers would eat the timeout.
-            await self._acquire_order_slot("cancel_order")
+            await self._acquire_endpoint_budget("cancel_order")
             ok, response = await self._cancel_with_retry(client_order_id, venue_order_id, symbol, is_trigger)
         except RateLimitGateTimeout as e:
             self._emit_cancel_rejected(
@@ -646,7 +646,7 @@ class CcxtConnector(ChannelEmitter):
         # orderId with -1102).
         vid = venue_order_id
         try:
-            await self._acquire_order_slot("edit_order")
+            await self._acquire_endpoint_budget("edit_order")
             if self._em.exchange.has.get("editOrder", False):
                 r = await self._edit_order_direct(
                     client_order_id, vid, symbol, side, order_type, wire_price, wire_amount
@@ -817,6 +817,7 @@ class CcxtConnector(ChannelEmitter):
 
     async def _do_set_leverage(self, instrument: Instrument, symbol: str, leverage: int) -> None:
         try:
+            await self._acquire_endpoint_budget("set_leverage")
             await self._em.exchange.set_leverage(leverage, symbol)
         except Exception as e:  # noqa: BLE001 — the caller is long gone; report on the channel
             logger.error(f"[{self.exchange_name}] Failed to set leverage {leverage} for {instrument.symbol}: {e}")

--- a/src/qubx/connectors/ccxt/exchange_manager.py
+++ b/src/qubx/connectors/ccxt/exchange_manager.py
@@ -12,7 +12,9 @@ from typing import Any, Callable, Optional
 import ccxt.pro as cxp
 
 from qubx import logger
+from qubx.connectors.ccxt.rate_limits import install_rate_limiter_hooks
 from qubx.core.interfaces import IHealthMonitor, ITimeProvider
+from qubx.rate_limiting import ExchangeRateLimiter
 
 # Constants for better maintainability
 DEFAULT_CHECK_INTERVAL_SECONDS = 60.0
@@ -72,6 +74,8 @@ class ExchangeManager:
 
         # Recreation callback management
         self._recreation_callbacks: list[Callable[[], None]] = []
+
+        self._rate_limiter: ExchangeRateLimiter | None = None
 
         # Use provided exchange or create new one
         if initial_exchange:
@@ -256,75 +260,28 @@ class ExchangeManager:
 
     # === Rate Limiting ===
 
-    def attach_rate_limiter(self, rate_limiter) -> None:
+    def attach_rate_limiter(self, rate_limiter: ExchangeRateLimiter) -> None:
         """Attach an ExchangeRateLimiter to this exchange manager.
 
-        Disables CCXT's built-in rate limiting and replaces the throttle
-        method with our rate limiter. Survives exchange recreation.
-
-        Args:
-            rate_limiter: ExchangeRateLimiter instance
+        Takes CCXT's own throttler out of the REST path and syncs our modeled budget from response
+        headers. Survives exchange recreation.
         """
+        # The factory cache key collides for empty-credential venues, so the data provider and the
+        # connector share one manager and attach the same limiter twice.
+        if self._rate_limiter is rate_limiter:
+            return
         self._rate_limiter = rate_limiter
-        self._apply_rate_limiter_to_exchange(self._exchange)
-        self.register_recreation_callback(lambda: self._apply_rate_limiter_to_exchange(self._exchange))
+        install_rate_limiter_hooks(self._exchange, rate_limiter, label=self._exchange_name)
+        # reads self._exchange at call time — recreation swaps it before firing the callbacks
+        self.register_recreation_callback(
+            lambda: install_rate_limiter_hooks(self._exchange, self._rate_limiter, label=self._exchange_name)
+        )
         logger.info(f"Rate limiter attached to {self._exchange_name}")
 
-    def _apply_rate_limiter_to_exchange(self, exchange: cxp.Exchange) -> None:
-        """Install our throttle and response-header-sync hooks on *exchange*.
-
-        Two hooks are installed per exchange:
-
-        1. **Throttle (pre-request)** — replaces CCXT's built-in throttle so every
-           REST call blocks on our token bucket first. ``acquire`` forwards the
-           CCXT-provided cost to the limiter as ``weight_override``.
-
-        2. **Response hook (post-request)** — wraps CCXT's ``on_rest_response`` to
-           invoke the exchange-specific header parser (OKX ``x-ratelimit-*``,
-           Binance ``X-MBX-USED-WEIGHT-1M``, etc.). The parser calls
-           ``rate_limiter.sync_from_exchange`` so our modeled budget tracks the
-           exchange's reported usage. Unlike ``CcxtStorage``'s best-effort sync,
-           this path runs atomically inside CCXT's fetch pipeline — no
-           concurrent-fetch race on ``last_response_headers``.
-
-        Both hooks are reapplied automatically after exchange recreation via
-        ``register_recreation_callback`` in :meth:`attach_rate_limiter`.
-        """
-        rate_limiter = getattr(self, "_rate_limiter", None)
-        if rate_limiter is None:
-            return
-
-        # 1) Throttle override — pre-request acquisition.
-        exchange.enableRateLimit = True
-
-        async def _rate_limit_throttle(cost=None):
-            if cost is None:
-                cost = 1.0
-            await rate_limiter.acquire("ccxt_rest", weight_override=float(cost))
-
-        exchange.throttle = _rate_limit_throttle
-
-        # 2) Response hook — post-response state sync.
-        from qubx.connectors.ccxt.rate_limits import get_header_parser
-
-        parser = get_header_parser(getattr(exchange, "id", ""))
-        if parser is not None:
-            _orig_on_rest = exchange.on_rest_response
-
-            def _header_sync_hook(code, reason, url, method, headers, body, req_headers, req_body):
-                try:
-                    if headers:
-                        parser(headers, rate_limiter)
-                except Exception as e:
-                    logger.debug(f"[{self._exchange_name}] header sync failed (non-fatal): {e}")
-                return _orig_on_rest(code, reason, url, method, headers, body, req_headers, req_body)
-
-            exchange.on_rest_response = _header_sync_hook
-
     @property
-    def rate_limiter(self):
+    def rate_limiter(self) -> ExchangeRateLimiter | None:
         """Access the attached rate limiter (if any)."""
-        return getattr(self, "_rate_limiter", None)
+        return self._rate_limiter
 
     @property
     def exchange(self) -> cxp.Exchange:

--- a/src/qubx/connectors/ccxt/rate_limits.py
+++ b/src/qubx/connectors/ccxt/rate_limits.py
@@ -46,6 +46,9 @@ def _default_endpoint_costs() -> dict[str, EndpointCosts]:
         "create_order": order,
         "cancel_order": order,
         "edit_order": order,
+        # leverage is an IP-weight endpoint here, not an order — but it must still be mapped, or it
+        # falls back to default_costs and charges the IP pool a second time
+        "set_leverage": EndpointCosts([]),
     }
 
 
@@ -213,7 +216,7 @@ def _kraken_config(exchange_name: str) -> ExchangeRateLimitConfig:
         # the pool counts half-tokens: a read is exactly 1 unit, and order endpoints add 4 on top of
         # that 1 to reach the venue's 10. 250 units/10s; the bucket starts full, so capacity +
         # 10*refill == 250 keeps the worst 10s window at exactly the documented 500 tokens.
-        # Under-counted (unused by our call paths): batch orders, cancelallorders, leveragepreferences.
+        # Under-counted (not on our call paths): batch orders, cancelallorders.
         order_surcharge = EndpointCosts([("ccxt_rest", 4)])
         return ExchangeRateLimitConfig(
             pools={
@@ -224,6 +227,9 @@ def _kraken_config(exchange_name: str) -> ExchangeRateLimitConfig:
                 "create_order": order_surcharge,
                 "cancel_order": order_surcharge,
                 "edit_order": order_surcharge,
+                # ccxt's set_leverage hits PUT leveragepreferences, which the venue bills like an
+                # order op — unlike Binance, where leverage is plain IP weight
+                "set_leverage": order_surcharge,
             },
             default_costs=EndpointCosts([("ccxt_rest", 1)]),
         )

--- a/src/qubx/connectors/ccxt/rate_limits.py
+++ b/src/qubx/connectors/ccxt/rate_limits.py
@@ -144,12 +144,22 @@ def _okx_config() -> ExchangeRateLimitConfig:
       counters are independent and per instrument; pooling them per account is conservative in both
       directions, and keeps us under the 1000/2sec sub-account cap by construction.
 
+    ``ccxt_rest`` is denominated in ccxt cost units, which OKX's ccxt table normalizes so that
+    ``cost * documented_budget == 20 units per 2s`` for every endpoint (candles 0.5x40, tickers
+    1x20, balance 2x10, order 1/3x60). One pool therefore expresses every per-endpoint limit at
+    once, and the single safety bound is ``capacity + 2*refill <= 20``: a full bucket plus one
+    window of refill must not outrun the tightest budget. That yields candles at 16 req/s against
+    OKX's 20, and balance at 4 against 5.
+
+    Conservative by construction, since it conflates IP-, User-ID- and per-instrument-scoped budgets
+    into one — with N instruments OKX would allow N times more on the per-instId endpoints.
+
     No ``HEADER_PARSERS`` entry: OKX publishes no rate-limit header at all and meters per endpoint /
     instrument id — see the note above ``HEADER_PARSERS``.
     """
     return ExchangeRateLimitConfig(
         pools={
-            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 20, 10.0, cooldown=15.0),
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 4, 8.0, cooldown=15.0),
             "orders": PoolConfig("orders", "account", 60, 30.0, cooldown=10.0),
         },
         endpoint_map=_default_endpoint_costs(),
@@ -169,12 +179,19 @@ def _bybit_config() -> ExchangeRateLimitConfig:
       for create and cancel). Bybit meters per endpoint; pooling the three is conservative. Not
       modelled: option ``cancel-all`` is 1/s, stricter than this pool.
 
+    ``ccxt_rest`` is denominated in ccxt cost units (v5 market endpoints cost 5, order create/cancel
+    2.5, wallet-balance 1), and sized against the IP rule at its worst case — the cheapest endpoint,
+    where one unit is one request. The bucket starts full, so ``capacity + 5*refill <= 600`` caps the
+    worst 5s window at exactly the venue's limit, and refill <= 120 caps the sustained rate. That is
+    the most this pool can allow without assuming which endpoints the traffic is made of; it gives
+    market data 100/5 = 20 req/s.
+
     No ``HEADER_PARSERS`` entry: v5's ``X-Bapi-Limit-*`` headers are per-endpoint, not per-IP — see
     the note above ``HEADER_PARSERS``.
     """
     return ExchangeRateLimitConfig(
         pools={
-            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 120, 24.0, cooldown=15.0),
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 100, 100.0, cooldown=15.0),
             "orders": PoolConfig("orders", "account", 10, 10.0, cooldown=10.0),
         },
         endpoint_map=_default_endpoint_costs(),
@@ -188,11 +205,17 @@ def _bybit_config() -> ExchangeRateLimitConfig:
 def _kraken_config(exchange_name: str) -> ExchangeRateLimitConfig:
     """Kraken rate limits.
 
-    Kraken Spot runs two independent counters, both decaying at a tier-dependent rate.
+    Kraken Spot runs three independent budgets with three different scopes: public market data per
+    IP (~1 req/s, and per IP+pair for OHLC/Trades), the private counter per API key (threshold/decay
+    by tier), and the trading counter per pair. One IP-scoped pool cannot express all three; the
+    public rule binds first for our workload (OHLCV warmup), so it is the one modelled.
 
-    REST counter (``ccxt_rest``), threshold / decay per second: starter 15 / 0.33, intermediate
-    20 / 0.5, pro 20 / 1.0. AddOrder and CancelOrder are explicitly excluded from it. ccxt supplies
-    the real per-call cost (public 1.0-1.2, balance 3, ledgers 6, orders 0).
+    ``ccxt_rest`` is therefore denominated in ccxt cost units, which for kraken are seconds of
+    pacing at ``rateLimit=1000ms`` — not Kraken counter points. refill 1.0 unit/s reproduces each
+    rule in turn: OHLC/Depth/Trades cost 1.2 => 0.83 req/s under the public 1/s allowance, Balance
+    costs 3 => 0.33/s which is the starter tier's decay for a cost-1 private call, Ledgers 6 =>
+    0.167/s against a real 0.165/s. Capacity is a deliberately modest burst: Kraken documents no
+    public burst tolerance, so this does not test an unwritten rule.
 
     Trading counter (``orders``), threshold / decay per second: starter 60 / 1.0, intermediate
     125 / 2.34, pro 180 / 3.75. Starter is modelled — the tier is not discoverable from the API.
@@ -234,10 +257,10 @@ def _kraken_config(exchange_name: str) -> ExchangeRateLimitConfig:
             default_costs=EndpointCosts([("ccxt_rest", 1)]),
         )
 
-    # Counter threshold → capacity, decay → refill; the decay is the lowest (starter) tier's.
+    # orders is in order count (starter tier's trading threshold/decay), ccxt_rest in ccxt units
     return ExchangeRateLimitConfig(
         pools={
-            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 20, 0.33, cooldown=30.0),
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 10, 1.0, cooldown=30.0),
             "orders": PoolConfig("orders", "account", 60, 1.0, cooldown=15.0),
         },
         # ccxt's per-endpoint cost (Balance=3, Ledgers=6, orders=0) always overrides the static 1.

--- a/src/qubx/connectors/ccxt/rate_limits.py
+++ b/src/qubx/connectors/ccxt/rate_limits.py
@@ -8,27 +8,56 @@ state with exchange-reported usage.
 References:
 - Binance: https://binance-docs.github.io/apidocs/spot/en/#limits
 - Binance Futures: https://binance-docs.github.io/apidocs/futures/en/#limits
+- Binance Portfolio Margin: https://developers.binance.com/docs/derivatives/portfolio-margin/general-info
 - OKX: https://www.okx.com/docs-v5/en/#overview-rate-limit
-- Kraken: https://docs.kraken.com/api/docs/guides/rate-limits
+- Kraken Spot REST: https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits
+- Kraken Spot trading: https://docs.kraken.com/api/docs/guides/spot-ratelimits
+- Kraken Futures: https://docs.kraken.com/api/docs/guides/futures-rate-limits
 - Bybit: https://bybit-exchange.github.io/docs/v5/rate-limit
 """
 
+from weakref import WeakKeyDictionary
+
+from qubx import logger
 from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, PoolConfig
 
+_BINANCE_UM = ("binance.um", "binance.um.mm", "binanceusdm", "binanceqv_usdm", "binance_um_mm")
+_BINANCE_CM = ("binance.cm", "binancecoinm")
+_BINANCE_PM = ("binance.pm", "binancepm")
 
-def create_ccxt_rate_limit_config(exchange_name: str, ccxt_exchange=None) -> ExchangeRateLimitConfig:
+
+# Placeholder weight for the "rest" endpoint: the throttle passes ccxt's real per-endpoint cost as
+# weight_override, which replaces it. The weight on order endpoints is literal — order-count limits
+# count orders, not weight.
+_CCXT_SUPPLIES_COST = 1
+
+
+def _default_endpoint_costs() -> dict[str, EndpointCosts]:
+    """Which pools each operation debits — routing, not limits. The limits are the ``pools``.
+
+    The same on every ccxt venue (Kraken Futures overrides it), since only the numbers differ, not
+    the topology. Order endpoints are listed even for venues without an ``orders`` pool: an unmapped
+    endpoint falls back to ``default_costs`` and would double-charge the IP pool, whereas a cost
+    naming an absent pool is simply skipped by the engine.
+    """
+    order = EndpointCosts([("orders", 1)])
+    return {
+        "rest": EndpointCosts([("ccxt_rest", _CCXT_SUPPLIES_COST)]),
+        "create_order": order,
+        "cancel_order": order,
+        "edit_order": order,
+    }
+
+
+def create_ccxt_rate_limit_config(exchange_name: str) -> ExchangeRateLimitConfig:
     """Create rate limit config for a CCXT exchange.
 
-    Handles exchange.market_type differentiation (spot vs futures).
-
-    Args:
-        exchange_name: Exchange name (e.g., "binance", "binance.um", "kraken")
-        ccxt_exchange: Optional CCXT exchange instance for auto-detection
+    Accepts both framework venue names (``BINANCE.UM``) and ccxt exchange ids (``binanceusdm``).
     """
     name = exchange_name.lower()
     base = name.split(".")[0]
 
-    if base in ("binance", "binanceusdm", "binancecoinm"):
+    if base.startswith("binance"):
         return _binance_config(name)
     elif base == "okx":
         return _okx_config()
@@ -37,58 +66,65 @@ def create_ccxt_rate_limit_config(exchange_name: str, ccxt_exchange=None) -> Exc
     elif base in ("kraken", "krakenfutures"):
         return _kraken_config(name)
     else:
-        return _default_config(exchange_name, ccxt_exchange)
+        return _default_config(exchange_name)
 
 
 # === Binance ===
 
 
 def _binance_config(exchange_name: str) -> ExchangeRateLimitConfig:
-    """Binance rate limits differentiated by market type.
+    """Binance rate limits per surface (verified against live ``exchangeInfo``, 2026-08-10).
 
-    Spot:
-    - IP weight: 6000/min (recently increased from 1200)
-    - UID weight: 180,000/min
-    - Orders: 10/sec, 200,000/day per account
+    | surface       | IP weight | orders   | order-count header |
+    |---------------|-----------|----------|--------------------|
+    | spot (api)    | 6000/1m   | 100/10s  | -10S               |
+    | USD-M (fapi)  | 2400/1m   | 300/10s  | -10S               |
+    | COIN-M (dapi) | 2400/1m   | 1200/1m  | -1M                |
+    | PM (papi)     | 6000/1m   | 1200/1m  | -1M                |
 
-    USDM Futures (binance.um):
-    - IP weight: 2400/min
-    - Orders: 300/10sec per account
+    fapi publishes both 300/10s and 1200/1m; one bucket models the 10s one, since a burst breaches it
+    long before the 1m. The residual gap is sustained flow: 30/s passes the 10s model but exceeds
+    1200/1m, and only the venue's own -1015 (which closes the gate) catches it. dapi publishes only
+    1200/1m, spot only 100/10s (plus 200000/1d, unmodelled).
 
-    COIN-M Futures (binance.cm):
-    - IP weight: 6000/min
-    - Orders: 300/10sec per account
-
-    Headers: X-MBX-USED-WEIGHT-1M, X-MBX-ORDER-COUNT-1S, X-MBX-ORDER-COUNT-1D
+    ``capacity`` must equal the modelled window's allowance and ``capacity / refill_rate`` its length:
+    ``sync_from_exchange`` derives ``remaining = capacity - used``, and ``_order_count_header`` picks
+    the header from that ratio. Changing either without the other silently disables the sync.
     """
-    if exchange_name in ("binance.um", "binanceusdm"):
-        # USDM Futures
+    if exchange_name in _BINANCE_UM:
         return ExchangeRateLimitConfig(
             pools={
                 "ccxt_rest": PoolConfig("ccxt_rest", "ip", 2400, 40.0, cooldown=30.0),
                 "orders": PoolConfig("orders", "account", 300, 30.0, cooldown=10.0),
             },
-            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            endpoint_map=_default_endpoint_costs(),
             default_costs=EndpointCosts([("ccxt_rest", 1)]),
         )
-    elif exchange_name in ("binance.cm", "binancecoinm"):
-        # COIN-M Futures
+    elif exchange_name in _BINANCE_CM:
+        return ExchangeRateLimitConfig(
+            pools={
+                "ccxt_rest": PoolConfig("ccxt_rest", "ip", 2400, 40.0, cooldown=30.0),
+                "orders": PoolConfig("orders", "account", 1200, 20.0, cooldown=10.0),
+            },
+            endpoint_map=_default_endpoint_costs(),
+            default_costs=EndpointCosts([("ccxt_rest", 1)]),
+        )
+    elif exchange_name in _BINANCE_PM:
         return ExchangeRateLimitConfig(
             pools={
                 "ccxt_rest": PoolConfig("ccxt_rest", "ip", 6000, 100.0, cooldown=30.0),
-                "orders": PoolConfig("orders", "account", 300, 30.0, cooldown=10.0),
+                "orders": PoolConfig("orders", "account", 1200, 20.0, cooldown=10.0),
             },
-            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            endpoint_map=_default_endpoint_costs(),
             default_costs=EndpointCosts([("ccxt_rest", 1)]),
         )
     else:
-        # Spot
         return ExchangeRateLimitConfig(
             pools={
                 "ccxt_rest": PoolConfig("ccxt_rest", "ip", 6000, 100.0, cooldown=30.0),
-                "orders": PoolConfig("orders", "account", 10, 10.0, cooldown=10.0),
+                "orders": PoolConfig("orders", "account", 100, 10.0, cooldown=10.0),
             },
-            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            endpoint_map=_default_endpoint_costs(),
             default_costs=EndpointCosts([("ccxt_rest", 1)]),
         )
 
@@ -97,20 +133,23 @@ def _binance_config(exchange_name: str) -> ExchangeRateLimitConfig:
 
 
 def _okx_config() -> ExchangeRateLimitConfig:
-    """OKX rate limits (unified across spot/futures).
+    """OKX v5 rate limits (unified across spot/futures).
 
     - REST: varies heavily by endpoint (2-60 req/2sec per endpoint)
-    - Trade endpoints: 60/2sec per account
     - Market data: 20/2sec per IP
+    - place / amend / cancel order: 60 req/2sec each, scoped per user id + instrument id. The three
+      counters are independent and per instrument; pooling them per account is conservative in both
+      directions, and keeps us under the 1000/2sec sub-account cap by construction.
 
-    Headers: x-ratelimit-remaining, x-ratelimit-limit, x-ratelimit-reset
+    No ``HEADER_PARSERS`` entry: OKX publishes no rate-limit header at all and meters per endpoint /
+    instrument id — see the note above ``HEADER_PARSERS``.
     """
     return ExchangeRateLimitConfig(
         pools={
             "ccxt_rest": PoolConfig("ccxt_rest", "ip", 20, 10.0, cooldown=15.0),
             "orders": PoolConfig("orders", "account", 60, 30.0, cooldown=10.0),
         },
-        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        endpoint_map=_default_endpoint_costs(),
         default_costs=EndpointCosts([("ccxt_rest", 1)]),
     )
 
@@ -119,18 +158,23 @@ def _okx_config() -> ExchangeRateLimitConfig:
 
 
 def _bybit_config() -> ExchangeRateLimitConfig:
-    """Bybit rate limits (unified v5 API).
+    """Bybit v5 rate limits.
 
-    - REST: 10 req/sec per endpoint per IP (varies by endpoint)
-    - Orders: 10/sec per account
-    - Rate limit info in response body: rate_limit_status, rate_limit_reset_ms
+    - IP rule modelled by ``ccxt_rest``: 600 req/5s per IP; breaching it returns HTTP 403 and bans
+      the IP for 10 minutes.
+    - Orders: 10 req/s per UID for create/amend/cancel on inverse/linear/option (spot allows 20/s
+      for create and cancel). Bybit meters per endpoint; pooling the three is conservative. Not
+      modelled: option ``cancel-all`` is 1/s, stricter than this pool.
+
+    No ``HEADER_PARSERS`` entry: v5's ``X-Bapi-Limit-*`` headers are per-endpoint, not per-IP — see
+    the note above ``HEADER_PARSERS``.
     """
     return ExchangeRateLimitConfig(
         pools={
             "ccxt_rest": PoolConfig("ccxt_rest", "ip", 120, 24.0, cooldown=15.0),
             "orders": PoolConfig("orders", "account", 10, 10.0, cooldown=10.0),
         },
-        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        endpoint_map=_default_endpoint_costs(),
         default_costs=EndpointCosts([("ccxt_rest", 1)]),
     )
 
@@ -141,51 +185,57 @@ def _bybit_config() -> ExchangeRateLimitConfig:
 def _kraken_config(exchange_name: str) -> ExchangeRateLimitConfig:
     """Kraken rate limits.
 
-    Kraken Spot uses a unique "call counter" system:
-    - Each API call adds to a counter (1-6 depending on endpoint)
-    - Counter decays at a fixed rate based on verification level
-    - Intermediate verified: max counter 20, decay 0.33/sec
-    - Pro verified: max counter 20, decay 1.0/sec
+    Kraken Spot runs two independent counters, both decaying at a tier-dependent rate.
 
-    Per-endpoint costs from CCXT:
-    - Public: 1.0-1.2 per call
-    - Private: 0-6 per call (orders=0, balance=3, ledgers=6)
-    - Orders: cost 0 (separate matching engine limit)
+    REST counter (``ccxt_rest``), threshold / decay per second: starter 15 / 0.33, intermediate
+    20 / 0.5, pro 20 / 1.0. AddOrder and CancelOrder are explicitly excluded from it. ccxt supplies
+    the real per-call cost (public 1.0-1.2, balance 3, ledgers 6, orders 0).
 
-    Kraken Futures:
-    - Simple: ~1.67 req/sec (600ms rateLimit)
-    - No per-endpoint weights documented
+    Trading counter (``orders``), threshold / decay per second: starter 60 / 1.0, intermediate
+    125 / 2.34, pro 180 / 3.75. Starter is modelled — the tier is not discoverable from the API.
+    Two known distortions, both documented rather than modelled: Kraken meters this counter per
+    *pair* while the pool is per account (over-throttles a multi-pair strategy), and its cost rises
+    with how young the order is (cancel costs 8 under 5s, decaying to 1 over 300s) while
+    ``_endpoint_map`` charges a flat 1 (under-throttles cancel-heavy flow).
 
-    Matching engine (order) limits (separate from REST):
-    - Spot: based on tier, typically 60/min for intermediate
-    - Futures: separate per-instrument limits
+    Kraken Futures runs one account-wide ``/derivatives`` budget of 500 cost units per 10s. Reads
+    (openorders, openpositions, accounts, fills) cost 2, order ops (sendorder, cancelorder,
+    editorder) cost 10, public endpoints (charts, instruments, tickers, orderbook) cost 0. There is
+    no separate order-count limit, so no ``orders`` pool. ``/history`` has its own 100-per-10min
+    pool; nothing here calls it.
+
+    Neither the Spot REST, Spot trading nor the Futures guide documents any rate-limit response
+    header, and ccxt parses none — hence no Kraken entry in ``HEADER_PARSERS``; breaches surface
+    reactively as ``EOrder:Rate limit exceeded`` (spot) / ``apiLimitExceeded`` (futures).
     """
-    if exchange_name in ("krakenfutures",):
+    if exchange_name in ("kraken.f", "krakenfutures"):
+        # ccxt declares no per-endpoint costs for krakenfutures and charges a flat 1 per request, so
+        # the pool counts half-tokens: a read is exactly 1 unit, and order endpoints add 4 on top of
+        # that 1 to reach the venue's 10. 250 units/10s; the bucket starts full, so capacity +
+        # 10*refill == 250 keeps the worst 10s window at exactly the documented 500 tokens.
+        # Under-counted (unused by our call paths): batch orders, cancelallorders, leveragepreferences.
+        order_surcharge = EndpointCosts([("ccxt_rest", 4)])
         return ExchangeRateLimitConfig(
             pools={
-                "ccxt_rest": PoolConfig("ccxt_rest", "ip", 10, 1.67, cooldown=15.0),
+                "ccxt_rest": PoolConfig("ccxt_rest", "account", 125, 12.5, cooldown=10.0),
             },
-            endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+            endpoint_map={
+                "rest": EndpointCosts([("ccxt_rest", _CCXT_SUPPLIES_COST)]),
+                "create_order": order_surcharge,
+                "cancel_order": order_surcharge,
+                "edit_order": order_surcharge,
+            },
             default_costs=EndpointCosts([("ccxt_rest", 1)]),
         )
 
-    # Kraken Spot — counter-decay system maps to token bucket:
-    # capacity=20 (max counter), refill=0.33/sec (intermediate) or 1.0/sec (pro)
-    # Using intermediate as default — can be overridden via config
+    # Counter threshold → capacity, decay → refill; the decay is the lowest (starter) tier's.
     return ExchangeRateLimitConfig(
         pools={
-            # Main REST counter (per IP, decays at 0.33/sec for intermediate tier)
             "ccxt_rest": PoolConfig("ccxt_rest", "ip", 20, 0.33, cooldown=30.0),
-            # Order matching engine (separate limit per account)
             "orders": PoolConfig("orders", "account", 60, 1.0, cooldown=15.0),
         },
-        endpoint_map={
-            # CCXT defines per-endpoint costs for Kraken — these are the weights
-            # that get passed through CCXT's calculateRateLimiterCost → our throttle override.
-            # Key costs: Balance=3, ClosedOrders=3, TradesHistory=6, Ledgers=6
-            # Orders have cost=0 in the REST counter (separate matching engine limit)
-            "ccxt_rest": EndpointCosts([("ccxt_rest", 1)]),
-        },
+        # ccxt's per-endpoint cost (Balance=3, Ledgers=6, orders=0) always overrides the static 1.
+        endpoint_map=_default_endpoint_costs(),
         default_costs=EndpointCosts([("ccxt_rest", 1)]),
     )
 
@@ -193,23 +243,20 @@ def _kraken_config(exchange_name: str) -> ExchangeRateLimitConfig:
 # === Default ===
 
 
-def _default_config(exchange_name: str, ccxt_exchange=None) -> ExchangeRateLimitConfig:
-    """Default conservative config for unknown exchanges.
-
-    Derives from CCXT's rateLimit property if exchange instance provided.
-    """
-    rate_limit_ms = 50  # default: 20 req/sec
-    if ccxt_exchange and hasattr(ccxt_exchange, "rateLimit"):
-        rate_limit_ms = ccxt_exchange.rateLimit or 50
-
-    rps = 1000.0 / rate_limit_ms
-    capacity = rps * 60  # 1 minute capacity
+def _default_config(exchange_name: str) -> ExchangeRateLimitConfig:
+    """Fallback for venues with no hand-tuned config — the numbers below are a guess, not a limit."""
+    rps = 20.0
+    capacity = rps * 60
+    logger.warning(
+        f"No rate limit config for '{exchange_name}' — guessing {rps:.0f} req/s "
+        f"(capacity {capacity:.0f}); add a config in qubx.connectors.ccxt.rate_limits"
+    )
 
     return ExchangeRateLimitConfig(
         pools={
             "ccxt_rest": PoolConfig("ccxt_rest", "ip", capacity, rps, cooldown=15.0),
         },
-        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        endpoint_map=_default_endpoint_costs(),
         default_costs=EndpointCosts([("ccxt_rest", 1)]),
     )
 
@@ -217,79 +264,132 @@ def _default_config(exchange_name: str, ccxt_exchange=None) -> ExchangeRateLimit
 # === Response Header Parsers ===
 
 
+def _header(headers: dict, name: str) -> str | None:
+    """Case-insensitive header lookup — ccxt copies aiohttp's raw casing, it does not normalize."""
+    value = headers.get(name)
+    if value is not None:
+        return value
+    lowered = name.lower()
+    for key, val in headers.items():
+        if key.lower() == lowered:
+            return val
+    return None
+
+
+def _order_count_header(pool: PoolConfig) -> str:
+    """The ``X-MBX-ORDER-COUNT-*`` header matching *pool*'s window.
+
+    Binance names the window ``(intervalNum)(intervalLetter)``, and a pool's window is
+    ``capacity / refill_rate`` under this module's denomination rule. Deriving it is what lets one
+    parser serve venues with different order windows — ``binance.um`` (10s) and ``binance.pm`` (1m)
+    share the ccxt id ``binanceusdm``, so a hardcoded name would be wrong for one of them.
+    """
+    seconds = pool.capacity / pool.refill_rate
+    if seconds < 60:
+        return f"X-MBX-ORDER-COUNT-{int(seconds)}S"
+    if seconds < 3600:
+        return f"X-MBX-ORDER-COUNT-{int(seconds // 60)}M"
+    return f"X-MBX-ORDER-COUNT-{int(seconds // 3600)}H"
+
+
+def _used_count(headers: dict, name: str) -> int | None:
+    """Header value as a usage count, or None when absent, unparseable, or negative.
+
+    Binance sends ``-1`` for "not applicable" — notably ``X-MBX-USED-WEIGHT-1M: -1`` on order
+    responses (observed on testnet). Treating it as a count yields ``remaining = capacity + 1`` and
+    resets the pool to full on every order placement.
+    """
+    raw = _header(headers, name)
+    if raw is None:
+        return None
+    try:
+        used = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return used if used >= 0 else None
+
+
 def parse_binance_headers(headers: dict, rate_limiter) -> None:
-    """Parse Binance rate limit headers and sync with rate limiter.
+    """Sync the IP weight pool from ``X-MBX-USED-WEIGHT-1M`` and the order pool from its
+    window-matched ``X-MBX-ORDER-COUNT-*``.
 
-    Binance returns:
-    - X-MBX-USED-WEIGHT-1M: weight used in current 1-minute window
-    - X-MBX-ORDER-COUNT-1S: orders placed in current 1-second window
-    - X-MBX-ORDER-COUNT-1D: orders placed in current day
+    Order-count headers ride only on order *placement* responses — cancels carry none — so every
+    other response skips that branch. Syncing them is what catches order flow we did not place
+    ourselves (manual trading, a second bot on the same key); our own count is otherwise exact,
+    though charging cancels locally makes it conservative until the next placement re-pins it.
     """
     if rate_limiter is None:
         return
 
-    # Try both casing conventions (CCXT normalizes to lowercase)
-    used_weight = headers.get("x-mbx-used-weight-1m") or headers.get("X-MBX-USED-WEIGHT-1M")
-    if used_weight:
-        try:
-            rate_limiter.sync_from_exchange("ccxt_rest", used=int(used_weight))
-        except Exception:
-            pass
+    used_weight = _used_count(headers, "X-MBX-USED-WEIGHT-1M")
+    if used_weight is not None:
+        rate_limiter.sync_from_exchange("ccxt_rest", used=used_weight)
 
-    order_count = headers.get("x-mbx-order-count-1s") or headers.get("X-MBX-ORDER-COUNT-1S")
-    if order_count and "orders" in rate_limiter.config.pools:
-        try:
-            rate_limiter.sync_from_exchange("orders", used=int(order_count))
-        except Exception:
-            pass
-
-
-def parse_okx_headers(headers: dict, rate_limiter) -> None:
-    """Parse OKX rate limit headers and sync with rate limiter.
-
-    OKX returns:
-    - x-ratelimit-remaining: remaining requests for this endpoint
-    - x-ratelimit-limit: total limit for this endpoint
-    - x-ratelimit-reset: timestamp when limit resets (ms)
-    """
-    if rate_limiter is None:
+    orders = rate_limiter.config.pools.get("orders")
+    if orders is None or orders.refill_rate <= 0:
         return
-
-    remaining = headers.get("x-ratelimit-remaining") or headers.get("X-RateLimit-Remaining")
-    if remaining:
-        try:
-            rate_limiter.sync_from_exchange("ccxt_rest", remaining=float(remaining))
-        except Exception:
-            pass
+    order_count = _used_count(headers, _order_count_header(orders))
+    if order_count is not None:
+        rate_limiter.sync_from_exchange("orders", used=order_count)
 
 
+# A venue gets a parser only when it publishes a header whose scope matches the pool being pinned:
+# a per-endpoint or per-instrument signal must never re-pin a venue-wide IP pool. OKX, Bybit and
+# Kraken all fail that test — see each ``_*_config`` docstring for which way.
 HEADER_PARSERS = {
     "binance": parse_binance_headers,
     "binanceusdm": parse_binance_headers,
     "binancecoinm": parse_binance_headers,
-    "okx": parse_okx_headers,
 }
 
 
-def get_header_parser(exchange_name: str):
-    """Get the response header parser for an exchange."""
-    name = exchange_name.lower().split(".")[0]
-    return HEADER_PARSERS.get(name)
+def get_header_parser(exchange_id: str):
+    """Get the response header parser for a ccxt exchange id (``exchange.id``)."""
+    return HEADER_PARSERS.get(exchange_id.lower())
 
 
-# NOTE: As of #264 these parsers are invoked from two fetch paths:
-#
-#   * ``qubx.data.storages.ccxt._sync_rate_limiter_from_response_headers`` after
-#     each successful OHLCV page fetch. Best-effort — ``last_response_headers`` is
-#     an exchange-wide attribute so under concurrent fetches the read may be from a
-#     neighboring request. Since all concurrent requests drain the same IP-scoped
-#     budget, an approximate reading is still strictly better than no sync.
-#
-#   * ``qubx.connectors.ccxt.exchange_manager.ExchangeManager._apply_rate_limiter_to_exchange``
-#     via CCXT's ``on_rest_response`` hook. This one is atomic per-request (the
-#     hook runs inside CCXT's fetch pipeline with the actual response headers), so
-#     the live path gets exact sync rather than best-effort.
-#
-# Both code paths call the parser, which in turn calls
-# ``rate_limiter.sync_from_exchange(...)`` to pin the modeled budget to the
-# server-reported remaining.
+# exchange -> its limiter. The hooks resolve it here at call time, so re-attaching a different
+# limiter re-points them rather than stacking a second wrapper. The value must not reference the
+# exchange, or the weak key could never be collected.
+_INSTALLED: WeakKeyDictionary = WeakKeyDictionary()
+
+
+def install_rate_limiter_hooks(exchange, rate_limiter, label: str = "") -> None:
+    """Route a ccxt exchange's REST throttle and response headers through *rate_limiter*.
+
+    ``fetch2`` only calls ``exchange.throttle`` when ``enableRateLimit`` is set, so the flag stays
+    on; shadowing the bound method is what takes ccxt's own throttler out of the REST path.
+    ccxt.pro's per-Client throttler is separate and still paces subscribe frames.
+    """
+    if rate_limiter is None:
+        return
+
+    already_installed = exchange in _INSTALLED
+    _INSTALLED[exchange] = rate_limiter
+    if already_installed:
+        return
+
+    exchange.enableRateLimit = True
+    original_on_rest = exchange.on_rest_response
+
+    async def _rate_limit_throttle(cost=None):
+        limiter = _INSTALLED.get(exchange)
+        if limiter is not None:
+            await limiter.acquire("rest", weight_override=float(1.0 if cost is None else cost))
+
+    exchange.throttle = _rate_limit_throttle
+
+    parser = get_header_parser(exchange.id or "")
+    if parser is None:
+        return
+
+    def _header_sync_hook(code, reason, url, method, headers, body, req_headers, req_body):
+        limiter = _INSTALLED.get(exchange)
+        try:
+            if headers and limiter is not None:
+                parser(headers, limiter)
+        except Exception as e:
+            logger.debug(f"[{label}] header sync failed (non-fatal): {e}")
+        return original_on_rest(code, reason, url, method, headers, body, req_headers, req_body)
+
+    exchange.on_rest_response = _header_sync_hook

--- a/src/qubx/data/storages/ccxt.py
+++ b/src/qubx/data/storages/ccxt.py
@@ -284,42 +284,6 @@ _RETRY_MAX_DELAY_S = 30.0
 _RETRY_JITTER_S = 1.0
 
 
-def _sync_rate_limiter_from_response_headers(ccxt_ex: Any, rate_limiter: Any) -> None:
-    """
-    Best-effort sync of the rate limiter's modeled state from the exchange's
-    last HTTP response headers.
-
-    Without this, the client-side token bucket flies blind to:
-        * cross-process / cross-bot contention on the same IP or account,
-        * drift between our ``PoolConfig`` and the exchange's real limits,
-        * pre-existing budget debt at process start.
-
-    This is a *best-effort* correction because ``ccxt_ex.last_response_headers``
-    is exchange-wide, not per-request — under concurrent fetches the attribute
-    may have been overwritten between the awaited response and this read.
-    That is acceptable in practice: every concurrent request drains the same
-    IP-scoped budget, so whatever remaining value we read is approximately
-    correct, and the limiter converges on subsequent syncs.
-
-    Any exception (missing attr, malformed header, parser bug) is swallowed
-    at DEBUG — header sync must never break a fetch.
-    """
-    if rate_limiter is None:
-        return
-    try:
-        from qubx.connectors.ccxt.rate_limits import get_header_parser
-
-        parser = get_header_parser(getattr(ccxt_ex, "id", ""))
-        if parser is None:
-            return
-        headers = getattr(ccxt_ex, "last_response_headers", None)
-        if not headers:
-            return
-        parser(headers, rate_limiter)
-    except Exception as e:
-        logger.debug(f"[CCXT] header sync failed (non-fatal): {e}")
-
-
 class CcxtFetchExhausted(RuntimeError):
     """
     Raised when one or more symbols exhaust all retry attempts during a
@@ -346,7 +310,7 @@ async def _retryable_fetch(
     call: Callable[[], Awaitable[_T]],
     *,
     rate_limiter: Any = None,
-    rate_limiter_endpoint: str = "ccxt_rest",
+    rate_limit_pool: str = "ccxt_rest",
     max_attempts: int = _RETRY_MAX_ATTEMPTS,
     base_delay: float = _RETRY_BASE_DELAY_S,
     max_delay: float = _RETRY_MAX_DELAY_S,
@@ -367,17 +331,14 @@ async def _retryable_fetch(
     ``AuthenticationError``, plus any non-CCXT exception) is re-raised
     immediately — permanent errors should not consume retry budget.
 
-    The rate-limiter interaction is handled here in two stages per attempt:
-        1. ``acquire(endpoint)`` before each call to block while the gate is closed.
-        2. ``report_limit_hit(endpoint=...)`` on ``RateLimitExceeded`` so the
-           gate closes for ``cooldown`` seconds, pausing all concurrent callers.
+    Budget is acquired inside CCXT's own pipeline by the throttle hook, not here; this function only
+    reports ``RateLimitExceeded`` back so the pool's gate closes for ``cooldown`` seconds.
 
     Args:
         call: Zero-arg callable returning the coroutine to invoke.
-        rate_limiter: Optional ``ExchangeRateLimiter``; if provided, calls are
-            gated and rate-limit hits are reported back to it.
-        rate_limiter_endpoint: Endpoint name used for ``acquire`` /
-            ``report_limit_hit`` lookups.
+        rate_limiter: Optional ``ExchangeRateLimiter``; if provided, rate-limit
+            hits are reported back to it.
+        rate_limit_pool: Pool whose gate is closed on ``RateLimitExceeded``.
         max_attempts: Total attempts including the initial one.
         base_delay: First retry delay in seconds; doubles each attempt.
         max_delay: Cap on the exponential delay.
@@ -390,15 +351,13 @@ async def _retryable_fetch(
     """
     last_exc: BaseException | None = None
     for attempt in range(1, max_attempts + 1):
-        if rate_limiter is not None:
-            await rate_limiter.acquire(rate_limiter_endpoint)
         try:
             return await call()
         except (ccxt.NetworkError, asyncio.TimeoutError) as e:
             last_exc = e
             if isinstance(e, ccxt.RateLimitExceeded) and rate_limiter is not None:
                 rate_limiter.report_limit_hit(
-                    endpoint=rate_limiter_endpoint,
+                    pool_name=rate_limit_pool,
                     reason=(f"{context}: " if context else "") + str(e)[:120],
                 )
             if attempt >= max_attempts:
@@ -489,6 +448,7 @@ class CcxtStorage(IStorage):
 
         from qubx.connectors.ccxt.exchanges import READER_CAPABILITIES
         from qubx.connectors.ccxt.factory import get_ccxt_exchange
+        from qubx.connectors.ccxt.rate_limits import install_rate_limiter_hooks
 
         # - the storage owns one background loop+thread; all exchanges run on it
         if self._loop is None:
@@ -497,6 +457,10 @@ class CcxtStorage(IStorage):
 
         if self._capabilities is None:
             self._capabilities = READER_CAPABILITIES.copy()
+
+        # Direct dict lookup — ``_get_rate_limiter`` needs ``self._exchanges[exchange]``, which must
+        # not be populated before ``load_markets()`` or a failure there caches a broken entry.
+        install_rate_limiter_hooks(ccxt_ex, self._rate_limiters.get(exchange), label=exchange)
 
         self._loop.submit(ccxt_ex.load_markets()).result()
         self._exchanges[exchange] = ccxt_ex
@@ -635,9 +599,8 @@ class CcxtStorage(IStorage):
         all_items: list = []
         current_since = since
 
-        # Get rate limiter for this exchange (if available). Retry + backoff + rate-limit
-        # acquisition are all encapsulated inside ``_retryable_fetch`` so this loop stays
-        # focused on pagination.
+        # Budget acquisition and header sync happen inside CCXT via the hooks installed by
+        # ``_ensure_exchange``; retry + backoff are encapsulated in ``_retryable_fetch``.
         _rl = self._get_rate_limiter(ccxt_ex)
         _ex_id = getattr(ccxt_ex, "id", "ccxt")
 
@@ -645,11 +608,7 @@ class CcxtStorage(IStorage):
             _since = current_since  # capture for the closure below
 
             async def _do_page() -> list:
-                batch = await method(since=_since, limit=limit, **method_kwargs)
-                # Best-effort: keep our modeled budget in sync with what the exchange
-                # actually reports — see ``_sync_rate_limiter_from_response_headers``.
-                _sync_rate_limiter_from_response_headers(ccxt_ex, _rl)
-                return batch
+                return await method(since=_since, limit=limit, **method_kwargs)
 
             batch = await _retryable_fetch(
                 _do_page,

--- a/src/qubx/data/storages/multi.py
+++ b/src/qubx/data/storages/multi.py
@@ -10,6 +10,7 @@ from qubx.core.basics import DataType
 from qubx.data.containers import RawData, RawMultiData
 from qubx.data.registry import storage
 from qubx.data.storage import IReader, IStorage
+from qubx.rate_limiting import RateLimitGateTimeout
 from qubx.utils.time import to_timedelta
 
 
@@ -459,24 +460,28 @@ class MultiStorage(IStorage):
 
     def get_reader(self, exchange: str, market: str) -> IReader:
         key = (exchange, market)
-        if key not in self._reader_cache:
-            readers: list[IReader] = []
-            for s in self._storages:
-                try:
-                    readers.append(s.get_reader(exchange, market))
-                except Exception as e:
-                    # the reader set is cached for the run, so a transient failure here (e.g. a rate
-                    # limit gate timeout) drops that storage for good — say so rather than swallow it
-                    logger.warning(f"{s.__class__.__name__} has no reader for {exchange}:{market}: {e}")
-            if not readers:
-                raise ValueError(
-                    f"No reader available for {exchange}:{market} in any of the {len(self._storages)} storages"
-                )
-            # - single reader: return directly; multiple: wrap in MultiReader
-            self._reader_cache[key] = (
-                MultiReader(readers, tolerance=self._tolerance, keep=self._keep) if len(readers) > 1 else readers[0]
-            )
-        return self._reader_cache[key]
+        if key in self._reader_cache:
+            return self._reader_cache[key]
+
+        readers: list[IReader] = []
+        transient = False
+        for s in self._storages:
+            try:
+                readers.append(s.get_reader(exchange, market))
+            except RateLimitGateTimeout as e:
+                # the venue is throttling us, not telling us this storage lacks the data
+                transient = True
+                logger.warning(f"{s.__class__.__name__} rate limited for {exchange}:{market}: {e}")
+            except Exception as e:
+                logger.debug(f"{s.__class__.__name__} has no reader for {exchange}:{market}: {e}")
+        if not readers:
+            raise ValueError(f"No reader available for {exchange}:{market} in any of the {len(self._storages)} storages")
+
+        reader = MultiReader(readers, tolerance=self._tolerance, keep=self._keep) if len(readers) > 1 else readers[0]
+        # caching a set built while a storage was throttled would drop it for the whole run
+        if not transient:
+            self._reader_cache[key] = reader
+        return reader
 
     def close(self) -> None:
         for reader in self._reader_cache.values():

--- a/src/qubx/data/storages/multi.py
+++ b/src/qubx/data/storages/multi.py
@@ -464,8 +464,10 @@ class MultiStorage(IStorage):
             for s in self._storages:
                 try:
                     readers.append(s.get_reader(exchange, market))
-                except Exception:
-                    pass
+                except Exception as e:
+                    # the reader set is cached for the run, so a transient failure here (e.g. a rate
+                    # limit gate timeout) drops that storage for good — say so rather than swallow it
+                    logger.warning(f"{s.__class__.__name__} has no reader for {exchange}:{market}: {e}")
             if not readers:
                 raise ValueError(
                     f"No reader available for {exchange}:{market} in any of the {len(self._storages)} storages"

--- a/src/qubx/rate_limiting/backend.py
+++ b/src/qubx/rate_limiting/backend.py
@@ -46,11 +46,12 @@ class IRateLimitBackend(ABC):
         """
 
     @abstractmethod
-    async def set_remaining(self, key: str, remaining: float) -> None:
+    async def set_remaining(self, key: str, remaining: float, capacity: float = 0, refill_rate: float = 0) -> None:
         """Force-set remaining tokens (for syncing with exchange-reported state).
 
         Used when exchange headers/responses tell us the actual remaining budget,
-        correcting any drift in our model.
+        correcting any drift in our model. `capacity`/`refill_rate` let a header that
+        arrives before the first acquire create the bucket.
         """
 
 
@@ -81,8 +82,10 @@ class InMemoryBackend(IRateLimitBackend):
             return None
         return limiter.get_available_tokens()
 
-    async def set_remaining(self, key: str, remaining: float) -> None:
+    async def set_remaining(self, key: str, remaining: float, capacity: float = 0, refill_rate: float = 0) -> None:
         limiter = self._limiters.get(key)
-        if limiter is not None:
-            limiter._tokens = remaining
-            limiter._last_refill = time.monotonic()
+        if limiter is None:
+            if capacity <= 0:
+                return
+            limiter = self._get_or_create(key, capacity, refill_rate)
+        limiter.set_tokens(remaining)

--- a/src/qubx/rate_limiting/config.py
+++ b/src/qubx/rate_limiting/config.py
@@ -15,11 +15,16 @@ class PoolConfig:
     A pool represents one independent rate limit enforced by the exchange.
     Exchanges typically have multiple pools (e.g., request weight + order count).
 
+    `capacity`/`refill_rate` are denominated in the unit the venue itself reports: request weight for
+    the Binance family (`X-MBX-USED-WEIGHT-1M`), ccxt cost elsewhere (a budget of
+    `1000 / exchange.rateLimit` units per second). No conversion is applied — the raw ccxt cost is
+    charged as-is.
+
     Args:
         name: Pool identifier (e.g., "request_weight", "orders", "sendtx")
         scope: What the limit is scoped to: "ip", "account", "address", or "local"
         capacity: Maximum tokens in the bucket
-        refill_rate: Tokens replenished per second (0 for quota pools)
+        refill_rate: Tokens replenished per second (0 for quota pools; rate pools require > 0)
         pool_type: "rate" for time-based refill, "quota" for externally-managed
         cooldown: Seconds to close gate when rate limit is hit
     """

--- a/src/qubx/rate_limiting/config.py
+++ b/src/qubx/rate_limiting/config.py
@@ -63,12 +63,13 @@ class ExchangeRateLimitConfig:
         pools: Named pool configurations
         endpoint_map: Maps endpoint names to their costs across pools
         default_costs: Fallback costs for unmapped endpoints
-        gate_max_wait: Max seconds to wait for a closed gate before raising timeout
+        gate_max_wait: Max seconds to wait for a closed gate before raising timeout. Must exceed the
+            longest pool cooldown, or a single reported 429 times out every waiter by construction.
         metrics_interval: Seconds between metric emissions (0 to disable)
     """
 
     pools: dict[str, PoolConfig] = field(default_factory=dict)
     endpoint_map: dict[str, EndpointCosts] = field(default_factory=dict)
     default_costs: EndpointCosts = field(default_factory=lambda: EndpointCosts([]))
-    gate_max_wait: float = 15.0
+    gate_max_wait: float = 35.0
     metrics_interval: float = 60.0

--- a/src/qubx/rate_limiting/engine.py
+++ b/src/qubx/rate_limiting/engine.py
@@ -6,6 +6,7 @@ behavior (gate management, acquisition, sync) to polymorphic pool objects.
 
 import asyncio
 import time
+import uuid
 from typing import Any
 
 from qubx import logger
@@ -14,6 +15,11 @@ from .backend import InMemoryBackend, IRateLimitBackend
 from .config import ExchangeRateLimitConfig
 from .pools import BasePool, QuotaPool, RatePool
 from .pools import RateLimitGateTimeout as RateLimitGateTimeout  # re-export
+
+# Fallback for a scope we cannot identify. Per-process, not a shared literal: an unknown identity is
+# no evidence of a shared one, and a shared literal collapses every bot on a shared backend onto one
+# bucket — 1/N of the budget each.
+_UNRESOLVED_SCOPE_ID = f"local_{uuid.uuid4().hex[:12]}"
 
 
 class ExchangeRateLimiter:
@@ -62,10 +68,16 @@ class ExchangeRateLimiter:
         backend = backend or InMemoryBackend()
         self._pools: dict[str, BasePool] = {}
         for pool_name, pool_config in config.pools.items():
-            scope_id = self._scope_ids.get(pool_config.scope, "local")
+            scope_id = self._scope_ids.get(pool_config.scope, _UNRESOLVED_SCOPE_ID)
             if pool_config.pool_type == "quota":
                 self._pools[pool_name] = QuotaPool(pool_config, exchange, scope_id)
             else:
+                if pool_config.refill_rate <= 0:
+                    # the token bucket divides a deficit by it
+                    raise ValueError(
+                        f"{exchange}: rate pool '{pool_name}' has refill_rate={pool_config.refill_rate}; "
+                        "rate pools require refill_rate > 0 (use pool_type='quota' for externally-managed pools)"
+                    )
                 self._pools[pool_name] = RatePool(pool_config, exchange, scope_id, backend)
 
     @property
@@ -265,6 +277,7 @@ class ExchangeRateLimiter:
                 {"name": "rate_limit.gate_closed", "value": 1.0 if state["gate_closed"] else 0.0, "tags": {**tags}}
             )
             metrics.append({"name": "rate_limit.hits", "value": float(state["hits"]), "tags": {**tags}})
+            metrics.append({"name": "rate_limit.gate_timeouts", "value": float(state["timeouts"]), "tags": {**tags}})
             metrics.append({"name": "rate_limit.wait_seconds", "value": state["total_wait_s"], "tags": {**tags}})
             metrics.append({"name": "rate_limit.consumed", "value": state["consumed"], "tags": {**tags}})
 

--- a/src/qubx/rate_limiting/ip_resolver.py
+++ b/src/qubx/rate_limiting/ip_resolver.py
@@ -66,12 +66,12 @@ class EgressIPResolver:
         return None
 
     async def start(self) -> None:
-        """Start periodic IP discovery."""
-        # Do initial discovery
-        ip = await self.discover()
-        if ip:
-            self._current_ip = ip
-            logger.info(f"Egress IP discovered: {ip}")
+        """Start periodic IP discovery, probing only when no IP is known yet."""
+        if self._current_ip is None:
+            ip = await self.discover()
+            if ip:
+                self._current_ip = ip
+                logger.info(f"Egress IP discovered: {ip}")
 
         # Start monitoring loop
         self._task = asyncio.ensure_future(self._monitor_loop())

--- a/src/qubx/rate_limiting/manager.py
+++ b/src/qubx/rate_limiting/manager.py
@@ -7,10 +7,11 @@ and per-exchange rate limiter creation via the connector registry.
 
 import asyncio
 import concurrent.futures
+import hashlib
 
 from qubx import logger
 
-from .backend import IRateLimitBackend, InMemoryBackend
+from .backend import InMemoryBackend, IRateLimitBackend
 from .engine import ExchangeRateLimiter
 
 
@@ -40,6 +41,10 @@ class RateLimitManager:
         if config is None:
             self._backend = None
             self._egress_ip = None
+            logger.warning(
+                "Rate limiting is DISABLED (no live.rate_limiting section) — venue calls are not governed by "
+                "Qubx rate limiting (ccxt's own throttler still paces REST, each ws client keeps its throttler)"
+            )
             return
 
         # Create backend
@@ -93,7 +98,9 @@ class RateLimitManager:
         for rl in self._rate_limiters.values():
             rl.update_scope_id("ip", f"ip_{new_ip}")
 
-    def get_or_create(self, exchange_name: str, connector_name: str) -> ExchangeRateLimiter | None:
+    def get_or_create(
+        self, exchange_name: str, connector_name: str, api_key: str | None = None
+    ) -> ExchangeRateLimiter | None:
         """Get or create a rate limiter for an exchange.
 
         Uses the connector registry to find the rate limit config factory.
@@ -101,6 +108,8 @@ class RateLimitManager:
         Args:
             exchange_name: Exchange name (e.g., "LIGHTER", "BINANCE.UM")
             connector_name: Connector type (e.g., "xlighter", "ccxt")
+            api_key: Venue API key, used only to derive the account scope id. Without it
+                account-scoped pools fall back to a per-process id (see engine.py).
 
         Returns:
             ExchangeRateLimiter or None if rate limiting is disabled or no config registered
@@ -120,6 +129,9 @@ class RateLimitManager:
         scope_ids = {}
         if self._egress_ip:
             scope_ids["ip"] = f"ip_{self._egress_ip}"
+        if api_key:
+            # hashed so the raw key never reaches a Redis key, a log line or a metric tag
+            scope_ids["account"] = f"acct_{hashlib.sha256(api_key.encode()).hexdigest()[:16]}"
 
         rate_limiter = ExchangeRateLimiter(
             exchange_name.lower(),

--- a/src/qubx/rate_limiting/manager.py
+++ b/src/qubx/rate_limiting/manager.py
@@ -41,7 +41,9 @@ class RateLimitManager:
         if config is None:
             self._backend = None
             self._egress_ip = None
-            logger.warning(
+            # INFO, not WARNING: no rate_limiting section is the default for most configs, and a
+            # warning on the common case just trains people to ignore warnings
+            logger.info(
                 "Rate limiting is DISABLED (no live.rate_limiting section) — venue calls are not governed by "
                 "Qubx rate limiting (ccxt's own throttler still paces REST, each ws client keeps its throttler)"
             )

--- a/src/qubx/rate_limiting/pools.py
+++ b/src/qubx/rate_limiting/pools.py
@@ -6,12 +6,16 @@ polymorphically — no pool_type branching in the engine.
 """
 
 import asyncio
+import math
+import time
 from typing import Any
 
 from qubx import logger
 
 from .backend import IRateLimitBackend
 from .config import PoolConfig
+
+_GATE_POLL_S = 0.25  # bounds only how late an early reopen (reset_gate / quota sync) is noticed
 
 
 class RateLimitGateTimeout(Exception):
@@ -23,18 +27,21 @@ class RateLimitGateTimeout(Exception):
 
 
 class BasePool:
-    """Base pool with gate mechanism and metrics tracking."""
+    """Base pool with gate mechanism and metrics tracking.
+
+    The gate is a monotonic deadline rather than an event, so it is observable and settable from
+    any thread or event loop without binding to one.
+    """
 
     def __init__(self, config: PoolConfig, exchange: str, scope_id: str):
         self._config = config
         self._exchange = exchange
         self._scope_id = scope_id
-        self._gate = asyncio.Event()
-        self._gate.set()
-        self._gate_task: asyncio.Task | None = None
+        self._gate_until: float = 0.0
         self.hits: int = 0
         self.total_wait: float = 0
         self.consumed: float = 0
+        self.timeouts: int = 0
 
     @property
     def name(self) -> str:
@@ -50,7 +57,7 @@ class BasePool:
 
     @property
     def is_gate_closed(self) -> bool:
-        return not self._gate.is_set()
+        return time.monotonic() < self._gate_until
 
     def update_scope_id(self, scope_id: str) -> None:
         self._scope_id = scope_id
@@ -59,23 +66,33 @@ class BasePool:
         raise NotImplementedError
 
     def close_gate(self, cooldown: float, reason: str) -> None:
-        raise NotImplementedError
+        verb = "extended" if self.is_gate_closed else "closed"
+        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name} ({cooldown:.1f}s): {reason}")
+        self._gate_until = max(self._gate_until, time.monotonic() + cooldown)
 
     def sync(self, remaining: float, capacity: float | None = None) -> None:
         raise NotImplementedError
 
     def reset_gate(self) -> None:
-        """Reopen gate and cancel any pending reopen task."""
-        self._gate.set()
-        self._cancel_gate_task()
+        self._gate_until = 0.0
 
     async def get_state(self) -> dict[str, Any]:
         raise NotImplementedError
 
-    def _cancel_gate_task(self) -> None:
-        if self._gate_task is not None and not self._gate_task.done():
-            self._gate_task.cancel()
-        self._gate_task = None
+    async def _wait_for_gate(self, gate_max_wait: float) -> None:
+        give_up_at = time.monotonic() + gate_max_wait
+        waited = False
+        while (now := time.monotonic()) < self._gate_until:
+            if now >= give_up_at:
+                self.timeouts += 1
+                raise RateLimitGateTimeout(
+                    f"{self._exchange}: gate for pool '{self.name}' did not reopen within {gate_max_wait:.0f}s",
+                    pool_name=self.name,
+                )
+            waited = True
+            await asyncio.sleep(min(self._gate_until - now, give_up_at - now, _GATE_POLL_S))
+        if waited:
+            logger.info(f"Rate limit gate reopened for {self._exchange}:{self.name}")
 
     def _base_state(self, remaining: float, capacity: float) -> dict[str, Any]:
         return {
@@ -91,11 +108,12 @@ class BasePool:
             "hits": self.hits,
             "total_wait_s": self.total_wait,
             "consumed": self.consumed,
+            "timeouts": self.timeouts,
         }
 
 
 class RatePool(BasePool):
-    """Time-based token bucket pool. Gate reopens on timer after cooldown."""
+    """Time-based token bucket pool. Gate reopens once the cooldown deadline passes."""
 
     def __init__(self, config: PoolConfig, exchange: str, scope_id: str, backend: IRateLimitBackend):
         super().__init__(config, exchange, scope_id)
@@ -110,39 +128,26 @@ class RatePool(BasePool):
         self._key = self._make_key()
 
     async def acquire(self, weight: float, gate_max_wait: float) -> None:
-        if not self._gate.is_set():
-            try:
-                await asyncio.wait_for(self._gate.wait(), timeout=gate_max_wait)
-            except asyncio.TimeoutError:
-                raise RateLimitGateTimeout(
-                    f"{self._exchange}: gate for pool '{self.name}' did not reopen "
-                    f"within {gate_max_wait:.0f}s",
-                    pool_name=self.name,
-                ) from None
+        if weight > self._config.capacity:
+            # a weight no bucket can ever hold never completes: the Redis backend retries forever
+            logger.warning(
+                f"Rate limit {self._exchange}:{self.name}: weight {weight} exceeds capacity "
+                f"{self._config.capacity}, clamping"
+            )
+            weight = self._config.capacity
+
+        await self._wait_for_gate(gate_max_wait)
 
         wait_time = await self._backend.acquire(self._key, weight, self._config.capacity, self._config.refill_rate)
         self.total_wait += wait_time
         self.consumed += weight
 
-    def close_gate(self, cooldown: float, reason: str) -> None:
-        verb = "extended" if not self._gate.is_set() else "closed"
-        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name} ({cooldown:.1f}s): {reason}")
-        self._gate.clear()
-        self._cancel_gate_task()
-        self._gate_task = asyncio.ensure_future(self._reopen_after(cooldown))
-
-    async def _reopen_after(self, delay: float) -> None:
-        try:
-            await asyncio.sleep(delay)
-            self._gate.set()
-            logger.info(f"Rate limit gate reopened for {self._exchange}:{self.name} after {delay:.1f}s")
-        except asyncio.CancelledError:
-            pass
-
     def sync(self, remaining: float, capacity: float | None = None) -> None:
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(self._backend.set_remaining(self._key, remaining))
+            loop.create_task(
+                self._backend.set_remaining(self._key, remaining, self._config.capacity, self._config.refill_rate)
+            )
         except RuntimeError:
             pass  # No running loop — skip sync (e.g., during shutdown)
 
@@ -165,9 +170,10 @@ class QuotaPool(BasePool):
         return self._remaining
 
     async def acquire(self, weight: float, gate_max_wait: float) -> None:
-        if not self._gate.is_set() or self._remaining <= 0:
+        if self.is_gate_closed or self._remaining <= 0:
             if self._remaining <= 0:
                 self.close_gate(self._config.cooldown, "quota depleted")
+            self.timeouts += 1
             raise RateLimitGateTimeout(
                 f"{self._exchange}: quota pool '{self.name}' depleted",
                 pool_name=self.name,
@@ -176,10 +182,9 @@ class QuotaPool(BasePool):
         self.consumed += weight
 
     def close_gate(self, cooldown: float, reason: str) -> None:
-        verb = "extended" if not self._gate.is_set() else "closed"
-        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name} ({cooldown:.1f}s): {reason}")
-        self._gate.clear()
-        self._cancel_gate_task()
+        verb = "extended" if self.is_gate_closed else "closed"
+        logger.warning(f"Rate limit gate {verb} for {self._exchange}:{self.name}: {reason}")
+        self._gate_until = math.inf  # no timer can reopen a quota gate, only the exchange can
 
     def sync(self, remaining: float, capacity: float | None = None) -> None:
         self._remaining = remaining
@@ -190,12 +195,9 @@ class QuotaPool(BasePool):
             # real account quota (best approximation when exchange only reports remaining)
             if capacity is None:
                 self._config.capacity = max(self._config.capacity, remaining)
-            if not self._gate.is_set():
-                self._cancel_gate_task()
-                self._gate.set()
-                logger.info(
-                    f"Rate limit gate reopened for {self._exchange}:{self.name} (remaining={remaining})"
-                )
+            if self.is_gate_closed:
+                self._gate_until = 0.0
+                logger.info(f"Rate limit gate reopened for {self._exchange}:{self.name} (remaining={remaining})")
 
     async def get_state(self) -> dict[str, Any]:
         return self._base_state(self._remaining, self._config.capacity)

--- a/src/qubx/rate_limiting/pools.py
+++ b/src/qubx/rate_limiting/pools.py
@@ -119,6 +119,7 @@ class RatePool(BasePool):
         super().__init__(config, exchange, scope_id)
         self._backend = backend
         self._key = self._make_key()
+        self._sync_tasks: set[asyncio.Task] = set()
 
     def _make_key(self) -> str:
         return f"ratelimit:{self._exchange}:{self._config.name}:{self._scope_id}"
@@ -145,11 +146,20 @@ class RatePool(BasePool):
     def sync(self, remaining: float, capacity: float | None = None) -> None:
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(
-                self._backend.set_remaining(self._key, remaining, self._config.capacity, self._config.refill_rate)
-            )
         except RuntimeError:
-            pass  # No running loop — skip sync (e.g., during shutdown)
+            return  # no running loop — skip sync (e.g. during shutdown)
+        task = loop.create_task(
+            self._backend.set_remaining(self._key, remaining, self._config.capacity, self._config.refill_rate)
+        )
+        # keep a reference so the task cannot be collected mid-flight, and retrieve its result:
+        # a header sync fires per response, so an unretrieved Redis error would log on every one
+        self._sync_tasks.add(task)
+        task.add_done_callback(self._on_sync_done)
+
+    def _on_sync_done(self, task: asyncio.Task) -> None:
+        self._sync_tasks.discard(task)
+        if not task.cancelled() and (exc := task.exception()) is not None:
+            logger.debug(f"Rate limit sync failed for {self._exchange}:{self.name}: {exc}")
 
     async def get_state(self) -> dict[str, Any]:
         remaining = await self._backend.get_remaining(self._key, self._config.capacity, self._config.refill_rate)

--- a/src/qubx/rate_limiting/redis_backend.py
+++ b/src/qubx/rate_limiting/redis_backend.py
@@ -135,6 +135,7 @@ class RedisBackend(IRateLimitBackend):
     async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
         acquire_script, _, _ = self._scripts_for_current_loop()
         now = time.time()
+        waited = 0.0
         while True:
             wait_ms = await acquire_script(
                 keys=[key],
@@ -142,10 +143,11 @@ class RedisBackend(IRateLimitBackend):
             )
             wait_ms = float(wait_ms)
             if wait_ms <= 0:
-                return 0.0
+                return waited
             # Need to wait — sleep and retry
             wait_s = wait_ms / 1000.0
             await asyncio.sleep(wait_s)
+            waited += wait_s
             now = time.time()
 
     async def get_remaining(self, key: str, capacity: float = 0, refill_rate: float = 0) -> float | None:
@@ -160,7 +162,8 @@ class RedisBackend(IRateLimitBackend):
             return None
         return result / 1000.0  # convert millitokens back
 
-    async def set_remaining(self, key: str, remaining: float) -> None:
+    async def set_remaining(self, key: str, remaining: float, capacity: float = 0, refill_rate: float = 0) -> None:
+        # the Lua script creates the key unconditionally, so bucket parameters are not needed here
         _, _, set_remaining_script = self._scripts_for_current_loop()
         now = time.time()
         await set_remaining_script(

--- a/src/qubx/utils/rate_limiter.py
+++ b/src/qubx/utils/rate_limiter.py
@@ -6,6 +6,7 @@ across different exchange connectors to comply with API rate limits.
 """
 
 import asyncio
+import threading
 import time
 from functools import wraps
 from typing import Callable, Optional
@@ -40,7 +41,10 @@ class TokenBucketRateLimiter:
 
         self._tokens = float(capacity)
         self._last_refill = time.monotonic()
-        self._lock = asyncio.Lock()
+        self._inflight = 0.0  # reserved by tasks still sleeping, i.e. not yet visible to the venue
+        # threading, not asyncio: the same limiter is shared by the runner loop and the
+        # storage/warmup background loops, which live on different threads
+        self._lock = threading.Lock()
 
     def _refill_tokens(self) -> None:
         """Refill tokens based on elapsed time since last refill."""
@@ -54,53 +58,67 @@ class TokenBucketRateLimiter:
 
     async def acquire(self, weight: float = 1.0) -> None:
         """
-        Acquire tokens from the bucket.
+        Reserve `weight` tokens, then sleep off any deficit.
 
-        If not enough tokens are available, waits until sufficient tokens
-        have been refilled.
+        Tokens may go negative: the reservation is taken under the lock so concurrent acquirers get
+        distinct increasing deadlines, and the sleep happens outside it so a waiter never blocks a
+        caller that still has budget.
+
+        A free call (weight 0, e.g. ccxt prices Kraken orders that way) must not queue behind an
+        existing deficit, so it returns before the reservation is taken.
+
+        A task cancelled mid-sleep leaks its reservation — refill absorbs it.
 
         Args:
             weight: Number of tokens to acquire (default: 1.0)
-
-        Raises:
-            ValueError: If weight exceeds bucket capacity
         """
+        if weight <= 0:
+            return
         if weight > self.capacity:
-            raise ValueError(f"Requested weight {weight} exceeds bucket capacity {self.capacity} for {self.name}")
+            logger.warning(f"Rate limiter {self.name}: weight {weight} exceeds capacity {self.capacity}, clamping")
+            weight = self.capacity
 
-        async with self._lock:
-            while True:
-                # Refill tokens based on elapsed time
-                self._refill_tokens()
+        with self._lock:
+            self._refill_tokens()
+            self._tokens -= weight
+            deficit = -self._tokens
+            if deficit > 0:
+                self._inflight += weight
 
-                # Check if we have enough tokens
-                if self._tokens >= weight:
-                    self._tokens -= weight
-                    return
+        if deficit <= 0:
+            return
 
-                # Calculate wait time for sufficient tokens
-                tokens_needed = weight - self._tokens
-                wait_time = tokens_needed / self.refill_rate
+        wait_time = deficit / self.refill_rate
+        if wait_time > 1.0:
+            logger.debug(
+                f"Rate limiter {self.name}: waiting {wait_time:.2f}s (deficit {deficit:.1f}, {self.refill_rate}/s)"
+            )
+        try:
+            await asyncio.sleep(wait_time)
+        finally:
+            with self._lock:
+                self._inflight = max(0.0, self._inflight - weight)
 
-                # Log warning for significant delays
-                if wait_time > 1.0:
-                    logger.debug(
-                        f"Rate limiter {self.name}: waiting {wait_time:.2f}s "
-                        f"(need {tokens_needed:.1f} tokens, refill rate: {self.refill_rate}/s)"
-                    )
+    def set_tokens(self, tokens: float) -> None:
+        """Pin to an exchange-reported level, keeping outstanding reservations owed.
 
-                # Release lock while waiting to allow other tasks to check
-                await asyncio.sleep(wait_time)
+        The venue has not yet seen the requests sleeping tasks reserved for, so its reported
+        remaining is reduced by them.
+        """
+        with self._lock:
+            self._tokens = min(self.capacity, tokens) - self._inflight
+            self._last_refill = time.monotonic()
 
     def get_available_tokens(self) -> float:
         """
         Get current number of available tokens (non-blocking).
 
         Returns:
-            Current token count
+            Current token count, 0 while outstanding reservations are still owed
         """
-        self._refill_tokens()
-        return self._tokens
+        with self._lock:
+            self._refill_tokens()
+            return max(0.0, self._tokens)
 
 
 class RateLimiterRegistry:

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -539,7 +539,13 @@ def create_strategy_context(
                 f"Exchange {venue_name} maps to canonical exchange {exchange_name}, "
                 "which is already configured — configure only one of them"
             )
-        rate_limiter = _rl_manager.get_or_create(venue_name, exchange_config.connector)
+        try:
+            # scopes account pools to this account; data-only venues have no entry and fall back
+            # to a per-process scope id rather than sharing one bucket across unrelated accounts
+            _venue_api_key = account_manager.get_exchange_credentials(venue_name).api_key
+        except KeyError:
+            _venue_api_key = None
+        rate_limiter = _rl_manager.get_or_create(venue_name, exchange_config.connector, api_key=_venue_api_key)
         _exchange_to_tcc[exchange_name] = (tcc := _create_tcc(exchange_name, venue_name, account_manager))
         # Both paper and live use a REAL market-data provider (live quotes/OHLC); only paper's
         # *execution* is simulated. The data provider may come from a different source than the

--- a/tests/integration/rate_limiting/test_redis_backend.py
+++ b/tests/integration/rate_limiting/test_redis_backend.py
@@ -13,6 +13,8 @@ import threading
 
 import pytest
 
+from qubx.rate_limiting.config import PoolConfig
+from qubx.rate_limiting.pools import RatePool
 from qubx.rate_limiting.redis_backend import RedisBackend
 
 
@@ -89,7 +91,7 @@ class TestRedisBackendCrossLoop:
         key = "qubx:test:rl:get_set"
 
         async def write():
-            await backend.set_remaining(key, remaining=42.0)
+            await backend.set_remaining(key, remaining=42.0, capacity=100.0, refill_rate=0.0)
 
         async def read() -> float | None:
             return await backend.get_remaining(key, capacity=100.0, refill_rate=0.0)
@@ -107,3 +109,43 @@ class TestRedisBackendCrossLoop:
             second.close()
 
         assert remaining == pytest.approx(42.0, abs=0.5)
+
+
+@pytest.mark.integration
+class TestRedisBackendWaitTime:
+    def test_acquire_returns_the_time_it_actually_slept(self, redis_service, clear_rate_limit_keys):
+        """R4: `rate_limit.wait_seconds` is the only visibility into a deficit stall."""
+        backend = RedisBackend(redis_service)
+        key = "qubx:test:rl:wait_time"
+
+        async def run() -> tuple[float, float]:
+            immediate = await backend.acquire(key, weight=10.0, capacity=10.0, refill_rate=10.0)
+            delayed = await backend.acquire(key, weight=5.0, capacity=10.0, refill_rate=10.0)
+            return immediate, delayed
+
+        loop = asyncio.new_event_loop()
+        try:
+            immediate, delayed = loop.run_until_complete(run())
+        finally:
+            loop.close()
+
+        assert immediate == 0.0  # negative control: an unblocked acquire reports no wait
+        assert delayed > 0.0
+
+    def test_oversized_weight_does_not_retry_forever(self, redis_service, clear_rate_limit_keys):
+        """R3: RatePool clamps before the backend's unbounded retry loop ever sees the weight."""
+        pool = RatePool(
+            PoolConfig("rest", "ip", capacity=10, refill_rate=10.0),
+            "test",
+            "oversized",
+            backend=RedisBackend(redis_service),
+        )
+        pool._key = "qubx:test:rl:oversized"  # keep the bucket inside the cleanup fixture's namespace
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(asyncio.wait_for(pool.acquire(1e6, gate_max_wait=1.0), timeout=10.0))
+        finally:
+            loop.close()
+
+        assert pool.consumed == 10.0

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
@@ -46,6 +46,7 @@ from qubx.core.events import (
     OrderRejectedEvent,
 )
 from qubx.core.series import Quote
+from qubx.rate_limiting import RateLimitGateTimeout
 from tests.qubx.core.utils_test import DummyTimeProvider
 
 CCXT_SYMBOL = "BTC/USDT:USDT"
@@ -82,6 +83,7 @@ def _make_connector(
 
     em = Mock()
     em.exchange = exchange
+    em.rate_limiter = None
 
     dp = Mock()
     dp.get_quote = Mock(return_value=_quote())
@@ -338,6 +340,72 @@ async def test_request_snapshot_failed_leg_left_none() -> None:
     assert snap.open_orders == []
     assert snap.positions is None  # failed leg omitted, not wiped
     assert len(snap.balances) == 1
+
+
+@pytest.fixture
+def warnings_logged():
+    records: list = []
+    sink_id = logger.add(lambda m: records.append(m.record), level="WARNING")
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
+
+
+def _positions_leg_warnings(records: list) -> list[str]:
+    return [r["message"] for r in records if "fetch_positions failed" in r["message"]]
+
+
+def _snapshot_exchange(positions_error: BaseException) -> Mock:
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.fetch_open_orders = AsyncMock(return_value=[_ws_order(status="open", cid="qubx_x", venue_id="V1")])
+    exchange.fetch_positions = AsyncMock(side_effect=positions_error)
+    exchange.fetch_balance = AsyncMock(return_value={"total": {"USDT": 7.0}, "used": {"USDT": 1.0}})
+    exchange.markets = {}
+    return exchange
+
+
+@pytest.mark.asyncio
+async def test_request_snapshot_positions_gate_timeout_left_none(warnings_logged) -> None:
+    # A rate-limit gate timeout is a leg failure like any other: positions omitted, the other legs
+    # still populated. The WARNING must name the exception type — operators need to tell
+    # "we throttled ourselves" apart from "the venue is down".
+    exchange = _snapshot_exchange(RateLimitGateTimeout("gate did not reopen within 30s", pool_name="ccxt_rest"))
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.request_snapshot()
+    await _drive(conn)
+
+    snap = sent[0].snapshot
+    assert snap.positions is None
+    assert [o.venue_order_id for o in snap.open_orders] == ["V1"]
+    assert len(snap.balances) == 1
+
+    messages = _positions_leg_warnings(warnings_logged)
+    assert len(messages) == 1, messages
+    assert "RateLimitGateTimeout" in messages[0]
+
+
+@pytest.mark.asyncio
+async def test_request_snapshot_positions_network_error_warning_is_generic(warnings_logged) -> None:
+    # negative control for the test above: a venue outage produces the same shape without the
+    # rate-limit wording, so the two are distinguishable from the log alone
+    exchange = _snapshot_exchange(ccxt.NetworkError("boom"))
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.request_snapshot()
+    await _drive(conn)
+
+    snap = sent[0].snapshot
+    assert snap.positions is None
+    assert [o.venue_order_id for o in snap.open_orders] == ["V1"]
+    assert len(snap.balances) == 1
+
+    messages = _positions_leg_warnings(warnings_logged)
+    assert len(messages) == 1, messages
+    assert "NetworkError" in messages[0]
+    assert "RateLimitGateTimeout" not in messages[0]
 
 
 @pytest.mark.asyncio

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -13,6 +13,7 @@ import ccxt
 import pytest
 
 from qubx.connectors.ccxt.connector import CcxtConnector, _LeverageInfo
+from qubx.connectors.ccxt.rate_limits import _default_endpoint_costs
 from qubx.core.basics import (
     CtrlChannel,
     Instrument,
@@ -35,6 +36,7 @@ from qubx.core.events import (
 )
 from qubx.core.exceptions import BadRequest, InvalidOrderParameters
 from qubx.core.series import Quote
+from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, ExchangeRateLimiter, PoolConfig
 from tests.qubx.core.utils_test import DummyTimeProvider
 
 
@@ -62,6 +64,7 @@ def _make_connector(
     *,
     exchange: Mock | None = None,
     data_provider: Mock | None = None,
+    rate_limiter: ExchangeRateLimiter | None = None,
 ) -> tuple[CcxtConnector, list, Mock]:
     """Build a connector with a capturing channel and a mocked exchange.
 
@@ -78,6 +81,7 @@ def _make_connector(
 
     em = Mock()
     em.exchange = exchange
+    em.rate_limiter = rate_limiter
 
     if data_provider is None:
         data_provider = Mock()
@@ -474,6 +478,8 @@ async def test_cancel_venue_reject_emits_cancel_rejected() -> None:
     assert isinstance(sent[0], OrderCancelRejectedEvent)
     assert sent[0].client_order_id == "qubx_BTCUSDT_1"
     assert sent[0].venue_order_id == "VENUE123"  # both ids carried so AM routes by either
+    # negative control for the gate-timeout cancel: only a rate-limited reject is coded
+    assert sent[0].code is None
 
 
 @pytest.mark.asyncio
@@ -891,5 +897,292 @@ def test_reads_none_inf_when_no_position() -> None:
     assert conn.get_max_instrument_notional(_instrument()) == float("inf")
     assert conn.get_margin_mode(_instrument()) is None
     assert conn.get_adl_level(_instrument()) is None
+
+
+# (11) order-count budget — every write charges the account-scoped `orders` pool
+_ORDERS_CAPACITY = 5
+
+
+@pytest.fixture
+def order_limiter():
+    """Real limiter (in-memory backend) with a small account-scoped ``orders`` pool.
+
+    ``cooldown`` sits far above ``gate_max_wait`` so a gate closed by a 429 is still closed
+    when the acquire gives up — otherwise the timeout path would be unobservable.
+    """
+    config = ExchangeRateLimitConfig(
+        pools={
+            "ccxt_rest": PoolConfig("ccxt_rest", "ip", 100, 100.0, cooldown=5.0),
+            "orders": PoolConfig("orders", "account", _ORDERS_CAPACITY, 1.0, cooldown=5.0),
+        },
+        endpoint_map=_default_endpoint_costs(),
+        default_costs=EndpointCosts([("ccxt_rest", 1)]),
+        gate_max_wait=0.05,
+    )
+    limiter = ExchangeRateLimiter("BINANCE.UM", config)
+    yield limiter
+    limiter.reset_gates()
+
+
+def _record_acquires(limiter: ExchangeRateLimiter, monkeypatch) -> list[str]:
+    """Record acquired endpoints while still draining the real pools."""
+    seen: list[str] = []
+    real_acquire = limiter.acquire
+
+    async def _recording(endpoint: str, **kw) -> None:
+        seen.append(endpoint)
+        await real_acquire(endpoint, **kw)
+
+    monkeypatch.setattr(limiter, "acquire", _recording)
+    return seen
+
+
+def _write_exchange() -> Mock:
+    """Exchange whose write calls all answer with a venue ack."""
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    del exchange.AMEND_QUANTITY_DIALECT
+    exchange.create_order = AsyncMock(
+        return_value={
+            "id": "VENUE123",
+            "clientOrderId": "qubx_BTCUSDT_1",
+            "status": "NEW",
+            "side": "buy",
+            "type": "limit",
+            "amount": 1.0,
+            "price": 100.0,
+            "timestamp": 1700000000000,
+            "cost": 0.0,
+            "timeInForce": "GTC",
+            "info": {},
+        }
+    )
+    exchange.cancel_order = AsyncMock(return_value={"id": "VENUE123", "clientOrderId": "qubx_BTCUSDT_1"})
+    exchange.edit_order = AsyncMock(return_value={"id": "VENUE123"})
+    return exchange
+
+
+class TestOrderRateLimiting:
+    """Order endpoints debit the account-scoped ``orders`` pool — nothing did before.
+
+    The IP weight of the same request is charged separately by the throttle override inside
+    ccxt's ``fetch2``, which is why these endpoints cost ``[("orders", 1)]`` and nothing else.
+    """
+
+    @pytest.mark.asyncio
+    async def test_submit_acquires_one_order_slot(self, order_limiter, monkeypatch) -> None:
+        acquires = _record_acquires(order_limiter, monkeypatch)
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        assert acquires == ["create_order"]
+        exchange.create_order.assert_awaited_once()
+        assert isinstance(sent[0], OrderAcceptedEvent)
+
+    @pytest.mark.asyncio
+    async def test_cancel_acquires_one_order_slot(self, order_limiter, monkeypatch) -> None:
+        acquires = _record_acquires(order_limiter, monkeypatch)
+        retrying = _write_exchange()
+        # one transient failure: an acquire inside _cancel_with_retry's loop would show up twice
+        retrying.cancel_order = AsyncMock(
+            side_effect=[
+                ccxt.NetworkError("connection reset"),
+                {"id": "VENUE123", "clientOrderId": "qubx_BTCUSDT_1"},
+            ]
+        )
+        conn, sent, exchange = _make_connector(exchange=retrying, rate_limiter=order_limiter)
+        conn.cancel_retry_interval = 0
+
+        conn.cancel_order(_order(venue_order_id="VENUE123"))
+        await _drive(conn)
+
+        assert exchange.cancel_order.await_count == 2
+        # one slot per cancel *operation*, not per retry inside _cancel_with_retry
+        assert acquires == ["cancel_order"]
+        assert isinstance(sent[0], OrderCanceledEvent)
+
+    @pytest.mark.asyncio
+    async def test_update_acquires_one_order_slot(self, order_limiter, monkeypatch) -> None:
+        acquires = _record_acquires(order_limiter, monkeypatch)
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+
+        conn.update_order(_order(venue_order_id="VENUE123"), price=102.0)
+        await _drive(conn)
+
+        assert acquires == ["edit_order"]
+        exchange.edit_order.assert_awaited_once()
+        assert isinstance(sent[0], OrderUpdatedEvent)
+
+    @pytest.mark.asyncio
+    async def test_submit_gate_timeout_rejects_without_calling_the_venue(self, order_limiter) -> None:
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        order_limiter.report_limit_hit(pool_name="orders", reason="venue 429")
+        assert order_limiter.is_gate_closed("orders")
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        exchange.create_order.assert_not_awaited()  # rejected before reaching the venue
+        assert len(sent) == 1
+        assert isinstance(sent[0], OrderRejectedEvent)
+        assert sent[0].code == "RateLimitGateTimeout"
+        assert "orders" in sent[0].reason
+
+    @pytest.mark.asyncio
+    async def test_cancel_gate_timeout_rejects_without_calling_the_venue(self, order_limiter) -> None:
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        order_limiter.report_limit_hit(pool_name="orders", reason="venue 429")
+
+        conn.cancel_order(_order(venue_order_id="VENUE123"))
+        await _drive(conn)
+
+        exchange.cancel_order.assert_not_awaited()
+        assert len(sent) == 1
+        assert isinstance(sent[0], OrderCancelRejectedEvent)
+        assert sent[0].reason.startswith("rate limited: ")
+        assert "orders" in sent[0].reason
+        # coded like submit/update, so a reject filter keyed on code catches rate-limited cancels
+        assert sent[0].code == "RateLimitGateTimeout"
+
+    @pytest.mark.asyncio
+    async def test_update_gate_timeout_rejects_without_calling_the_venue(self, order_limiter) -> None:
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        order_limiter.report_limit_hit(pool_name="orders", reason="venue 429")
+
+        conn.update_order(_order(venue_order_id="VENUE123"), price=102.0)
+        await _drive(conn)
+
+        exchange.edit_order.assert_not_awaited()
+        assert len(sent) == 1
+        assert isinstance(sent[0], OrderUpdateRejectedEvent)
+        assert sent[0].code == "RateLimitGateTimeout"
+
+    @pytest.mark.asyncio
+    async def test_closed_rest_gate_does_not_block_an_order(self, order_limiter, monkeypatch) -> None:
+        # A read-path 429 closes the IP gate; orders cost ``[("orders", 1)]`` only, so placement
+        # stays open. Pin it — widening that cost list must be a deliberate decision.
+        acquires = _record_acquires(order_limiter, monkeypatch)
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        order_limiter.report_limit_hit(pool_name="ccxt_rest", reason="read-path 429")
+        assert order_limiter.is_gate_closed("ccxt_rest")
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        assert acquires == ["create_order"]
+        exchange.create_order.assert_awaited_once()
+        assert isinstance(sent[0], OrderAcceptedEvent)
+
+    @pytest.mark.asyncio
+    async def test_no_rate_limiter_still_submits(self) -> None:
+        """Negative control: without a limiter the write path is untouched."""
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=None)
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        exchange.create_order.assert_awaited_once()
+        assert isinstance(sent[0], OrderAcceptedEvent)
+
+    @pytest.mark.asyncio
+    async def test_order_pool_is_actually_drained(self, order_limiter) -> None:
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+
+        for _ in range(3):
+            conn.submit_order(_order_request())
+        await _drive(conn)
+
+        assert exchange.create_order.await_count == 3
+        assert len(sent) == 3
+        state = await order_limiter.get_pool_state("orders")
+        assert state is not None
+        assert state["consumed"] == 3.0
+        assert state["remaining"] < _ORDERS_CAPACITY  # tokens really left the bucket
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            ccxt.RateLimitExceeded("binance -1015 too many new orders"),
+            ccxt.DDoSProtection("EOrder:Rate limit exceeded"),
+        ],
+        ids=["binance_-1015", "kraken_EOrder"],
+    )
+    async def test_venue_order_limit_closes_only_the_orders_gate(self, order_limiter, error) -> None:
+        """The pool is a proactive model: only the venue's own verdict reveals budget another actor
+        on the account spent. ccxt maps that verdict to two sibling types, so both need wiring.
+        """
+        conn, _sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        exchange.create_order = AsyncMock(side_effect=error)
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        assert order_limiter.is_gate_closed("orders")
+        assert not order_limiter.is_gate_closed("ccxt_rest"), "an order-budget breach says nothing about the IP pool"
+
+    @pytest.mark.asyncio
+    async def test_venue_order_limit_on_update_closes_the_orders_gate(self, order_limiter) -> None:
+        conn, _sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        exchange.edit_order = AsyncMock(side_effect=ccxt.RateLimitExceeded("binance -1015"))
+
+        conn.update_order(_order(venue_order_id="VENUE123"), price=102.0)
+        await _drive(conn)
+
+        assert order_limiter.is_gate_closed("orders")
+        assert not order_limiter.is_gate_closed("ccxt_rest")
+
+    @pytest.mark.asyncio
+    async def test_venue_order_limit_on_cancel_closes_the_orders_gate(self, order_limiter) -> None:
+        conn, _sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        exchange.cancel_order = AsyncMock(side_effect=ccxt.DDoSProtection("EOrder:Rate limit exceeded"))
+        conn.cancel_timeout = 0  # one attempt, no retry backoff
+
+        conn.cancel_order(_order(venue_order_id="VENUE123"))
+        await _drive(conn)
+
+        assert order_limiter.is_gate_closed("orders")
+        assert not order_limiter.is_gate_closed("ccxt_rest")
+
+    @pytest.mark.asyncio
+    async def test_reports_the_orders_pool_by_name_not_by_endpoint(self, order_limiter, monkeypatch) -> None:
+        """``endpoint=`` would close every pool in that endpoint's cost list, not just ``orders``."""
+        hits: list[dict] = []
+        monkeypatch.setattr(order_limiter, "report_limit_hit", lambda **kw: hits.append(kw))
+        conn, _sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        exchange.create_order = AsyncMock(side_effect=ccxt.RateLimitExceeded("binance -1015"))
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        assert len(hits) == 1
+        assert hits[0]["pool_name"] == "orders"
+        assert "endpoint" not in hits[0]
+        assert "-1015" in hits[0]["reason"]
+
+    @pytest.mark.asyncio
+    async def test_non_rate_limit_venue_error_leaves_the_gate_open(self, order_limiter) -> None:
+        """Negative control: a rejection is not a budget breach."""
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=order_limiter)
+        exchange.create_order = AsyncMock(side_effect=ccxt.InsufficientFunds("balance too low"))
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        assert isinstance(sent[0], OrderRejectedEvent)
+        assert not order_limiter.is_gate_closed("orders")
+
+    @pytest.mark.asyncio
+    async def test_venue_order_limit_without_a_limiter_still_rejects(self) -> None:
+        """Negative control: reporting is skipped, the reject still goes out."""
+        conn, sent, exchange = _make_connector(exchange=_write_exchange(), rate_limiter=None)
+        exchange.create_order = AsyncMock(side_effect=ccxt.RateLimitExceeded("binance -1015"))
+
+        conn.submit_order(_order_request())
+        await _drive(conn)
+
+        assert isinstance(sent[0], OrderRejectedEvent)
 
 

--- a/tests/qubx/connectors/ccxt/test_ccxt_cost_contract.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_cost_contract.py
@@ -1,0 +1,39 @@
+"""Pins the installed ccxt's REST cost contract.
+
+The rate limit configs and the storage's "charge ccxt's real weight" path are sized against these
+numbers; a ccxt version bump that changes them silently invalidates those decisions. Verified
+against ccxt 4.5.50.
+"""
+
+import ccxt
+import ccxt.pro as cxp
+
+
+def test_ccxt_version_is_visible_on_failure():
+    # not a pin on the version — it just puts the version in the failure output of the tests below
+    assert ccxt.__version__
+
+
+def test_binanceusdm_rate_limit_is_50ms():
+    assert cxp.binanceusdm().rateLimit == 50
+
+
+def test_fapi_open_orders_without_symbol_costs_40():
+    exchange = cxp.binanceusdm()
+    config = exchange.api["fapiPrivate"]["get"]["openOrders"]
+    assert config["noSymbol"] == 40
+    assert exchange.calculate_rate_limiter_cost("fapiPrivate", "GET", "openOrders", {}, config) == 40
+
+
+def test_fapi_open_orders_with_symbol_costs_1():
+    # negative control: the 40 is the no-symbol surcharge, not the endpoint's base cost
+    exchange = cxp.binanceusdm()
+    config = exchange.api["fapiPrivate"]["get"]["openOrders"]
+    assert config["cost"] == 1
+    assert exchange.calculate_rate_limiter_cost("fapiPrivate", "GET", "openOrders", {"symbol": "BTCUSDT"}, config) == 1
+
+
+def test_binance_spot_trades_costs_2():
+    exchange = cxp.binance()
+    assert exchange.api["public"]["get"]["trades"] == 2
+    assert exchange.calculate_rate_limiter_cost("public", "GET", "trades", {}, {"cost": 2}) == 2

--- a/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
@@ -58,6 +58,7 @@ def _make_connector(cls: type[CcxtConnector], exchange: Mock | None = None) -> t
 
     em = Mock()
     em.exchange = exchange
+    em.rate_limiter = None
 
     dp = Mock()
     dp.get_quote = Mock(return_value=_quote())
@@ -590,6 +591,7 @@ async def test_bitfinex_snapshot_venue_figures_pinned_all_none() -> None:
 def _factory_kwargs() -> dict:
     em = Mock()
     em.exchange = Mock()
+    em.rate_limiter = None
     return dict(
         channel=Mock(),
         time_provider=DummyTimeProvider(),

--- a/tests/qubx/connectors/ccxt/test_exchange_manager.py
+++ b/tests/qubx/connectors/ccxt/test_exchange_manager.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 from qubx.connectors.ccxt.exchange_manager import ExchangeManager
+from qubx.connectors.ccxt.rate_limits import HEADER_PARSERS
 from qubx.core.basics import Instrument, LiveTimeProvider
 from qubx.core.lookups import lookup
 from qubx.health.dummy import DummyHealthMonitor
@@ -373,7 +374,7 @@ class TestExchangeManagerIntegration:
 # ─── rate-limiter wiring tests (xLydianSoftware/Qubx#264) ─────────────────────
 
 
-def _make_bare_mock_exchange(id: str = "okx") -> Mock:
+def _make_bare_mock_exchange(id: str = "binanceusdm") -> Mock:
     """A Mock that mimics enough of a CCXT exchange for ``attach_rate_limiter`` to run."""
     mock = Mock()
     mock.id = id
@@ -398,7 +399,7 @@ def _make_manager(exchange) -> ExchangeManager:
 
 class TestExchangeManagerRateLimiterWiring:
     def test_attach_rate_limiter_overrides_throttle(self):
-        mock_exchange = _make_bare_mock_exchange("okx")
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
         original_throttle = mock_exchange.throttle
         manager = _make_manager(mock_exchange)
 
@@ -409,8 +410,8 @@ class TestExchangeManagerRateLimiterWiring:
         assert mock_exchange.enableRateLimit is True
 
     def test_attach_rate_limiter_installs_header_sync_for_known_exchange(self):
-        """For OKX (known exchange), on_rest_response is wrapped."""
-        mock_exchange = _make_bare_mock_exchange("okx")
+        """For a venue with a registered parser, on_rest_response is wrapped."""
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
         original_on_rest = mock_exchange.on_rest_response
         manager = _make_manager(mock_exchange)
 
@@ -422,7 +423,7 @@ class TestExchangeManagerRateLimiterWiring:
     def test_header_sync_hook_calls_parser_and_preserves_original(self):
         """When the hook fires, parser is called with the headers AND the original
         ``on_rest_response`` is still invoked so CCXT's own logic runs."""
-        mock_exchange = _make_bare_mock_exchange("okx")
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
         original_on_rest = mock_exchange.on_rest_response
         original_on_rest.return_value = "orig-return-value"
         manager = _make_manager(mock_exchange)
@@ -430,44 +431,47 @@ class TestExchangeManagerRateLimiterWiring:
         rate_limiter = Mock()
         manager.attach_rate_limiter(rate_limiter)
 
-        # Call the installed hook with a representative OKX response
-        headers = {"x-ratelimit-remaining": "15"}
+        # Call the installed hook with a representative response
+        headers = {"X-MBX-USED-WEIGHT-1M": "15"}
         result = mock_exchange.on_rest_response(
-            200, "OK", "https://okx", "GET", headers, "{}", {}, None,
+            200, "OK", "https://binance", "GET", headers, "{}", {}, None,
         )
 
         # Original still called and its return value preserved
         original_on_rest.assert_called_once_with(
-            200, "OK", "https://okx", "GET", headers, "{}", {}, None,
+            200, "OK", "https://binance", "GET", headers, "{}", {}, None,
         )
         assert result == "orig-return-value"
 
         # Parser should have called sync_from_exchange with the parsed remaining
         rate_limiter.sync_from_exchange.assert_called_once()
         _args, kwargs = rate_limiter.sync_from_exchange.call_args
-        assert kwargs.get("remaining") == 15.0
+        assert kwargs.get("used") == 15
 
     def test_header_sync_hook_tolerates_parser_failure(self):
         """A buggy parser must not break the response pipeline."""
-        mock_exchange = _make_bare_mock_exchange("okx")
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
         original_on_rest = mock_exchange.on_rest_response
         original_on_rest.return_value = None
         manager = _make_manager(mock_exchange)
 
         rate_limiter = Mock()
 
-        with patch(
-            "qubx.connectors.ccxt.rate_limits.parse_okx_headers",
-            side_effect=RuntimeError("simulated parser bug"),
-        ):
+        def _boom(headers, limiter):
+            raise RuntimeError("simulated parser bug")
+
+        # patch the registry entry: HEADER_PARSERS holds a direct reference, so patching the
+        # module-level name would leave get_header_parser returning the real parser
+        with patch.dict(HEADER_PARSERS, {"binanceusdm": _boom}):
             manager.attach_rate_limiter(rate_limiter)
             # Should not raise despite the broken parser
             mock_exchange.on_rest_response(
-                200, "OK", "u", "GET", {"x-ratelimit-remaining": "10"}, "{}", {}, None,
+                200, "OK", "u", "GET", {"X-MBX-USED-WEIGHT-1M": "10"}, "{}", {}, None,
             )
 
         # Original still called even when parser raised
         original_on_rest.assert_called_once()
+        rate_limiter.sync_from_exchange.assert_not_called()
 
     def test_unknown_exchange_skips_header_sync(self):
         """For an exchange with no registered parser, on_rest_response stays untouched."""
@@ -485,7 +489,7 @@ class TestExchangeManagerRateLimiterWiring:
 
     def test_wiring_reapplies_after_recreation(self):
         """Both throttle and on_rest_response are reapplied on exchange recreation."""
-        first_exchange = _make_bare_mock_exchange("okx")
+        first_exchange = _make_bare_mock_exchange("binanceusdm")
         manager = _make_manager(first_exchange)
 
         rate_limiter = Mock()
@@ -494,7 +498,7 @@ class TestExchangeManagerRateLimiterWiring:
         first_wrapped_throttle = first_exchange.throttle
 
         # Simulate recreation: swap in a new exchange then fire registered callbacks
-        second_exchange = _make_bare_mock_exchange("okx")
+        second_exchange = _make_bare_mock_exchange("binanceusdm")
         original_on_rest_second = second_exchange.on_rest_response
         original_throttle_second = second_exchange.throttle
         manager._exchange = second_exchange
@@ -508,3 +512,69 @@ class TestExchangeManagerRateLimiterWiring:
         assert second_exchange.enableRateLimit is True
         assert second_exchange.on_rest_response is not original_on_rest_second
         assert second_exchange.throttle is not original_throttle_second
+
+        # and the reapplied hook drives the parser against the still-attached limiter
+        second_exchange.on_rest_response(200, "OK", "u", "GET", {"X-MBX-USED-WEIGHT-1M": "5"}, "{}", {}, None)
+        rate_limiter.sync_from_exchange.assert_called_once_with("ccxt_rest", used=5)
+
+
+class TestAttachRateLimiterIdempotence:
+    """The factory cache key collides for empty-credential venues, so the data provider and the
+    connector share one manager and attach the same limiter twice."""
+
+    def test_attaching_the_same_limiter_twice_wraps_once(self):
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
+        manager = _make_manager(mock_exchange)
+        rate_limiter = Mock()
+
+        manager.attach_rate_limiter(rate_limiter)
+        wrapped_once = mock_exchange.on_rest_response
+        manager.attach_rate_limiter(rate_limiter)
+
+        assert mock_exchange.on_rest_response is wrapped_once
+        assert len(manager._recreation_callbacks) == 1
+
+        mock_exchange.on_rest_response(200, "OK", "u", "GET", {"X-MBX-USED-WEIGHT-1M": "5"}, "{}", {}, None)
+        assert rate_limiter.sync_from_exchange.call_count == 1
+
+    def test_attaching_a_different_limiter_still_reapplies(self):
+        # negative control: the identity guard must not block a genuine swap
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
+        manager = _make_manager(mock_exchange)
+        first, second = Mock(), Mock()
+
+        manager.attach_rate_limiter(first)
+        manager.attach_rate_limiter(second)
+
+        assert manager.rate_limiter is second
+
+        # the hook is installed once and resolves the limiter at call time, so a swap re-points it
+        # rather than stacking a second wrapper — the replaced limiter must stop receiving syncs
+        mock_exchange.on_rest_response(200, "OK", "u", "GET", {"X-MBX-USED-WEIGHT-1M": "5"}, "{}", {}, None)
+        second.sync_from_exchange.assert_called_once_with("ccxt_rest", used=5)
+        first.sync_from_exchange.assert_not_called()
+
+    def test_apply_delegates_to_the_shared_installer(self):
+        """Keeps ExchangeManager and CcxtStorage on one installation path."""
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
+        manager = _make_manager(mock_exchange)
+        rate_limiter = Mock()
+
+        with patch("qubx.connectors.ccxt.exchange_manager.install_rate_limiter_hooks") as installer:
+            manager.attach_rate_limiter(rate_limiter)
+
+        installer.assert_called_once_with(mock_exchange, rate_limiter, label=manager._exchange_name)
+
+    def test_recreation_callback_delegates_to_the_shared_installer(self):
+        mock_exchange = _make_bare_mock_exchange("binanceusdm")
+        manager = _make_manager(mock_exchange)
+        rate_limiter = Mock()
+        manager.attach_rate_limiter(rate_limiter)
+
+        second_exchange = _make_bare_mock_exchange("binanceusdm")
+        manager._exchange = second_exchange
+        with patch("qubx.connectors.ccxt.exchange_manager.install_rate_limiter_hooks") as installer:
+            for cb in manager._recreation_callbacks:
+                cb()
+
+        installer.assert_called_once_with(second_exchange, rate_limiter, label=manager._exchange_name)

--- a/tests/qubx/connectors/ccxt/test_rate_limits.py
+++ b/tests/qubx/connectors/ccxt/test_rate_limits.py
@@ -97,6 +97,20 @@ class TestEndpointMap:
         assert create_ccxt_rate_limit_config(venue).endpoint_map["rest"].costs == [("ccxt_rest", 1)]
 
     @pytest.mark.parametrize("venue", _VENUES)
+    def test_set_leverage_is_mapped_so_it_cannot_double_charge_ip(self, venue: str):
+        # unmapped would fall back to default_costs and charge ccxt_rest on top of the throttle
+        assert "set_leverage" in create_ccxt_rate_limit_config(venue).endpoint_map
+
+    @pytest.mark.parametrize("venue", [v for v in _VENUES if v != "kraken.f"])
+    def test_set_leverage_adds_nothing_beyond_ip_weight(self, venue: str):
+        # Binance & co. bill leverage as plain IP weight, already taken by the throttle
+        assert create_ccxt_rate_limit_config(venue).endpoint_map["set_leverage"].costs == []
+
+    def test_kraken_futures_bills_set_leverage_like_an_order(self):
+        # ccxt's set_leverage hits PUT leveragepreferences, cost 10 at the venue
+        assert create_ccxt_rate_limit_config("kraken.f").endpoint_map["set_leverage"].costs == [("ccxt_rest", 4)]
+
+    @pytest.mark.parametrize("venue", _VENUES)
     def test_orders_is_never_reachable_from_default_costs(self, venue: str):
         # negative control: order endpoints must be the only route into the orders pool
         assert [pool for pool, _ in create_ccxt_rate_limit_config(venue).default_costs.costs] == ["ccxt_rest"]

--- a/tests/qubx/connectors/ccxt/test_rate_limits.py
+++ b/tests/qubx/connectors/ccxt/test_rate_limits.py
@@ -1,0 +1,698 @@
+"""Tests for ``qubx.connectors.ccxt.rate_limits``: venue configs, header parsers, hook installation."""
+
+import inspect
+from unittest.mock import Mock, patch
+
+import ccxt.pro as cxp
+import pytest
+
+from qubx import logger
+from qubx.connectors.ccxt.exchanges import EXCHANGE_ALIASES
+from qubx.connectors.ccxt.rate_limits import (
+    HEADER_PARSERS,
+    _order_count_header,
+    create_ccxt_rate_limit_config,
+    get_header_parser,
+    install_rate_limiter_hooks,
+    parse_binance_headers,
+)
+from qubx.rate_limiting import ExchangeRateLimiter, PoolConfig
+
+_ORDER_ENDPOINTS = ("create_order", "cancel_order", "edit_order")
+
+_VENUES = [
+    "binance",
+    "binance.um",
+    "binance.cm",
+    "binance.pm",
+    "binance.um.mm",
+    "okx",
+    "bybit",
+    "kraken",
+    "kraken.f",
+    "not-a-real-venue",
+]
+
+
+class _RecordingLimiter:
+    """Records ``sync_from_exchange`` calls. ``config`` is a real one so a parser that probes
+    ``config.pools`` sees production shape."""
+
+    def __init__(self, venue: str = "binance.um"):
+        self.config = create_ccxt_rate_limit_config(venue)
+        self.syncs: list[tuple[str, dict]] = []
+
+    def sync_from_exchange(self, pool_name: str, **kwargs) -> None:
+        self.syncs.append((pool_name, kwargs))
+
+
+class _RecordingThrottle:
+    """Records what the installed throttle forwards to ``acquire``."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, float | None]] = []
+
+    async def acquire(self, endpoint: str, weight_override: float | None = None) -> None:
+        self.calls.append((endpoint, weight_override))
+
+
+def _mock_exchange(id: str = "no-parser-for-this-id") -> Mock:
+    """Mirrors ``_make_bare_mock_exchange`` in test_exchange_manager. ``throttle`` /
+    ``on_rest_response`` must be explicit so a replacement is detectable, and ``enableRateLimit``
+    starts ``False`` so the installer turning it on is observable."""
+    mock = Mock()
+    mock.id = id
+    mock.enableRateLimit = False
+    mock.throttle = Mock(name="throttle_original")
+    mock.on_rest_response = Mock(name="on_rest_response_original")
+    return mock
+
+
+@pytest.fixture
+def warnings_logged():
+    records: list = []
+    sink_id = logger.add(lambda m: records.append(m.record), level="WARNING")
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
+
+
+class TestEndpointMap:
+    @pytest.mark.parametrize("venue", _VENUES)
+    @pytest.mark.parametrize("endpoint", _ORDER_ENDPOINTS)
+    def test_order_endpoint_is_mapped(self, venue: str, endpoint: str):
+        # unmapped means falling back to default_costs, which would charge the IP pool twice
+        assert endpoint in create_ccxt_rate_limit_config(venue).endpoint_map
+
+    # kraken.f has no orders pool — it surcharges the shared budget instead (see TestKrakenConfig)
+    @pytest.mark.parametrize("venue", [v for v in _VENUES if v != "kraken.f"])
+    @pytest.mark.parametrize("endpoint", _ORDER_ENDPOINTS)
+    def test_order_endpoint_charges_only_the_orders_pool(self, venue: str, endpoint: str):
+        assert create_ccxt_rate_limit_config(venue).endpoint_map[endpoint].costs == [("orders", 1)]
+
+    @pytest.mark.parametrize("venue", _VENUES)
+    def test_rest_endpoint_charges_only_the_ip_pool(self, venue: str):
+        # endpoint "rest" -> pool "ccxt_rest"; the 1 is a placeholder ccxt's cost overrides
+        assert create_ccxt_rate_limit_config(venue).endpoint_map["rest"].costs == [("ccxt_rest", 1)]
+
+    @pytest.mark.parametrize("venue", _VENUES)
+    def test_orders_is_never_reachable_from_default_costs(self, venue: str):
+        # negative control: order endpoints must be the only route into the orders pool
+        assert [pool for pool, _ in create_ccxt_rate_limit_config(venue).default_costs.costs] == ["ccxt_rest"]
+
+    async def test_order_endpoint_is_a_noop_when_the_venue_has_no_orders_pool(self):
+        config = create_ccxt_rate_limit_config("not-a-real-venue")
+        assert "orders" not in config.pools
+        limiter = ExchangeRateLimiter("not-a-real-venue", config)
+
+        await limiter.acquire("create_order")
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == 0
+
+
+class TestBinanceConfigs:
+    def test_pm_gets_papi_numbers(self):
+        pools = create_ccxt_rate_limit_config("binance.pm").pools
+        assert (pools["ccxt_rest"].capacity, pools["ccxt_rest"].refill_rate) == (6000, 100.0)
+        assert (pools["orders"].capacity, pools["orders"].refill_rate) == (1200, 20.0)
+
+    def test_pm_order_budget_is_not_the_spot_one(self):
+        pm = create_ccxt_rate_limit_config("binance.pm").pools["orders"]
+        spot = create_ccxt_rate_limit_config("binance").pools["orders"]
+        assert pm.capacity != spot.capacity
+
+    def test_spot_order_budget(self):
+        pools = create_ccxt_rate_limit_config("binance").pools
+        assert (pools["orders"].capacity, pools["orders"].refill_rate) == (100, 10.0)
+        assert (pools["ccxt_rest"].capacity, pools["ccxt_rest"].refill_rate) == (6000, 100.0)
+
+    def test_coin_m_ip_budget_matches_dapi(self):
+        # dapi publishes ORDERS MINUTE/1 only — no 10s window, unlike fapi
+        pools = create_ccxt_rate_limit_config("binance.cm").pools
+        assert (pools["ccxt_rest"].capacity, pools["ccxt_rest"].refill_rate) == (2400, 40.0)
+        assert (pools["orders"].capacity, pools["orders"].refill_rate) == (1200, 20.0)
+
+    def test_usd_m_ip_budget_matches_fapi(self):
+        pools = create_ccxt_rate_limit_config("binance.um").pools
+        assert (pools["ccxt_rest"].capacity, pools["ccxt_rest"].refill_rate) == (2400, 40.0)
+        assert (pools["orders"].capacity, pools["orders"].refill_rate) == (300, 30.0)
+
+    def test_market_maker_venue_routes_to_usd_m(self):
+        assert create_ccxt_rate_limit_config("binance.um.mm").pools == create_ccxt_rate_limit_config("binance.um").pools
+
+    @pytest.mark.parametrize(
+        "ccxt_id, venue",
+        [
+            ("binancepm", "binance.pm"),
+            ("binanceqv_usdm", "binance.um"),
+            ("binance_um_mm", "binance.um"),
+            ("binanceusdm", "binance.um"),
+            ("binancecoinm", "binance.cm"),
+        ],
+    )
+    def test_ccxt_id_shaped_name_gets_the_same_config_as_the_venue_name(self, ccxt_id: str, venue: str):
+        # binanceusdm/binancecoinm were already dispatched before the alias tuples; the others were not
+        assert create_ccxt_rate_limit_config(ccxt_id).pools == create_ccxt_rate_limit_config(venue).pools
+
+    @pytest.mark.parametrize("ccxt_id", ["binancepm", "binanceqv_usdm", "binance_um_mm"])
+    def test_ccxt_id_shaped_name_does_not_fall_through_to_the_default(self, ccxt_id: str):
+        # _default_config ships a single pool; a binance config always carries orders too
+        assert set(create_ccxt_rate_limit_config(ccxt_id).pools) == {"ccxt_rest", "orders"}
+
+    @pytest.mark.parametrize("venue, capacity", [("okx", 20), ("bybit", 120), ("kraken", 20)])
+    def test_binance_dispatch_does_not_swallow_other_venues(self, venue: str, capacity: float):
+        # negative control for the startswith("binance") dispatch
+        assert create_ccxt_rate_limit_config(venue).pools["ccxt_rest"].capacity == capacity
+
+
+class TestOrderCountHeaderDerivation:
+    @pytest.mark.parametrize(
+        "venue, header",
+        # windows verified against live exchangeInfo rateLimits (2026-08-11): spot ORDERS SECOND/10,
+        # fapi ORDERS SECOND/10 + MINUTE/1, dapi ORDERS MINUTE/1 only, papi 1200/min per docs
+        [
+            ("binance", "X-MBX-ORDER-COUNT-10S"),
+            ("binance.um", "X-MBX-ORDER-COUNT-10S"),
+            ("binance.cm", "X-MBX-ORDER-COUNT-1M"),
+            ("binance.pm", "X-MBX-ORDER-COUNT-1M"),
+        ],
+    )
+    def test_pool_window_derives_the_header_binance_actually_emits(self, venue: str, header: str):
+        assert _order_count_header(create_ccxt_rate_limit_config(venue).pools["orders"]) == header
+
+    @pytest.mark.parametrize(
+        "capacity, refill, header",
+        [(300, 30.0, "X-MBX-ORDER-COUNT-10S"), (1200, 20.0, "X-MBX-ORDER-COUNT-1M"), (60, 60.0, "X-MBX-ORDER-COUNT-1S")],
+    )
+    def test_window_to_interval_letter(self, capacity: float, refill: float, header: str):
+        assert _order_count_header(PoolConfig("orders", "account", capacity, refill)) == header
+
+    @pytest.mark.parametrize("venue", ["binance", "binance.um", "binance.cm", "binance.pm"])
+    def test_pool_window_is_one_binance_publishes(self, venue: str):
+        # capacity/refill_rate is the header window; retuning either alone yields a name like
+        # "-15S" that Binance never emits, silently disabling the sync
+        pool = create_ccxt_rate_limit_config(venue).pools["orders"]
+        assert pool.capacity / pool.refill_rate in (10.0, 60.0)
+
+
+class TestKrakenConfig:
+    def test_kraken_futures_gets_the_derivatives_budget(self):
+        config = create_ccxt_rate_limit_config("kraken.f")
+        pool = config.pools["ccxt_rest"]
+        assert set(config.pools) == {"ccxt_rest"}  # no separate order limit is documented
+        assert (pool.capacity, pool.refill_rate, pool.scope) == (125, 12.5, "account")
+
+    def test_kraken_futures_worst_window_matches_the_documented_budget(self):
+        # half-tokens: the bucket starts full, so capacity + 10*refill is the worst 10s window and
+        # must equal the venue's 500 cost units per 10s
+        pool = create_ccxt_rate_limit_config("kraken.f").pools["ccxt_rest"]
+        assert (pool.capacity + 10 * pool.refill_rate) * 2 == 500
+
+    @pytest.mark.parametrize("endpoint", _ORDER_ENDPOINTS)
+    async def test_kraken_futures_order_costs_five_units(self, endpoint: str):
+        # ccxt charges a flat 1 for every krakenfutures endpoint, so the map tops order ops up from
+        # a read's 1 unit to the 5 half-tokens the venue bills (10 cost units)
+        config = create_ccxt_rate_limit_config("kraken.f")
+        limiter = ExchangeRateLimiter("kraken.f", config)
+
+        await limiter.acquire("rest", weight_override=1.0)  # the throttle leg of the same call
+        await limiter.acquire(endpoint)
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == 5
+
+    async def test_kraken_futures_read_costs_one_unit(self):
+        # negative control: a plain read is not surcharged
+        limiter = ExchangeRateLimiter("kraken.f", create_ccxt_rate_limit_config("kraken.f"))
+
+        await limiter.acquire("rest", weight_override=1.0)
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == 1
+
+    def test_kraken_futures_venue_name_and_ccxt_id_agree(self):
+        assert create_ccxt_rate_limit_config("kraken.f").pools == create_ccxt_rate_limit_config("krakenfutures").pools
+
+    def test_kraken_spot_keeps_the_counter_pools(self):
+        # negative control: the futures branch must not capture spot
+        pools = create_ccxt_rate_limit_config("kraken").pools
+        assert (pools["ccxt_rest"].capacity, pools["ccxt_rest"].refill_rate) == (20, 0.33)
+        assert (pools["orders"].capacity, pools["orders"].refill_rate) == (60, 1.0)
+
+
+class TestBinanceHeaderParser:
+    def test_used_weight_syncs_the_ip_pool(self):
+        limiter = _RecordingLimiter()
+        parse_binance_headers({"X-MBX-USED-WEIGHT-1M": "1234"}, limiter)
+        assert limiter.syncs == [("ccxt_rest", {"used": 1234})]
+
+    @pytest.mark.parametrize("header", ["x-mbx-used-weight-1m", "X-MBX-USED-WEIGHT-1M", "X-Mbx-Used-Weight-1M"])
+    def test_lookup_is_case_insensitive(self, header: str):
+        limiter = _RecordingLimiter()
+        parse_binance_headers({header: "7"}, limiter)
+        assert limiter.syncs == [("ccxt_rest", {"used": 7})]
+
+    @pytest.mark.parametrize(
+        "venue, expected_used",
+        # each surface publishes a different order window, and um/pm share the ccxt id binanceusdm,
+        # so the header has to be chosen from the venue's own pool rather than hardcoded
+        [("binance", 7), ("binance.um", 7), ("binance.cm", 9), ("binance.pm", 9)],
+    )
+    def test_orders_pool_syncs_from_the_window_matched_header(self, venue: str, expected_used: int):
+        limiter = _RecordingLimiter(venue)
+        parse_binance_headers(
+            {
+                "X-MBX-USED-WEIGHT-1M": "10",
+                "X-MBX-ORDER-COUNT-1S": "3",
+                "X-MBX-ORDER-COUNT-10S": "7",
+                "X-MBX-ORDER-COUNT-1M": "9",
+                "X-MBX-ORDER-COUNT-1D": "900",
+            },
+            limiter,
+        )
+
+        assert limiter.syncs == [("ccxt_rest", {"used": 10}), ("orders", {"used": expected_used})]
+
+    def test_real_order_response_does_not_reset_the_ip_pool(self):
+        # verbatim headers from a testnet POST /fapi/v1/order: Binance sends -1 for "not
+        # applicable", and treating it as a count gives remaining = capacity + 1
+        limiter = _RecordingLimiter("binance.um")
+        parse_binance_headers(
+            {"x-mbx-used-weight-1m": "-1", "x-mbx-order-count-10s": "1", "x-mbx-order-count-1m": "1"}, limiter
+        )
+        assert limiter.syncs == [("orders", {"used": 1})]
+
+    @pytest.mark.parametrize("value", ["-1", "-100"])
+    def test_negative_weight_is_not_a_count(self, value: str):
+        limiter = _RecordingLimiter("binance.um")
+        parse_binance_headers({"X-MBX-USED-WEIGHT-1M": value}, limiter)
+        assert limiter.syncs == []
+
+    def test_zero_is_a_real_count_not_a_sentinel(self):
+        # negative control: 0 used is legitimate at the start of a window and must still sync
+        limiter = _RecordingLimiter("binance.um")
+        parse_binance_headers({"X-MBX-USED-WEIGHT-1M": "0"}, limiter)
+        assert limiter.syncs == [("ccxt_rest", {"used": 0})]
+
+    def test_order_count_for_another_window_is_ignored(self):
+        # negative control: reading the wrong window would re-pin a 10s pool from a 1s count and
+        # silently defeat it — only the matching header may sync
+        limiter = _RecordingLimiter("binance.um")
+        parse_binance_headers({"X-MBX-ORDER-COUNT-1S": "3", "X-MBX-ORDER-COUNT-1M": "9"}, limiter)
+        assert limiter.syncs == []
+
+    def test_order_count_header_is_case_insensitive(self):
+        limiter = _RecordingLimiter("binance.pm")
+        parse_binance_headers({"x-mbx-order-count-1m": "9"}, limiter)
+        assert limiter.syncs == [("orders", {"used": 9})]
+
+    def test_venue_without_an_orders_pool_syncs_nothing(self):
+        # negative control: krakenfutures-shaped configs have no orders pool
+        limiter = _RecordingLimiter("kraken.f")
+        assert "orders" not in limiter.config.pools
+        parse_binance_headers({"X-MBX-ORDER-COUNT-1M": "9"}, limiter)
+        assert limiter.syncs == []
+
+    def test_weight_header_alone_syncs_only_the_ip_pool(self):
+        limiter = _RecordingLimiter("binance.um")
+        parse_binance_headers({"X-MBX-USED-WEIGHT-1M": "9"}, limiter)
+        assert limiter.syncs == [("ccxt_rest", {"used": 9})]
+
+    @pytest.mark.parametrize("value", ["abc", "", None, "12.5"])
+    def test_malformed_value_is_silent(self, value):
+        limiter = _RecordingLimiter()
+        parse_binance_headers({"X-MBX-USED-WEIGHT-1M": value}, limiter)
+        assert limiter.syncs == []
+
+    def test_silent_without_a_limiter(self):
+        parse_binance_headers({"X-MBX-USED-WEIGHT-1M": "10"}, None)
+
+
+def _constructed_ccxt_ids() -> dict[str, str]:
+    """``exchange.id`` of every ccxt class the factory can build, keyed by the name it resolves."""
+    names = set(EXCHANGE_ALIASES.values()) | {"binance", "binanceusdm", "binancecoinm", "okx", "bybit", "kraken"}
+    ids = {}
+    for name in sorted(names):
+        cls = getattr(cxp, name, None)
+        if cls is None:
+            continue  # optional-dependency exchanges (bitfinex_f) are not registered
+        ids[name] = cls().id
+    return ids
+
+
+class TestHeaderParserRegistry:
+    def test_binanceusdm_resolves_to_the_binance_parser(self):
+        assert get_header_parser("binanceusdm") is parse_binance_headers
+
+    def test_binance_portfolio_margin_inherits_the_binanceusdm_id(self):
+        # binance.pm's header sync exists only because the subclass chain keeps ccxt's id
+        assert cxp.binancepm().id == "binanceusdm"
+        assert get_header_parser(cxp.binancepm().id) is parse_binance_headers
+
+    def test_binance_portfolio_margin_chain_overrides_describe_without_setting_id(self):
+        from qubx.connectors.ccxt.exchanges.binance.exchange import BinancePortfolioMargin, BinanceQVUSDM
+
+        for cls in (BinancePortfolioMargin, BinanceQVUSDM):
+            assert "describe" in cls.__dict__, f"{cls.__name__} no longer overrides describe()"
+            assert cls().id == "binanceusdm", f"{cls.__name__} now sets its own id — re-check HEADER_PARSERS"
+
+    def test_lookup_is_case_insensitive(self):
+        assert get_header_parser("BinanceUsdm") is parse_binance_headers
+
+    def test_unknown_id_has_no_parser(self):
+        assert get_header_parser("not-an-exchange") is None
+
+    def test_lookup_is_by_ccxt_id_not_venue_name(self):
+        # negative control: no ccxt id contains a dot, so the venue name is not a key
+        assert get_header_parser("binance.um") is None
+        assert get_header_parser("binance.pm") is None
+
+    def test_every_registered_key_is_an_id_qubx_constructs(self):
+        ids = set(_constructed_ccxt_ids().values())
+        assert set(HEADER_PARSERS) <= ids, f"dead parser registrations: {sorted(set(HEADER_PARSERS) - ids)}"
+
+    def test_factory_alias_names_are_not_ccxt_ids(self):
+        # negative control for the audit above: registering under a factory alias would be dead code
+        ids = _constructed_ccxt_ids()
+        assert ids["custom_krakenfutures"] == "krakenfutures"
+        assert ids["gateio_futures"] == "gate"
+        assert ids["binancepm"] == "binanceusdm"
+
+    def test_only_binance_ids_are_registered(self):
+        assert set(HEADER_PARSERS) == {"binance", "binanceusdm", "binancecoinm"}
+
+    @pytest.mark.parametrize("ccxt_id", ["okx", "bybit", "kraken", "krakenfutures"])
+    def test_venues_metering_per_endpoint_have_no_parser(self, ccxt_id: str):
+        # okx/bybit meter per endpoint (okx also publishes no rate-limit header at all); syncing such
+        # a signal into the venue-wide ccxt_rest pool would re-pin it to full on every response
+        assert get_header_parser(ccxt_id) is None
+
+
+class TestInstallRateLimiterHooks:
+    async def test_ccxt_cost_is_forwarded_as_weight_override(self):
+        exchange, limiter = _mock_exchange(), _RecordingThrottle()
+        install_rate_limiter_hooks(exchange, limiter)
+
+        await exchange.throttle(7)
+
+        assert limiter.calls == [("rest", 7.0)]
+
+    async def test_omitted_cost_becomes_one(self):
+        exchange, limiter = _mock_exchange(), _RecordingThrottle()
+        install_rate_limiter_hooks(exchange, limiter)
+
+        await exchange.throttle()
+
+        assert limiter.calls == [("rest", 1.0)]
+
+    async def test_none_cost_becomes_one(self):
+        exchange, limiter = _mock_exchange(), _RecordingThrottle()
+        install_rate_limiter_hooks(exchange, limiter)
+
+        await exchange.throttle(None)
+
+        assert limiter.calls == [("rest", 1.0)]
+
+    async def test_zero_cost_charges_zero(self):
+        limiter = ExchangeRateLimiter("binance.um", create_ccxt_rate_limit_config("binance.um"))
+        exchange = _mock_exchange()
+        install_rate_limiter_hooks(exchange, limiter)
+
+        await exchange.throttle(0)
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == 0.0
+
+        # positive control: the same path does charge a non-zero cost
+        await exchange.throttle(4)
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == 4.0
+
+    async def test_consumed_accumulates_exactly(self):
+        # consumed, not remaining — remaining refills by wall clock and is not deterministic
+        limiter = ExchangeRateLimiter("binance.um", create_ccxt_rate_limit_config("binance.um"))
+        exchange = _mock_exchange()
+        install_rate_limiter_hooks(exchange, limiter)
+
+        for cost in (2, 3, 0.5):
+            await exchange.throttle(cost)
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == pytest.approx(5.5)
+
+    def test_binance_klines_at_limit_1000_really_costs_five(self):
+        ccxt_exchange = cxp.binanceusdm()
+        config = ccxt_exchange.api["fapiPublic"]["get"]["klines"]
+        assert ccxt_exchange.calculate_rate_limiter_cost("fapiPublic", "GET", "klines", {"limit": 1000}, config) == 5
+        # negative control: the 5 is limit-dependent, not a constant
+        assert ccxt_exchange.calculate_rate_limiter_cost("fapiPublic", "GET", "klines", {}, config) == 1
+
+    async def test_real_klines_cost_is_charged_end_to_end(self):
+        ccxt_exchange = cxp.binanceusdm()
+        config = ccxt_exchange.api["fapiPublic"]["get"]["klines"]
+        cost = ccxt_exchange.calculate_rate_limiter_cost("fapiPublic", "GET", "klines", {"limit": 1000}, config)
+
+        limiter = ExchangeRateLimiter("binance.um", create_ccxt_rate_limit_config("binance.um"))
+        exchange = _mock_exchange()
+        install_rate_limiter_hooks(exchange, limiter)
+        await exchange.throttle(cost)
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == 5.0
+
+    async def test_ccxt_own_throttler_is_never_invoked(self):
+        ccxt_exchange = cxp.binanceusdm()
+        throttler_calls: list = []
+
+        async def _recording_throttler(cost=None):
+            throttler_calls.append(cost)
+
+        ccxt_exchange.throttler = _recording_throttler
+
+        # negative control: unhooked, ccxt's REST path does reach its own throttler
+        await ccxt_exchange.throttle(3)
+        assert throttler_calls == [3]
+
+        limiter = _RecordingThrottle()
+        install_rate_limiter_hooks(ccxt_exchange, limiter)
+        await ccxt_exchange.throttle(5)
+
+        assert throttler_calls == [3]
+        assert limiter.calls == [("rest", 5.0)]
+
+    def test_enable_rate_limit_stays_on(self):
+        # fetch2 only calls exchange.throttle when the flag is set — turning it off disables all
+        # REST throttling instead of just ccxt's
+        exchange = _mock_exchange()
+        install_rate_limiter_hooks(exchange, _RecordingThrottle())
+        assert exchange.enableRateLimit is True
+
+        ccxt_exchange = cxp.binanceusdm()
+        install_rate_limiter_hooks(ccxt_exchange, _RecordingThrottle())
+        assert ccxt_exchange.enableRateLimit is True
+
+    def test_no_limiter_is_a_noop(self):
+        # an id that does have a parser, so the header hook would land if anything were installed
+        exchange = _mock_exchange("binanceusdm")
+        original_throttle, original_hook = exchange.throttle, exchange.on_rest_response
+
+        install_rate_limiter_hooks(exchange, None)
+
+        assert exchange.throttle is original_throttle
+        assert exchange.on_rest_response is original_hook
+        assert exchange.enableRateLimit is False
+
+    def test_unknown_id_leaves_on_rest_response_untouched(self):
+        # negative control for the header hook: the throttle is installed either way
+        exchange = _mock_exchange("no-parser-for-this-id")
+        original_hook, original_throttle = exchange.on_rest_response, exchange.throttle
+
+        install_rate_limiter_hooks(exchange, _RecordingThrottle())
+
+        assert exchange.on_rest_response is original_hook
+        assert exchange.throttle is not original_throttle
+        assert exchange.enableRateLimit is True
+
+    def test_header_hook_syncs_and_preserves_the_original_return_value(self):
+        exchange = _mock_exchange("binanceusdm")
+        original_hook = exchange.on_rest_response
+        original_hook.return_value = "orig-return-value"
+        limiter = _RecordingLimiter("binance.um")
+        install_rate_limiter_hooks(exchange, limiter)
+
+        args = (200, "OK", "https://binance", "GET", {"X-MBX-USED-WEIGHT-1M": "9"}, "{}", {}, None)
+        result = exchange.on_rest_response(*args)
+
+        assert result == "orig-return-value"
+        original_hook.assert_called_once_with(*args)
+        assert limiter.syncs == [("ccxt_rest", {"used": 9})]
+
+    def test_header_hook_tolerates_a_raising_parser(self):
+        def _boom(headers, rate_limiter):
+            raise RuntimeError("simulated parser bug")
+
+        exchange = _mock_exchange("binanceusdm")
+        original_hook = exchange.on_rest_response
+        original_hook.return_value = "orig-return-value"
+
+        # patch the registry entry, not the module attribute — HEADER_PARSERS holds a direct
+        # reference, so patching the module-level name would not be seen by get_header_parser
+        with patch.dict(HEADER_PARSERS, {"binanceusdm": _boom}):
+            install_rate_limiter_hooks(exchange, _RecordingLimiter("binance.um"))
+            result = exchange.on_rest_response(200, "OK", "u", "GET", {"X-MBX-USED-WEIGHT-1M": "9"}, "{}", {}, None)
+
+        assert result == "orig-return-value"
+        original_hook.assert_called_once()
+
+    @pytest.mark.parametrize("headers", [None, {}])
+    def test_header_hook_skips_empty_headers(self, headers):
+        exchange = _mock_exchange("binanceusdm")
+        original_hook = exchange.on_rest_response
+        limiter = _RecordingLimiter("binance.um")
+        install_rate_limiter_hooks(exchange, limiter)
+
+        exchange.on_rest_response(200, "OK", "u", "GET", headers, "{}", {}, None)
+
+        assert limiter.syncs == []
+        original_hook.assert_called_once()
+
+
+class TestInstallDoesNotPinTheExchange:
+    def test_hooked_exchange_is_still_collectable(self):
+        # the install registry must not hold anything referencing the exchange, or every recreated
+        # exchange (markets, currencies, closures) stays alive for the life of the process
+        import gc
+        import weakref
+
+        from qubx.connectors.ccxt.rate_limits import _INSTALLED
+
+        exchange = _mock_exchange("binanceusdm")
+        exchange.on_rest_response = exchange.__class__.__call__  # a bound method, as ccxt's is
+        ref = weakref.ref(exchange)
+        install_rate_limiter_hooks(exchange, _RecordingThrottle(), label="x")
+        before = len(_INSTALLED)
+
+        del exchange
+        gc.collect()
+
+        assert ref() is None
+        assert len(_INSTALLED) < before
+
+
+class TestInstallIsIdempotent:
+    """A second install must not stack a wrapper on top of the first — ExchangeManager reinstalls
+    on every exchange recreation, and each extra layer would re-charge the pool per request."""
+
+    def test_second_install_does_not_re_wrap_on_rest_response(self):
+        exchange = _mock_exchange("binanceusdm")
+        limiter = _RecordingLimiter("binance.um")
+
+        install_rate_limiter_hooks(exchange, limiter)
+        install_rate_limiter_hooks(exchange, limiter)
+
+        exchange.on_rest_response(200, "OK", "u", "GET", {"X-MBX-USED-WEIGHT-1M": "9"}, "{}", {}, None)
+
+        # a doubled wrapper would run the parser twice for this one response
+        assert limiter.syncs == [("ccxt_rest", {"used": 9})]
+
+    def test_second_install_keeps_the_first_throttle(self):
+        exchange = _mock_exchange("binanceusdm")
+        limiter = _RecordingLimiter("binance.um")
+
+        install_rate_limiter_hooks(exchange, limiter)
+        first_throttle, first_hook = exchange.throttle, exchange.on_rest_response
+
+        install_rate_limiter_hooks(exchange, limiter)
+
+        assert exchange.throttle is first_throttle
+        assert exchange.on_rest_response is first_hook
+
+    async def test_second_install_charges_the_pool_once_per_request(self):
+        limiter = ExchangeRateLimiter("binance.um", create_ccxt_rate_limit_config("binance.um"))
+        exchange = _mock_exchange("binanceusdm")
+
+        install_rate_limiter_hooks(exchange, limiter)
+        install_rate_limiter_hooks(exchange, limiter)
+
+        await exchange.throttle(3)
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None and state["consumed"] == 3.0
+
+    def test_mock_exchange_still_gets_hooks_on_the_first_call(self):
+        # negative control for the guard: Mock answers any getattr with a truthy child, so a
+        # truthiness test would read it as already-installed and skip installation entirely
+        exchange = _mock_exchange("binanceusdm")
+        limiter = _RecordingLimiter("binance.um")
+        marker = getattr(exchange.throttle, "_qubx_rate_limiter", None)
+        assert bool(marker) is True and marker is not limiter
+        original_throttle, original_hook = exchange.throttle, exchange.on_rest_response
+
+        install_rate_limiter_hooks(exchange, limiter)
+
+        assert exchange.throttle is not original_throttle
+        assert exchange.on_rest_response is not original_hook
+        assert exchange.enableRateLimit is True
+
+    async def test_a_different_limiter_re_points_the_hooks(self):
+        # negative control for the skip: the guard keys on limiter identity, so a genuine swap must
+        # rewire — and must replace our previous wrapper, not stack a second one on top of it
+        exchange = _mock_exchange("binanceusdm")
+        original_hook = exchange.on_rest_response
+        first, second = _RecordingLimiter("binance.um"), _RecordingLimiter("binance.um")
+
+        install_rate_limiter_hooks(exchange, first)
+        install_rate_limiter_hooks(exchange, second)
+
+        exchange.on_rest_response(200, "OK", "u", "GET", {"X-MBX-USED-WEIGHT-1M": "5"}, "{}", {}, None)
+
+        assert first.syncs == []
+        assert second.syncs == [("ccxt_rest", {"used": 5})]
+        original_hook.assert_called_once()  # the venue's own handler still runs exactly once
+
+    async def test_a_different_limiter_re_points_the_throttle(self):
+        exchange = _mock_exchange("binanceusdm")
+        first, second = _RecordingThrottle(), _RecordingThrottle()
+
+        install_rate_limiter_hooks(exchange, first)
+        install_rate_limiter_hooks(exchange, second)
+        await exchange.throttle(2)
+
+        assert first.calls == []
+        assert second.calls == [("rest", 2.0)]
+
+    async def test_second_install_on_a_real_ccxt_exchange_is_a_noop(self):
+        ccxt_exchange = cxp.binanceusdm()
+        limiter = _RecordingThrottle()
+
+        install_rate_limiter_hooks(ccxt_exchange, limiter)
+        first_throttle = ccxt_exchange.throttle
+        install_rate_limiter_hooks(ccxt_exchange, limiter)
+
+        assert ccxt_exchange.throttle is first_throttle
+        await ccxt_exchange.throttle(2)
+        assert limiter.calls == [("rest", 2.0)]
+
+
+class TestDefaultConfig:
+    def test_unknown_venue_warns_naming_the_venue_and_the_guess(self, warnings_logged):
+        create_ccxt_rate_limit_config("some-brand-new-venue")
+
+        messages = [record["message"] for record in warnings_logged]
+        assert any("some-brand-new-venue" in m and "20 req/s" in m for m in messages), messages
+
+    def test_known_venue_does_not_warn(self, warnings_logged):
+        # negative control
+        for venue in ("binance.um", "binance.pm", "okx", "bybit", "kraken", "kraken.f"):
+            create_ccxt_rate_limit_config(venue)
+        assert warnings_logged == []
+
+    def test_default_config_shape(self):
+        config = create_ccxt_rate_limit_config("some-brand-new-venue")
+        assert set(config.pools) == {"ccxt_rest"}
+        assert (config.pools["ccxt_rest"].capacity, config.pools["ccxt_rest"].refill_rate) == (1200.0, 20.0)
+
+    def test_signature_takes_only_the_venue_name(self):
+        # the dead ccxt_exchange auto-derivation parameter is gone
+        assert list(inspect.signature(create_ccxt_rate_limit_config).parameters) == ["exchange_name"]

--- a/tests/qubx/connectors/ccxt/test_rate_limits.py
+++ b/tests/qubx/connectors/ccxt/test_rate_limits.py
@@ -331,14 +331,22 @@ class TestBinanceHeaderParser:
 
 
 def _constructed_ccxt_ids() -> dict[str, str]:
-    """``exchange.id`` of every ccxt class the factory can build, keyed by the name it resolves."""
+    """``exchange.id`` of every ccxt class the factory can build, keyed by the name it resolves.
+
+    Classes that cannot be built bare are skipped — bitfinex_f's ``__init__`` starts a websocket on
+    ``self.asyncio_loop``, which is None outside a running loop. The callers still assert that every
+    registered parser id was resolved, so a skip cannot hide a dead registration.
+    """
     names = set(EXCHANGE_ALIASES.values()) | {"binance", "binanceusdm", "binancecoinm", "okx", "bybit", "kraken"}
     ids = {}
     for name in sorted(names):
         cls = getattr(cxp, name, None)
         if cls is None:
-            continue  # optional-dependency exchanges (bitfinex_f) are not registered
-        ids[name] = cls().id
+            continue  # optional-dependency exchanges are absent unless their extra is installed
+        try:
+            ids[name] = cls().id
+        except Exception:
+            continue
     return ids
 
 

--- a/tests/qubx/connectors/ccxt/test_rate_limits.py
+++ b/tests/qubx/connectors/ccxt/test_rate_limits.py
@@ -175,10 +175,51 @@ class TestBinanceConfigs:
         # _default_config ships a single pool; a binance config always carries orders too
         assert set(create_ccxt_rate_limit_config(ccxt_id).pools) == {"ccxt_rest", "orders"}
 
-    @pytest.mark.parametrize("venue, capacity", [("okx", 20), ("bybit", 120), ("kraken", 20)])
+    @pytest.mark.parametrize("venue, capacity", [("okx", 4), ("bybit", 100), ("kraken", 10)])
     def test_binance_dispatch_does_not_swallow_other_venues(self, venue: str, capacity: float):
         # negative control for the startswith("binance") dispatch
         assert create_ccxt_rate_limit_config(venue).pools["ccxt_rest"].capacity == capacity
+
+
+class TestPoolWindowSafety:
+    """A pool charged in ccxt cost units must not outrun the venue's own window.
+
+    The bucket starts full, so the worst case over the venue's window W is ``capacity + W*refill``.
+    These are the arithmetic that a pool sized in *request counts* silently fails.
+    """
+
+    def test_bybit_worst_window_stays_within_the_ip_rule(self):
+        # 600 requests / 5s per IP (403 + 10min ban). Worst case is the cheapest endpoint we call,
+        # where one cost unit is one request.
+        pool = create_ccxt_rate_limit_config("bybit").pools["ccxt_rest"]
+        assert pool.capacity + 5 * pool.refill_rate <= 600
+        assert pool.refill_rate <= 120
+
+    def test_okx_worst_window_stays_within_every_endpoint_budget(self):
+        # ccxt normalises okx so cost * budget == 20 units per 2s for every endpoint, so one bound
+        # covers them all
+        pool = create_ccxt_rate_limit_config("okx").pools["ccxt_rest"]
+        assert pool.capacity + 2 * pool.refill_rate <= 20
+
+    def test_kraken_public_reads_stay_within_the_documented_one_per_second(self):
+        pool = create_ccxt_rate_limit_config("kraken").pools["ccxt_rest"]
+        ohlc_cost = cxp.kraken().api["public"]["get"]["OHLC"]
+        assert pool.refill_rate / ohlc_cost <= 1.0
+
+    @pytest.mark.parametrize(
+        "venue, endpoint, cost, floor",
+        # regression floors: these venues were sized in request counts and ran 3-25x too slow
+        [("bybit", "v5/market/kline", 5, 20.0), ("kraken", "OHLC", 1.2, 0.8), ("okx", "market/candles", 0.5, 16.0)],
+    )
+    def test_market_data_throughput_floor(self, venue: str, endpoint: str, cost: float, floor: float):
+        pool = create_ccxt_rate_limit_config(venue).pools["ccxt_rest"]
+        assert pool.refill_rate / cost >= floor
+
+    @pytest.mark.parametrize("venue", _VENUES)
+    def test_gate_max_wait_outlasts_every_cooldown(self, venue: str):
+        # otherwise one reported 429 times out every waiter by construction
+        cfg = create_ccxt_rate_limit_config(venue)
+        assert cfg.gate_max_wait > max(p.cooldown for p in cfg.pools.values())
 
 
 class TestOrderCountHeaderDerivation:
@@ -252,7 +293,7 @@ class TestKrakenConfig:
     def test_kraken_spot_keeps_the_counter_pools(self):
         # negative control: the futures branch must not capture spot
         pools = create_ccxt_rate_limit_config("kraken").pools
-        assert (pools["ccxt_rest"].capacity, pools["ccxt_rest"].refill_rate) == (20, 0.33)
+        assert (pools["ccxt_rest"].capacity, pools["ccxt_rest"].refill_rate) == (10, 1.0)
         assert (pools["orders"].capacity, pools["orders"].refill_rate) == (60, 1.0)
 
 

--- a/tests/qubx/data/test_ccxt_storage_rate_limit.py
+++ b/tests/qubx/data/test_ccxt_storage_rate_limit.py
@@ -19,7 +19,9 @@ The tests in this file exercise the warmup OHLCV fetch path against a
    the budget and triggers 429s. This proves the mock is exercising the
    code path and that the positive test isn't vacuously passing.
 
-3. **Wiring regression** — every page fetch goes through ``limiter.acquire``.
+3. **Wiring regression** — every page fetch is charged through the throttle
+   hook ``_ensure_exchange`` installs, at the real ccxt cost, and every
+   response drives a header sync through ``on_rest_response``.
 """
 
 from __future__ import annotations
@@ -33,7 +35,9 @@ from unittest.mock import Mock
 import ccxt
 import pytest
 
+from qubx.connectors.ccxt import factory
 from qubx.connectors.ccxt.exchange_manager import ExchangeManager
+from qubx.connectors.ccxt.rate_limits import install_rate_limiter_hooks
 from qubx.core.basics import LiveTimeProvider
 from qubx.data.storages.ccxt import CcxtFetchExhausted, CcxtStorage, _retryable_fetch
 from qubx.health.dummy import DummyHealthMonitor
@@ -66,6 +70,8 @@ class FakeCcxtExchange:
         latency_ms: float = 5.0,
         id: str = "fake",
         server_budget: int | None = None,
+        throttle_cost: float = 1.0,
+        stale_headers: dict[str, str] | None = None,
     ) -> None:
         self.id = id
         self.name = id
@@ -76,10 +82,17 @@ class FakeCcxtExchange:
         self._arrivals: list[float] = []
         self.call_count = 0
         self.rate_limit_hits = 0
-        # Server-reported budget, exposed to callers via ``last_response_headers``
-        # to drive ``_sync_rate_limiter_from_response_headers``. When set, each
-        # successful call decrements it so the header value reflects real usage.
+        # Cost CCXT computes for this endpoint and hands to ``throttle`` (klines with limit=1000
+        # is weight 5 on binance.um, 1.2 on kraken, ...).
+        self.throttle_cost = throttle_cost
+        # Server-reported budget, published in the per-response headers handed to
+        # ``on_rest_response``. When set, each successful call decrements it so the header
+        # value reflects real usage.
         self._server_budget = server_budget
+        self._used_weight = 0
+        # When set, the exchange-wide attribute deliberately diverges from the per-request
+        # headers — a sync that reads it instead of the hook argument is then visible.
+        self.stale_headers = stale_headers
         self.last_response_headers: dict[str, str] = {}
         # CCXT-side hooks — real CCXT invokes ``self.throttle(cost)`` inside
         # ``fetch2()`` and ``self.on_rest_response(...)`` after the HTTP response.
@@ -109,9 +122,9 @@ class FakeCcxtExchange:
         **_: Any,
     ) -> list[list[float]]:
         self.call_count += 1
-        # 1) Pre-request throttle (CCXT calls this inside fetch2). If ExchangeManager
-        #    is attached, this acquires a token from the shared rate limiter.
-        await self.throttle(1.0)
+        # 1) Pre-request throttle (CCXT calls this inside fetch2 with the endpoint's cost).
+        #    Once the hooks are installed this acquires ``throttle_cost`` from the rate limiter.
+        await self.throttle(self.throttle_cost)
 
         now = time.monotonic()
         # drop arrivals outside the sliding window
@@ -127,22 +140,25 @@ class FakeCcxtExchange:
         self._arrivals.append(now)
         await asyncio.sleep(self._latency_s)
 
-        # Publish rate-limit headers as a real exchange would.
+        # Publish rate-limit headers as a real exchange would. Casing is deliberately neither
+        # the canonical constant nor lowercase — the parsers' lookup must be case-insensitive.
+        response_headers: dict[str, str] = {}
         if self._server_budget is not None:
             self._server_budget = max(0, self._server_budget - 1)
-            self.last_response_headers = {
-                # OKX style
+            self._used_weight += 1
+            response_headers = {
+                # no parser reads this one — it rides along as a negative control
                 "x-ratelimit-remaining": str(self._server_budget),
-                # Binance style
-                "x-mbx-used-weight-1m": str(max(0, 1200 - self._server_budget)),
+                "X-Mbx-Used-Weight-1m": str(self._used_weight),  # Binance style
             }
+            self.last_response_headers = self.stale_headers or response_headers
 
-        # 2) Post-response hook (CCXT calls this inside fetch2 after headers are
-        #    parsed). If ExchangeManager is attached, this invokes the header parser
-        #    which calls ``rate_limiter.sync_from_exchange(...)``.
+        # 2) Post-response hook (CCXT calls this inside fetch2 with THIS request's headers).
+        #    Once the hooks are installed this invokes the header parser, which calls
+        #    ``rate_limiter.sync_from_exchange(...)``.
         self.on_rest_response(
             200, "OK", f"https://fake/{symbol}", "GET",
-            self.last_response_headers, "{}", {}, None,
+            response_headers, "{}", {}, None,
         )
 
         # Simulate OKX-style behavior: cap each page at ``bars_per_page`` regardless of
@@ -163,7 +179,7 @@ def _build_rate_limiter(*, capacity: int, refill_rate: float, cooldown: float = 
                 "ccxt_rest", "ip", capacity, refill_rate, cooldown=cooldown
             ),
         },
-        endpoint_map={"ccxt_rest": EndpointCosts([("ccxt_rest", 1)])},
+        endpoint_map={"rest": EndpointCosts([("ccxt_rest", 1)])},
         default_costs=EndpointCosts([("ccxt_rest", 1)]),
     )
     return ExchangeRateLimiter("FAKE.X", config)
@@ -188,6 +204,9 @@ def _build_storage(
     trigger 429s (the negative control in ``TestCcxtStorageRateLimitBudget``)
     don't explode with ``CcxtFetchExhausted``; each test opts-in when it
     wants the strict behavior.
+
+    Injecting ``_exchanges`` bypasses ``_ensure_exchange``, so the hook install it does must be
+    mirrored here — without it nothing throttles the storage path and the whole file goes vacuous.
     """
     storage = CcxtStorage(
         retry_max_attempts=retry_max_attempts,
@@ -197,6 +216,7 @@ def _build_storage(
     )
     storage._exchanges = {"FAKE.X": exchange}  # type: ignore[assignment]
     storage._rate_limiters = {"FAKE.X": limiter} if limiter is not None else {}
+    install_rate_limiter_hooks(exchange, limiter, label="FAKE.X")
     return storage
 
 
@@ -205,6 +225,17 @@ def _bar_span(n_bars: int) -> tuple[int, int]:
     since = 1_700_000_000_000  # arbitrary fixed epoch-ms
     until = since + (n_bars - 1) * TF_MS
     return since, until
+
+
+def _span_for_pages(n_pages: int, bars_per_page: int = 10) -> tuple[int, int]:
+    """Window that makes the pagination loop issue exactly *n_pages* fetches.
+
+    Page k ends at ``since + (k*bpp - 1)*TF + (k-1)`` (the cursor bumps by 1ms per page) and the
+    loop stops on the first page whose last bar reaches ``until``; half a page of slack lands
+    ``until`` strictly between page n-1 and page n.
+    """
+    since = 1_700_000_000_000
+    return since, since + (n_pages * bars_per_page - bars_per_page // 2) * TF_MS
 
 
 def _instruments(*qubx_syms: str) -> list[tuple[str, str]]:
@@ -316,12 +347,110 @@ class TestCcxtStorageRateLimitBudget:
         assert len(acquire_calls) >= expected_min, (
             f"expected ≥{expected_min} acquire calls, got {len(acquire_calls)}"
         )
-        assert all(e == "ccxt_rest" for e in acquire_calls), (
-            f"unexpected endpoints: {set(acquire_calls) - {'ccxt_rest'}}"
+        assert all(e == "rest" for e in acquire_calls), f"unexpected endpoints: {set(acquire_calls) - {'rest'}}"
+
+
+@pytest.mark.asyncio
+class TestStorageChargesRealCcxtCost:
+    """
+    The storage no longer charges a flat 1 per page: CCXT hands ``throttle`` the endpoint's real
+    cost (binance.um klines at limit=1000 is weight 5) and the override forwards it verbatim as
+    ``weight_override``. Charging 1 there under-counts the IP budget five-fold.
+    """
+
+    BARS_PER_PAGE = 10
+    PAGES = 3
+
+    @pytest.mark.parametrize("cost", [5.0, 1.0])
+    async def test_consumed_is_pages_times_the_ccxt_cost(self, cost: float):
+        fake = FakeCcxtExchange(
+            max_rps=1000, bars_per_page=self.BARS_PER_PAGE, latency_ms=0.0, throttle_cost=cost
         )
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        since, until = _span_for_pages(self.PAGES, self.BARS_PER_PAGE)
+        await storage._async_fetch_ohlcv_multi(fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until)
+
+        assert fake.call_count == self.PAGES
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None
+        assert state["consumed"] == pytest.approx(self.PAGES * cost)
+
+    async def test_nothing_is_consumed_without_a_limiter(self):
+        """Negative control: the charge originates in the hook, so no limiter means no hook."""
+        fake = FakeCcxtExchange(
+            max_rps=1000, bars_per_page=self.BARS_PER_PAGE, latency_ms=0.0, throttle_cost=5.0
+        )
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=None)
+
+        since, until = _span_for_pages(self.PAGES, self.BARS_PER_PAGE)
+        await storage._async_fetch_ohlcv_multi(fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until)
+
+        assert fake.call_count == self.PAGES
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None
+        assert state["consumed"] == 0.0
+
+
+class TestEnsureExchangeInstallsHooks:
+    """``load_markets()`` is itself a REST call (a heavy one on binance), so the hooks have to be
+    on the exchange before it is submitted."""
+
+    def _fake_with_load_markets(self, monkeypatch) -> tuple[FakeCcxtExchange, list[bool]]:
+        fake = FakeCcxtExchange(max_rps=1000, latency_ms=0.0)
+        default_throttle = fake.throttle
+        throttled_at_load: list[bool] = []
+
+        async def _load_markets(*_a: Any, **_kw: Any) -> dict:
+            throttled_at_load.append(fake.throttle is not default_throttle)
+            return {}
+
+        fake.load_markets = _load_markets  # type: ignore[attr-defined]
+        # ``_ensure_exchange`` imports the factory inside the function, so patch the module attr
+        monkeypatch.setattr(factory, "get_ccxt_exchange", lambda *_a, **_kw: fake)
+        return fake, throttled_at_load
+
+    def test_hooks_are_installed_before_load_markets(self, monkeypatch):
+        fake, throttled_at_load = self._fake_with_load_markets(monkeypatch)
+        limiter = _build_rate_limiter(capacity=100, refill_rate=100.0)
+        storage = CcxtStorage(rate_limiters={"FAKE.X": limiter})
+        try:
+            assert storage._ensure_exchange("FAKE.X") is fake
+        finally:
+            storage.close()
+
+        assert throttled_at_load == [True]
+
+    def test_no_limiter_leaves_the_exchange_untouched(self, monkeypatch):
+        """Negative control: the flag above tracks the install, not the mere act of connecting."""
+        fake, throttled_at_load = self._fake_with_load_markets(monkeypatch)
+        storage = CcxtStorage()
+        try:
+            storage._ensure_exchange("FAKE.X")
+        finally:
+            storage.close()
+
+        assert throttled_at_load == [False]
 
 
 # ─── retry helper unit tests ──────────────────────────────────────────────────
+
+
+class _ThrottlingFailingExchange(FakeCcxtExchange):
+    """Fails the first ``fail_times`` calls *after* paying the throttle, like a real 429 does."""
+
+    def __init__(self, *, fail_times: int, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._fail_times = fail_times
+
+    async def fetch_ohlcv(self, *args: Any, **kwargs: Any) -> list[list[float]]:
+        if self.call_count < self._fail_times:
+            self.call_count += 1
+            await self.throttle(self.throttle_cost)
+            raise ccxt.NetworkError(f"boom on attempt {self.call_count}")
+        return await super().fetch_ohlcv(*args, **kwargs)
 
 
 @pytest.mark.asyncio
@@ -436,14 +565,14 @@ class TestRetryableFetch:
             )
         assert attempts == 1
 
-    async def test_acquires_rate_limiter_before_each_attempt(self):
+    async def test_does_not_acquire_the_limiter_directly(self):
+        """Acquisition lives in the throttle override inside ``fetch2``; a second acquire here
+        would double-charge every attempt."""
         attempts = 0
-        acquire_count = 0
 
-        class _Limiter:
-            async def acquire(self, endpoint: str) -> None:
-                nonlocal acquire_count
-                acquire_count += 1
+        class _ExplodingLimiter:
+            async def acquire(self, *a: Any, **kw: Any) -> None:
+                raise AssertionError("_retryable_fetch must not acquire — the throttle hook does")
 
             def report_limit_hit(self, **kw: Any) -> None:
                 pass
@@ -457,7 +586,7 @@ class TestRetryableFetch:
 
         result = await _retryable_fetch(
             call,
-            rate_limiter=_Limiter(),
+            rate_limiter=_ExplodingLimiter(),
             max_attempts=5,
             base_delay=0.0,
             jitter=0.0,
@@ -465,7 +594,45 @@ class TestRetryableFetch:
         )
         assert result == "ok"
         assert attempts == 3
-        assert acquire_count == 3  # once per attempt
+
+    async def test_every_attempt_is_charged_through_the_throttle(self):
+        """Retries are not free: each attempt re-enters ``fetch2`` and pays the endpoint's cost."""
+        fake = _ThrottlingFailingExchange(fail_times=2, max_rps=1000, latency_ms=0.0, throttle_cost=2.0)
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1000.0)
+        install_rate_limiter_hooks(fake, limiter, label="FAKE.X")
+
+        result = await _retryable_fetch(
+            lambda: fake.fetch_ohlcv("BTC/USDT", "1h"),
+            rate_limiter=limiter,
+            max_attempts=5,
+            base_delay=0.0,
+            jitter=0.0,
+            sleep=self._no_sleep,
+        )
+        assert len(result) > 0
+        assert fake.call_count == 3
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None
+        assert state["consumed"] == pytest.approx(3 * 2.0)
+
+    async def test_nothing_is_charged_without_the_throttle_hook(self):
+        """Negative control for the test above: the charge comes from the installed hook, not
+        from ``_retryable_fetch``."""
+        fake = _ThrottlingFailingExchange(fail_times=2, max_rps=1000, latency_ms=0.0, throttle_cost=2.0)
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1000.0)
+
+        await _retryable_fetch(
+            lambda: fake.fetch_ohlcv("BTC/USDT", "1h"),
+            rate_limiter=limiter,
+            max_attempts=5,
+            base_delay=0.0,
+            jitter=0.0,
+            sleep=self._no_sleep,
+        )
+        assert fake.call_count == 3
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None
+        assert state["consumed"] == 0.0
 
     async def test_reports_rate_limit_hit_to_limiter(self):
         hits: list[dict[str, Any]] = []
@@ -489,7 +656,7 @@ class TestRetryableFetch:
         await _retryable_fetch(
             call,
             rate_limiter=_Limiter(),
-            rate_limiter_endpoint="ccxt_rest",
+            rate_limit_pool="ccxt_rest",
             context="OKX BTCUSDT",
             max_attempts=3,
             base_delay=0.0,
@@ -497,7 +664,10 @@ class TestRetryableFetch:
             sleep=self._no_sleep,
         )
         assert len(hits) == 1
-        assert hits[0]["endpoint"] == "ccxt_rest"
+        assert hits[0]["pool_name"] == "ccxt_rest"
+        # ``endpoint=`` would close every pool in that endpoint's cost list — including ``orders``,
+        # stalling the write path on a read-path 429.
+        assert "endpoint" not in hits[0]
         assert "OKX BTCUSDT" in hits[0]["reason"]
 
     async def test_non_rate_limit_errors_do_not_report_to_limiter(self):
@@ -695,7 +865,6 @@ class TestCcxtStorageFlakyExchangeRetries:
             latency_ms=0.0,
         )
         # Patch: fail only for one specific symbol to get a partial outcome.
-        original_fetch = flaky.fetch_ohlcv
 
         async def selective_fetch(symbol, timeframe, **kw):
             if symbol == "LINK/USDT":
@@ -728,14 +897,13 @@ class TestCcxtStorageFlakyExchangeRetries:
 @pytest.mark.asyncio
 class TestResponseHeaderSync:
     """
-    Verify that ``_sync_rate_limiter_from_response_headers`` is invoked for every
-    successful page fetch and that the rate limiter's modeled state is updated
-    from the exchange-reported budget.
+    Verify that the ``on_rest_response`` hook installed by ``_ensure_exchange`` invokes the
+    exchange's header parser for every successful page fetch, and that the parsed budget
+    actually moves the rate limiter's modeled state.
 
-    The sync is best-effort — when concurrency is in play the exchange-wide
-    ``last_response_headers`` attribute may be read from a different request than
-    our own. We don't test that race here (it's accepted in the design); we only
-    verify that the wiring happens and that the parser is invoked with real values.
+    The hook runs inside CCXT's fetch pipeline with THIS request's headers — unlike the deleted
+    best-effort read of the exchange-wide ``last_response_headers``, which under concurrency
+    could belong to a neighbouring request.
     """
 
     BARS_PER_PAGE = 10
@@ -744,26 +912,38 @@ class TestResponseHeaderSync:
     def _spans(self) -> tuple[int, int]:
         return _bar_span(self.BARS_PER_PAGE * self.PAGES_PER_SYMBOL)
 
-    async def test_okx_headers_drive_sync_from_exchange(self):
-        starting_budget = 20
+    @staticmethod
+    def _spy_sync(limiter: ExchangeRateLimiter) -> list[dict[str, Any]]:
+        """Record every ``sync_from_exchange`` call while still applying it."""
+        calls: list[dict[str, Any]] = []
+        real_sync = limiter.sync_from_exchange
+
+        def _spy(pool_name: str, **kw: Any) -> None:
+            calls.append({"pool_name": pool_name, **kw})
+            real_sync(pool_name, **kw)
+
+        limiter.sync_from_exchange = _spy  # type: ignore[method-assign]
+        return calls
+
+    @staticmethod
+    def _drive_hook(fake: FakeCcxtExchange, headers: dict[str, str]) -> None:
+        """Invoke the installed post-response hook exactly as CCXT's fetch pipeline does."""
+        fake.on_rest_response(200, "OK", "https://fake/BTC-USDT", "GET", headers, "{}", {}, None)
+
+    async def test_headers_drive_sync_once_per_page(self):
         fake = FakeCcxtExchange(
-            id="okx",
+            id="binanceusdm",
             max_rps=1000,
             bars_per_page=self.BARS_PER_PAGE,
             latency_ms=0.0,
-            server_budget=starting_budget,
+            server_budget=20,
         )
         limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
         storage = _build_storage(exchange=fake, limiter=limiter)
+        # The sync must ride the installed hook — a bound method would still be the fake's no-op.
+        assert getattr(fake.on_rest_response, "__self__", None) is None
 
-        sync_calls: list[dict[str, Any]] = []
-        real_sync = limiter.sync_from_exchange
-
-        def _spy_sync(pool_name: str, **kw: Any) -> None:
-            sync_calls.append({"pool_name": pool_name, **kw})
-            real_sync(pool_name, **kw)
-
-        limiter.sync_from_exchange = _spy_sync  # type: ignore[method-assign]
+        sync_calls = self._spy_sync(limiter)
 
         since, until = self._spans()
         await storage._async_fetch_ohlcv_multi(
@@ -776,16 +956,114 @@ class TestResponseHeaderSync:
         # that it's > 1 and matches the exchange's actual call count).
         assert len(sync_calls) == fake.call_count
         assert len(sync_calls) >= self.PAGES_PER_SYMBOL
-        # each call targets the rest pool with a numeric remaining budget.
-        for call in sync_calls:
-            assert call["pool_name"] == "ccxt_rest"
-            assert "remaining" in call and call["remaining"] >= 0
-        # budget decrements monotonically and by exactly one per successful call.
-        remainings = [c["remaining"] for c in sync_calls]
-        assert remainings == sorted(remainings, reverse=True), (
-            f"expected monotonically-decreasing remaining, got {remainings}"
+        assert all(c["pool_name"] == "ccxt_rest" for c in sync_calls)
+        # used weight climbs by exactly one per successful call
+        assert [c["used"] for c in sync_calls] == list(range(1, fake.call_count + 1))
+
+    async def test_binance_headers_drive_sync_from_exchange(self):
+        """Binance reports *used* weight, in whatever casing aiohttp handed ccxt."""
+        fake = FakeCcxtExchange(
+            id="binanceusdm",
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+            server_budget=500,
+            throttle_cost=5.0,  # so the pinned level differs from what the acquires alone leave
         )
-        assert remainings[-1] == starting_budget - fake.call_count
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+        sync_calls = self._spy_sync(limiter)
+
+        since, until = _span_for_pages(3, self.BARS_PER_PAGE)
+        await storage._async_fetch_ohlcv_multi(
+            fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+
+        # neither the canonical constant nor lowercase — the parser's lookup is case-insensitive
+        assert "X-Mbx-Used-Weight-1m" in fake.last_response_headers
+        assert "X-MBX-USED-WEIGHT-1M" not in fake.last_response_headers
+        assert fake.call_count == 3
+        assert [c["used"] for c in sync_calls] == [1, 2, 3]
+        assert all(c["pool_name"] == "ccxt_rest" for c in sync_calls)
+
+        await asyncio.sleep(0.01)  # RatePool.sync applies through a task
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None
+        assert state["consumed"] == pytest.approx(3 * 5.0)
+        # pinned to capacity - used by the header, not to the 100 - 15 the acquires alone leave
+        assert state["remaining"] == pytest.approx(97.0, abs=2.0)
+
+    async def test_sync_reads_the_hook_headers_not_the_stale_attribute(self):
+        """``last_response_headers`` is exchange-wide and lags; the hook argument is this
+        request's truth. Point them at different budgets and the limiter must see the hook's."""
+        fake = FakeCcxtExchange(
+            id="binanceusdm",
+            max_rps=1000,
+            bars_per_page=self.BARS_PER_PAGE,
+            latency_ms=0.0,
+            server_budget=50,
+            stale_headers={"X-Mbx-Used-Weight-1m": "999"},
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+        sync_calls = self._spy_sync(limiter)
+
+        since, until = _span_for_pages(3, self.BARS_PER_PAGE)
+        await storage._async_fetch_ohlcv_multi(
+            fake, [("BTC/USDT", "BTCUSDT")], "1h", since, until
+        )
+
+        assert fake.last_response_headers["X-Mbx-Used-Weight-1m"] == "999"  # the decoy is in place
+        assert [c["used"] for c in sync_calls] == [1, 2, 3]
+
+    async def test_header_sync_moves_pool_state(self):
+        fake = FakeCcxtExchange(id="binanceusdm", max_rps=1000, latency_ms=0.0)
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1.0)
+        install_rate_limiter_hooks(fake, limiter, label="FAKE.X")
+
+        await limiter.acquire("rest")  # the bucket only exists once something acquires
+        before = await limiter.get_pool_state("ccxt_rest")
+        assert before is not None
+        assert before["remaining"] == pytest.approx(99.0, abs=1.0)
+
+        self._drive_hook(fake, {"X-Mbx-Used-Weight-1m": "93"})  # 100 capacity - 93 used
+        await asyncio.sleep(0.01)
+
+        after = await limiter.get_pool_state("ccxt_rest")
+        assert after is not None
+        assert after["remaining"] == pytest.approx(7.0, abs=1.0)
+
+    async def test_headerless_response_leaves_pool_state_alone(self):
+        """Negative control for the two tests above: no headers, no movement."""
+        fake = FakeCcxtExchange(id="binanceusdm", max_rps=1000, latency_ms=0.0)
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1.0)
+        install_rate_limiter_hooks(fake, limiter, label="FAKE.X")
+
+        await limiter.acquire("rest")
+        self._drive_hook(fake, {})
+        await asyncio.sleep(0.01)
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None
+        assert state["remaining"] == pytest.approx(99.0, abs=1.0)
+
+    async def test_header_sync_creates_a_never_acquired_bucket(self):
+        """``set_remaining`` now seeds the bucket from the pool config, so a header that lands
+        before the first acquire is applied instead of discarded."""
+        fake = FakeCcxtExchange(id="binanceusdm", max_rps=1000, latency_ms=0.0)
+        limiter = _build_rate_limiter(capacity=100, refill_rate=1.0)
+        install_rate_limiter_hooks(fake, limiter, label="FAKE.X")
+
+        untouched = await limiter.get_pool_state("ccxt_rest")
+        assert untouched is not None
+        assert untouched["remaining"] == 100.0  # nothing acquired yet -> capacity fallback
+
+        self._drive_hook(fake, {"X-Mbx-Used-Weight-1m": "88"})  # 100 capacity - 88 used
+        await asyncio.sleep(0.01)
+
+        state = await limiter.get_pool_state("ccxt_rest")
+        assert state is not None
+        assert state["remaining"] == pytest.approx(12.0, abs=1.0)
 
     async def test_unknown_exchange_skips_sync_silently(self):
         """If the exchange id has no registered parser, sync is a no-op (no error)."""
@@ -813,7 +1091,7 @@ class TestResponseHeaderSync:
     async def test_empty_headers_skip_sync_silently(self):
         """When the exchange hasn't populated headers yet, sync is a no-op."""
         fake = FakeCcxtExchange(
-            id="okx",
+            id="binanceusdm",
             max_rps=1000,
             bars_per_page=self.BARS_PER_PAGE,
             latency_ms=0.0,
@@ -838,10 +1116,10 @@ class TestResponseHeaderSync:
         def _broken_parser(headers: dict, rl: Any) -> None:
             raise RuntimeError("simulated parser bug")
 
-        monkeypatch.setitem(rate_limits.HEADER_PARSERS, "okx", _broken_parser)
+        monkeypatch.setitem(rate_limits.HEADER_PARSERS, "binanceusdm", _broken_parser)
 
         fake = FakeCcxtExchange(
-            id="okx",
+            id="binanceusdm",
             max_rps=1000,
             bars_per_page=self.BARS_PER_PAGE,
             latency_ms=0.0,
@@ -860,7 +1138,7 @@ class TestResponseHeaderSync:
     async def test_no_rate_limiter_skips_sync(self):
         """When no limiter is attached, don't even attempt to parse headers."""
         fake = FakeCcxtExchange(
-            id="okx",
+            id="binanceusdm",
             max_rps=1000,
             bars_per_page=self.BARS_PER_PAGE,
             latency_ms=0.0,
@@ -893,15 +1171,25 @@ class TestRateLimiterE2ECrossSubsystem:
     and verifies end-to-end:
 
     * Combined arrival rate never trips the exchange's 429 budget.
-    * ``limiter.acquire`` fires for every request across both paths (throttle
-      side on ExchangeManager, CcxtStorage-internal acquire for storage side).
-    * ``on_rest_response`` hook fires with correct headers for every
-      ExchangeManager-originated response.
+    * ``limiter.acquire`` fires for every request across both paths — both now go
+      through the throttle override, the storage's via ``install_rate_limiter_hooks``.
     * ``limiter.sync_from_exchange`` is called from both paths and decrements
       a shared remaining-budget view.
 
     The test is self-contained — no network, no real CCXT exchange instance.
     """
+
+    def _wire_manager(self, fake: FakeCcxtExchange, limiter: ExchangeRateLimiter) -> ExchangeManager:
+        """Attach *limiter* through the real ``attach_rate_limiter`` code path."""
+        manager = ExchangeManager(
+            exchange_name="binance.um",
+            factory_params={"exchange": "binance.um"},
+            initial_exchange=fake,
+            health_monitor=DummyHealthMonitor(),
+            time_provider=LiveTimeProvider(),
+        )
+        manager.attach_rate_limiter(limiter)
+        return manager
 
     async def test_shared_limiter_across_storage_and_manager(self):
         # --- Budget design -----------------------------------------------------
@@ -909,17 +1197,18 @@ class TestRateLimiterE2ECrossSubsystem:
         # throughput over any 1s window is ≤ 10 (half of the mock's 20/s threshold).
         # Gap must stay generous: scheduling jitter can make the limiter's sliding
         # throughput briefly higher than its steady refill rate.
+        # No server budget: the header sync re-pins the bucket to ``min(capacity, reported)`` on
+        # every response, which would fight the pacing this test measures. Sync is covered below.
         fake = FakeCcxtExchange(
-            id="okx",
+            id="binanceusdm",
             max_rps=20,
             window_sec=1.0,
             bars_per_page=10,
             latency_ms=2.0,
-            server_budget=1_000,
+            server_budget=None,
         )
         limiter = _build_rate_limiter(capacity=5, refill_rate=5.0, cooldown=0.2)
 
-        # --- CcxtStorage side --------------------------------------------------
         storage = _build_storage(exchange=fake, limiter=limiter)
         # Spy on limiter.acquire to count how many times each path hit the bucket.
         acquire_count = 0
@@ -931,29 +1220,7 @@ class TestRateLimiterE2ECrossSubsystem:
             await real_acquire(endpoint, **kw)
 
         limiter.acquire = _spy_acquire  # type: ignore[method-assign]
-
-        sync_count = 0
-        real_sync = limiter.sync_from_exchange
-
-        def _spy_sync(pool_name, **kw):
-            nonlocal sync_count
-            sync_count += 1
-            real_sync(pool_name, **kw)
-
-        limiter.sync_from_exchange = _spy_sync  # type: ignore[method-assign]
-
-        # --- ExchangeManager side ---------------------------------------------
-        # Wire the same limiter via the real attach_rate_limiter code path.
-        # This replaces fake.throttle with one that calls limiter.acquire, and
-        # wraps fake.on_rest_response with the header-sync hook.
-        manager = ExchangeManager(
-            exchange_name="okx",
-            factory_params={"exchange": "okx"},
-            initial_exchange=fake,
-            health_monitor=DummyHealthMonitor(),
-            time_provider=LiveTimeProvider(),
-        )
-        manager.attach_rate_limiter(limiter)
+        manager = self._wire_manager(fake, limiter)
 
         # --- Concurrent traffic -----------------------------------------------
         storage_symbols = _instruments("BTCUSDT", "ETHUSDT", "SOLUSDT")
@@ -970,7 +1237,7 @@ class TestRateLimiterE2ECrossSubsystem:
             hits = 0
             for i in range(10):
                 bars = await manager.exchange.fetch_ohlcv(
-                    f"BTC/USDT", "1h", since=since + i * TF_MS, limit=1,
+                    "BTC/USDT", "1h", since=since + i * TF_MS, limit=1,
                 )
                 hits += len(bars)
             return hits
@@ -991,21 +1258,66 @@ class TestRateLimiterE2ECrossSubsystem:
             assert len(bars) > 0, f"storage path: no bars for {sym}"
         assert manager_bars > 0, "manager path: no bars returned"
 
-        # Every exchange call must have gone through the limiter's acquire() —
-        # either via CcxtStorage's pre-fetch acquire or via the ExchangeManager-
-        # attached throttle override.
+        # Every exchange call must have gone through the limiter's acquire() — the
+        # throttle override is now the single charging point for both paths.
         assert acquire_count >= fake.call_count, (
             f"acquire fired {acquire_count} times for {fake.call_count} exchange "
             "calls — some requests bypassed the limiter"
         )
 
-        # Header sync must have fired for every successful call (both paths feed
-        # the same limiter): once per ExchangeManager call via on_rest_response,
-        # once per CcxtStorage page via best-effort last_response_headers read.
-        assert sync_count >= fake.call_count, (
-            f"sync_from_exchange fired {sync_count} times for {fake.call_count} "
-            "calls — some responses did not drive limiter sync"
+    async def test_both_paths_drive_header_sync(self):
+        """Every response on either path feeds the shared limiter's modeled budget.
+
+        The limiter is deliberately generous here — this pins the sync wiring, not pacing.
+        """
+        fake = FakeCcxtExchange(
+            id="binanceusdm",
+            max_rps=1000,
+            window_sec=1.0,
+            bars_per_page=10,
+            latency_ms=0.0,
+            server_budget=1_000,
         )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        sync_count = 0
+        real_sync = limiter.sync_from_exchange
+
+        def _spy_sync(pool_name, **kw):
+            nonlocal sync_count
+            sync_count += 1
+            real_sync(pool_name, **kw)
+
+        limiter.sync_from_exchange = _spy_sync  # type: ignore[method-assign]
+        manager = self._wire_manager(fake, limiter)
+
+        since, until = _span_for_pages(3)
+        await storage._async_fetch_ohlcv_multi(fake, _instruments("BTCUSDT"), "1h", since, until)
+        await manager.exchange.fetch_ohlcv("BTC/USDT", "1h", since=since, limit=1)
+
+        assert fake.call_count == 4  # 3 storage pages + 1 manager call
+        # Each response drives at least one sync; the shared fake is wrapped by both wirings,
+        # so the parser may run more than once per response (separate exchanges in production).
+        assert sync_count >= fake.call_count
+
+    async def test_parserless_exchange_drives_no_sync(self):
+        """Negative control for the test above: no parser for the id, no sync at all."""
+        fake = FakeCcxtExchange(
+            id="exchange-without-a-parser", max_rps=1000, latency_ms=0.0, server_budget=1_000
+        )
+        limiter = _build_rate_limiter(capacity=1000, refill_rate=1000.0)
+        storage = _build_storage(exchange=fake, limiter=limiter)
+
+        sync_calls: list[Any] = []
+        limiter.sync_from_exchange = lambda *a, **kw: sync_calls.append((a, kw))  # type: ignore[method-assign]
+        self._wire_manager(fake, limiter)
+
+        since, until = _span_for_pages(3)
+        await storage._async_fetch_ohlcv_multi(fake, _instruments("BTCUSDT"), "1h", since, until)
+
+        assert fake.call_count == 3
+        assert sync_calls == []
 
     async def test_exchange_manager_path_alone_stays_under_budget(self):
         """Isolate the live path: rapid-fire REST calls through ExchangeManager.throttle

--- a/tests/qubx/data/test_multi_storage.py
+++ b/tests/qubx/data/test_multi_storage.py
@@ -9,6 +9,7 @@ from qubx.core.basics import DataType
 from qubx.data.containers import RawData, RawMultiData
 from qubx.data.storage import IReader, IStorage
 from qubx.data.storages.multi import MultiReader, MultiStorage
+from qubx.rate_limiting import RateLimitGateTimeout
 
 # ---------------------------------------------------------------------------
 # helpers
@@ -436,6 +437,31 @@ class TestMultiStorage:
         reader = MultiStorage([bad, good]).get_reader("BINANCE.UM", "SWAP")
 
         assert reader is good_reader
+
+    def test_rate_limited_storage_is_not_dropped_for_the_run(self):
+        # a gate timeout is transient, but the reader set is cached — caching it while a storage was
+        # throttled would exclude that storage for the whole process
+        good_reader, recovered = MagicMock(spec=IReader), MagicMock(spec=IReader)
+        throttled = _mock_storage(reader=recovered)
+        throttled.get_reader.side_effect = [RateLimitGateTimeout("gate closed", pool_name="ccxt_rest"), recovered]
+        good = _mock_storage(reader=good_reader)
+        ms = MultiStorage([throttled, good])
+
+        first = ms.get_reader("BINANCE.UM", "SWAP")
+        second = ms.get_reader("BINANCE.UM", "SWAP")
+
+        assert first is good_reader  # degraded while throttled
+        assert isinstance(second, MultiReader)  # both storages back once the gate reopened
+
+    def test_permanently_absent_storage_is_still_cached(self):
+        # negative control: a storage that simply has no reader here must not defeat caching
+        good_reader = MagicMock(spec=IReader)
+        absent = _mock_storage()
+        absent.get_reader.side_effect = ValueError("no such reader")
+        ms = MultiStorage([absent, _mock_storage(reader=good_reader)])
+
+        assert ms.get_reader("BINANCE.UM", "SWAP") is ms.get_reader("BINANCE.UM", "SWAP")
+        assert absent.get_reader.call_count == 1
 
     def test_two_handy_storages_overlapping_ohlc(self):
         """

--- a/tests/qubx/rate_limiting/test_backend.py
+++ b/tests/qubx/rate_limiting/test_backend.py
@@ -4,7 +4,9 @@ import asyncio
 
 import pytest
 
+from qubx.rate_limiting import PoolConfig
 from qubx.rate_limiting.backend import InMemoryBackend
+from qubx.rate_limiting.pools import RatePool
 
 
 class TestSetRemaining:
@@ -94,3 +96,37 @@ class TestGetRemaining:
         backend = InMemoryBackend()
         await backend.acquire("k", 4.0, 10.0, 0.1)
         assert await backend.get_remaining("k", 10.0, 0.1) == pytest.approx(6.0, abs=0.5)
+
+
+class TestSyncTaskLifecycle:
+    """``RatePool.sync`` fires a background task per response header — it must not leak or go quiet."""
+
+    async def test_sync_failure_is_retrieved_not_left_unhandled(self):
+        pool = RatePool(PoolConfig("p", "ip", 100, 10.0), "ex", "local", _ExplodingBackend())
+        unhandled: list = []
+        asyncio.get_running_loop().set_exception_handler(lambda _loop, ctx: unhandled.append(ctx))
+
+        pool.sync(50)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert unhandled == [], f"unretrieved task exception: {unhandled}"
+        assert pool._sync_tasks == set(), "task reference leaked after completion"
+
+    async def test_sync_task_is_referenced_while_in_flight(self):
+        # negative control: an unreferenced task can be collected mid-flight
+        pool = RatePool(PoolConfig("p", "ip", 100, 10.0), "ex", "local", _SlowBackend())
+        pool.sync(50)
+        assert len(pool._sync_tasks) == 1
+        await asyncio.sleep(0.05)
+        assert pool._sync_tasks == set()
+
+
+class _ExplodingBackend(InMemoryBackend):
+    async def set_remaining(self, key, remaining, capacity=0, refill_rate=0):
+        raise RuntimeError("redis blip")
+
+
+class _SlowBackend(InMemoryBackend):
+    async def set_remaining(self, key, remaining, capacity=0, refill_rate=0):
+        await asyncio.sleep(0.01)

--- a/tests/qubx/rate_limiting/test_backend.py
+++ b/tests/qubx/rate_limiting/test_backend.py
@@ -1,0 +1,96 @@
+"""Tests for InMemoryBackend — bucket creation from a header sync and reservation-safe pinning."""
+
+import asyncio
+
+import pytest
+
+from qubx.rate_limiting.backend import InMemoryBackend
+
+
+class TestSetRemaining:
+    @pytest.mark.asyncio
+    async def test_creates_missing_bucket_when_capacity_is_given(self):
+        """A header can arrive before the first acquire; the bucket has to be created for it."""
+        backend = InMemoryBackend()
+        await backend.set_remaining("k", 5.0, capacity=100, refill_rate=10)
+        assert await backend.get_remaining("k") == pytest.approx(5.0, abs=0.5)
+
+    @pytest.mark.asyncio
+    async def test_without_capacity_is_a_noop(self):
+        """Negative control: a zero-capacity bucket would clamp every later acquire to 0."""
+        backend = InMemoryBackend()
+        await backend.set_remaining("k", 5.0)
+        assert await backend.get_remaining("k") is None
+
+    @pytest.mark.asyncio
+    async def test_clamps_to_capacity(self):
+        backend = InMemoryBackend()
+        await backend.set_remaining("k", 500.0, capacity=100, refill_rate=10)
+        assert await backend.get_remaining("k") == pytest.approx(100.0, abs=0.5)
+
+    @pytest.mark.asyncio
+    async def test_preserves_outstanding_reservations(self):
+        """R1: pinning to an exchange-reported level must not erase a sleeping waiter's debt.
+
+        A naive `self._tokens = min(capacity, tokens)` reports the full 10 here — the waiter would
+        still fire *and* new arrivals would spend against a balance that no longer carries it.
+        """
+        backend = InMemoryBackend()
+        key, capacity, refill = "k", 10.0, 0.1
+
+        await backend.acquire(key, 10.0, capacity, refill)  # drains the bucket
+        waiter = asyncio.create_task(backend.acquire(key, 6.0, capacity, refill))
+        await asyncio.sleep(0.05)
+
+        await backend.set_remaining(key, 10.0, capacity, refill)
+
+        remaining = await backend.get_remaining(key, capacity, refill)
+        assert remaining == pytest.approx(4.0, abs=0.5), "outstanding reservation was not kept owed"
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+    @pytest.mark.asyncio
+    async def test_preserves_reservations_across_repeated_syncs(self):
+        """Every response header re-pins, so one sync must not be the whole life of the debt."""
+        backend = InMemoryBackend()
+        key, capacity, refill = "k", 10.0, 0.1
+
+        await backend.acquire(key, 10.0, capacity, refill)  # drains the bucket
+        waiter = asyncio.create_task(backend.acquire(key, 6.0, capacity, refill))
+        await asyncio.sleep(0.05)
+
+        for sync in (1, 2, 3):
+            await backend.set_remaining(key, 10.0, capacity, refill)
+            remaining = await backend.get_remaining(key, capacity, refill)
+            assert remaining == pytest.approx(4.0, abs=0.5), f"sync #{sync} dropped the reservation"
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+
+class TestGetRemaining:
+    @pytest.mark.asyncio
+    async def test_is_safe_to_call_during_an_acquire(self):
+        backend = InMemoryBackend()
+        key, capacity, refill = "k", 10.0, 0.1
+
+        await backend.acquire(key, 10.0, capacity, refill)
+        waiter = asyncio.create_task(backend.acquire(key, 5.0, capacity, refill))
+        await asyncio.sleep(0.05)
+
+        remaining = await asyncio.wait_for(backend.get_remaining(key, capacity, refill), timeout=1.0)
+        assert remaining == 0.0, "outstanding debt must read as 0, never negative"
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+    @pytest.mark.asyncio
+    async def test_reports_a_positive_balance_when_nothing_is_owed(self):
+        """Negative control: the 0 above is the debt, not a backend that always reads 0."""
+        backend = InMemoryBackend()
+        await backend.acquire("k", 4.0, 10.0, 0.1)
+        assert await backend.get_remaining("k", 10.0, 0.1) == pytest.approx(6.0, abs=0.5)

--- a/tests/qubx/rate_limiting/test_cross_loop.py
+++ b/tests/qubx/rate_limiting/test_cross_loop.py
@@ -1,0 +1,173 @@
+"""Cross-loop / cross-thread behaviour of the gate and the token bucket.
+
+The gate used to be an `asyncio.Event` and the reopen a task, both of which bind to the first loop
+that touches them; the bucket used to hold an `asyncio.Lock`. Qubx drives one limiter from the
+runner loop, the ccxt `AsyncThreadLoop` and the storage/warmup loops, so any such binding surfaces
+as `RuntimeError: ... attached to a different loop`. These are plain unit tests — no Redis.
+"""
+
+import asyncio
+import threading
+from typing import Any, Callable, Coroutine
+
+import pytest
+
+from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, ExchangeRateLimiter, PoolConfig
+from qubx.rate_limiting.engine import RateLimitGateTimeout
+from qubx.utils.rate_limiter import TokenBucketRateLimiter
+
+
+def _make_config(cooldown: float = 30.0, gate_max_wait: float = 0.2) -> ExchangeRateLimitConfig:
+    return ExchangeRateLimitConfig(
+        pools={
+            "rest": PoolConfig("rest", "ip", capacity=100, refill_rate=50.0, cooldown=cooldown),
+            "orders": PoolConfig("orders", "account", capacity=10, refill_rate=5.0, cooldown=cooldown),
+        },
+        endpoint_map={"r": EndpointCosts([("rest", 1)])},
+        default_costs=EndpointCosts([("rest", 1)]),
+        gate_max_wait=gate_max_wait,
+    )
+
+
+def _run_on_new_loop(factory: Callable[[], Coroutine[Any, Any, Any]]) -> Any:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(factory())
+    finally:
+        loop.close()
+
+
+class TestGateIsNotBoundToALoop:
+    def test_gate_awaited_on_one_loop_is_still_a_gate_on_another(self):
+        """The gate must survive the loop that first waited on it (bound `asyncio.Event` today)."""
+        limiter = ExchangeRateLimiter("x", _make_config(cooldown=30.0, gate_max_wait=0.2))
+        try:
+
+            async def on_loop_a():
+                limiter.report_limit_hit(pool_name="rest", retry_after=30.0, reason="test")
+                await limiter.acquire("r")
+
+            with pytest.raises(RateLimitGateTimeout):
+                _run_on_new_loop(on_loop_a)
+
+            try:
+                _run_on_new_loop(lambda: limiter.acquire("r"))
+            except RateLimitGateTimeout as e:
+                assert e.pool_name == "rest"
+            except RuntimeError as e:
+                pytest.fail(f"cross-loop RuntimeError leaked out of the gate: {e}")
+            else:
+                pytest.fail("gate should still be closed on the second loop")
+        finally:
+            limiter.reset_gates()
+
+    def test_gate_max_wait_is_still_enforced(self):
+        """Negative control: a deadline-based gate must still time out, not silently pass through."""
+        limiter = ExchangeRateLimiter("x", _make_config(cooldown=30.0, gate_max_wait=0.1))
+        limiter.report_limit_hit(pool_name="rest", retry_after=30.0, reason="test")
+        try:
+            with pytest.raises(RateLimitGateTimeout) as exc_info:
+                _run_on_new_loop(lambda: limiter.acquire("r"))
+            assert exc_info.value.pool_name == "rest"
+        finally:
+            limiter.reset_gates()
+
+
+class TestGateFromThreadWithoutLoop:
+    def test_report_limit_hit_does_not_raise(self):
+        """`report_limit_hit` is called from ccxt callbacks that may run on a bare thread."""
+        limiter = ExchangeRateLimiter("x", _make_config(cooldown=30.0))
+        errors: list[BaseException] = []
+
+        def worker():
+            try:
+                limiter.report_limit_hit(pool_name="rest", retry_after=30.0, reason="bare thread")
+            except BaseException as e:
+                errors.append(e)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join(timeout=5)
+        try:
+            assert not thread.is_alive(), "worker thread did not finish"
+            assert not errors, f"report_limit_hit raised without a running loop: {errors[0]!r}"
+            assert limiter.is_gate_closed("rest")
+        finally:
+            limiter.reset_gates()
+
+    def test_gate_closed_from_thread_reopens_for_a_waiter_on_another_loop(self):
+        limiter = ExchangeRateLimiter("x", _make_config(cooldown=1.0, gate_max_wait=10.0))
+        thread = threading.Thread(
+            target=lambda: limiter.report_limit_hit(pool_name="rest", retry_after=1.0, reason="bare thread")
+        )
+        thread.start()
+        thread.join(timeout=5)
+        try:
+            assert limiter.is_gate_closed("rest")
+
+            async def waiter():
+                await asyncio.wait_for(limiter.acquire("r"), timeout=10.0)
+
+            _run_on_new_loop(waiter)
+            assert not limiter.is_gate_closed("rest")
+        finally:
+            limiter.reset_gates()
+
+
+def _one_pool_config(capacity: float, refill_rate: float) -> ExchangeRateLimitConfig:
+    return ExchangeRateLimitConfig(
+        pools={"rest": PoolConfig("rest", "ip", capacity=capacity, refill_rate=refill_rate)},
+        endpoint_map={"r": EndpointCosts([("rest", 1)])},
+        default_costs=EndpointCosts([("rest", 1)]),
+        gate_max_wait=5.0,
+    )
+
+
+class TestTokenBucketAcrossLoops:
+    def test_a_second_loop_pays_for_what_the_first_loop_spent(self):
+        # refill is slow enough that loop A's drain is still owed when loop B asks
+        limiter = ExchangeRateLimiter("x", _one_pool_config(capacity=10, refill_rate=0.5))
+
+        _run_on_new_loop(lambda: limiter.acquire("r", weight_override=10))
+
+        async def contend_on_loop_b():
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(limiter.acquire("r"), 0.1)
+
+        try:
+            _run_on_new_loop(contend_on_loop_b)
+        except RuntimeError as e:
+            pytest.fail(f"cross-loop RuntimeError leaked out of the token bucket: {e}")
+
+    def test_an_undrained_bucket_serves_a_second_loop_at_once(self):
+        """Negative control: the timeout above is loop A's spend, not a per-loop stall."""
+        limiter = ExchangeRateLimiter("x", _one_pool_config(capacity=10, refill_rate=0.5))
+
+        _run_on_new_loop(lambda: limiter.acquire("r"))
+
+        async def contend_on_loop_b():
+            await asyncio.wait_for(asyncio.gather(limiter.acquire("r"), limiter.acquire("r")), 0.1)
+
+        try:
+            _run_on_new_loop(contend_on_loop_b)
+        except RuntimeError as e:
+            pytest.fail(f"cross-loop RuntimeError leaked out of the token bucket: {e}")
+
+    def test_cancelled_acquire_leaks_its_reservation(self):
+        """R7: the debit happens before the sleep and is never rolled back — refill absorbs it."""
+        limiter = TokenBucketRateLimiter(capacity=10, refill_rate=1.0, name="test")
+
+        async def scenario():
+            await limiter.acquire(10)
+            leaked = asyncio.create_task(limiter.acquire(5))
+            await asyncio.sleep(0.05)
+            leaked.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await leaked
+
+            # the cancelled task's 5 tokens stay owed, so a fresh caller still has to wait them off
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(limiter.acquire(1), timeout=0.2)
+            assert limiter.get_available_tokens() == 0.0
+
+        _run_on_new_loop(scenario)

--- a/tests/qubx/rate_limiting/test_engine.py
+++ b/tests/qubx/rate_limiting/test_engine.py
@@ -1,16 +1,37 @@
 """Tests for the rate limiting engine — quota pool behavior."""
 
 import asyncio
+import math
+import time
+from typing import Any
 
 import pytest
 
-from qubx.rate_limiting import ExchangeRateLimiter, ExchangeRateLimitConfig, PoolConfig, EndpointCosts
+from qubx import logger
+from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, ExchangeRateLimiter, PoolConfig
 from qubx.rate_limiting.engine import RateLimitGateTimeout
+from qubx.rate_limiting.pools import QuotaPool
+
+
+@pytest.fixture
+def captured_logs():
+    lines: list[tuple[str, str]] = []
+    sink_id = logger.add(lambda m: lines.append((m.record["level"].name, m.record["message"])), level="DEBUG")
+    yield lines
+    logger.remove(sink_id)
+
+
+def _metric(metrics: list[dict[str, Any]], name: str, pool: str) -> float:
+    values = [m["value"] for m in metrics if m["name"] == name and m["tags"]["pool"] == pool]
+    assert len(values) == 1, f"expected exactly one {name} for pool {pool}, got {values}"
+    return values[0]
 
 
 def _make_config(
     quota_capacity: float = 1000,
-    cooldown: float = 0.5,
+    # cooldown must stay well above gate_max_wait, else a closed gate reopens inside the
+    # wait and a test meant to observe the timeout passes for the wrong reason
+    cooldown: float = 30.0,
     gate_max_wait: float = 1.0,
 ) -> ExchangeRateLimitConfig:
     """Create a minimal config with one rate pool and one quota pool."""
@@ -115,13 +136,11 @@ class TestQuotaAcquireFailsFast:
 
         limiter.sync_from_exchange("quota_pool", remaining=0)
 
-        t0 = asyncio.get_event_loop().time()
+        # the wait_for bound *is* the assertion: waiting out gate_max_wait surfaces as
+        # TimeoutError instead of RateLimitGateTimeout
         with pytest.raises(RateLimitGateTimeout) as exc_info:
-            await limiter.acquire("use_quota")
-        elapsed = asyncio.get_event_loop().time() - t0
+            await asyncio.wait_for(limiter.acquire("use_quota"), timeout=2.0)
 
-        # Should be near-instant, not 5s
-        assert elapsed < 1.0
         assert exc_info.value.pool_name == "quota_pool"
 
 
@@ -163,3 +182,135 @@ class TestSyncFromExchangeReopensQuotaGate:
         # sync_from_exchange with positive remaining reopens
         limiter.sync_from_exchange("quota_pool", remaining=100)
         assert not limiter.is_gate_closed("quota_pool")
+
+
+class TestGateTimeoutMetric:
+    @pytest.mark.asyncio
+    async def test_gate_timeouts_metric_counts_a_forced_timeout(self):
+        config = _make_config(gate_max_wait=0.05, cooldown=30.0)
+        limiter = ExchangeRateLimiter("test", config)
+        try:
+            assert _metric(await limiter.collect_metrics(), "rate_limit.gate_timeouts", "rate_pool") == 0.0
+
+            limiter.report_limit_hit(pool_name="rate_pool", retry_after=30.0, reason="test")
+            with pytest.raises(RateLimitGateTimeout):
+                await limiter.acquire("use_rate_only")
+
+            metrics = await limiter.collect_metrics()
+            assert _metric(metrics, "rate_limit.gate_timeouts", "rate_pool") == 1.0
+            # negative control: the untouched pool's counter stays put
+            assert _metric(metrics, "rate_limit.gate_timeouts", "quota_pool") == 0.0
+        finally:
+            limiter.reset_gates()
+
+
+class TestRefillRatePrecondition:
+    def test_rate_pool_without_refill_rate_is_rejected(self):
+        """The bucket divides a deficit by refill_rate; 0 there is a hang, not a limit."""
+        config = ExchangeRateLimitConfig(pools={"bad": PoolConfig("bad", "ip", capacity=100, refill_rate=0.0)})
+
+        with pytest.raises(ValueError) as exc_info:
+            ExchangeRateLimiter("test", config)
+
+        assert "refill_rate" in str(exc_info.value)
+        assert "'bad'" in str(exc_info.value)
+
+    def test_negative_refill_rate_is_rejected(self):
+        config = ExchangeRateLimitConfig(pools={"bad": PoolConfig("bad", "ip", capacity=100, refill_rate=-1.0)})
+
+        with pytest.raises(ValueError, match="refill_rate"):
+            ExchangeRateLimiter("test", config)
+
+    def test_quota_pool_without_refill_rate_is_fine(self):
+        """Negative control: quota pools are externally managed and legitimately have no refill."""
+        config = ExchangeRateLimitConfig(
+            pools={"q": PoolConfig("q", "address", capacity=100, refill_rate=0.0, pool_type="quota")}
+        )
+
+        limiter = ExchangeRateLimiter("test", config)
+        assert limiter.get_quota_remaining("q") == 100
+
+
+class TestClosedQuotaGateFailsFast:
+    @pytest.mark.asyncio
+    async def test_closed_quota_gate_does_not_wait_gate_max_wait(self):
+        config = _make_config(gate_max_wait=5.0)
+        limiter = ExchangeRateLimiter("test", config)
+
+        limiter.report_limit_hit(pool_name="quota_pool", retry_after=1.0, reason="test")
+        assert limiter._pools["quota_pool"]._gate_until == math.inf
+
+        # as above: the wait_for bound is what pins "does not sit out gate_max_wait"
+        with pytest.raises(RateLimitGateTimeout) as exc_info:
+            await asyncio.wait_for(limiter.acquire("use_quota"), timeout=2.0)
+
+        assert exc_info.value.pool_name == "quota_pool"
+
+    @pytest.mark.asyncio
+    async def test_infinite_gate_deadline_still_honours_gate_max_wait(self):
+        """An `inf` deadline must not produce a nan/infinite sleep inside `_wait_for_gate`."""
+        pool = QuotaPool(PoolConfig("q", "address", capacity=100, refill_rate=0.0, pool_type="quota"), "test", "s")
+        pool.close_gate(1.0, "test")
+        assert pool._gate_until == math.inf
+
+        start = time.monotonic()
+        with pytest.raises(RateLimitGateTimeout) as exc_info:
+            await asyncio.wait_for(pool._wait_for_gate(0.3), timeout=5.0)
+
+        assert time.monotonic() - start >= 0.25
+        assert exc_info.value.pool_name == "q"
+        assert pool.timeouts == 1
+
+
+class TestZeroWeightStillRespectsTheGate:
+    @pytest.mark.asyncio
+    async def test_closed_gate_rejects_a_zero_weight_acquire(self):
+        """A free call (ccxt costs Kraken orders 0) skips the bucket, never the gate — the gate is
+        the venue telling us to stop, and cost 0 is a ccxt pricing quirk, not a free pass."""
+        limiter = ExchangeRateLimiter("test", _make_config(gate_max_wait=0.05, cooldown=30.0))
+        limiter.report_limit_hit(pool_name="rate_pool", retry_after=30.0, reason="test")
+        try:
+            with pytest.raises(RateLimitGateTimeout) as exc_info:
+                await asyncio.wait_for(limiter.acquire("use_rate_only", weight_override=0), timeout=2.0)
+
+            assert exc_info.value.pool_name == "rate_pool"
+        finally:
+            limiter.reset_gates()
+
+    @pytest.mark.asyncio
+    async def test_open_gate_admits_a_zero_weight_acquire_free(self):
+        """Negative control: with the gate open the free call costs nothing and does not wait."""
+        limiter = ExchangeRateLimiter("test", _make_config())
+
+        await asyncio.wait_for(limiter.acquire("use_rate_only", weight_override=0), timeout=2.0)
+
+        state = await limiter.get_pool_state("rate_pool")
+        assert state is not None
+        assert state["consumed"] == 0.0
+        assert state["remaining"] == pytest.approx(100, abs=1.0)
+
+
+class TestOversizedWeightClamp:
+    @pytest.mark.asyncio
+    async def test_weight_above_capacity_is_clamped_and_warns(self, captured_logs):
+        """R3: an unclampable weight makes RedisBackend.acquire retry forever with no log."""
+        limiter = ExchangeRateLimiter("test", _make_config())
+
+        await asyncio.wait_for(limiter.acquire("use_rate_only", weight_override=1e6), timeout=2.0)
+
+        state = await limiter.get_pool_state("rate_pool")
+        assert state is not None
+        assert state["consumed"] == 100.0
+        assert [m for lvl, m in captured_logs if lvl == "WARNING" and "exceeds capacity" in m]
+
+    @pytest.mark.asyncio
+    async def test_weight_within_capacity_is_charged_verbatim(self, captured_logs):
+        """Negative control: the clamp is conditional, not a blanket capacity charge."""
+        limiter = ExchangeRateLimiter("test", _make_config())
+
+        await asyncio.wait_for(limiter.acquire("use_rate_only", weight_override=40), timeout=2.0)
+
+        state = await limiter.get_pool_state("rate_pool")
+        assert state is not None
+        assert state["consumed"] == 40.0
+        assert not [m for _, m in captured_logs if "exceeds capacity" in m]

--- a/tests/qubx/rate_limiting/test_manager.py
+++ b/tests/qubx/rate_limiting/test_manager.py
@@ -1,0 +1,143 @@
+"""Tests for RateLimitManager and EgressIPResolver."""
+
+import asyncio
+
+import pytest
+
+from qubx import logger
+from qubx.connectors.registry import ConnectorRegistry
+from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, PoolConfig
+from qubx.rate_limiting.engine import _UNRESOLVED_SCOPE_ID
+from qubx.rate_limiting.ip_resolver import EgressIPResolver
+from qubx.rate_limiting.manager import RateLimitManager
+from qubx.utils.runner.configs import RateLimitingConfig
+
+_EGRESS_IP = "203.0.113.7"  # literal, so no IP discovery (and no network I/O) happens
+
+
+def _rl_config() -> ExchangeRateLimitConfig:
+    return ExchangeRateLimitConfig(
+        pools={
+            "rest": PoolConfig("rest", "ip", capacity=100, refill_rate=50.0),
+            "orders": PoolConfig("orders", "account", capacity=10, refill_rate=5.0),
+        },
+        endpoint_map={"r": EndpointCosts([("rest", 1)])},
+        default_costs=EndpointCosts([("rest", 1)]),
+    )
+
+
+@pytest.fixture
+def captured_logs():
+    lines: list[tuple[str, str]] = []
+    sink_id = logger.add(lambda m: lines.append((m.record["level"].name, m.record["message"])), level="DEBUG")
+    yield lines
+    logger.remove(sink_id)
+
+
+@pytest.fixture
+def registered_config(monkeypatch):
+    monkeypatch.setattr(ConnectorRegistry, "get_rate_limit_config", lambda name, exchange_name: _rl_config())
+
+
+def _limiter_for(api_key: str | None, exchange: str = "venue"):
+    loop = asyncio.new_event_loop()
+    try:
+        manager = RateLimitManager(RateLimitingConfig(egress_ip=_EGRESS_IP), loop)
+        return manager.get_or_create(exchange, "ccxt", api_key=api_key)
+    finally:
+        loop.close()
+
+
+class TestDisabledWarning:
+    def test_disabled_manager_warns_once(self, captured_logs):
+        loop = asyncio.new_event_loop()
+        try:
+            manager = RateLimitManager(None, loop)
+            assert not manager.is_enabled
+        finally:
+            loop.close()
+
+        warnings = [m for lvl, m in captured_logs if lvl == "WARNING" and "disabled" in m.lower()]
+        assert len(warnings) == 1, warnings
+
+    def test_enabled_manager_does_not_warn(self, captured_logs):
+        """Negative control: the warning is about the missing section, not about construction."""
+        loop = asyncio.new_event_loop()
+        try:
+            manager = RateLimitManager(RateLimitingConfig(egress_ip=_EGRESS_IP), loop)
+            assert manager.is_enabled
+        finally:
+            loop.close()
+
+        assert not [m for lvl, m in captured_logs if lvl == "WARNING" and "disabled" in m.lower()]
+
+
+class TestAccountScoping:
+    def test_different_api_keys_get_different_account_pool_keys(self, registered_config):
+        """R2: without this, every bot on a shared backend shares one `orders` bucket."""
+        a = _limiter_for("KEY-A")
+        b = _limiter_for("KEY-B")
+        a_again = _limiter_for("KEY-A")
+        assert a is not None and b is not None and a_again is not None
+
+        key_a = a._pools["orders"]._key
+        key_b = b._pools["orders"]._key
+        assert key_a != key_b
+        assert key_a == a_again._pools["orders"]._key, "same api_key must resolve to the same bucket"
+        assert "KEY-A" not in key_a, "raw api key must never reach a bucket key"
+
+    def test_ip_scoped_pool_is_unaffected_by_the_api_key(self, registered_config):
+        """Negative control: only the account scope moves — the IP scope stays shared."""
+        a = _limiter_for("KEY-A")
+        b = _limiter_for("KEY-B")
+        assert a is not None and b is not None
+        assert a._pools["rest"]._key == b._pools["rest"]._key
+
+    def test_missing_api_key_falls_back_to_a_per_process_id(self, registered_config):
+        """R2 fallback: unresolvable is not evidence of shared — never the literal `local`."""
+        limiter = _limiter_for(None)
+        assert limiter is not None
+
+        key = limiter._pools["orders"]._key
+        assert not key.endswith(":local")
+        assert key.endswith(_UNRESOLVED_SCOPE_ID)
+        assert _UNRESOLVED_SCOPE_ID.startswith("local_")
+
+
+class TestEgressIPResolver:
+    @pytest.mark.asyncio
+    async def test_start_skips_discovery_when_already_primed(self, monkeypatch):
+        resolver = EgressIPResolver(check_interval=3600, initial_ip="1.2.3.4")
+        calls: list[int] = []
+
+        async def fake_discover():
+            calls.append(1)
+            return "5.6.7.8"
+
+        monkeypatch.setattr(resolver, "discover", fake_discover)
+        try:
+            await resolver.start()
+            assert calls == []
+            assert resolver.current_ip == "1.2.3.4"
+        finally:
+            resolver.stop()
+            await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_start_discovers_when_not_primed(self, monkeypatch):
+        """Negative control: the skip is conditional, not a dead discovery path."""
+        resolver = EgressIPResolver(check_interval=3600)
+        calls: list[int] = []
+
+        async def fake_discover():
+            calls.append(1)
+            return "5.6.7.8"
+
+        monkeypatch.setattr(resolver, "discover", fake_discover)
+        try:
+            await resolver.start()
+            assert len(calls) == 1
+            assert resolver.current_ip == "5.6.7.8"
+        finally:
+            resolver.stop()
+            await asyncio.sleep(0)

--- a/tests/qubx/rate_limiting/test_manager.py
+++ b/tests/qubx/rate_limiting/test_manager.py
@@ -49,7 +49,7 @@ def _limiter_for(api_key: str | None, exchange: str = "venue"):
 
 
 class TestDisabledWarning:
-    def test_disabled_manager_warns_once(self, captured_logs):
+    def test_disabled_manager_says_so_once(self, captured_logs):
         loop = asyncio.new_event_loop()
         try:
             manager = RateLimitManager(None, loop)
@@ -57,8 +57,10 @@ class TestDisabledWarning:
         finally:
             loop.close()
 
-        warnings = [m for lvl, m in captured_logs if lvl == "WARNING" and "disabled" in m.lower()]
-        assert len(warnings) == 1, warnings
+        # INFO, not WARNING: absent rate_limiting is the common case, so a warning would be noise
+        lines = [m for lvl, m in captured_logs if lvl == "INFO" and "disabled" in m.lower()]
+        assert len(lines) == 1, lines
+        assert not [m for lvl, m in captured_logs if lvl == "WARNING" and "disabled" in m.lower()]
 
     def test_enabled_manager_does_not_warn(self, captured_logs):
         """Negative control: the warning is about the missing section, not about construction."""

--- a/tests/qubx/utils/runner/test_rate_limiter_account_scope.py
+++ b/tests/qubx/utils/runner/test_rate_limiter_account_scope.py
@@ -1,0 +1,93 @@
+"""The runner must scope account pools by the venue's own API key.
+
+Dropping the ``api_key=`` argument in ``create_strategy_context`` is invisible everywhere else:
+limiters are still built, they just fall back to a per-process account scope — so every bot on
+the box shares one ``orders`` bucket. Data-only venues have no credentials entry and must keep
+that fallback rather than inherit some other account's scope.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qubx.core.interfaces import IStrategy
+from qubx.rate_limiting.manager import RateLimitManager
+from qubx.utils.runner.accounts import ExchangeCredentials, ExchangeSettings
+from qubx.utils.runner.configs import ExchangeConfig, LiveConfig, LoggingConfig, StrategyConfig
+from qubx.utils.runner.runner import create_strategy_context
+
+
+class _StopAfterVenueLoop(Exception):
+    """Stands in for aux-config resolution — the first statement after the venue loop."""
+
+
+class _Accounts:
+    """AccountConfigurationManager stand-in: only the two per-venue lookups are used."""
+
+    def __init__(self, api_keys: dict[str, str]) -> None:
+        self._api_keys = api_keys
+
+    def get_exchange_credentials(self, exchange: str) -> ExchangeCredentials:
+        # KeyError for venues without an entry, exactly like the real manager
+        return ExchangeCredentials(
+            exchange=exchange, name="acct", api_key=self._api_keys[exchange.upper()], secret="secret"
+        )
+
+    def get_exchange_settings(self, exchange: str) -> ExchangeSettings:
+        return ExchangeSettings(exchange=exchange)
+
+
+class _Strategy(IStrategy):
+    pass
+
+
+def _config(venues: list[str]) -> StrategyConfig:
+    return StrategyConfig(
+        strategy=_Strategy,
+        live=LiveConfig(
+            exchanges={v: ExchangeConfig(connector="ccxt", universe=[]) for v in venues},
+            logging=LoggingConfig(logger="InMemoryLogsWriter"),
+        ),
+    )
+
+
+def _get_or_create_calls(venues: list[str], api_keys: dict[str, str]) -> list[tuple[str, str, str | None]]:
+    """Run create_strategy_context up to the end of the venue loop, recording limiter creation."""
+    calls: list[tuple[str, str, str | None]] = []
+
+    def _record(self, exchange_name: str, connector_name: str, api_key: str | None = None):
+        calls.append((exchange_name, connector_name, api_key))
+        return None
+
+    with (
+        patch.object(RateLimitManager, "get_or_create", _record),
+        patch("qubx.utils.runner.runner._setup_strategy_logging", return_value=MagicMock()),
+        patch("qubx.utils.runner.runner._create_tcc", return_value=MagicMock()),
+        patch("qubx.utils.runner.runner.ConnectorRegistry.get_data_provider", return_value=MagicMock()),
+        patch("qubx.utils.runner.runner.ConnectorRegistry.get_connector", return_value=MagicMock()),
+        patch("qubx.utils.runner.runner.resolve_aux_config", side_effect=_StopAfterVenueLoop),
+        pytest.raises(_StopAfterVenueLoop),
+    ):
+        create_strategy_context(
+            config=_config(venues),
+            account_manager=_Accounts(api_keys),
+            paper=False,
+            restored_state=None,
+            stg_name="test",
+        )
+    return calls
+
+
+class TestRateLimiterAccountScope:
+    def test_configured_account_key_reaches_the_limiter(self):
+        assert _get_or_create_calls(["BINANCE.UM"], {"BINANCE.UM": "live-key"}) == [("BINANCE.UM", "ccxt", "live-key")]
+
+    def test_each_venue_is_scoped_by_its_own_key(self):
+        calls = _get_or_create_calls(["BINANCE.UM", "KRAKEN.F"], {"BINANCE.UM": "a", "KRAKEN.F": "b"})
+
+        assert calls == [("BINANCE.UM", "ccxt", "a"), ("KRAKEN.F", "ccxt", "b")]
+
+    def test_venue_without_credentials_keeps_the_fallback_scope(self):
+        calls = _get_or_create_calls(["BINANCE.UM", "KRAKEN.F"], {"BINANCE.UM": "live-key"})
+
+        assert calls == [("BINANCE.UM", "ccxt", "live-key"), ("KRAKEN.F", "ccxt", None)]

--- a/tests/qubx/utils/test_rate_limiter.py
+++ b/tests/qubx/utils/test_rate_limiter.py
@@ -5,7 +5,17 @@ import time
 
 import pytest
 
+from qubx import logger
+from qubx.utils.misc import BackgroundEventLoop
 from qubx.utils.rate_limiter import RateLimiterRegistry, TokenBucketRateLimiter, rate_limited
+
+
+@pytest.fixture
+def captured_logs():
+    lines: list[tuple[str, str]] = []
+    sink_id = logger.add(lambda m: lines.append((m.record["level"].name, m.record["message"])), level="DEBUG")
+    yield lines
+    logger.remove(sink_id)
 
 
 class TestTokenBucketRateLimiter:
@@ -36,7 +46,7 @@ class TestTokenBucketRateLimiter:
         elapsed = time.monotonic() - start
 
         assert elapsed >= 0.4  # Allow some slack for timing
-        assert elapsed < 0.7  # But not too much
+        assert elapsed < 2.0  # But bounded — generous, since `just test` runs under xdist load
 
     @pytest.mark.asyncio
     async def test_refill_over_time(self):
@@ -50,9 +60,9 @@ class TestTokenBucketRateLimiter:
         # Wait for refill (0.3 seconds = 30 tokens at 100/sec)
         await asyncio.sleep(0.3)
 
-        # Should have ~80 tokens now (50 + 30)
-        assert limiter.get_available_tokens() >= 75  # Allow slack
-        assert limiter.get_available_tokens() <= 85
+        # Should have ~80 tokens now (50 + 30), never above capacity
+        available = limiter.get_available_tokens()
+        assert 75 <= available <= 100
 
     @pytest.mark.asyncio
     async def test_capacity_limit(self):
@@ -66,12 +76,173 @@ class TestTokenBucketRateLimiter:
         assert limiter.get_available_tokens() == pytest.approx(10, rel=0.1)
 
     @pytest.mark.asyncio
-    async def test_acquire_exceeds_capacity(self):
-        """Test that acquiring more than capacity raises error."""
+    async def test_acquire_exceeds_capacity_clamps_and_warns(self, captured_logs):
+        """A weight no bucket can ever hold must not raise (nor stall) — it is clamped."""
         limiter = TokenBucketRateLimiter(capacity=10, refill_rate=10, name="test")
 
-        with pytest.raises(ValueError, match="exceeds bucket capacity"):
-            await limiter.acquire(20)
+        await asyncio.wait_for(limiter.acquire(20), timeout=2.0)
+
+        assert limiter.get_available_tokens() == pytest.approx(0.0, abs=0.1)
+        assert [m for lvl, m in captured_logs if lvl == "WARNING" and "exceeds capacity" in m]
+
+    @pytest.mark.asyncio
+    async def test_acquire_at_capacity_does_not_warn(self, captured_logs):
+        """Negative control: the clamp warning fires only above capacity."""
+        limiter = TokenBucketRateLimiter(capacity=10, refill_rate=10, name="test")
+
+        await limiter.acquire(10)
+
+        assert not [m for _, m in captured_logs if "exceeds capacity" in m]
+
+    @pytest.mark.asyncio
+    async def test_waiter_does_not_block_a_caller_with_budget(self):
+        """The reservation is taken under the lock; the sleep happens outside it."""
+        limiter = TokenBucketRateLimiter(capacity=10, refill_rate=1, name="test")
+
+        await limiter.acquire(10)  # drains
+        waiter = asyncio.create_task(limiter.acquire(5))  # ~5s deficit
+        await asyncio.sleep(0.05)
+
+        limiter.set_tokens(10)  # exchange re-pins to full; the 5 stays owed → 5 free
+
+        start = time.monotonic()
+        await asyncio.wait_for(limiter.acquire(1), timeout=0.5)
+        assert time.monotonic() - start < 0.5
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("pinned,expected", [(100, 70), (10, 0)])
+    async def test_set_tokens_keeps_outstanding_debt_owed(self, pinned: float, expected: float):
+        """A pin is reduced by what sleepers still owe; a pin below the debt leaves nothing."""
+        limiter = TokenBucketRateLimiter(capacity=100, refill_rate=1, name="test")
+
+        await limiter.acquire(100)  # drains
+        waiter = asyncio.create_task(limiter.acquire(30))  # 30 owed
+        await asyncio.sleep(0.05)
+
+        limiter.set_tokens(pinned)
+        assert limiter.get_available_tokens() == pytest.approx(expected, abs=1.0)
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+    @pytest.mark.asyncio
+    async def test_set_tokens_keeps_debt_owed_across_repeated_syncs(self):
+        """Headers re-pin on every response, so the debt has to outlive every sync, not just the first."""
+        limiter = TokenBucketRateLimiter(capacity=100, refill_rate=1, name="test")
+
+        await limiter.acquire(100)  # drains
+        waiter = asyncio.create_task(limiter.acquire(30))  # 30 owed
+        await asyncio.sleep(0.05)
+
+        for sync in (1, 2, 3):
+            limiter.set_tokens(100)
+            assert limiter.get_available_tokens() == pytest.approx(70, abs=2.0), f"sync #{sync} dropped the debt"
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+    @pytest.mark.asyncio
+    async def test_set_tokens_pins_verbatim_once_the_waiter_woke(self):
+        """The debt is released when the reservation becomes visible to the venue."""
+        limiter = TokenBucketRateLimiter(capacity=100, refill_rate=20, name="test")
+
+        await limiter.acquire(100)  # drains
+        await asyncio.wait_for(limiter.acquire(30), timeout=10)  # ~1.5s of deficit, then wakes
+
+        limiter.set_tokens(70)
+        assert limiter.get_available_tokens() == pytest.approx(70, abs=5.0)
+
+    @pytest.mark.asyncio
+    async def test_set_tokens_without_debt_pins_verbatim(self):
+        """Negative control: with nothing owed the pin is applied as-is (and clamped)."""
+        limiter = TokenBucketRateLimiter(capacity=100, refill_rate=1, name="test")
+
+        limiter.set_tokens(40)
+        assert limiter.get_available_tokens() == pytest.approx(40, abs=1.0)
+
+        limiter.set_tokens(500)
+        assert limiter.get_available_tokens() == pytest.approx(100, abs=1.0)
+
+    @pytest.mark.asyncio
+    async def test_repeated_set_tokens_without_debt_pins_verbatim(self):
+        """Negative control for the repeated-sync case: nothing owed, nothing subtracted."""
+        limiter = TokenBucketRateLimiter(capacity=100, refill_rate=1, name="test")
+
+        for sync in (1, 2, 3):
+            limiter.set_tokens(100)
+            assert limiter.get_available_tokens() == pytest.approx(100, abs=1.0), f"sync #{sync} lost tokens"
+
+    @pytest.mark.asyncio
+    async def test_zero_weight_acquire_skips_an_existing_deficit(self):
+        """ccxt prices Kraken AddOrder/CancelOrder at 0; such a call must not queue behind data-fetch
+        debt (this bucket is Kraken spot: a -10 deficit at 0.33/s is a 30s sleep)."""
+        limiter = TokenBucketRateLimiter(capacity=20, refill_rate=0.33, name="test")
+
+        await limiter.acquire(20)  # drains
+        debtor = asyncio.create_task(limiter.acquire(10))
+        await asyncio.sleep(0.05)
+        owed = limiter._tokens  # the deficit is not observable through the public read (it clamps at 0)
+
+        await asyncio.wait_for(limiter.acquire(0), timeout=0.5)
+
+        assert limiter._tokens == pytest.approx(owed, abs=0.1), "a free call must not touch the bucket"
+
+        debtor.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await debtor
+
+    @pytest.mark.asyncio
+    async def test_positive_weight_still_waits_out_the_same_deficit(self):
+        """Negative control: only weight 0 is free."""
+        limiter = TokenBucketRateLimiter(capacity=20, refill_rate=0.33, name="test")
+
+        await limiter.acquire(20)
+        debtor = asyncio.create_task(limiter.acquire(10))
+        await asyncio.sleep(0.05)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(limiter.acquire(1), timeout=0.2)
+
+        debtor.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await debtor
+
+    @pytest.mark.asyncio
+    async def test_fifo_order_preserved_under_deficit(self):
+        """Each acquirer gets a distinct increasing deadline, so wakeups keep launch order."""
+        limiter = TokenBucketRateLimiter(capacity=10, refill_rate=10, name="test")
+        order: list[int] = []
+
+        async def worker(task_id: int):
+            await limiter.acquire(5)
+            order.append(task_id)
+
+        await asyncio.gather(*(worker(i) for i in range(5)))
+
+        assert order == [0, 1, 2, 3, 4]
+
+    def test_shared_across_threads(self):
+        """One limiter driven from two loops on two threads — one budget, no loop binding."""
+        limiter = TokenBucketRateLimiter(capacity=100, refill_rate=1.0, name="shared")
+        loop_a = BackgroundEventLoop("rl-test-a")
+        loop_b = BackgroundEventLoop("rl-test-b")
+
+        try:
+            future_a = loop_a.submit(limiter.acquire(30))
+            future_b = loop_b.submit(limiter.acquire(20))
+            future_a.result(timeout=10)
+            future_b.result(timeout=10)
+        finally:
+            loop_a.stop()
+            loop_b.stop()
+
+        assert limiter.get_available_tokens() == pytest.approx(50, abs=5)
 
     @pytest.mark.asyncio
     async def test_concurrent_acquires(self):
@@ -259,8 +430,9 @@ class TestRateLimitedDecorator:
         class TestClient:
             def __init__(self):
                 self._rate_limiters = RateLimiterRegistry()
-                rest_limiter = TokenBucketRateLimiter(capacity=10, refill_rate=10, name="rest")
-                ws_limiter = TokenBucketRateLimiter(capacity=20, refill_rate=20, name="ws")
+                # low refill so the post-acquire reads don't drift under parallel test load
+                rest_limiter = TokenBucketRateLimiter(capacity=10, refill_rate=1, name="rest")
+                ws_limiter = TokenBucketRateLimiter(capacity=20, refill_rate=1, name="ws")
                 self._rate_limiters.register_limiter("rest", rest_limiter)
                 self._rate_limiters.register_limiter("ws", ws_limiter)
 


### PR DESCRIPTION
Addresses the CCXT rate-limiting audit in xLydianSoftware/exchanges#32.

## How it works now

Rate limiting has two layers that were previously conflated.

**Pools are the budgets.** Each venue declares an IP-scoped `ccxt_rest` pool and, where the venue
publishes one, an account-scoped `orders` pool, with capacity and refill taken from the venue's own
documentation. **`endpoint_map` is routing** — which pools an operation debits, not what the limits
are. The shape is shared across ccxt venues (`_default_endpoint_costs`) because only the numbers
differ; Kraken Futures overrides it, since that venue has one shared budget where an order costs 5x
a read and no separate order counter.

**REST weight** is charged by a throttle installed on the ccxt exchange. `install_rate_limiter_hooks`
replaces `exchange.throttle`, which is what takes ccxt's own throttler out of the REST path — `fetch2`
gates the call on `enableRateLimit`, so that flag stays on. ccxt supplies the per-endpoint cost, so a
1000-bar klines page costs 5 rather than 1. The same function installs the response-header hook, and
is now shared by `ExchangeManager` and `CcxtStorage`; previously only the former had it, so warmup and
aux readers ran unthrottled by us and double-throttled by ccxt.

**Order counts** are charged by the connector, which acquires `create_order` / `cancel_order` /
`edit_order` before the venue call. An order therefore debits two independent budgets: one IP weight
via the throttle, one order slot via the connector. A closed gate rejects before the request leaves,
as a typed event carrying `code="RateLimitGateTimeout"`.

**Venue feedback** arrives through response headers where the header's scope matches the pool it would
pin. For Binance that is `X-MBX-USED-WEIGHT-1M` for the IP pool and a window-matched
`X-MBX-ORDER-COUNT-*` for the order pool — the header name is derived from `capacity / refill_rate`,
so one parser serves `binance.um` (10s window) and `binance.pm` (1m window) even though both resolve
to the ccxt id `binanceusdm`. `-1` is Binance's "not applicable" sentinel and is ignored. Where no
header has the right scope, the model runs alone and 429s close the gate reactively.

**Concurrency.** One limiter instance is shared by the runner loop, the storage loop and each warmup
loop, which live on different threads. Gates are a monotonic deadline rather than an `asyncio.Event`,
and the token bucket takes its reservation under a `threading.Lock` and sleeps the deficit outside it.
Neither binds to an event loop, and a gate can be closed from a thread with no loop at all.

**Scoping.** Account-scoped pools derive their Redis scope id from a hash of the venue API key.
Previously they fell back to the literal `"local"`, which on a shared Redis backend would have
collapsed every bot onto one order budget.

## What changed

| Area | Change |
|---|---|
| `connectors/ccxt/connector.py` | order/cancel/edit acquire the `orders` pool; gate timeouts become typed rejects; venue order-limit errors close the orders gate |
| `connectors/ccxt/rate_limits.py` | `install_rate_limiter_hooks` extracted and shared; `_default_endpoint_costs`; venue configs corrected; window-matched order-count sync; case-insensitive header lookup; OKX parser removed |
| `connectors/ccxt/exchange_manager.py` | delegates to the shared installer; attach is idempotent |
| `data/storages/ccxt.py` | installs the shared hook before `load_markets`; per-page flat acquire and the best-effort `last_response_headers` sync removed |
| `rate_limiting/pools.py`, `utils/rate_limiter.py` | deadline gates, reservation bucket, oversized-weight clamp |
| `rate_limiting/manager.py`, `engine.py`, `utils/runner/runner.py` | account scope id; `rate_limit.gate_timeouts`; warning when rate limiting is disabled |
| `rate_limiting/redis_backend.py` | `acquire` returns the time it actually waited, so `rate_limit.wait_seconds` is meaningful under Redis |

### Venue configs

| Venue | `ccxt_rest` | `orders` | Note |
|---|---|---|---|
| binance (spot) | 6000 / 100 | 100 / 10 | orders capacity was 10 |
| binance.um | 2400 / 40 | 300 / 30 | models the 300/10s window |
| binance.cm | 2400 / 40 | 1200 / 20 | IP was 6000; dapi publishes only 1200/1m |
| binance.pm | 6000 / 100 | 1200 / 20 | previously fell through to the spot config |
| okx | 20 / 10 | 60 / 30 | |
| bybit | 120 / 24 | 10 / 10 | |
| kraken | 20 / 0.33 | 60 / 1.0 | |
| kraken.f | 125 / 12.5 (account) | — | previously got the Kraken *spot* config |

`binance.um.mm` and ccxt-id-shaped names (`binancepm`, `binanceqv_usdm`, `binance_um_mm`) now route
to their venue config instead of the generic fallback, which warns when it is used.

## Issue coverage

Fixed: #1 orders pool acquired, #2 binance.pm/cm configs, #3 loop-bound primitives, #6 disabled-state
logging and gate-timeout visibility, #8 storage weights and double-throttling, #9 dead auto-derivation,
#11 misleading docstrings, #12 tests.

Not built, with the reasoning recorded in the code: #4 (ccxt's per-api-group cost scaling is not a
uniform transform — Binance's papi table mixes IP-, order- and weight-denominated entries, so a single
scalar would be wrong in both directions; the unit is documented on `PoolConfig` and pinned by
`test_ccxt_cost_contract.py`), #5 (no endpoint signal exists at the throttle seam; the lock-across-sleep
that made this acute is gone), #7 (ccxt.pro already throttles subscribe frames per connection, which is
the scope the venue limits, and the seam runs after the handshake so it cannot affect connection rate),
#10 for Bybit and Kraken (Bybit's `X-Bapi-Limit-*` are per-endpoint and Kraken publishes none).

#13 belongs to xlydian-platform.

## Verification

2615 unit tests pass. New coverage includes cross-loop gate and bucket use, the reservation bucket's
sync semantics, throttle weight semantics end to end, header parsing and registry hygiene, the account
scope id, and a ccxt contract test pinning the cost numbers the design depends on.

Also exercised against Binance USD-M testnet through the production code path: real per-endpoint costs
charged, ccxt's throttler never invoked, IP-weight and order-count header sync landing on the pools,
the orders pool debited by real order flow, a closed gate rejecting without reaching the venue, one
limiter shared across two event loops on two threads, and the storage path charging real page weights.
