### PR TITLE
fix(cli): gate simulate's ~/projects sys.path injection behind --dev

### DIFF
--- a/src/qubx/cli/commands.py
+++ b/src/qubx/cli/commands.py
@@ -332,6 +332,9 @@ def run(
     help="Write simulation logs to a specific file path.",
     show_default=True,
 )
+@click.option(
+    "--dev", is_flag=True, default=False, help="Enable dev mode (adds ~/projects to path).", show_default=True
+)
 def simulate(
     config_file: Path,
     start: str | None,
@@ -340,6 +343,7 @@ def simulate(
     report: str | None,
     name: str | None,
     log_file: str | None,
+    dev: bool,
 ):
     """
     Simulates the strategy with the given configuration file.
@@ -347,7 +351,8 @@ def simulate(
     from qubx.utils.misc import add_project_to_system_path, logo
     from qubx.utils.runner.runner import simulate_strategy
 
-    add_project_to_system_path()
+    if dev:
+        add_project_to_system_path()  # Adds ~/projects in dev mode
     add_project_to_system_path(str(config_file.parent))
     logo()
     logger.info(f"Process PID: <g>{os.getpid()}</g>")


### PR DESCRIPTION
## Problem

`qubx simulate` calls `add_project_to_system_path()` unconditionally, which scans `~/projects/*` and inserts every project's `src/` at `sys.path[0]` — ahead of the venv's installed (editable) packages.

Running the CLI from a **git worktree** then silently imports the **main checkout's** strategy code instead of the worktree's editable install. Branch-only parameters are dropped without any error by `set_parameters_to_object` (it only sets attrs the class already has), and the simulation runs to completion with the wrong code while looking perfectly healthy.

Caught in practice today: a frab worktree sim ran 30% through with its feature parameter silently inactive — the only visible trace was the param missing from the `-l DEBUG` "new parameters:" dump.

## Fix

`qubx run` already gates the `~/projects` insertion behind `--dev`:

```python
if dev:
    add_project_to_system_path()  # Adds ~/projects in dev mode
add_project_to_system_path(config_file.parent)
```

`simulate` now does exactly the same (same flag, same help text). The config-parent insertion stays unconditional — it carries no shadowing risk and supports modules placed next to the config.

## Behavior change

Users who relied on `qubx simulate` implicitly importing strategies from `~/projects` without having them installed in the active environment must now pass `--dev`. Anyone running from an installed/editable package (the normal `uv run` project flow) is unaffected — except their venv is no longer silently shadowed.

Verified: `uv run qubx simulate --help` shows the flag; default run no longer inserts `~/projects` paths.
