### PR TITLE
fix(data): stop QuestDBReader treating the symbols manifest as an authority

### DIFF
--- a/src/qubx/data/storages/questdb.py
+++ b/src/qubx/data/storages/questdb.py
@@ -228,39 +228,27 @@ class SymbolsManifestManager:
             col_name = "asset" if "fundamental" in tname.lower() else symbol_column_name
 
             try:
-                if last_updated is None:
-                    # Full bootstrap - table not in manifest
-                    logger.debug(f"Bootstrapping manifest for table: {tname}")
-                    query = f'SELECT DISTINCT({col_name}) FROM "{tname}"'
-                else:
-                    # Incremental update - only query new data
-                    logger.debug(f"Incrementally updating manifest for table: {tname}")
-                    query = f"SELECT DISTINCT({col_name}) FROM \"{tname}\" WHERE timestamp > '{last_updated}'"
-
+                # Always a full DISTINCT scan (dictionary-backed for SYMBOL columns). An
+                # incremental scan gated on `timestamp > last_updated` compares DATA time
+                # against a wall-clock watermark, so backfilled rows (historical timestamps
+                # inserted later) would never register their symbols.
+                logger.debug(f"Refreshing manifest for table: {tname}")
+                query = f'SELECT DISTINCT({col_name}) FROM "{tname}"'
                 _, records = self.pgc.execute(query)
-                new_symbols = {r[0] for r in records if r[0]}
+                found = {r[0] for r in records if r[0]}
 
+                new_symbols = found - result[tname]
                 if new_symbols:
-                    # Add new symbols to result
                     result[tname].update(new_symbols)
-
-                    # Insert new symbols into manifest
                     self._insert_symbols(tname, new_symbols, now)
 
                 # Even if no new symbols, update the timestamp for existing ones
                 # to mark that we've checked
-                if last_updated is not None and result[tname]:
-                    self._touch_symbols(tname, result[tname], now)
+                if last_updated is not None and (existing := result[tname] - new_symbols):
+                    self._touch_symbols(tname, existing, now)
 
             except Exception as e:
-                logger.warning(f"Failed to update manifest for {tname}: {e}")
-                # Fall back to direct query
-                try:
-                    query = f'SELECT DISTINCT({col_name}) FROM "{tname}"'
-                    _, records = self.pgc.execute(query)
-                    result[tname] = {r[0] for r in records if r[0]}
-                except Exception as e2:
-                    logger.error(f"Failed to query symbols from {tname}: {e2}")
+                logger.error(f"Failed to query symbols from {tname}: {e}")
 
     def _insert_symbols(self, table_name: str, symbols: set[str], timestamp: pd.Timestamp) -> None:
         """Insert new symbols into manifest."""
@@ -568,16 +556,18 @@ class QuestDBReader(IReader):
         (storage_symbols, xtable) = self._dtype_lookup.get(str(dtype).lower(), (set(), None))
         if xtable is None or not storage_symbols:
             raise ValueError(f"Can't find table for {dtype} data !")
-        if data_id not in storage_symbols:
-            raise ValueError(f"{xtable.table_name} doesn't contain data for {data_id} !")
 
+        # - probe the table itself rather than trusting the manifest cache; UNION dedups
+        # - identical rows, so a single-timestamp symbol yields one row, not two
         _query = f"""(SELECT timestamp FROM "{xtable.table_name}" WHERE symbol='{data_id}' ORDER BY timestamp ASC LIMIT 1)
                         UNION
                    (SELECT timestamp FROM "{xtable.table_name}" WHERE symbol='{data_id}' ORDER BY timestamp DESC LIMIT 1)
                 """
         _r = self.pgc.execute(_query)[1]
-        _sr = sorted([np.datetime64(_r[0][0]), np.datetime64(_r[1][0])])
-        return _sr[0], _sr[1]
+        if not _r:
+            raise ValueError(f"{xtable.table_name} doesn't contain data for {data_id} !")
+        _sr = sorted(np.datetime64(r[0]) for r in _r)
+        return _sr[0], _sr[-1]
 
     @_auto_refresh
     def read(
@@ -605,12 +595,14 @@ class QuestDBReader(IReader):
         if xtable is None or not storage_symbols:
             raise ValueError(f"Can't find table for {dtype} data !")
 
-        # - handle symbols: empty collection means "all available" — no WHERE filter
+        # - handle symbols: empty collection means "all available" — no WHERE filter.
+        # - the manifest (storage_symbols) is a lookup cache, never an authority: requested
+        # - symbols go to the WHERE clause as-is, so a stale manifest cannot hide table rows
+        # - (a symbol truly absent from the table just returns no rows)
         if isinstance(data_id, (list, tuple, set)) and not data_id:
             req_symbols = set()
         else:
-            req_symbols = set(data_id if isinstance(data_id, (list, tuple, set)) else [data_id])
-            req_symbols = storage_symbols & req_symbols
+            req_symbols = {str(s).upper() for s in (data_id if isinstance(data_id, (list, tuple, set)) else [data_id])}
 
         # - check if it has any timeframe for resampling
         _, dt_params = DataType.from_str(dtype)

--- a/tests/qubx/data/test_questdb_storage.py
+++ b/tests/qubx/data/test_questdb_storage.py
@@ -1,5 +1,141 @@
+import re
+from datetime import timedelta
+
+import pandas as pd
+import pytest
+
 from qubx.core.basics import DataType
-from qubx.data.storages.questdb import xLTableMetaInfo
+from qubx.data.storages.questdb import QuestDBReader, SymbolsManifestManager, xLTableMetaInfo
+
+FUNDING_TABLE = "binance.umswap.funding_payment"
+
+
+class FakePGC:
+    """Answers exactly the SQL QuestDBReader/SymbolsManifestManager issue, honoring symbol filters.
+
+    ``funding_rows``: (timestamp, symbol, funding_rate, funding_interval_hours) tuples — the table.
+    ``manifest_rows``: (table_name, symbol, last_updated) tuples — pre-existing manifest state.
+    """
+
+    def __init__(self, funding_rows=(), manifest_rows=()):
+        self.funding_rows = sorted(funding_rows)
+        self.manifest_rows = list(manifest_rows)
+        self.queries: list[str] = []
+
+    def _symbol_filter(self, ql: str) -> set[str] | None:
+        m = re.search(r"symbol\s*(?:=\s*'([^']+)'|in \(([^)]*)\))", ql)
+        if m is None:
+            return None
+        if m.group(1):
+            return {m.group(1).upper()}
+        return {s.strip().strip("'").upper() for s in m.group(2).split(",")}
+
+    def execute(self, query: str):
+        self.queries.append(query)
+        ql = " ".join(query.split()).lower()
+        if "from tables()" in ql:
+            return ["table_name"], [["_qubx_symbols_manifest"], [FUNDING_TABLE]]
+        if "_qubx_symbols_manifest" in ql:
+            return ["table_name", "symbol", "last_updated"], [list(r) for r in self.manifest_rows]
+        if "distinct" in ql:
+            m = re.search(r"where timestamp > '([^']+)'", ql)
+            rows = self.funding_rows
+            if m:
+                floor = pd.Timestamp(m.group(1))
+                rows = [r for r in rows if pd.Timestamp(r[0]) > floor]
+            return ["symbol"], [[s] for s in sorted({r[1] for r in rows})]
+        if f'from "{FUNDING_TABLE}"' in ql:
+            wanted = self._symbol_filter(ql)
+            rows = [r for r in self.funding_rows if wanted is None or r[1].upper() in wanted]
+            if "limit 1" in ql:  # get_time_range's min/max UNION probe (UNION dedups equal rows)
+                if not rows:
+                    return ["timestamp"], []
+                ts = sorted(r[0] for r in rows)
+                return ["timestamp"], [[ts[0]]] if ts[0] == ts[-1] else [[ts[0]], [ts[-1]]]
+            return ["timestamp", "symbol", "funding_rate", "funding_interval_hours"], [list(r) for r in rows]
+        raise AssertionError(f"unexpected query: {query}")
+
+    def execute_no_result(self, query: str) -> None:
+        self.queries.append(query)
+
+
+def _reader(pgc: FakePGC, manifest_symbols: set[str]) -> QuestDBReader:
+    meta = xLTableMetaInfo.decode_table_metadata(FUNDING_TABLE)
+    assert meta is not None
+    return QuestDBReader(
+        "BINANCE.UM",
+        "SWAP",
+        [meta],
+        pgc,
+        synthetic_ohlc_timeframes_types=False,
+        min_symbols_for_all_data_request=50,
+        symbols_by_table={FUNDING_TABLE: set(manifest_symbols)},
+        manifest_manager=None,  # never consulted: refresh interval far exceeds the test
+        lookup_refresh_interval=timedelta(days=365),
+    )
+
+
+_ROWS = [
+    (pd.Timestamp("2025-11-01 00:00"), "BTCUSDT", 0.0001, 8.0),
+    (pd.Timestamp("2025-11-01 08:00"), "BTCUSDT", 0.0002, 8.0),
+    (pd.Timestamp("2025-11-01 00:00"), "BNBUSDT", 0.0003, 8.0),
+]
+
+
+class TestManifestIsNotAuthority:
+    """The symbols manifest is a lookup cache; a stale one must never hide rows the table holds."""
+
+    def test_read_returns_symbols_missing_from_manifest(self):
+        pgc = FakePGC(funding_rows=_ROWS)
+        reader = _reader(pgc, manifest_symbols={"BNBUSDT"})  # stale: BTCUSDT not registered
+        res = reader.read(["BTCUSDT", "BNBUSDT"], "funding_payment", start="2025-11-01", stop="2025-11-02")
+        assert {k: len(v) for k, v in res.raws.items()} == {"BTCUSDT": 2, "BNBUSDT": 1}
+        data_queries = [q for q in pgc.queries if "funding_rate" in q]
+        assert any("BTCUSDT" in q and "BNBUSDT" in q for q in data_queries), "both symbols must be in the WHERE"
+
+    def test_read_of_unknown_symbol_stays_filtered(self):
+        # pre-fix an empty manifest intersection dropped the WHERE clause and scanned the whole table
+        pgc = FakePGC(funding_rows=_ROWS)
+        reader = _reader(pgc, manifest_symbols={"BNBUSDT"})
+        res = reader.read(["BTCUSDT"], "funding_payment", start="2025-11-01", stop="2025-11-02")
+        assert set(res.raws) == {"BTCUSDT"}
+        data_queries = [q for q in pgc.queries if "funding_rate" in q]
+        assert all("BNBUSDT" not in q for q in data_queries), "unfiltered all-data scan leaked other symbols"
+
+    def test_get_time_range_probes_table_not_manifest(self):
+        reader = _reader(FakePGC(funding_rows=_ROWS), manifest_symbols={"BNBUSDT"})
+        t0, t1 = reader.get_time_range("BTCUSDT", "funding_payment")
+        assert pd.Timestamp(t0) == pd.Timestamp("2025-11-01 00:00")
+        assert pd.Timestamp(t1) == pd.Timestamp("2025-11-01 08:00")
+
+    def test_get_time_range_single_row_table(self):
+        reader = _reader(FakePGC(funding_rows=_ROWS[2:]), manifest_symbols={"BNBUSDT"})
+        t0, t1 = reader.get_time_range("BNBUSDT", "funding_payment")
+        assert pd.Timestamp(t0) == pd.Timestamp(t1) == pd.Timestamp("2025-11-01 00:00")
+
+    def test_get_time_range_absent_symbol_raises(self):
+        reader = _reader(FakePGC(funding_rows=_ROWS), manifest_symbols={"BNBUSDT"})
+        with pytest.raises(ValueError, match="NOPEUSDT"):
+            reader.get_time_range("NOPEUSDT", "funding_payment")
+
+
+class TestManifestRefreshSeesBackfills:
+    def test_stale_refresh_discovers_backfilled_symbols(self):
+        # BTCUSDT rows were backfilled: their DATA timestamps predate the manifest watermark,
+        # so the old incremental refresh (WHERE timestamp > last_updated) could never see them.
+        watermark = pd.Timestamp.utcnow().tz_localize(None) - pd.Timedelta(days=3)
+        rows = [
+            (watermark - pd.Timedelta(days=300), "BTCUSDT", 0.0001, 8.0),
+            (watermark - pd.Timedelta(days=1), "ETHUSDT", 0.0001, 8.0),
+        ]
+        pgc = FakePGC(funding_rows=rows, manifest_rows=[(FUNDING_TABLE, "ETHUSDT", watermark.to_pydatetime())])
+        mgr = SymbolsManifestManager(pgc, cache_ttl=timedelta(hours=24))
+        meta = xLTableMetaInfo.decode_table_metadata(FUNDING_TABLE)
+        assert meta is not None
+        out = mgr.get_symbols_for_tables([meta])
+        assert out[FUNDING_TABLE] == {"BTCUSDT", "ETHUSDT"}
+        inserts = [q for q in pgc.queries if q.startswith("INSERT")]
+        assert any("BTCUSDT" in q for q in inserts), "discovered symbol must be persisted to the manifest"
 
 
 class TestQuestDbStorages:


### PR DESCRIPTION
## Problem

`QuestDBReader` treats the `_qubx_symbols_manifest` cache as an authority, which made a Hyperliquid open-interest backfill on quantlab invisible in a batch-composition-dependent way:

- `read()` intersected requested symbols with the cached manifest and silently dropped any symbol the manifest didn't know — even when the table holds its rows. Worse, an **empty** intersection dropped the WHERE clause entirely (all-data scan), so reads "worked" only when *no* requested symbol was manifest-known. One manifest-known symbol in a batch poisoned everyone else:

  ```
  read(["BTCUSDC", "DOTUSDC"], "open_interest(15m)", ...)  -> BTC 672 rows  (unfiltered accident)
  read(["BTCUSDC", "BNBUSDC"], "open_interest(15m)", ...)  -> BTC 0 rows   (BNB in manifest -> WHERE symbol IN ('BNBUSDC'))
  ```

- The root staleness: the incremental manifest refresh ran `SELECT DISTINCT(symbol) ... WHERE timestamp > last_updated`, comparing **data timestamps** against a **wall-clock watermark**. Backfilled rows carry historical timestamps, so a backfill can never register its symbols. On quantlab the cron `hyperliquid.swap.open_interest_15m` manifest knew 10 symbols while the table held 421.

- `get_time_range()` had the same disease (raised for manifest-unknown symbols instead of probing the table, hiding backfilled ranges) plus a latent `IndexError` for single-timestamp symbols (`UNION` dedups the two probe rows).

## Fix

- `read()`: requested symbols go to the WHERE clause as-is (upper-cased); the manifest only drives the `min_symbols_for_all_data_request` heuristic. A symbol truly absent from the table harmlessly returns no rows. This also removes the accidental full-table scan for unknown symbols.
- Manifest refresh: always a full `SELECT DISTINCT(symbol)` (dictionary-backed for QuestDB SYMBOL columns — measured ms-to-single-digit-seconds on quantlab's largest 1m tables, and the WHERE-gated variant defeats that fast path anyway, so the "optimization" was also slower).
- `get_time_range()`: probes the table, raises only when the probe returns nothing, and handles the one-row UNION result.

## Tests

- `tests/qubx/data/test_questdb_storage.py`: new `FakePGC` that honors symbol filters in the SQL it's handed; 6 new tests covering the pruned-read, the accidental all-data scan, backfill-blind refresh, and the `get_time_range` cases. All fail on `dev`, pass here.
- Full unit suite: 2225 passed, 5 skipped.

## Verification against the real incident

On quantlab, the stale manifests were additionally repaired operationally (11,491 missing symbol registrations inserted across ~130 BIN/HPL tables). The poison-pair read above now returns 672/672 with a properly filtered query, and `get_time_range` reports the true backfilled range (2025-01-01 →) — this PR prevents the class of bug from recurring on the next backfill.
