### PR TITLE
feat: safe state persistence & bounded outbound I/O (platform #375)

### DIFF
--- a/docs/superpowers/plans/2026-08-19-safe-state-persistence.md
+++ b/docs/superpowers/plans/2026-08-19-safe-state-persistence.md
@@ -1,0 +1,1320 @@
+# Safe State Persistence & Bounded Outbound I/O — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The event loop never performs network I/O; every network call is bounded in time; every buffer is bounded in space (qubx side of xlydian-platform#375).
+
+**Architecture:** A `SafeStatePersistence` wrapper gives all persistence calls async per-key latest-wins semantics with read-your-writes and fail-fast startup validation; a shared `BoundedWorker` primitive (single thread, drop-oldest deque) replaces the unbounded `ThreadPoolExecutor`s in `RedisStreamsExporter` and `QuestDBMetricEmitter`; all redis/QuestDB clients gain socket timeouts and keepalive. Health monitor gains a `STATE_PERSISTENCE_STALE` degradation.
+
+**Tech Stack:** Python 3.12, redis-py, questdb-client, loguru (`from qubx import logger`), pytest (`just test` = `uv run pytest -m "not integration and not e2e" --ignore=debug -v -n auto`).
+
+**Spec:** `docs/superpowers/specs/2026-08-19-safe-state-persistence-design.md`
+
+## Global Constraints
+
+- Work in worktree `~/devs/Qubx/.worktrees/safe-state-persistence`, branch `feat/safe-state-persistence` (off `dev`). **Never push to `dev` directly** — pushing to `dev` triggers the full release pipeline. The branch is pushed and PR'd at the end.
+- Modern typing (`str | None`, `dict`, `tuple`), ruff line length 120.
+- Logging only via `from qubx import logger`.
+- All commands via `uv run ...` from the worktree root.
+- `IStatePersistence` protocol (`src/qubx/core/interfaces.py:59`) must NOT change.
+- Client timeout defaults (spec §2): `socket_connect_timeout=2.0, socket_timeout=5.0, socket_keepalive=True, health_check_interval=30` — overridable via constructor kwargs.
+- Fail-fast startup (spec D3): probe budget 60s, backoff `0.5,1,2,4,8,10,10,...`; exhaustion raises `StatePersistenceUnavailable`.
+
+---
+
+### Task 1: `BoundedWorker` primitive
+
+**Files:**
+- Create: `src/qubx/utils/threading.py`
+- Create: `tests/qubx/utils/__init__.py` (empty, if missing)
+- Test: `tests/qubx/utils/test_bounded_worker.py`
+
+**Interfaces:**
+- Consumes: stdlib only.
+- Produces (used by Tasks 3, 7, 8):
+  ```python
+  class BoundedWorker:
+      def __init__(self, name: str, maxlen: int, warn_every_s: float = 30.0) -> None: ...
+      def submit(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None: ...  # never blocks, never raises
+      def stop(self, flush_timeout_s: float = 5.0) -> None: ...  # drain best-effort, then join
+      @property
+      def dropped(self) -> int: ...  # total items dropped since construction
+      @property
+      def queued(self) -> int: ...
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/qubx/utils/test_bounded_worker.py
+import threading
+import time
+
+from qubx.utils.threading import BoundedWorker
+
+
+def _wait(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_executes_in_fifo_order_and_stop_flushes():
+    out: list[int] = []
+    w = BoundedWorker("t1", maxlen=100)
+    for i in range(20):
+        w.submit(out.append, i)
+    w.stop(flush_timeout_s=2.0)
+    assert out == list(range(20))
+
+
+def test_submit_never_blocks_and_drops_oldest_when_full():
+    gate = threading.Event()
+    out: list[int] = []
+
+    def task(i: int) -> None:
+        gate.wait(5.0)
+        out.append(i)
+
+    w = BoundedWorker("t2", maxlen=3)
+    t0 = time.monotonic()
+    for i in range(10):  # 1 in-flight (blocked on gate), 3 queued max, rest dropped-oldest
+        w.submit(task, i)
+    assert time.monotonic() - t0 < 0.5  # submit never blocked
+    assert _wait(lambda: w.dropped >= 6)
+    gate.set()
+    w.stop(flush_timeout_s=2.0)
+    # the in-flight item plus the LAST 3 queued survive; older ones were dropped
+    assert out[0] == 0 and out[-3:] == [7, 8, 9]
+    assert w.dropped == 6
+
+
+def test_task_exception_does_not_kill_worker():
+    out: list[str] = []
+    w = BoundedWorker("t3", maxlen=10)
+    w.submit(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    w.submit(out.append, "alive")
+    w.stop(flush_timeout_s=2.0)
+    assert out == ["alive"]
+
+
+def test_submit_after_stop_is_noop():
+    w = BoundedWorker("t4", maxlen=10)
+    w.stop()
+    w.submit(lambda: None)  # must not raise
+    assert w.queued == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/utils/test_bounded_worker.py -v`
+Expected: FAIL (ModuleNotFoundError: `qubx.utils.threading`)
+
+- [ ] **Step 3: Implement `BoundedWorker`**
+
+```python
+# src/qubx/utils/threading.py
+"""Bounded background-work primitives (spec: 2026-08-19-safe-state-persistence).
+
+Absolute imports mean ``import threading`` below resolves to the stdlib even
+though this module shares its name.
+"""
+import threading
+import time
+from collections import deque
+from typing import Any, Callable
+
+from qubx import logger
+
+
+class BoundedWorker:
+    """Single daemon worker thread over a drop-oldest bounded queue.
+
+    ``submit`` never blocks and never raises: when the queue is full the OLDEST
+    pending item is dropped (counted, warned at most once per ``warn_every_s``).
+    One worker per instance is deliberate — it preserves FIFO ordering, which
+    redis-stream exports rely on.
+    """
+
+    def __init__(self, name: str, maxlen: int, warn_every_s: float = 30.0) -> None:
+        self._name = name
+        self._maxlen = maxlen
+        self._warn_every_s = warn_every_s
+        self._queue: deque[tuple[Callable[..., Any], tuple, dict]] = deque()
+        self._cond = threading.Condition()
+        self._dropped = 0
+        self._dropped_unreported = 0
+        self._last_warn = 0.0
+        self._stopped = False
+        self._thread = threading.Thread(target=self._run, name=f"BoundedWorker-{name}", daemon=True)
+        self._thread.start()
+
+    @property
+    def dropped(self) -> int:
+        return self._dropped
+
+    @property
+    def queued(self) -> int:
+        with self._cond:
+            return len(self._queue)
+
+    def submit(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        with self._cond:
+            if self._stopped:
+                return
+            if len(self._queue) >= self._maxlen:
+                self._queue.popleft()
+                self._dropped += 1
+                self._dropped_unreported += 1
+                now = time.monotonic()
+                if now - self._last_warn >= self._warn_every_s:
+                    logger.warning(
+                        f"[BoundedWorker:{self._name}] queue full (maxlen={self._maxlen}) — "
+                        f"dropped {self._dropped_unreported} oldest items since last report"
+                    )
+                    self._last_warn = now
+                    self._dropped_unreported = 0
+            self._queue.append((fn, args, kwargs))
+            self._cond.notify()
+
+    def _run(self) -> None:
+        while True:
+            with self._cond:
+                while not self._queue and not self._stopped:
+                    self._cond.wait()
+                if not self._queue and self._stopped:
+                    return
+                fn, args, kwargs = self._queue.popleft()
+            try:
+                fn(*args, **kwargs)
+            except Exception as e:
+                logger.warning(f"[BoundedWorker:{self._name}] task failed: {e}")
+
+    def stop(self, flush_timeout_s: float = 5.0) -> None:
+        with self._cond:
+            self._stopped = True
+            self._cond.notify_all()
+        self._thread.join(timeout=flush_timeout_s)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/utils/test_bounded_worker.py -v`
+Expected: 4 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/utils/threading.py tests/qubx/utils/
+git commit -m "feat(utils): BoundedWorker — single-thread drop-oldest bounded work queue"
+```
+
+---
+
+### Task 2: Client timeouts in `RedisStatePersistence`
+
+**Files:**
+- Modify: `src/qubx/state/redis.py:33-60` (constructor only)
+- Test: `tests/qubx/state/__init__.py` (create empty), `tests/qubx/state/test_redis_client_options.py`
+
+**Interfaces:**
+- Produces: `RedisStatePersistence.__init__` gains keyword-only params
+  `socket_connect_timeout: float = 2.0, socket_timeout: float = 5.0, socket_keepalive: bool = True, health_check_interval: int = 30` — forwarded to `redis.from_url`. Everything else unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/qubx/state/test_redis_client_options.py
+from unittest.mock import MagicMock, patch
+
+from qubx.state.redis import RedisStatePersistence
+
+
+def test_client_created_with_bounded_failure_defaults():
+    with patch("qubx.state.redis.redis.from_url", return_value=MagicMock()) as from_url:
+        RedisStatePersistence(redis_url="redis://localhost:6379/0", strategy_name="s")
+    kwargs = from_url.call_args.kwargs
+    assert kwargs["socket_connect_timeout"] == 2.0
+    assert kwargs["socket_timeout"] == 5.0
+    assert kwargs["socket_keepalive"] is True
+    assert kwargs["health_check_interval"] == 30
+
+
+def test_timeouts_overridable():
+    with patch("qubx.state.redis.redis.from_url", return_value=MagicMock()) as from_url:
+        RedisStatePersistence(redis_url="redis://localhost:6379/0", strategy_name="s", socket_timeout=1.5)
+    assert from_url.call_args.kwargs["socket_timeout"] == 1.5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/state/test_redis_client_options.py -v`
+Expected: FAIL (KeyError: 'socket_connect_timeout')
+
+- [ ] **Step 3: Implement**
+
+In `RedisStatePersistence.__init__`, extend the signature after `indent: int | None = 2` with:
+
+```python
+        *,
+        socket_connect_timeout: float = 2.0,
+        socket_timeout: float = 5.0,
+        socket_keepalive: bool = True,
+        health_check_interval: int = 30,
+```
+
+and replace `self._redis = redis.from_url(redis_url)` with:
+
+```python
+        # - bounded-failure client: a dead peer costs seconds, never TCP-retransmission
+        #   minutes (incident 2026-08-19; platform #375). Retry policy lives in the
+        #   SafeStatePersistence wrapper, not here.
+        self._redis = redis.from_url(
+            redis_url,
+            socket_connect_timeout=socket_connect_timeout,
+            socket_timeout=socket_timeout,
+            socket_keepalive=socket_keepalive,
+            health_check_interval=health_check_interval,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/state/test_redis_client_options.py -v`
+Expected: 2 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/state/redis.py tests/qubx/state/
+git commit -m "fix(state): bounded-failure redis client defaults (timeouts, keepalive)"
+```
+
+---
+
+### Task 3: `SafeStatePersistence` — async core with read-your-writes
+
+**Files:**
+- Create: `src/qubx/state/safe.py`
+- Test: `tests/qubx/state/test_safe.py`
+
+**Interfaces:**
+- Consumes: `IStatePersistence` protocol (`qubx.core.interfaces`).
+- Produces (used by Tasks 4, 5, 6):
+  ```python
+  class SafeStatePersistence(IStatePersistence):
+      def __init__(self, backend: IStatePersistence, *,
+                   staleness_threshold_s: float = 60.0,
+                   flush_timeout_s: float = 5.0,
+                   retry_backoff_s: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0, 16.0, 30.0),
+                   sleep_fn: Callable[[float], None] = time.sleep) -> None: ...
+      def save(self, key: str, value: Any) -> None            # buffers; eager json dry-run; never network-blocks
+      def load(self, key: str, default: Any = None) -> Any     # pending-first read-your-writes
+      def delete(self, key: str) -> bool
+      def exists(self, key: str) -> bool
+      def last_success_age(self) -> float | None               # seconds since last successful write; None before first
+      def stop(self) -> None                                   # bounded flush + join
+      staleness_threshold_s: float                             # threshold the health monitor reads (Task 6)
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/qubx/state/test_safe.py
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from qubx.state.safe import SafeStatePersistence
+
+
+class FakeBackend:
+    """Scriptable IStatePersistence backend: can hang (Event) or fail N times."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, Any] = {}
+        self.saves: list[tuple[str, Any]] = []
+        self.gate = threading.Event()
+        self.gate.set()  # open by default
+        self.fail_saves_remaining = 0
+
+    def save(self, key: str, value: Any) -> None:
+        self.gate.wait(10.0)
+        if self.fail_saves_remaining > 0:
+            self.fail_saves_remaining -= 1
+            raise ConnectionError("backend down")
+        self.saves.append((key, value))
+        self.store[key] = value
+
+    def load(self, key: str, default: Any = None) -> Any:
+        self.gate.wait(10.0)
+        return self.store.get(key, default)
+
+    def delete(self, key: str) -> bool:
+        return self.store.pop(key, None) is not None
+
+    def exists(self, key: str) -> bool:
+        return key in self.store
+
+
+def _wait(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+@pytest.fixture
+def backend() -> FakeBackend:
+    return FakeBackend()
+
+
+@pytest.fixture
+def sp(backend):
+    p = SafeStatePersistence(backend, retry_backoff_s=(0.01, 0.02), sleep_fn=lambda s: time.sleep(min(s, 0.02)))
+    yield p
+    backend.gate.set()
+    p.stop()
+
+
+def test_save_returns_instantly_while_backend_hangs(sp, backend):
+    backend.gate.clear()  # backend hangs forever
+    t0 = time.monotonic()
+    sp.save("state", {"a": 1})
+    assert time.monotonic() - t0 < 0.05  # THE loop-liveness invariant
+
+
+def test_unserializable_value_raises_at_call_site(sp):
+    with pytest.raises(TypeError):
+        sp.save("bad", object())
+
+
+def test_write_through_and_last_success_age(sp, backend):
+    assert sp.last_success_age() is None
+    sp.save("k", {"v": 1})
+    assert _wait(lambda: backend.store.get("k") == {"v": 1})
+    assert sp.last_success_age() is not None and sp.last_success_age() < 1.0
+
+
+def test_latest_wins_per_key_while_blocked(sp, backend):
+    backend.gate.clear()
+    sp.save("k", 1)
+    sp.save("k", 2)
+    sp.save("other", "x")
+    backend.gate.set()
+    assert _wait(lambda: backend.store.get("k") == 2 and backend.store.get("other") == "x")
+    assert ("k", 1) not in backend.saves  # the stale intermediate was never written
+
+
+def test_read_your_writes_before_flush(sp, backend):
+    backend.gate.clear()
+    sp.save("k", {"pending": True})
+    assert sp.load("k") == {"pending": True}   # served from pending, no network
+    assert sp.exists("k") is True
+
+
+def test_tombstones(sp, backend):
+    backend.store["k"] = "old"
+    backend.gate.clear()
+    sp.delete("k")
+    assert sp.load("k", default="D") == "D"
+    assert sp.exists("k") is False
+    backend.gate.set()
+    assert _wait(lambda: "k" not in backend.store)
+
+
+def test_failed_batch_remerge_does_not_clobber_newer(sp, backend):
+    backend.fail_saves_remaining = 1
+    sp.save("k", "v1")            # first write attempt fails
+    time.sleep(0.005)
+    sp.save("k", "v2")            # arrives while retry pending
+    assert _wait(lambda: backend.store.get("k") == "v2")
+    assert not _wait(lambda: backend.store.get("k") == "v1", timeout=0.2)
+
+
+def test_stop_flushes_pending(backend):
+    p = SafeStatePersistence(backend, sleep_fn=lambda s: time.sleep(min(s, 0.01)))
+    p.save("final", 42)
+    p.stop()
+    assert backend.store.get("final") == 42
+
+
+def test_load_propagates_backend_errors(sp, backend):
+    def boom(key, default=None):
+        raise ConnectionError("down")
+    backend.load = boom  # type: ignore[assignment]
+    with pytest.raises(ConnectionError):
+        sp.load("missing")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/state/test_safe.py -v`
+Expected: FAIL (ModuleNotFoundError: `qubx.state.safe`)
+
+- [ ] **Step 3: Implement `SafeStatePersistence`**
+
+```python
+# src/qubx/state/safe.py
+"""Async wrapper making any IStatePersistence backend safe for the event loop.
+
+Contract (spec 2026-08-19-safe-state-persistence, D2): all writes are buffered
+per-key (latest wins) and flushed by ONE background writer thread; ``load``
+consults the pending buffer first (read-your-writes); no caller ever blocks on
+the network and network errors never raise from ``save``/``delete``.
+"""
+import json
+import threading
+import time
+from typing import Any, Callable
+
+from qubx import logger
+from qubx.core.interfaces import IStatePersistence
+
+_TOMBSTONE = object()
+
+
+class SafeStatePersistence(IStatePersistence):
+    def __init__(
+        self,
+        backend: IStatePersistence,
+        *,
+        staleness_threshold_s: float = 60.0,
+        flush_timeout_s: float = 5.0,
+        retry_backoff_s: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0, 16.0, 30.0),
+        sleep_fn: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._backend = backend
+        self.staleness_threshold_s = staleness_threshold_s
+        self._flush_timeout_s = flush_timeout_s
+        self._retry_backoff_s = retry_backoff_s
+        self._sleep = sleep_fn
+
+        self._pending: dict[str, Any] = {}
+        self._cond = threading.Condition()
+        self._stopped = False
+        self._last_success: float | None = None
+        self._consecutive_failures = 0
+        self._last_fail_log = 0.0
+        self._writer = threading.Thread(target=self._run, name="StatePersistenceWriter", daemon=True)
+        self._writer.start()
+
+    # ------------------------------------------------------------------ writes
+    def save(self, key: str, value: Any) -> None:
+        json.dumps(value)  # - eager dry-run: programming errors (TypeError/ValueError) stay loud at the call site
+        with self._cond:
+            self._pending[key] = value
+            self._cond.notify()
+
+    def delete(self, key: str) -> bool:
+        with self._cond:
+            self._pending[key] = _TOMBSTONE
+            self._cond.notify()
+        return True  # optimistic: actual backend result is async
+
+    # ------------------------------------------------------------------- reads
+    def load(self, key: str, default: Any = None) -> Any:
+        with self._cond:
+            if key in self._pending:
+                v = self._pending[key]
+                return default if v is _TOMBSTONE else v
+        return self._backend.load(key, default)
+
+    def exists(self, key: str) -> bool:
+        with self._cond:
+            if key in self._pending:
+                return self._pending[key] is not _TOMBSTONE
+        return self._backend.exists(key)
+
+    # ------------------------------------------------------------------ health
+    def last_success_age(self) -> float | None:
+        return None if self._last_success is None else time.monotonic() - self._last_success
+
+    @property
+    def consecutive_failures(self) -> int:
+        return self._consecutive_failures
+
+    # ------------------------------------------------------------------ writer
+    def _run(self) -> None:
+        while True:
+            with self._cond:
+                while not self._pending and not self._stopped:
+                    self._cond.wait()
+                if not self._pending and self._stopped:
+                    return
+                batch, self._pending = self._pending, {}
+
+            failed: dict[str, Any] = {}
+            for key, value in batch.items():
+                try:
+                    if value is _TOMBSTONE:
+                        self._backend.delete(key)
+                    else:
+                        self._backend.save(key, value)
+                    self._last_success = time.monotonic()
+                    self._consecutive_failures = 0
+                except (TypeError, ValueError):
+                    logger.error(f"[SafeStatePersistence] unserializable value for '{key}' reached writer; dropped")
+                except Exception as e:
+                    failed[key] = value
+                    self._consecutive_failures += 1
+                    now = time.monotonic()
+                    if now - self._last_fail_log >= 30.0:
+                        logger.warning(
+                            f"[SafeStatePersistence] backend write failed ({self._consecutive_failures} in a row): {e}"
+                        )
+                        self._last_fail_log = now
+
+            if failed:
+                with self._cond:
+                    for key, value in failed.items():
+                        self._pending.setdefault(key, value)  # - newer pending values win over the failed batch
+                    if self._stopped:
+                        return  # - do not backoff-sleep during shutdown
+                backoff = self._retry_backoff_s[min(self._consecutive_failures, len(self._retry_backoff_s)) - 1]
+                self._sleep(backoff)
+
+    def stop(self) -> None:
+        with self._cond:
+            self._stopped = True
+            self._cond.notify_all()
+        self._writer.join(timeout=self._flush_timeout_s)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/state/test_safe.py -v`
+Expected: 10 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/state/safe.py tests/qubx/state/test_safe.py
+git commit -m "feat(state): SafeStatePersistence — async per-key latest-wins wrapper with read-your-writes"
+```
+
+---
+
+### Task 4: Startup validation + `StatePersistenceUnavailable`
+
+**Files:**
+- Modify: `src/qubx/core/exceptions.py` (append)
+- Modify: `src/qubx/state/safe.py` (add `validate_startup`)
+- Test: `tests/qubx/state/test_safe.py` (append)
+
+**Interfaces:**
+- Produces (used by Task 5):
+  ```python
+  class StatePersistenceUnavailable(BaseError): ...   # qubx.core.exceptions
+
+  SafeStatePersistence.validate_startup(
+      self, deadline_s: float = 60.0,
+      probe_backoff_s: tuple[float, ...] = (0.5, 1.0, 2.0, 4.0, 8.0, 10.0),
+      clock: Callable[[], float] = time.monotonic,
+  ) -> None   # raises StatePersistenceUnavailable on budget exhaustion
+  ```
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/qubx/state/test_safe.py`)
+
+```python
+from qubx.core.exceptions import StatePersistenceUnavailable
+
+
+def test_validate_startup_succeeds_after_transient_failures(backend):
+    calls = {"n": 0}
+
+    def flaky_exists(key: str) -> bool:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("not yet")
+        return False
+
+    backend.exists = flaky_exists  # type: ignore[assignment]
+    p = SafeStatePersistence(backend, sleep_fn=lambda s: None)
+    p.validate_startup(deadline_s=60.0)
+    assert calls["n"] == 3
+    p.stop()
+
+
+def test_validate_startup_exhausts_budget_and_raises(backend):
+    def always_down(key: str) -> bool:
+        raise ConnectionError("down")
+
+    backend.exists = always_down  # type: ignore[assignment]
+    fake_now = {"t": 0.0}
+    slept: list[float] = []
+
+    def fake_sleep(s: float) -> None:
+        slept.append(s)
+        fake_now["t"] += s
+
+    p = SafeStatePersistence(backend, sleep_fn=fake_sleep)
+    with pytest.raises(StatePersistenceUnavailable):
+        p.validate_startup(deadline_s=60.0, clock=lambda: fake_now["t"])
+    assert slept[:6] == [0.5, 1.0, 2.0, 4.0, 8.0, 10.0]  # spec D3 schedule
+    assert sum(slept) >= 60.0
+    p.stop()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/state/test_safe.py -k validate_startup -v`
+Expected: FAIL (ImportError: `StatePersistenceUnavailable`)
+
+- [ ] **Step 3: Implement**
+
+Append to `src/qubx/core/exceptions.py`:
+
+```python
+class StatePersistenceUnavailable(BaseError):
+    """State persistence is enabled but unreachable/unreadable at startup.
+
+    Fatal by design (incident 2026-08-19, platform #375): starting a bot that
+    silently lost its persisted state is worse than crash-looping until the
+    backend returns.
+    """
+```
+
+Append to `SafeStatePersistence` (import `StatePersistenceUnavailable` from `qubx.core.exceptions` at top of `safe.py`):
+
+```python
+    def validate_startup(
+        self,
+        deadline_s: float = 60.0,
+        probe_backoff_s: tuple[float, ...] = (0.5, 1.0, 2.0, 4.0, 8.0, 10.0),
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Probe the backend with backoff for up to ``deadline_s``; raise on exhaustion (spec D3)."""
+        start = clock()
+        attempt = 0
+        last_err: Exception | None = None
+        while True:
+            try:
+                self._backend.exists("__qubx_probe__")
+                logger.info(f"[SafeStatePersistence] backend validated after {attempt + 1} attempt(s)")
+                return
+            except Exception as e:
+                last_err = e
+                elapsed = clock() - start
+                if elapsed >= deadline_s:
+                    raise StatePersistenceUnavailable(
+                        f"state persistence unreachable after {elapsed:.0f}s ({attempt + 1} attempts): {last_err}"
+                    ) from last_err
+                backoff = probe_backoff_s[min(attempt, len(probe_backoff_s) - 1)]
+                logger.warning(f"[SafeStatePersistence] startup probe failed (attempt {attempt + 1}): {e}; retrying in {backoff}s")
+                self._sleep(backoff)
+                attempt += 1
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/state/test_safe.py -v`
+Expected: 12 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/exceptions.py src/qubx/state/safe.py tests/qubx/state/test_safe.py
+git commit -m "feat(state): fail-fast startup validation with 60s backoff budget"
+```
+
+---
+
+### Task 5: Factory wiring
+
+**Files:**
+- Modify: `src/qubx/utils/runner/factory.py` (function `create_state_persistence`, currently at :445)
+- Test: `tests/qubx/state/test_factory_wrapping.py`
+
+**Interfaces:**
+- Consumes: `SafeStatePersistence` (Task 3/4), `StatePersistenceConfig` (has `type: str`, `parameters: dict`, `snapshot_interval: str | None = "5s"`).
+- Produces: `create_state_persistence(...)` returns `SafeStatePersistence` for any non-Dummy backend, already startup-validated; staleness threshold = `max(3 × snapshot_interval_seconds, 60.0)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/qubx/state/test_factory_wrapping.py
+from unittest.mock import patch
+
+from qubx.state.dummy import DummyStatePersistence
+from qubx.state.safe import SafeStatePersistence
+from qubx.utils.runner.configs import StatePersistenceConfig
+from qubx.utils.runner.factory import create_state_persistence
+
+
+class InMemoryBackend:
+    def __init__(self, strategy_name: str = "", **kwargs):
+        self.store = {}
+        self.probed = False
+
+    def save(self, key, value):
+        self.store[key] = value
+
+    def load(self, key, default=None):
+        return self.store.get(key, default)
+
+    def delete(self, key):
+        return self.store.pop(key, None) is not None
+
+    def exists(self, key):
+        self.probed = True
+        return key in self.store
+
+
+def test_real_backend_is_wrapped_and_validated():
+    cfg = StatePersistenceConfig(type="RedisStatePersistence", parameters={}, snapshot_interval="5s")
+    with patch("qubx.utils.runner.factory.class_import", return_value=InMemoryBackend):
+        sp = create_state_persistence(cfg, "strat")
+    assert isinstance(sp, SafeStatePersistence)
+    assert sp.staleness_threshold_s == 60.0  # max(3*5s, 60s)
+    sp.stop()
+
+
+def test_threshold_scales_with_long_snapshot_interval():
+    cfg = StatePersistenceConfig(type="RedisStatePersistence", parameters={}, snapshot_interval="1m")
+    with patch("qubx.utils.runner.factory.class_import", return_value=InMemoryBackend):
+        sp = create_state_persistence(cfg, "strat")
+    assert sp.staleness_threshold_s == 180.0  # max(3*60s, 60s)
+    sp.stop()
+
+
+def test_dummy_backend_is_not_wrapped():
+    cfg = StatePersistenceConfig(type="DummyStatePersistence", parameters={})
+    with patch("qubx.utils.runner.factory.class_import", return_value=DummyStatePersistence):
+        sp = create_state_persistence(cfg, "strat")
+    assert isinstance(sp, DummyStatePersistence)
+
+
+def test_none_config_returns_none():
+    assert create_state_persistence(None, "strat") is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/state/test_factory_wrapping.py -v`
+Expected: `test_real_backend_is_wrapped_and_validated` FAILs (returns `InMemoryBackend`, not `SafeStatePersistence`)
+
+- [ ] **Step 3: Implement**
+
+In `factory.py`, add imports:
+
+```python
+import pandas as pd
+
+from qubx.state.dummy import DummyStatePersistence
+from qubx.state.safe import SafeStatePersistence
+```
+
+and in `create_state_persistence`, replace
+
+```python
+        persistence = persistence_class(**params)
+        logger.info(f"Created state persistence: {persistence_class_name}")
+        return persistence
+```
+
+with
+
+```python
+        persistence = persistence_class(**params)
+        logger.info(f"Created state persistence: {persistence_class_name}")
+
+        if isinstance(persistence, DummyStatePersistence):
+            return persistence
+
+        # - wrap every real backend (spec D2/D4): async latest-wins writes, read-your-writes,
+        #   fail-fast startup (D3). StatePersistenceUnavailable propagates and kills the runner.
+        interval_s = pd.Timedelta(config.snapshot_interval).total_seconds() if config.snapshot_interval else 0.0
+        safe = SafeStatePersistence(persistence, staleness_threshold_s=max(3.0 * interval_s, 60.0))
+        safe.validate_startup()
+        return safe
+```
+
+(the surrounding `except Exception ... raise` already makes the failure fatal to the runner — `runner.py:653` performs no fallback.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/state/test_factory_wrapping.py tests/qubx/state -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/utils/runner/factory.py tests/qubx/state/test_factory_wrapping.py
+git commit -m "feat(runner): wrap real state backends in SafeStatePersistence with fail-fast startup"
+```
+
+---
+
+### Task 6: Health integration — `STATE_PERSISTENCE_STALE`
+
+**Files:**
+- Modify: `src/qubx/core/status.py` (`DegradeReason`)
+- Modify: `src/qubx/health/base.py` (new setter + check, call in `_monitor_loop` at :533)
+- Modify: `src/qubx/core/context.py` (wire after `self._health_monitor.set_status(self._status)` at :216; note `self._state_persistence` is assigned at :217 — insert the wiring after that line)
+- Test: `tests/qubx/health/test_state_staleness.py`
+
+**Interfaces:**
+- Consumes: `SafeStatePersistence.last_success_age()`, `.staleness_threshold_s` (Task 3), `ContextStatus.add/clear`, `record_gauge(name, value, tags)` (`health/base.py:526`).
+- Produces: `DegradeReason.STATE_PERSISTENCE_STALE = "state_persistence_stale"`;
+  `BaseHealthMonitor.set_state_persistence(sp: Any) -> None`; `BaseHealthMonitor.check_state_persistence() -> None`; gauge `state_persistence_lag` (seconds).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/qubx/health/test_state_staleness.py
+import numpy as np
+
+from qubx.core.basics import ITimeProvider
+from qubx.core.status import ContextStatus, DegradeReason
+from qubx.health.base import BaseHealthMonitor
+
+
+class FixedTime(ITimeProvider):
+    def __init__(self) -> None:
+        self.now = np.datetime64("2026-08-19T00:00:00", "ns")
+
+    def time(self) -> np.datetime64:
+        return self.now
+
+
+class StubSafePersistence:
+    staleness_threshold_s = 60.0
+
+    def __init__(self) -> None:
+        self.age: float | None = 0.0
+
+    def last_success_age(self) -> float | None:
+        return self.age
+
+
+def _make_monitor():
+    monitor = BaseHealthMonitor(FixedTime())
+    status = ContextStatus()
+    monitor.set_status(status)
+    sp = StubSafePersistence()
+    monitor.set_state_persistence(sp)
+    return monitor, status, sp
+
+
+def test_degrades_when_stale_and_clears_on_recovery():
+    monitor, status, sp = _make_monitor()
+
+    sp.age = 10.0
+    monitor.check_state_persistence()
+    assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+
+    sp.age = 120.0
+    monitor.check_state_persistence()
+    assert any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+
+    sp.age = 1.0
+    monitor.check_state_persistence()
+    assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+
+
+def test_no_persistence_wired_is_noop():
+    monitor = BaseHealthMonitor(FixedTime())
+    monitor.set_status(ContextStatus())
+    monitor.check_state_persistence()  # must not raise
+
+
+def test_age_none_before_first_write_is_not_stale():
+    monitor, status, sp = _make_monitor()
+    sp.age = None
+    monitor.check_state_persistence()
+    assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+```
+
+(If `BaseHealthMonitor(FixedTime())` needs more constructor args, mirror the fixture at `tests/qubx/health/test_base.py:93-97` — it constructs a monitor from a `MockTimeProvider`; reuse its argument pattern verbatim.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/health/test_state_staleness.py -v`
+Expected: FAIL (AttributeError: `set_state_persistence`)
+
+- [ ] **Step 3: Implement**
+
+`src/qubx/core/status.py` — extend the enum:
+
+```python
+class DegradeReason(StrEnum):
+    INTERNAL_QUEUE_OVERFLOW = "internal_queue_overflow"
+    EXCHANGE_MAINTENANCE = "exchange_maintenance"
+    STATE_PERSISTENCE_STALE = "state_persistence_stale"
+```
+
+`src/qubx/health/base.py` — add next to `set_status` (`:252`), following the
+`check_queue_drain` degrade/clear pattern (`:257-293`):
+
+```python
+    def set_state_persistence(self, persistence: Any) -> None:
+        """Wire a SafeStatePersistence (duck-typed: needs last_success_age() and
+        staleness_threshold_s) so the monitor can report write staleness."""
+        self._state_persistence = persistence
+        self._state_stale = False
+
+    def check_state_persistence(self) -> None:
+        sp = getattr(self, "_state_persistence", None)
+        if sp is None or self._status is None:
+            return
+        age = sp.last_success_age()
+        if age is not None:
+            self.record_gauge("state_persistence_lag", age)
+        threshold = sp.staleness_threshold_s
+        stale = age is not None and age > threshold
+        if stale and not getattr(self, "_state_stale", False):
+            self._state_stale = True
+            logger.warning(
+                f"[health] state not persisted for {age:.0f}s (threshold {threshold:.0f}s) — "
+                "context DEGRADED (state_persistence_stale)"
+            )
+            self._status.add(
+                DegradeReason.STATE_PERSISTENCE_STALE, self.time_provider.time(),
+                message=f"no successful state write for {age:.0f}s",
+            )
+        elif not stale and getattr(self, "_state_stale", False):
+            self._state_stale = False
+            logger.info("[health] state persistence recovered — state_persistence_stale cleared")
+            self._status.clear(DegradeReason.STATE_PERSISTENCE_STALE)
+```
+
+In `_monitor_loop` (`:533`), inside the `try:` after `self.check_queue_drain(current_size)`:
+
+```python
+                self.check_state_persistence()
+```
+
+`src/qubx/core/context.py` — after line 217 (`self._state_persistence = state_persistence or DummyStatePersistence()`):
+
+```python
+        if hasattr(self._state_persistence, "last_success_age"):
+            self._health_monitor.set_state_persistence(self._state_persistence)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/health/ -v`
+Expected: new tests PASS, existing `test_base.py` still PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/status.py src/qubx/health/base.py src/qubx/core/context.py tests/qubx/health/test_state_staleness.py
+git commit -m "feat(health): STATE_PERSISTENCE_STALE degradation + state_persistence_lag gauge"
+```
+
+---
+
+### Task 7: `RedisStreamsExporter` — BoundedWorker + client timeouts
+
+**Files:**
+- Modify: `src/qubx/exporters/redis_streams.py` (`:66` client, `:82` executor, `:102-109` stop, `:145` submit)
+- Test: `tests/qubx/exporters/test_redis_streams_bounded.py`
+
+**Interfaces:**
+- Consumes: `BoundedWorker` (Task 1).
+- Produces: same public exporter API; constructor param `max_workers: int = 2` becomes deprecated-ignored (kept for config compat, log a deprecation debug); new param `max_queue: int = 1000`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/qubx/exporters/test_redis_streams_bounded.py
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from qubx.exporters.redis_streams import RedisStreamsExporter
+
+
+def _make_exporter(**kwargs):
+    with patch("qubx.exporters.redis_streams.redis.from_url", return_value=MagicMock()) as from_url:
+        exp = RedisStreamsExporter(redis_url="redis://localhost:6379/0", strategy_name="s", **kwargs)
+    return exp, from_url
+
+
+def test_client_has_bounded_failure_defaults():
+    _, from_url = _make_exporter()
+    kwargs = from_url.call_args.kwargs
+    assert kwargs["socket_connect_timeout"] == 2.0
+    assert kwargs["socket_timeout"] == 5.0
+    assert kwargs["socket_keepalive"] is True
+
+
+def test_stream_writes_preserve_fifo_order():
+    exp, _ = _make_exporter()
+    seen: list[int] = []
+    for i in range(50):
+        exp._worker.submit(seen.append, i)
+    exp._worker.stop(flush_timeout_s=2.0)
+    assert seen == list(range(50))
+
+
+def test_queue_bounded_under_hung_backend():
+    exp, _ = _make_exporter(max_queue=5)
+    gate = threading.Event()
+    exp._worker.submit(gate.wait, 5.0)  # occupy the worker
+    t0 = time.monotonic()
+    for i in range(50):
+        exp._worker.submit(lambda: None)
+    assert time.monotonic() - t0 < 0.5
+    assert exp._worker.dropped >= 44
+    gate.set()
+    exp.stop()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/exporters/test_redis_streams_bounded.py -v`
+Expected: FAIL (no `socket_connect_timeout` kwarg; no `_worker` attribute)
+
+- [ ] **Step 3: Implement**
+
+In `redis_streams.py`:
+- add `from qubx.utils.threading import BoundedWorker`; add constructor param `max_queue: int = 1000`.
+- `:66` → same client kwargs block as Task 2 (`socket_connect_timeout=2.0, socket_timeout=5.0, socket_keepalive=True, health_check_interval=30`).
+- `:82` → replace `self._executor = ThreadPoolExecutor(...)` with:
+
+```python
+        # - single bounded worker: preserves XADD ordering per stream (2 pool workers could
+        #   reorder targets) and bounds memory/burst under outages (platform #375).
+        if max_workers != 2:
+            logger.debug("[RedisStreamsExporter] max_workers is deprecated and ignored (single bounded worker)")
+        self._worker = BoundedWorker("redis_exporter", maxlen=max_queue)
+```
+
+- `:145` (and any other `self._executor.submit(...)` in the file — grep for them) → `self._worker.submit(...)` with identical arguments.
+- `stop()` (`:102-109`): replace `self._executor.shutdown(wait=False, cancel_futures=True)` with `self._worker.stop(flush_timeout_s=5.0)`.
+- Remove the now-unused `from concurrent.futures import ThreadPoolExecutor` import.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/exporters/ -v`
+Expected: new tests PASS, existing exporter tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/exporters/redis_streams.py tests/qubx/exporters/test_redis_streams_bounded.py
+git commit -m "fix(exporters): bounded single-worker redis exporter with client timeouts (fixes XADD reordering)"
+```
+
+---
+
+### Task 8: `QuestDBMetricEmitter` — BoundedWorker + Sender timeouts
+
+**Files:**
+- Modify: `src/qubx/emitters/questdb.py` (`:70` conn str, `:74` executor, `:96/:125/:179/:299/:314/:409` submit/stop sites)
+- Test: `tests/qubx/emitters/test_questdb_bounded.py`
+
+**Interfaces:**
+- Consumes: `BoundedWorker` (Task 1).
+- Produces: same public emitter API; new param `max_queue: int = 10_000`; conn string gains `request_timeout=5000;retry_timeout=5000;`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/qubx/emitters/test_questdb_bounded.py
+from qubx.emitters.questdb import QuestDBMetricEmitter
+from qubx.utils.threading import BoundedWorker
+
+
+def test_conn_string_has_bounded_timeouts():
+    em = QuestDBMetricEmitter(host="qdb.local", port=9000)
+    assert "request_timeout=5000;" in em._conn_str
+    assert "retry_timeout=5000;" in em._conn_str
+    em._worker.stop()
+
+
+def test_uses_bounded_worker():
+    em = QuestDBMetricEmitter(host="qdb.local", port=9000, max_queue=123)
+    assert isinstance(em._worker, BoundedWorker)
+    assert em._worker._maxlen == 123
+    em._worker.stop()
+```
+
+(If `QuestDBMetricEmitter.__init__` requires more args, copy the minimal construction used in `tests/qubx/emitters/metric_emitters_test.py` and adapt.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/emitters/test_questdb_bounded.py -v`
+Expected: FAIL (`request_timeout` not in conn str)
+
+- [ ] **Step 3: Implement**
+
+In `questdb.py`:
+- `:70` → `self._conn_str = f"http::addr={host}:{port};request_timeout=5000;retry_timeout=5000;"`
+  (client default `retry_timeout` is 10000 — halved so a dead server costs ≤10s per flush attempt; verified against installed `questdb.ingress.Sender` API.)
+- `:74` → `self._worker = BoundedWorker("questdb_emitter", maxlen=max_queue)` with new constructor param `max_queue: int = 10_000`; `max_workers` kept but deprecated-ignored (debug log), as in Task 7.
+- Every `self._executor.submit(...)` (`:96, :179, :299, :314, :409`) → `self._worker.submit(...)`.
+- `:125` `self._executor.shutdown(wait=False, cancel_futures=True)` → `self._worker.stop(flush_timeout_s=5.0)`.
+- Remove unused `ThreadPoolExecutor` import.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/emitters/ -v`
+Expected: new tests PASS, `metric_emitters_test.py` and `strategy_tables_test.py` PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/emitters/questdb.py tests/qubx/emitters/test_questdb_bounded.py
+git commit -m "fix(emitters): bounded questdb emitter queue + ILP request/retry timeouts"
+```
+
+---
+
+### Task 9: Integration test (docker redis), full validation, PR
+
+**Files:**
+- Create: `tests/qubx/state/test_safe_integration.py`
+- Test: full suite + lint
+
+**Interfaces:** consumes everything above; produces the PR.
+
+- [ ] **Step 1: Write the integration test**
+
+```python
+# tests/qubx/state/test_safe_integration.py
+"""Integration: SafeStatePersistence vs a real redis that gets frozen mid-run.
+
+``docker pause`` freezes the server process WITHOUT closing TCP connections —
+the closest reproduction of the 2026-08-19 half-open-socket incident.
+Requires docker; runs only under `-m integration`.
+"""
+import json
+import subprocess
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+CONTAINER = f"qubx-test-redis-{uuid.uuid4().hex[:8]}"
+PORT = 63790
+
+
+@pytest.fixture(scope="module")
+def redis_container():
+    subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", CONTAINER, "-p", f"{PORT}:6379", "redis:7-alpine"],
+        check=True, capture_output=True,
+    )
+    time.sleep(1.0)
+    yield CONTAINER
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+
+
+def _pause():
+    subprocess.run(["docker", "pause", CONTAINER], check=True, capture_output=True)
+
+
+def _unpause():
+    subprocess.run(["docker", "unpause", CONTAINER], check=True, capture_output=True)
+
+
+def test_event_loop_liveness_through_redis_freeze(redis_container):
+    from qubx.state.redis import RedisStatePersistence
+    from qubx.state.safe import SafeStatePersistence
+
+    backend = RedisStatePersistence(
+        redis_url=f"redis://localhost:{PORT}/0", strategy_name="itest", socket_timeout=1.0, socket_connect_timeout=1.0
+    )
+    sp = SafeStatePersistence(backend, retry_backoff_s=(0.5, 1.0))
+    sp.validate_startup(deadline_s=10.0)
+
+    sp.save("k", {"phase": 1})
+    deadline = time.monotonic() + 5.0
+    while sp.last_success_age() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert sp.last_success_age() is not None
+
+    _pause()
+    try:
+        t0 = time.monotonic()
+        sp.save("k", {"phase": 2})           # must return instantly despite frozen server
+        assert time.monotonic() - t0 < 0.05
+        assert sp.load("k") == {"phase": 2}  # read-your-writes while frozen
+        time.sleep(3.0)
+        assert sp.last_success_age() > 2.0   # staleness visibly grows
+    finally:
+        _unpause()
+
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        if json.loads(backend._redis.get("state:itest:k") or "null") == {"phase": 2}:
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("pending write was not flushed after recovery")
+    sp.stop()
+
+
+def test_cold_start_against_frozen_redis_fails_fast(redis_container):
+    from qubx.core.exceptions import StatePersistenceUnavailable
+    from qubx.state.redis import RedisStatePersistence
+    from qubx.state.safe import SafeStatePersistence
+
+    _pause()
+    try:
+        backend = RedisStatePersistence(
+            redis_url=f"redis://localhost:{PORT}/0", strategy_name="itest2",
+            socket_timeout=1.0, socket_connect_timeout=1.0,
+        )
+        sp = SafeStatePersistence(backend)
+        t0 = time.monotonic()
+        with pytest.raises(StatePersistenceUnavailable):
+            sp.validate_startup(deadline_s=5.0)
+        assert time.monotonic() - t0 < 15.0  # bounded, not TCP-retransmission minutes
+        sp.stop()
+    finally:
+        _unpause()
+```
+
+- [ ] **Step 2: Run the integration test (requires docker)**
+
+Run: `uv run pytest tests/qubx/state/test_safe_integration.py -m integration -v`
+Expected: 2 PASS (skip gracefully and note it in the PR if docker is unavailable on this machine)
+
+- [ ] **Step 3: Full validation**
+
+Run: `uv run pytest -m "not integration and not e2e" --ignore=debug -q -n 4` (NOT `-n auto` — cgroup-unaware CPU count OOMs CI-sized environments; locally 4 is safe) and `just lint` (or `uv run ruff check src tests` if no lint recipe).
+Expected: suite green, lint clean.
+
+- [ ] **Step 4: Commit and push the branch (NOT dev)**
+
+```bash
+git add tests/qubx/state/test_safe_integration.py
+git commit -m "test(state): integration — SafeStatePersistence liveness through docker-paused redis"
+git push -u origin feat/safe-state-persistence
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --base dev --title "feat: safe state persistence & bounded outbound I/O (platform #375)" \
+  --body "Implements docs/superpowers/specs/2026-08-19-safe-state-persistence-design.md — see spec for the incident analysis and decisions (D1-D4).
+
+- SafeStatePersistence: async per-key latest-wins writes, read-your-writes, fail-fast 60s startup validation (StatePersistenceUnavailable), bounded flush on stop
+- Redis clients (state + streams exporter): socket/connect timeouts, keepalive, health checks
+- BoundedWorker replaces unbounded ThreadPoolExecutors in RedisStreamsExporter (also fixes XADD reordering) and QuestDBMetricEmitter; QuestDB Sender gains request/retry timeouts
+- Health: DegradeReason.STATE_PERSISTENCE_STALE + state_persistence_lag gauge
+
+Closes the qubx side of xLydianSoftware/xlydian-platform#375 (epic #374, incident 2026-08-19)."
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: §1→T3/T4, §2→T2, §3→T1, §4→T7, §5→T8, §6→T5, §7→T6, §8 (no `processing.py` change) → enforced by touching nothing there; failure timeline → T9 integration; testing section → per-task tests + T9; rollout → PR to dev only.
+- `delete()` returning optimistic `True` is a documented semantic change (was: actual backend result); acceptable — no caller in qubx/strategies branches on it (verified: only frab/quantkit use save/load).
+- Task 6 test constructs `BaseHealthMonitor` minimally; if the constructor needs extra args the task instructs reusing the existing fixture pattern from `tests/qubx/health/test_base.py` — not a placeholder, the pattern exists in-repo.

--- a/docs/superpowers/plans/2026-08-19-safe-state-persistence.md
+++ b/docs/superpowers/plans/2026-08-19-safe-state-persistence.md
@@ -1313,6 +1313,238 @@ Closes the qubx side of xLydianSoftware/xlydian-platform#375 (epic #374, inciden
 
 ---
 
+### Task 10: Resilient rate-limit backend (client timeouts + local fallback + 30s breaker)
+
+Implements spec section "Rate-limit backend resilience (increment 2)". Read that
+section first — decisions RL-D1…RL-D4 are binding.
+
+**Files:**
+- Modify: `src/qubx/rate_limiting/redis_backend.py` (ctor timeout kwargs → `from_url`)
+- Modify: `src/qubx/rate_limiting/backend.py` (add non-abstract `async def close()` no-op to `IRateLimitBackend`)
+- Create: `src/qubx/rate_limiting/resilient.py` (`ResilientRateLimitBackend`)
+- Modify: `src/qubx/rate_limiting/manager.py` (`_create_backend` wraps redis in the composite)
+- Modify: `src/qubx/rate_limiting/__init__.py` (export `ResilientRateLimitBackend`)
+- Test: `tests/qubx/rate_limiting/test_resilient.py`
+- Test: `tests/qubx/rate_limiting/test_redis_client_options.py`
+- Test: `tests/qubx/rate_limiting/test_resilient_integration.py` (docker, `pytest.mark.integration`)
+
+**Interfaces:**
+- Consumes: `IRateLimitBackend`, `InMemoryBackend` (backend.py), `RedisBackend` (redis_backend.py), `from qubx import logger`
+- Produces: `ResilientRateLimitBackend(primary: IRateLimitBackend, fallback: IRateLimitBackend | None = None, breaker_cooldown_s: float = 30.0)` implementing the full `IRateLimitBackend` surface + `close()`; `RedisBackend(redis_url, *, socket_connect_timeout=2.0, socket_timeout=5.0, socket_keepalive=True, health_check_interval=30)`
+
+- [ ] **Step 1: Failing unit tests for the composite**
+
+`tests/qubx/rate_limiting/test_resilient.py` — a `FakeBackend(IRateLimitBackend)`
+records calls and can be set to raise or to block on an `asyncio.Event`:
+
+```python
+class FakeBackend(IRateLimitBackend):
+    def __init__(self) -> None:
+        self.acquire_calls = 0
+        self.get_calls = 0
+        self.set_calls = 0
+        self.closed = False
+        self.raise_exc: Exception | None = None
+        self.block_on: asyncio.Event | None = None
+
+    async def acquire(self, key, weight, capacity, refill_rate) -> float:
+        self.acquire_calls += 1
+        if self.block_on is not None:
+            await self.block_on.wait()
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return 0.0
+
+    async def get_remaining(self, key, capacity=0, refill_rate=0):
+        self.get_calls += 1
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return 1.0
+
+    async def set_remaining(self, key, remaining, capacity=0, refill_rate=0) -> None:
+        self.set_calls += 1
+        if self.raise_exc is not None:
+            raise self.raise_exc
+
+    async def close(self) -> None:
+        self.closed = True
+```
+
+Tests (all `async def` via anyio/asyncio marker used elsewhere in this test dir;
+no sleeps — force breaker timing by assigning `backend._broken_until` directly):
+
+1. `test_passthrough_when_primary_healthy` — acquire/get/set hit primary; fallback untouched.
+2. `test_error_opens_breaker_and_serves_fallback` — primary raises `ConnectionError`; acquire returns via fallback; a second acquire does not touch primary (`acquire_calls` stays 1).
+3. `test_probe_after_cooldown_single_caller` — after the error, set `resilient._broken_until = 0.0`; primary healed (`raise_exc = None`); next acquire probes primary and closes the breaker; the following acquire also hits primary.
+4. `test_concurrent_callers_stay_local_while_probe_inflight` — primary healed but blocked on an `Event`; force probe due; start task A (probes, blocks), then await call B → must be served by fallback (primary `acquire_calls == 1`); release the event; A completes; next call hits primary.
+5. `test_probe_failure_reopens` — probe raises again → immediate next call goes to fallback without touching primary.
+6. `test_set_and_get_follow_policy` — with breaker open, `get_remaining`/`set_remaining` route to fallback.
+7. `test_cancelled_error_propagates` — primary raises `asyncio.CancelledError`: it propagates out of acquire and the breaker stays closed.
+8. `test_close_closes_both` — `close()` closes primary and fallback.
+
+`tests/qubx/rate_limiting/test_redis_client_options.py` — mirror
+`tests/qubx/state/test_redis_client_options.py`: monkeypatch
+`redis.asyncio.from_url` with a MagicMock (whose `register_script` returns
+MagicMocks), invoke `RedisBackend("redis://x")._scripts_for_current_loop()`
+inside a running loop, and assert `from_url` received
+`socket_connect_timeout=2.0, socket_timeout=5.0, socket_keepalive=True,
+health_check_interval=30` (plus the existing `decode_responses=True,
+single_connection_client=True`).
+
+- [ ] **Step 2: Run tests, verify they fail** (`ResilientRateLimitBackend` doesn't exist; `from_url` lacks kwargs)
+
+- [ ] **Step 3: Implement**
+
+`src/qubx/rate_limiting/backend.py` — append to `IRateLimitBackend` (non-abstract):
+
+```python
+    async def close(self) -> None:
+        """Release backend resources for the current event loop. Default: no-op."""
+        return None
+```
+
+`src/qubx/rate_limiting/redis_backend.py` — ctor gains keyword-only params with
+the RL-D1 defaults, stored as a `self._client_kwargs` dict merged into the
+existing `from_url` call in `_scripts_for_current_loop` (keep
+`decode_responses=True, single_connection_client=True`).
+
+`src/qubx/rate_limiting/resilient.py`:
+
+```python
+import time
+
+from redis.exceptions import RedisError
+
+from qubx import logger
+
+from .backend import InMemoryBackend, IRateLimitBackend
+
+_BACKEND_ERRORS = (RedisError, OSError)
+
+
+class ResilientRateLimitBackend(IRateLimitBackend):
+    """Composite: primary (redis) with local fallback and a circuit breaker.
+
+    Primary healthy → pass-through. Primary error → breaker opens for
+    breaker_cooldown_s and calls are served by the local fallback (per-bot
+    pacing, no cross-bot coordination). Cooldown expiry → exactly one caller
+    probes the primary; concurrent callers stay on the fallback until the
+    probe resolves. State is plain monotonic floats shared across event
+    loops — races are benign (worst case: two probes).
+    """
+
+    def __init__(
+        self,
+        primary: IRateLimitBackend,
+        fallback: IRateLimitBackend | None = None,
+        breaker_cooldown_s: float = 30.0,
+    ):
+        self._primary = primary
+        self._fallback = fallback or InMemoryBackend()
+        self._breaker_cooldown_s = breaker_cooldown_s
+        self._broken = False
+        self._broken_until = 0.0
+        self._probe_inflight = False
+
+    def _use_primary(self) -> bool:
+        """Route decision for this call; claims the probe slot when one is due."""
+        if not self._broken:
+            return True
+        if self._probe_inflight or time.monotonic() < self._broken_until:
+            return False
+        self._probe_inflight = True
+        return True
+
+    def _on_success(self) -> None:
+        self._probe_inflight = False
+        if self._broken:
+            self._broken = False
+            logger.info("Rate-limit redis backend recovered — resuming cross-bot coordination")
+
+    def _on_error(self, exc: Exception) -> None:
+        self._probe_inflight = False
+        if not self._broken:
+            logger.warning(
+                f"Rate-limit redis backend unavailable ({exc!r}) — "
+                f"falling back to local buckets for {self._breaker_cooldown_s:.0f}s"
+            )
+        self._broken = True
+        self._broken_until = time.monotonic() + self._breaker_cooldown_s
+
+    async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
+        if self._use_primary():
+            try:
+                waited = await self._primary.acquire(key, weight, capacity, refill_rate)
+            except _BACKEND_ERRORS as e:
+                self._on_error(e)
+            else:
+                self._on_success()
+                return waited
+        return await self._fallback.acquire(key, weight, capacity, refill_rate)
+
+    async def get_remaining(self, key: str, capacity: float = 0, refill_rate: float = 0) -> float | None:
+        if self._use_primary():
+            try:
+                remaining = await self._primary.get_remaining(key, capacity, refill_rate)
+            except _BACKEND_ERRORS as e:
+                self._on_error(e)
+            else:
+                self._on_success()
+                return remaining
+        return await self._fallback.get_remaining(key, capacity, refill_rate)
+
+    async def set_remaining(self, key: str, remaining: float, capacity: float = 0, refill_rate: float = 0) -> None:
+        if self._use_primary():
+            try:
+                await self._primary.set_remaining(key, remaining, capacity, refill_rate)
+            except _BACKEND_ERRORS as e:
+                self._on_error(e)
+            else:
+                self._on_success()
+                return
+        await self._fallback.set_remaining(key, remaining, capacity, refill_rate)
+
+    async def close(self) -> None:
+        await self._primary.close()
+        await self._fallback.close()
+```
+
+`src/qubx/rate_limiting/manager.py::_create_backend` — wrap:
+
+```python
+        if config.backend == "redis" and config.redis_url:
+            try:
+                from .redis_backend import RedisBackend
+                from .resilient import ResilientRateLimitBackend
+
+                return ResilientRateLimitBackend(RedisBackend(config.redis_url))
+            except Exception as e:
+                logger.error(f"Failed to create Redis rate limit backend: {e}, falling back to local")
+        return InMemoryBackend()
+```
+
+`__init__.py`: add `ResilientRateLimitBackend` to the imports and `__all__`.
+
+- [ ] **Step 4: Run unit tests, verify pass** (`uv run pytest tests/qubx/rate_limiting/ -q`)
+
+- [ ] **Step 5: Integration test** — `tests/qubx/rate_limiting/test_resilient_integration.py`,
+mirroring `tests/qubx/state/test_safe_integration.py`'s docker fixture (own
+container name e.g. `qubx-rl-itest-redis` and own port, `redis:7-alpine`,
+`pytestmark = pytest.mark.integration`):
+  1. Build `ResilientRateLimitBackend(RedisBackend(url))`; `acquire` succeeds via primary (verify the `ratelimit:` key exists through a separate control client).
+  2. `docker pause` → next `acquire` returns in < 8 s (socket timeout → fallback) and the one after in < 0.5 s (breaker open, no timeout tax).
+  3. `docker unpause` → force `_broken_until = 0.0` → `acquire` routes to primary again (control client sees the key's `last_refill` advance).
+
+- [ ] **Step 6: Full check + commit**
+
+```bash
+uv run ruff check src/qubx/rate_limiting tests/qubx/rate_limiting && uv run ruff format --check src/qubx/rate_limiting tests/qubx/rate_limiting
+uv run pytest tests/qubx/rate_limiting -q
+git add -A && git commit -m "feat(rate-limiting): resilient redis backend — client timeouts, local fallback, 30s circuit breaker"
+```
+
+---
+
 ## Self-review notes
 
 - Spec coverage: §1→T3/T4, §2→T2, §3→T1, §4→T7, §5→T8, §6→T5, §7→T6, §8 (no `processing.py` change) → enforced by touching nothing there; failure timeline → T9 integration; testing section → per-task tests + T9; rollout → PR to dev only.

--- a/docs/superpowers/specs/2026-08-19-safe-state-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-19-safe-state-persistence-design.md
@@ -204,3 +204,86 @@ books when bumping.
   same signal.
 - control-api redis retry + QuestDB circuit breaker (#376), Postgres/QuestDB
   server-side keepalives and caps (#377, #378).
+
+## Rate-limit backend resilience (increment 2, agreed with Yuriy 2026-08-19)
+
+The redis rate-limit backend (`qubx/rate_limiting/redis_backend.py`) shares the
+incident's root cause and — via control-api's `BuiltinDefaults` → `redis-ratelimit`
+preset (`env:REDIS_URL`, the same redis as state persistence) — is enabled for
+every platform-deployed bot:
+
+- `aioredis.from_url(url, decode_responses=True, single_connection_client=True)`
+  with **no socket timeouts** → a half-open socket hangs each script call ~15 min.
+- `RatePool.acquire`'s backend await is unbounded (`gate_max_wait` bounds only the
+  gate) and unprotected: after the hang, `ConnectionError` propagates into order
+  placement (ccxt REST throttle hook; qubx_lighter `send_tx`/`ws_subscribe`/REST).
+- `single_connection_client=True` serializes every script call behind the hung one.
+
+Net effect of a redis outage today: a silent multi-minute trading halt per bot.
+
+### Decisions
+
+- **RL-D1 — client timeouts.** `RedisBackend` gains keyword-only ctor params
+  forwarded to `from_url`: `socket_connect_timeout=2.0`, `socket_timeout=5.0`,
+  `socket_keepalive=True`, `health_check_interval=30` (mirroring
+  `RedisStatePersistence`). Safe: every command is a fast Lua eval — no blocking
+  commands — so `socket_timeout` cannot false-positive on a healthy server.
+- **RL-D2 — fail-open to local buckets.** New composite
+  `ResilientRateLimitBackend(IRateLimitBackend)` in
+  `src/qubx/rate_limiting/resilient.py`: primary (redis) + fallback
+  (`InMemoryBackend`, same per-key capacity/refill params). Trading never blocks
+  on rate-limit redis. Accepted degradation: each bot self-paces at the full
+  budget without cross-bot coordination; in-process 429 gates
+  (`report_limit_hit`) and ccxt's own throttler contain the residual venue risk.
+  Recovery needs no state reconciliation: expired redis keys re-init full and
+  header syncs recalibrate from venue-reported usage (the ground truth).
+  `InMemoryBackend` is a safe cross-loop fallback — `TokenBucketRateLimiter`
+  deliberately uses `threading.Lock` + monotonic time, no loop-bound primitives.
+- **RL-D3 — circuit breaker, 30 s.** First primary failure opens the breaker:
+  all calls go straight to the fallback (no per-call timeout tax). When the
+  cooldown expires, exactly one caller probes the primary (a probe-in-flight
+  flag keeps concurrent callers on the fallback); probe failure re-opens for
+  another 30 s, success closes. Breaker state lives on the composite (shared
+  across the per-loop redis clients) as plain monotonic floats — benign races
+  (worst case: two probes) are acceptable.
+- **RL-D4 — observability: logs only.** WARNING on the open transition
+  ("falling back to local buckets"), INFO on recovery. No new metric, no
+  `DegradeReason` — a redis outage already surfaces via
+  `state_persistence_stale`, and double-flagging one root cause is noise.
+  Transition-only logging is naturally throttled (≤2 lines per cooldown).
+- **Errors caught:** `(redis.exceptions.RedisError, OSError)` — covers redis
+  `TimeoutError`/`ConnectionError` and the builtin `ConnectionError`/`TimeoutError`
+  (both `OSError` subclasses). `asyncio.CancelledError` (`BaseException`)
+  propagates untouched.
+- **`close()` joins the `IRateLimitBackend` contract** as a non-abstract
+  `async def close(self) -> None` no-op default (no hasattr probing);
+  `RedisBackend` already overrides it; the composite closes primary then
+  fallback.
+- **Wiring:** `RateLimitManager._create_backend` returns
+  `ResilientRateLimitBackend(RedisBackend(url))` for `backend == "redis"`;
+  the existing creation-failure fallback to plain `InMemoryBackend` stays.
+- **No config schema changes** (`breaker_cooldown_s: float = 30.0` is a ctor
+  default, not YAML) and **no platform-repo changes**: same preset contract,
+  no metric renames (the bot-health dashboard reads `rate_limit.utilization`,
+  unchanged — and during outages pool metrics now flow from local state
+  instead of timing out).
+
+### Failure timeline (target)
+
+t0: redis dies half-open → first acquire hangs ≤5 s (socket_timeout) → error →
+breaker opens (WARNING), call served from the local bucket. t0+ε…t0+30 s: all
+calls local, sub-ms overhead, orders unaffected. t0+30 s: one probe pays ≤5 s,
+fails, re-opens. … redis recovers → next probe succeeds → INFO, primary resumes,
+cross-bot coordination restored.
+
+### Testing
+
+Unit (`tests/qubx/rate_limiting/test_resilient.py`, fake primary): pass-through
+on success (fallback untouched); error → fallback + breaker opens; no primary
+calls during cooldown; exactly one probe after cooldown with concurrent callers
+staying local (Event-synchronized, no sleeps); probe success/failure
+transitions; `get_remaining`/`set_remaining` follow the same policy;
+CancelledError propagates. Client-options test asserting the `from_url` timeout
+kwargs (mirrors `tests/qubx/state/test_redis_client_options.py`). Integration
+(docker `pause`, mirrors `test_safe_integration.py`): acquire returns quickly
+via fallback while redis is paused; unpause → recovery to primary.

--- a/docs/superpowers/specs/2026-08-19-safe-state-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-19-safe-state-persistence-design.md
@@ -1,0 +1,206 @@
+# Safe state persistence & bounded outbound I/O
+
+**Date:** 2026-08-19
+**Issue:** xLydianSoftware/xlydian-platform#375 (epic #374 — incident 2026-08-19)
+**Status:** approved design, pre-implementation
+
+## Problem
+
+A hard power-cycle of the prod platform node (2026-08-19) killed TCP peers without
+RST and exposed that qubx performs **unbounded blocking network I/O on the event
+path**:
+
+1. `RedisStatePersistence` builds its client as bare `redis.from_url(url)` — no
+   socket timeouts, no keepalive, no retry policy (`state/redis.py`).
+2. The periodic state snapshot (`_handle_state_snapshot`, `processing.py`) runs on
+   **ProcessorThread** — the single event loop — and calls `persistence.save()`
+   inline. With a half-open socket the synchronous `SET` sat in TCP retransmission
+   for ~15 minutes. Four high-frequency bots (two real-money) froze completely:
+   event queues grew to 280–430k, positions unmanaged, balance reconciles stopped.
+   Two more real-money bots had the same call wedge past self-heal and needed pod
+   restarts. Same failure class as the earlier okx-am-agg zombie (18 days
+   undetected pre-health-panel).
+3. `RedisStreamsExporter` and `QuestDBMetricEmitter` are already off the event
+   path (ThreadPoolExecutor) but share two flaws: their clients also lack
+   timeouts (a worker task can hang ~15 min, serializing the pool), and the
+   executor queues are **unbounded** — outages accumulate tasks in memory and
+   flush as a burst on recovery (implicated in the QuestDB O3 merge storm and a
+   pod OOM during the incident).
+
+## Design principle
+
+**The event loop never performs network I/O, and every network call anywhere is
+bounded in time; every buffer is bounded in space.**
+
+## Decisions (agreed with Yuriy, 2026-08-19)
+
+| # | Decision |
+|---|----------|
+| D1 | Scope covers all three layers: client timeouts, async state persistence, bounded exporter/emitter queues — one change. |
+| D2 | Contract A: *all* persistence calls are async with read-your-writes; no caller ever blocks on the network. |
+| D3 | If persistence is enabled and unreachable/unreadable at startup: **exit the bot** (running with potentially lost state is worse than crash-looping). Grace: ~60s exponential backoff, then exit non-zero. Corrupt stored JSON at startup is equally fatal; a missing key is not. |
+| D4 | Implementation shape: wrapper layer (`SafeStatePersistence`) + shared `BoundedWorker` primitive; transports stay dumb and synchronous. |
+
+## Components
+
+### 1. `qubx/state/safe.py` — `SafeStatePersistence(IStatePersistence)` (new)
+
+Wraps any real backend. Owns:
+
+- **Pending buffer**: `dict[key -> value | _Tombstone]` under a lock — per-key
+  latest-wins. Bounded by construction (one value per key).
+- **Writer thread** (daemon, named `StatePersistenceWriter`): waits on an event,
+  swaps the pending dict out, writes each entry through the backend
+  (`save`/`delete`). On failure, merges failed keys back (newer pending values
+  win) and retries with exponential backoff (1s → 30s cap). Tracks
+  `last_success_ts` and `consecutive_failures`; failure logging throttled.
+- **API semantics**:
+  - `save(key, value)`: eager `json.dumps` **dry-run in the caller's thread** so
+    `TypeError`/`ValueError` on unserializable values still raise at the call
+    site (programming errors stay loud); then buffer + wake writer. Never blocks
+    on network; never raises network errors.
+  - `load(key, default)`: pending buffer first (read-your-writes, tombstones
+    honored), then backend (bounded by client timeouts). Mid-run network failure
+    raises to the caller — existing strategy code (frab) already documents
+    graceful degradation.
+  - `delete(key)` / `exists(key)`: tombstone in pending; `exists` consults
+    pending (incl. tombstones) before the backend.
+  - `stop()`: bounded flush (default 5s) so clean shutdowns persist final state.
+  - `last_success_age() -> float | None`: seconds since last successful write
+    (None until first write) — consumed by the health monitor.
+- **Startup validation** (called by the factory before the context starts):
+  probe the backend (`exists("__qubx_probe__")`) with exponential backoff
+  (0.5s, 1, 2, 4, 8, then 10s steps) up to a **60s budget**; on exhaustion raise
+  `StatePersistenceUnavailable` — the runner treats this as fatal and the
+  process exits non-zero (D3). Corrupt-JSON on any load during startup
+  propagates (fatal); `None`/missing key does not.
+
+`DummyStatePersistence` is never wrapped.
+
+### 2. `qubx/state/redis.py` (modified)
+
+Stays synchronous and dumb. Client construction gains bounded-failure defaults,
+all overridable through the existing `StatePersistenceConfig.parameters`
+passthrough (zero config changes required for deployed bots):
+
+```python
+redis.from_url(
+    url,
+    socket_connect_timeout=2.0,
+    socket_timeout=5.0,
+    socket_keepalive=True,
+    health_check_interval=30,
+)
+```
+
+No client-level retry (the wrapper owns retry policy).
+
+### 3. `qubx/utils/threading.py` — `BoundedWorker` (new)
+
+The shared layer-3 primitive: single daemon worker thread + `deque(maxlen=N)`
+(**drop-oldest**) + dropped-item counter + throttled warning (at most one per
+30s: "dropped M items since last report"). `submit(fn, *args)` never blocks.
+`stop(flush_timeout)` drains best-effort.
+
+Single worker per instance is deliberate: it also restores FIFO ordering for
+redis-stream exports (the current 2-worker pool can reorder `XADD`s — a latent
+bug for downstream target consumers).
+
+### 4. `qubx/exporters/redis_streams.py` (modified)
+
+- `ThreadPoolExecutor(max_workers=2)` → one `BoundedWorker(maxlen=1000)`.
+- Client gains the same timeout/keepalive kwargs as §2.
+- Behavior change to document: under a prolonged outage, oldest queued exports
+  are dropped (counted + warned). For target streams this is *safer* than the
+  status quo — replaying stale targets to a live executor after recovery is
+  worse than skipping them.
+
+### 5. `qubx/emitters/questdb.py` (modified)
+
+- `ThreadPoolExecutor(max_workers=1)` → `BoundedWorker(maxlen=10_000)` (metrics
+  are cheap and numerous; dropping oldest under outage is free).
+- `Sender` construction gains bounded timeouts (verified against the installed
+  client API): `request_timeout=5000`, `retry_timeout=5000` (ms; client default
+  retry_timeout is 10000 — halved so a dead server costs ≤10s per flush attempt
+  instead of stacking).
+
+### 6. `qubx/utils/runner/factory.py` (modified)
+
+`create_state_persistence()` wraps any real backend:
+`SafeStatePersistence(backend)` + startup validation (D3) before returning.
+
+### 7. Health integration (`qubx/core/status.py`, `qubx/health/base.py`)
+
+- New `DegradeReason.STATE_PERSISTENCE_STALE`.
+- The existing health-monitor thread (which survived the incident and detected
+  the queue overflow) additionally polls `persistence.last_success_age()` when
+  the context's persistence is a `SafeStatePersistence`:
+  - age > `max(3 × snapshot_interval, 60s)` → set
+    `DEGRADED(STATE_PERSISTENCE_STALE, scope="state")`;
+  - recovery → clear, log.
+- Emit gauge `state_persistence_lag` via the metric emitter (feeds the
+  platform-side staleness alert, xlydian-platform#379).
+
+### 8. Unchanged on purpose
+
+`_handle_state_snapshot` keeps building the snapshot dict on ProcessorThread —
+that is where the consistent view of positions/orders/balances lives — and its
+existing `persistence.save("state", snapshot)` call becomes non-blocking purely
+via the wrapper. `IStatePersistence` protocol is unchanged; all consumers
+(frab `AssetOverrides`/`RebalancerState`, quantkit drawdown tracker, control-api
+readers) keep working with strictly better failure behavior.
+
+## Failure timeline (the incident, replayed against this design)
+
+Node power-cycles; redis peer half-open:
+
+1. Next snapshot tick: build on ProcessorThread (~ms), `save()` buffers, returns.
+   **Event loop never blocks.** Quotes keep processing.
+2. Writer thread hits `socket_timeout=5s`, logs, backs off, retries. Pending
+   holds exactly one latest snapshot + any dirty strategy keys.
+3. After 60s of staleness: context → DEGRADED(STATE_PERSISTENCE_STALE); the
+   `state_persistence_lag` gauge climbs; platform alert fires (#379).
+4. Redis returns (≤ backoff lag ≈ 30s): one write per dirty key — no burst, no
+   memory growth, no O3 storm. DEGRADED clears.
+5. If instead the *bot* restarts mid-outage: startup probe fails for 60s →
+   exit non-zero → crash-loop until redis is back (loud, safe; no amnesia).
+
+## Testing
+
+Unit (fake backend with scripted delays/failures/permanent hangs):
+- `save()` returns <1ms while backend hangs forever; loop-liveness invariant.
+- Read-your-writes incl. tombstones; latest-wins under repeated failure; failed
+  batch re-merge does not clobber newer pending values.
+- Backoff schedule; `last_success_age` accounting; throttled logging.
+- Startup validation: success inside the budget after N failures; exhaustion
+  raises; corrupt-JSON fatal; missing key benign.
+- `BoundedWorker`: drop-oldest, counters, warn throttling, FIFO order, bounded
+  stop/flush.
+- Exporter: ordering preserved (single worker); drops counted under a hung fake.
+
+Integration (docker redis, CI marker): mid-run `SIGSTOP` of redis-server →
+assert event processing continues, DEGRADED flips, recovery re-persists, and a
+subsequent cold start against the stopped server exits within ~70s.
+
+Manual platform acceptance (per #375): kill redis under a live paper bot; event
+loop continues within seconds; state writes resume on reconnect.
+
+## Rollout
+
+Lands on Qubx `dev` (full CI → dev PyPI release). Bots inherit it when their
+releases rebuild against the new qubx. No config changes required; timeout
+overrides available via `StatePersistenceConfig.parameters` if ever needed.
+Deployed old-release bots (factors v0.1.x etc.) remain on the old behavior until
+their next release bump — worth prioritizing the paper feeders and real-money
+books when bumping.
+
+## Related platform work (out of scope here, tracked in #374)
+
+- xlydian-platform#379: per-bot staleness alert on the redis `state:{bot}:state`
+  timestamp (>60s), superseding the metrics-based BotMetricsStale approach of
+  PR #365 — the snapshot is *built on the event loop*, so its freshness is a
+  direct liveness probe of the exact thread that froze; this design's
+  `state_persistence_lag` gauge and DEGRADED reason are the in-bot halves of the
+  same signal.
+- control-api redis retry + QuestDB circuit breaker (#376), Postgres/QuestDB
+  server-side keepalives and caps (#377, #378).

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -216,10 +216,9 @@ class StrategyContext(IStrategyContext):
         # - the monitor writes degradations into the context's status (queue backlog today)
         self._health_monitor.set_status(self._status)
         self._state_persistence = state_persistence or DummyStatePersistence()
-        if hasattr(self._state_persistence, "last_success_age") and hasattr(
-            self._health_monitor, "set_state_persistence"
-        ):
-            self._health_monitor.set_state_persistence(self._state_persistence)
+        # - the monitor observes write health; inert for backends that don't track it
+        #   (last_success_age() -> None) and for monitors that ignore the wiring
+        self._health_monitor.set_state_persistence(self._state_persistence)
         self._state_snapshot_interval = state_snapshot_interval
         self._rate_limiting_config = rate_limiting_config
         self.event_loop = event_loop
@@ -601,14 +600,13 @@ class StrategyContext(IStrategyContext):
             logger.error(f"[StrategyContext] :: Failed to close logging: {e}")
             logger.opt(colors=False).error(traceback.format_exc())
 
-        # PRIORITY 7: Flush pending state persistence (bounded — SafeStatePersistence only;
-        # DummyStatePersistence and other backends without a bounded stop() are left alone)
-        if hasattr(self._state_persistence, "last_success_age"):
-            try:
-                self._state_persistence.stop()
-            except Exception as e:
-                logger.error(f"[StrategyContext] :: Failed to stop state persistence: {e}")
-                logger.opt(colors=False).error(traceback.format_exc())
+        # PRIORITY 7: Flush pending state persistence (bounded; the interface default
+        # is a no-op for backends without a background writer)
+        try:
+            self._state_persistence.stop()
+        except Exception as e:
+            logger.error(f"[StrategyContext] :: Failed to stop state persistence: {e}")
+            logger.opt(colors=False).error(traceback.format_exc())
 
         # CLEANUP: Restore signal handlers and deregister atexit
         try:

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -216,6 +216,8 @@ class StrategyContext(IStrategyContext):
         # - the monitor writes degradations into the context's status (queue backlog today)
         self._health_monitor.set_status(self._status)
         self._state_persistence = state_persistence or DummyStatePersistence()
+        if hasattr(self._state_persistence, "last_success_age"):
+            self._health_monitor.set_state_persistence(self._state_persistence)
         self._state_snapshot_interval = state_snapshot_interval
         self._rate_limiting_config = rate_limiting_config
         self.event_loop = event_loop
@@ -596,6 +598,15 @@ class StrategyContext(IStrategyContext):
         except Exception as e:
             logger.error(f"[StrategyContext] :: Failed to close logging: {e}")
             logger.opt(colors=False).error(traceback.format_exc())
+
+        # PRIORITY 7: Flush pending state persistence (bounded — SafeStatePersistence only;
+        # DummyStatePersistence and other backends without a bounded stop() are left alone)
+        if hasattr(self._state_persistence, "last_success_age"):
+            try:
+                self._state_persistence.stop()
+            except Exception as e:
+                logger.error(f"[StrategyContext] :: Failed to stop state persistence: {e}")
+                logger.opt(colors=False).error(traceback.format_exc())
 
         # CLEANUP: Restore signal handlers and deregister atexit
         try:

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -216,7 +216,9 @@ class StrategyContext(IStrategyContext):
         # - the monitor writes degradations into the context's status (queue backlog today)
         self._health_monitor.set_status(self._status)
         self._state_persistence = state_persistence or DummyStatePersistence()
-        if hasattr(self._state_persistence, "last_success_age"):
+        if hasattr(self._state_persistence, "last_success_age") and hasattr(
+            self._health_monitor, "set_state_persistence"
+        ):
             self._health_monitor.set_state_persistence(self._state_persistence)
         self._state_snapshot_interval = state_snapshot_interval
         self._rate_limiting_config = rate_limiting_config

--- a/src/qubx/core/exceptions.py
+++ b/src/qubx/core/exceptions.py
@@ -81,3 +81,12 @@ class SimulationConfigError(Exception):
 
 class WarmupValidationError(Exception):
     pass
+
+
+class StatePersistenceUnavailable(BaseError):
+    """State persistence is enabled but unreachable/unreadable at startup.
+
+    Fatal by design (incident 2026-08-19, platform #375): starting a bot that
+    silently lost its persisted state is worse than crash-looping until the
+    backend returns.
+    """

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -126,6 +126,31 @@ class IStatePersistence(Protocol):
         """
         ...
 
+    # Write-health staleness threshold in seconds. Only consulted when
+    # last_success_age() returns a value; implementations that track write
+    # health should derive it from their write cadence.
+    staleness_threshold_s: float = 60.0
+
+    def last_success_age(self) -> float | None:
+        """
+        Age in seconds of the last confirmed successful write to the backend.
+
+        Returns:
+            Seconds since the last successful write, or None if this
+            implementation does not track write health. Callers must skip
+            staleness checks when None is returned.
+        """
+        return None
+
+    def stop(self) -> None:
+        """
+        Flush pending writes (bounded) and release backend resources.
+
+        Called once during context shutdown. Implementations without a
+        background writer keep this no-op default.
+        """
+        return None
+
 
 class ITradeDataExport:
     """Interface for exporting trading data to external systems."""
@@ -1998,6 +2023,14 @@ class IHealthMonitor(IHealthWriter, IHealthReader):
 
     def stop(self) -> None:
         """Stop the health metrics monitor."""
+        ...
+
+    def set_state_persistence(self, persistence: IStatePersistence) -> None:
+        """
+        Wire the context's state persistence so the monitor can observe write
+        health (last_success_age) and degrade on staleness. Monitors that do
+        not track persistence health keep this no-op default.
+        """
         ...
 
     def subscribe(self, instrument: Instrument, event_type: str) -> None:

--- a/src/qubx/core/status.py
+++ b/src/qubx/core/status.py
@@ -27,6 +27,7 @@ class QubxStatus(StrEnum):
 class DegradeReason(StrEnum):
     INTERNAL_QUEUE_OVERFLOW = "internal_queue_overflow"
     EXCHANGE_MAINTENANCE = "exchange_maintenance"
+    STATE_PERSISTENCE_STALE = "state_persistence_stale"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -42,7 +42,6 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         stats_interval: str = "1m",
         flush_interval: str = "5s",
         tags: dict[str, Any] | None = None,
-        max_workers: int = 1,
         max_queue: int = 10_000,
     ):
         """
@@ -56,8 +55,6 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             stats_to_emit: Optional list of specific stats to emit
             stats_interval: Interval for emitting strategy stats (default: "1m")
             tags: Dictionary of default tags/labels to include with all metrics
-            max_workers: Deprecated and ignored — kept for config compatibility. QuestDB
-                operations now run on a single bounded worker (see ``max_queue``).
             max_queue: Maximum number of pending QuestDB operations queued on the background
                 worker before the oldest is dropped.
         """
@@ -81,8 +78,6 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._last_flush = None
         # - single bounded worker: bounds memory/burst under outages instead of an unbounded
         #   ThreadPoolExecutor queue (platform incident 2026-08-14).
-        if max_workers != 1:
-            logger.debug("[QuestDBMetricEmitter] max_workers is deprecated and ignored (single bounded worker)")
         self._worker = BoundedWorker("questdb_emitter", maxlen=max_queue)
         self._stopped = False
 

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -6,7 +6,6 @@ This module provides an implementation of IMetricEmitter that exports metrics to
 
 import datetime
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, cast
 
 import numpy as np
@@ -18,6 +17,7 @@ from qubx.core.basics import Deal, Instrument, Signal, TargetPosition, dt_64
 from qubx.core.interfaces import IAccountViewer, IStrategyContext
 from qubx.emitters.base import BaseMetricEmitter
 from qubx.utils.questdb import QuestDBClient
+from qubx.utils.threading import BoundedWorker
 from qubx.utils.time import to_timedelta
 
 
@@ -43,6 +43,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         flush_interval: str = "5s",
         tags: dict[str, Any] | None = None,
         max_workers: int = 1,
+        max_queue: int = 10_000,
     ):
         """
         Initialize the QuestDB Metric Emitter.
@@ -55,7 +56,10 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             stats_to_emit: Optional list of specific stats to emit
             stats_interval: Interval for emitting strategy stats (default: "1m")
             tags: Dictionary of default tags/labels to include with all metrics
-            max_workers: Maximum number of worker threads for QuestDB operations
+            max_workers: Deprecated and ignored — kept for config compatibility. QuestDB
+                operations now run on a single bounded worker (see ``max_queue``).
+            max_queue: Maximum number of pending QuestDB operations queued on the background
+                worker before the oldest is dropped.
         """
         # Initialize default tags with strategy name
         default_tags = tags or {}
@@ -67,11 +71,19 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._table_name = table_name
         self._signals_table_name = signals_table_name
         self._deals_table_name = deals_table_name
-        self._conn_str = f"http::addr={host}:{port};"
+        # - bounded-failure ILP client: a dead/stalled QuestDB costs seconds, not an unbounded
+        #   hang (incident 2026-08-14: metrics QuestDB hang + unbounded queues burst-flush on
+        #   recovery). retry_timeout halved from the client default (10000) so a dead server
+        #   costs <=10s per flush attempt.
+        self._conn_str = f"http::addr={host}:{port};request_timeout=5000;retry_timeout=5000;"
         self._flush_interval = to_timedelta(flush_interval)
         self._sender = self._try_get_sender()
         self._last_flush = None
-        self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="questdb_emitter")
+        # - single bounded worker: bounds memory/burst under outages instead of an unbounded
+        #   ThreadPoolExecutor queue (platform incident 2026-08-14).
+        if max_workers != 1:
+            logger.debug("[QuestDBMetricEmitter] max_workers is deprecated and ignored (single bounded worker)")
+        self._worker = BoundedWorker("questdb_emitter", maxlen=max_queue)
         self._stopped = False
 
         # Strategy-owned tables declared via ensure_table: name -> column/symbol sets.
@@ -93,7 +105,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         if pd.Timestamp.now() - self._last_flush >= self._flush_interval:
             if self._sender is not None:
                 try:
-                    self._executor.submit(self._flush_sender)
+                    self._worker.submit(self._flush_sender)
                 except Exception as e:
                     logger.error(f"[QuestDBMetricEmitter] Failed to queue flush operation: {e}")
             self._last_flush = pd.Timestamp.now()
@@ -116,15 +128,15 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self.stop()
 
     def stop(self) -> None:
-        """Flush pending metrics and shut down the executor and sender."""
+        """Flush pending metrics and shut down the background worker and sender."""
         if self._stopped:
             return
         self._stopped = True
 
         try:
-            self._executor.shutdown(wait=False, cancel_futures=True)
+            self._worker.stop(flush_timeout_s=5.0)
         except Exception as e:
-            self._log_warning(f"Error during executor shutdown: {e}")
+            self._log_warning(f"Error during worker shutdown: {e}")
 
         if self._sender is not None:
             try:
@@ -175,8 +187,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             return
 
         try:
-            # Submit the metric emission to the thread pool
-            self._executor.submit(self._emit_to_questdb, name, value, tags, timestamp)
+            # Submit the metric emission to the background worker
+            self._worker.submit(self._emit_to_questdb, name, value, tags, timestamp)
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to queue metric {name}: {e}")
 
@@ -296,7 +308,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             return
 
         try:
-            self._executor.submit(self._emit_signals_to_questdb, time, signals, account, target_positions)
+            self._worker.submit(self._emit_signals_to_questdb, time, signals, account, target_positions)
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to queue signals emission: {e}")
 
@@ -311,7 +323,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             return
 
         try:
-            self._executor.submit(self._emit_deals_to_questdb, time, instrument, deals, account)
+            self._worker.submit(self._emit_deals_to_questdb, time, instrument, deals, account)
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to queue deals emission: {e}")
 
@@ -406,7 +418,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
                 else:
                     columns[k] = v
             at = self._convert_timestamp(timestamp) if timestamp is not None else datetime.datetime.now()
-            self._executor.submit(self._emit_record_to_questdb, table, symbols, columns, at)
+            self._worker.submit(self._emit_record_to_questdb, table, symbols, columns, at)
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to queue record for '{table}': {e}")
 

--- a/src/qubx/exporters/redis_streams.py
+++ b/src/qubx/exporters/redis_streams.py
@@ -43,7 +43,6 @@ class RedisStreamsExporter(ITradeDataExport):
         position_changes_stream: Optional[str] = None,
         max_stream_length: int = 1000,
         formatter: Optional[IExportFormatter] = None,
-        max_workers: int = 2,
         max_queue: int = 1000,
         account: Optional[IAccountViewer] = None,
     ):
@@ -61,8 +60,6 @@ class RedisStreamsExporter(ITradeDataExport):
             position_changes_stream: Custom stream name for position changes (default: "strategy:{strategy_name}:position_changes")
             max_stream_length: Maximum length of each stream
             formatter: Formatter to use for formatting data (default: DefaultFormatter)
-            max_workers: Deprecated and ignored — kept for config compatibility. Redis
-                operations now run on a single bounded worker (see ``max_queue``).
             max_queue: Maximum number of pending Redis operations queued on the background
                 worker before the oldest is dropped.
             account: Optional account viewer to get account information like total capital, leverage, etc.
@@ -93,8 +90,6 @@ class RedisStreamsExporter(ITradeDataExport):
 
         # - single bounded worker: preserves XADD ordering per stream (2 pool workers could
         #   reorder targets) and bounds memory/burst under outages (platform #375).
-        if max_workers != 2:
-            logger.debug("[RedisStreamsExporter] max_workers is deprecated and ignored (single bounded worker)")
         self._worker = BoundedWorker("redis_exporter", maxlen=max_queue)
         self._stopped = False
 

--- a/src/qubx/exporters/redis_streams.py
+++ b/src/qubx/exporters/redis_streams.py
@@ -4,7 +4,6 @@ Redis Streams Exporter for trading data.
 This module provides an implementation of ITradeDataExport that exports trading data to Redis Streams.
 """
 
-from concurrent.futures import ThreadPoolExecutor
 from time import sleep
 from typing import Any, Dict, List, Optional, cast
 
@@ -17,6 +16,7 @@ from qubx import logger
 from qubx.core.basics import Instrument, Signal, TargetPosition, dt_64
 from qubx.core.interfaces import IAccountViewer, ITradeDataExport
 from qubx.exporters.formatters import DefaultFormatter, IExportFormatter
+from qubx.utils.threading import BoundedWorker
 
 # Simple retry policy for transient Redis errors (connection drops, timeouts).
 # Non-retryable errors (e.g. encoding bugs) are logged and dropped immediately.
@@ -44,6 +44,7 @@ class RedisStreamsExporter(ITradeDataExport):
         max_stream_length: int = 1000,
         formatter: Optional[IExportFormatter] = None,
         max_workers: int = 2,
+        max_queue: int = 1000,
         account: Optional[IAccountViewer] = None,
     ):
         """
@@ -60,10 +61,21 @@ class RedisStreamsExporter(ITradeDataExport):
             position_changes_stream: Custom stream name for position changes (default: "strategy:{strategy_name}:position_changes")
             max_stream_length: Maximum length of each stream
             formatter: Formatter to use for formatting data (default: DefaultFormatter)
-            max_workers: Maximum number of worker threads for Redis operations
+            max_workers: Deprecated and ignored — kept for config compatibility. Redis
+                operations now run on a single bounded worker (see ``max_queue``).
+            max_queue: Maximum number of pending Redis operations queued on the background
+                worker before the oldest is dropped.
             account: Optional account viewer to get account information like total capital, leverage, etc.
         """
-        self._redis = redis.from_url(redis_url)
+        # - bounded-failure client: a dead peer costs seconds, never TCP-retransmission
+        #   minutes (incident 2026-08-19; platform #375).
+        self._redis = redis.from_url(
+            redis_url,
+            socket_connect_timeout=2.0,
+            socket_timeout=5.0,
+            socket_keepalive=True,
+            health_check_interval=30,
+        )
         self._strategy_name = strategy_name
 
         self._export_signals = export_signals
@@ -79,7 +91,11 @@ class RedisStreamsExporter(ITradeDataExport):
 
         self._instrument_to_previous_leverage = {}
 
-        self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="redis_exporter")
+        # - single bounded worker: preserves XADD ordering per stream (2 pool workers could
+        #   reorder targets) and bounds memory/burst under outages (platform #375).
+        if max_workers != 2:
+            logger.debug("[RedisStreamsExporter] max_workers is deprecated and ignored (single bounded worker)")
+        self._worker = BoundedWorker("redis_exporter", maxlen=max_queue)
         self._stopped = False
 
         if account:
@@ -100,15 +116,15 @@ class RedisStreamsExporter(ITradeDataExport):
         self.stop()
 
     def stop(self) -> None:
-        """Shut down the executor and close the Redis connection."""
+        """Shut down the worker and close the Redis connection."""
         if self._stopped:
             return
         self._stopped = True
 
         try:
-            self._executor.shutdown(wait=False, cancel_futures=True)
+            self._worker.stop(flush_timeout_s=5.0)
         except Exception as e:
-            self._log_warning(f"Error during executor shutdown: {e}")
+            self._log_warning(f"Error during worker shutdown: {e}")
 
         try:
             self._redis.close()
@@ -141,8 +157,8 @@ class RedisStreamsExporter(ITradeDataExport):
             # Prepare data for Redis
             redis_data = self._prepare_for_redis(data)
 
-            # Submit the task to the executor
-            self._executor.submit(self._add_to_redis_stream_impl, stream, redis_data, self._max_stream_length)
+            # Submit the task to the background worker
+            self._worker.submit(self._add_to_redis_stream_impl, stream, redis_data, self._max_stream_length)
         except Exception as e:
             logger.exception(
                 f"[RedisStreamsExporter] Failed to queue Redis stream operation for '{stream}', data={data}: {e}"

--- a/src/qubx/exporters/redis_streams.py
+++ b/src/qubx/exporters/redis_streams.py
@@ -313,4 +313,4 @@ class RedisStreamsExporter(ITradeDataExport):
                 f"{previous_leverage:0.2%} -> {new_leverage:0.2%} @ {price}"
             )
         except Exception:
-            logger.exception(f"[RedisStreamsExporter] Failed to export position change")
+            logger.exception("[RedisStreamsExporter] Failed to export position change")

--- a/src/qubx/health/base.py
+++ b/src/qubx/health/base.py
@@ -2,13 +2,13 @@ import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Callable
 
 import numpy as np
 
 from qubx import logger
 from qubx.core.basics import CtrlChannel, DataType, Instrument, dt_64, td_64
-from qubx.core.interfaces import IHealthMonitor, IMetricEmitter, ITimeProvider, LatencyMetrics
+from qubx.core.interfaces import IHealthMonitor, IMetricEmitter, IStatePersistence, ITimeProvider, LatencyMetrics
 from qubx.core.status import ContextStatus, DegradeReason, QubxStatus
 from qubx.core.utils import recognize_timeframe
 from qubx.utils import convert_tf_str_td64
@@ -87,9 +87,8 @@ class BaseHealthMonitor(IHealthMonitor):
         self._queue_degraded = False  # - the monitor's own edge tracker: status is written only on transitions
         self._status: ContextStatus | None = None
 
-        # State-persistence staleness: wired in by set_state_persistence (duck-typed —
-        # needs last_success_age() and staleness_threshold_s); None until wired.
-        self._state_persistence: Any = None
+        # State-persistence staleness: wired in by set_state_persistence; None until wired.
+        self._state_persistence: IStatePersistence | None = None
         self._state_stale = False  # - the monitor's own edge tracker, same pattern as _queue_degraded
 
         # Initialize metrics storage
@@ -297,9 +296,10 @@ class BaseHealthMonitor(IHealthMonitor):
             DegradeReason.INTERNAL_QUEUE_OVERFLOW, now, message=f"queue size {size}, no drain for {for_str}"
         )
 
-    def set_state_persistence(self, persistence: Any) -> None:
-        """Wire a SafeStatePersistence (duck-typed: needs last_success_age() and
-        staleness_threshold_s) so the monitor can report write staleness."""
+    def set_state_persistence(self, persistence: IStatePersistence) -> None:
+        """Wire the context's state persistence so the monitor can report write
+        staleness. Backends that don't track write health (last_success_age()
+        is None) are wired but never produce a gauge or degradation."""
         self._state_persistence = persistence
         self._state_stale = False
 
@@ -322,7 +322,8 @@ class BaseHealthMonitor(IHealthMonitor):
                 "context DEGRADED (state_persistence_stale)"
             )
             self._status.add(
-                DegradeReason.STATE_PERSISTENCE_STALE, self.time_provider.time(),
+                DegradeReason.STATE_PERSISTENCE_STALE,
+                self.time_provider.time(),
                 scope="state",
                 message=f"no successful state write for {age:.0f}s",
             )

--- a/src/qubx/health/base.py
+++ b/src/qubx/health/base.py
@@ -2,7 +2,7 @@ import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 import numpy as np
 
@@ -86,6 +86,11 @@ class BaseHealthMonitor(IHealthMonitor):
         self._last_drain_time: dt_64 | None = None
         self._queue_degraded = False  # - the monitor's own edge tracker: status is written only on transitions
         self._status: ContextStatus | None = None
+
+        # State-persistence staleness: wired in by set_state_persistence (duck-typed —
+        # needs last_success_age() and staleness_threshold_s); None until wired.
+        self._state_persistence: Any = None
+        self._state_stale = False  # - the monitor's own edge tracker, same pattern as _queue_degraded
 
         # Initialize metrics storage
         self._queue_size = DequeFloat64(buffer_size)  # Store last 1000 queue size measurements
@@ -291,6 +296,39 @@ class BaseHealthMonitor(IHealthMonitor):
         self._status.add(
             DegradeReason.INTERNAL_QUEUE_OVERFLOW, now, message=f"queue size {size}, no drain for {for_str}"
         )
+
+    def set_state_persistence(self, persistence: Any) -> None:
+        """Wire a SafeStatePersistence (duck-typed: needs last_success_age() and
+        staleness_threshold_s) so the monitor can report write staleness."""
+        self._state_persistence = persistence
+        self._state_stale = False
+
+    def check_state_persistence(self) -> None:
+        """One staleness observation: records the current write-lag gauge and
+        degrades/clears STATE_PERSISTENCE_STALE on threshold crossings, mirroring
+        check_queue_drain's edge-tracked add/clear pattern."""
+        sp = self._state_persistence
+        if sp is None or self._status is None:
+            return
+        age = sp.last_success_age()
+        if age is not None:
+            self.record_gauge("state_persistence_lag", age)
+        threshold = sp.staleness_threshold_s
+        stale = age is not None and age > threshold
+        if stale and not self._state_stale:
+            self._state_stale = True
+            logger.warning(
+                f"[health] state not persisted for {age:.0f}s (threshold {threshold:.0f}s) — "
+                "context DEGRADED (state_persistence_stale)"
+            )
+            self._status.add(
+                DegradeReason.STATE_PERSISTENCE_STALE, self.time_provider.time(),
+                message=f"no successful state write for {age:.0f}s",
+            )
+        elif not stale and self._state_stale:
+            self._state_stale = False
+            logger.info("[health] state persistence recovered — state_persistence_stale cleared")
+            self._status.clear(DegradeReason.STATE_PERSISTENCE_STALE)
 
     def set_event_queue_size(self, size: int) -> None:
         self._queue_size.push_back(float(size))
@@ -538,6 +576,8 @@ class BaseHealthMonitor(IHealthMonitor):
                     current_size = self._channel._queue.qsize()
                     self.set_event_queue_size(current_size)
                     self.check_queue_drain(current_size)
+
+                self.check_state_persistence()
 
                 # Perform cleanup of old order requests
                 self._cleanup_old_order_requests()

--- a/src/qubx/health/base.py
+++ b/src/qubx/health/base.py
@@ -323,12 +323,13 @@ class BaseHealthMonitor(IHealthMonitor):
             )
             self._status.add(
                 DegradeReason.STATE_PERSISTENCE_STALE, self.time_provider.time(),
+                scope="state",
                 message=f"no successful state write for {age:.0f}s",
             )
         elif not stale and self._state_stale:
             self._state_stale = False
             logger.info("[health] state persistence recovered — state_persistence_stale cleared")
-            self._status.clear(DegradeReason.STATE_PERSISTENCE_STALE)
+            self._status.clear(DegradeReason.STATE_PERSISTENCE_STALE, scope="state")
 
     def set_event_queue_size(self, size: int) -> None:
         self._queue_size.push_back(float(size))

--- a/src/qubx/rate_limiting/__init__.py
+++ b/src/qubx/rate_limiting/__init__.py
@@ -17,9 +17,10 @@ Usage:
     >>> await limiter.acquire("fetch_ohlcv")
 """
 
-from qubx.rate_limiting.backend import IRateLimitBackend, InMemoryBackend
+from qubx.rate_limiting.backend import InMemoryBackend, IRateLimitBackend
 from qubx.rate_limiting.config import EndpointCosts, ExchangeRateLimitConfig, PoolConfig
 from qubx.rate_limiting.engine import ExchangeRateLimiter, RateLimitGateTimeout
+from qubx.rate_limiting.resilient import ResilientRateLimitBackend
 
 __all__ = [
     "EndpointCosts",
@@ -29,4 +30,5 @@ __all__ = [
     "InMemoryBackend",
     "PoolConfig",
     "RateLimitGateTimeout",
+    "ResilientRateLimitBackend",
 ]

--- a/src/qubx/rate_limiting/backend.py
+++ b/src/qubx/rate_limiting/backend.py
@@ -54,6 +54,10 @@ class IRateLimitBackend(ABC):
         arrives before the first acquire create the bucket.
         """
 
+    async def close(self) -> None:
+        """Release backend resources for the current event loop. Default: no-op."""
+        return None
+
 
 class InMemoryBackend(IRateLimitBackend):
     """In-process token bucket backend.

--- a/src/qubx/rate_limiting/manager.py
+++ b/src/qubx/rate_limiting/manager.py
@@ -64,8 +64,9 @@ class RateLimitManager:
         if config.backend == "redis" and config.redis_url:
             try:
                 from .redis_backend import RedisBackend
+                from .resilient import ResilientRateLimitBackend
 
-                return RedisBackend(config.redis_url)
+                return ResilientRateLimitBackend(RedisBackend(config.redis_url))
             except Exception as e:
                 logger.error(f"Failed to create Redis rate limit backend: {e}, falling back to local")
         return InMemoryBackend()

--- a/src/qubx/rate_limiting/redis_backend.py
+++ b/src/qubx/rate_limiting/redis_backend.py
@@ -95,9 +95,21 @@ class RedisBackend(IRateLimitBackend):
 
     Args:
         redis_url: Redis connection URL (e.g., "redis://redis.platform.svc:6379/0")
+        socket_connect_timeout: Max seconds to wait for a TCP connection to Redis
+        socket_timeout: Max seconds to wait for a socket read/write to Redis
+        socket_keepalive: Enable TCP keepalive on the underlying socket
+        health_check_interval: Seconds between health-check pings on idle connections
     """
 
-    def __init__(self, redis_url: str):
+    def __init__(
+        self,
+        redis_url: str,
+        *,
+        socket_connect_timeout: float = 2.0,
+        socket_timeout: float = 5.0,
+        socket_keepalive: bool = True,
+        health_check_interval: int = 30,
+    ):
         # - fail fast on misconfiguration, but don't create the client here:
         #   the async Redis client (with single_connection_client=True) holds an
         #   internal asyncio.Lock that binds to whichever event loop first awaits
@@ -106,6 +118,12 @@ class RedisBackend(IRateLimitBackend):
         import redis.asyncio as _aioredis  # noqa: F401
 
         self._redis_url = redis_url
+        self._client_kwargs = dict(
+            socket_connect_timeout=socket_connect_timeout,
+            socket_timeout=socket_timeout,
+            socket_keepalive=socket_keepalive,
+            health_check_interval=health_check_interval,
+        )
         self._loop_clients: WeakKeyDictionary[asyncio.AbstractEventLoop, tuple] = WeakKeyDictionary()
         logger.info(f"Redis rate limit backend configured: {redis_url}")
 
@@ -121,7 +139,10 @@ class RedisBackend(IRateLimitBackend):
         entry = self._loop_clients.get(loop)
         if entry is None:
             client = aioredis.from_url(
-                self._redis_url, decode_responses=True, single_connection_client=True
+                self._redis_url,
+                decode_responses=True,
+                single_connection_client=True,
+                **self._client_kwargs,
             )
             scripts = (
                 client.register_script(_LUA_ACQUIRE),

--- a/src/qubx/rate_limiting/resilient.py
+++ b/src/qubx/rate_limiting/resilient.py
@@ -1,3 +1,53 @@
+"""Resilient rate-limit backend: redis primary + local fallback + circuit breaker.
+
+``ResilientRateLimitBackend`` composes a primary backend (normally redis, for
+cross-bot coordination) with a local fallback (``InMemoryBackend``, per-bot
+pacing only) behind a circuit breaker, so trading never blocks on rate-limit
+redis. See design doc "Rate-limit backend resilience (increment 2)" (RL-D1
+through RL-D4) for the accepted degradation and recovery contract.
+
+Breaker protocol:
+    - Healthy (``_broken`` is False): every call goes to the primary.
+    - Primary error opens the breaker: ``_broken = True``,
+      ``_broken_until = now + breaker_cooldown_s``; every call is served by
+      the fallback until the cooldown expires — no per-call timeout tax.
+    - Once the cooldown expires, exactly one caller claims the probe slot
+      (``_route()``, ``_probe_inflight``) and is routed to the primary; other
+      concurrent callers stay on the fallback while the probe is in flight.
+    - Only the probe's own outcome may change breaker state: probe success
+      closes the breaker, probe failure re-opens it for another cooldown. A
+      *stale* success or error — from a call dispatched before the breaker
+      opened, landing after another call already changed the state — is not
+      evidence about the probe and is ignored (see F2 / review Finding 2).
+    - The probe slot is released on every exit path, including
+      ``asyncio.CancelledError`` and any exception outside
+      ``_BACKEND_ERRORS`` (see F1 / review Finding 1): those propagate to the
+      caller with the breaker state left as-is, but the slot is freed so a
+      later call can still probe and recover.
+
+Accepted limitations (parked by design, not bugs):
+    - A probe against a *healthy but saturated* redis can hold the slot for
+      the bucket's full deficit, not just the socket-timeout bound, because
+      ``RedisBackend.acquire`` loops internally until it has budget. During
+      that window every other call in the bot runs uncoordinated on a fresh
+      local bucket (review Finding 3).
+    - If the primary fails after already sleeping through part of a
+      multi-iteration acquire, the accumulated wait is discarded and the
+      fallback call starts its wait from zero — the caller's reported
+      ``waited`` undercounts the real wall-clock wait during that one call.
+      This is conservative (it can only under-report pressure, never make
+      the caller wait less than it actually did) and never affects
+      correctness (review Finding 4).
+    - The ``redis`` import below is module-level, not lazy like
+      ``redis_backend.py``'s in-function imports — acceptable because
+      ``redis`` is already a hard ``qubx`` dependency (review Finding 7).
+
+Races: two callers can both observe the cooldown as expired and both start a
+probe before either sets ``_probe_inflight`` — this is a plain read-modify
+write on process-local bytecode-level attributes, not a lock. That race hits
+the primary twice instead of once; it is benign and accepted.
+"""
+
 import time
 
 from redis.exceptions import RedisError
@@ -12,12 +62,15 @@ _BACKEND_ERRORS = (RedisError, OSError)
 class ResilientRateLimitBackend(IRateLimitBackend):
     """Composite: primary (redis) with local fallback and a circuit breaker.
 
-    Primary healthy → pass-through. Primary error → breaker opens for
-    breaker_cooldown_s and calls are served by the local fallback (per-bot
-    pacing, no cross-bot coordination). Cooldown expiry → exactly one caller
-    probes the primary; concurrent callers stay on the fallback until the
-    probe resolves. State is plain monotonic floats shared across event
-    loops — races are benign (worst case: two probes).
+    See the module docstring for the full breaker protocol and the accepted
+    limitations. In short: primary healthy → pass-through; primary error →
+    breaker opens for ``breaker_cooldown_s`` and calls are served by the
+    local fallback; cooldown expiry → exactly one caller probes the primary
+    while concurrent callers stay on the fallback; only that probe's outcome
+    can close (on success) or re-open (on failure) the breaker. Breaker
+    state (``_broken``, ``_broken_until``, ``_probe_inflight``) is plain
+    attributes shared across event loops — the one accepted race is two
+    concurrent probes.
     """
 
     def __init__(
@@ -33,23 +86,24 @@ class ResilientRateLimitBackend(IRateLimitBackend):
         self._broken_until = 0.0
         self._probe_inflight = False
 
-    def _use_primary(self) -> bool:
-        """Route decision for this call; claims the probe slot when one is due."""
+    def _route(self) -> tuple[bool, bool]:
+        """(use_primary, is_probe) for this call; claims the probe slot when one is due."""
         if not self._broken:
-            return True
+            return True, False
         if self._probe_inflight or time.monotonic() < self._broken_until:
-            return False
+            return False, False
         self._probe_inflight = True
-        return True
+        return True, True
 
-    def _on_success(self) -> None:
-        self._probe_inflight = False
-        if self._broken:
+    def _on_success(self, is_probe: bool) -> None:
+        if is_probe:
+            self._probe_inflight = False
             self._broken = False
             logger.info("Rate-limit redis backend recovered — resuming cross-bot coordination")
 
-    def _on_error(self, exc: Exception) -> None:
-        self._probe_inflight = False
+    def _on_error(self, exc: Exception, is_probe: bool) -> None:
+        if is_probe:
+            self._probe_inflight = False
         if not self._broken:
             logger.warning(
                 f"Rate-limit redis backend unavailable ({exc!r}) — "
@@ -59,38 +113,57 @@ class ResilientRateLimitBackend(IRateLimitBackend):
         self._broken_until = time.monotonic() + self._breaker_cooldown_s
 
     async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
-        if self._use_primary():
+        use_primary, is_probe = self._route()
+        if use_primary:
             try:
                 waited = await self._primary.acquire(key, weight, capacity, refill_rate)
             except _BACKEND_ERRORS as e:
-                self._on_error(e)
+                self._on_error(e, is_probe)
+            except BaseException:
+                # CancelledError and non-enumerated errors: release the probe slot and
+                # propagate — the breaker state itself is left as-is
+                if is_probe:
+                    self._probe_inflight = False
+                raise
             else:
-                self._on_success()
+                self._on_success(is_probe)
                 return waited
         return await self._fallback.acquire(key, weight, capacity, refill_rate)
 
     async def get_remaining(self, key: str, capacity: float = 0, refill_rate: float = 0) -> float | None:
-        if self._use_primary():
+        use_primary, is_probe = self._route()
+        if use_primary:
             try:
                 remaining = await self._primary.get_remaining(key, capacity, refill_rate)
             except _BACKEND_ERRORS as e:
-                self._on_error(e)
+                self._on_error(e, is_probe)
+            except BaseException:
+                if is_probe:
+                    self._probe_inflight = False
+                raise
             else:
-                self._on_success()
+                self._on_success(is_probe)
                 return remaining
         return await self._fallback.get_remaining(key, capacity, refill_rate)
 
     async def set_remaining(self, key: str, remaining: float, capacity: float = 0, refill_rate: float = 0) -> None:
-        if self._use_primary():
+        use_primary, is_probe = self._route()
+        if use_primary:
             try:
                 await self._primary.set_remaining(key, remaining, capacity, refill_rate)
             except _BACKEND_ERRORS as e:
-                self._on_error(e)
+                self._on_error(e, is_probe)
+            except BaseException:
+                if is_probe:
+                    self._probe_inflight = False
+                raise
             else:
-                self._on_success()
+                self._on_success(is_probe)
                 return
         await self._fallback.set_remaining(key, remaining, capacity, refill_rate)
 
     async def close(self) -> None:
-        await self._primary.close()
-        await self._fallback.close()
+        try:
+            await self._primary.close()
+        finally:
+            await self._fallback.close()

--- a/src/qubx/rate_limiting/resilient.py
+++ b/src/qubx/rate_limiting/resilient.py
@@ -14,11 +14,15 @@ Breaker protocol:
     - Once the cooldown expires, exactly one caller claims the probe slot
       (``_route()``, ``_probe_inflight``) and is routed to the primary; other
       concurrent callers stay on the fallback while the probe is in flight.
-    - Only the probe's own outcome may change breaker state: probe success
-      closes the breaker, probe failure re-opens it for another cooldown. A
-      *stale* success or error — from a call dispatched before the breaker
-      opened, landing after another call already changed the state — is not
-      evidence about the probe and is ignored (see F2 / review Finding 2).
+    - Open and close are asymmetric. Closing requires the probe: only the
+      probe's success closes the breaker, so a *stale* success — from a call
+      dispatched before the breaker opened, landing after — is ignored (see
+      F2 / review Finding 2). Opening does not: ANY primary error opens or
+      re-arms the cooldown, stale or not, because an error is evidence of an
+      unhealthy primary regardless of when the call was dispatched. A stale
+      error landing right after a successful probe therefore re-opens the
+      breaker for a full cooldown — accepted: it costs one 30 s local-only
+      window at the tail of an outage, never a hang.
     - The probe slot is released on every exit path, including
       ``asyncio.CancelledError`` and any exception outside
       ``_BACKEND_ERRORS`` (see F1 / review Finding 1): those propagate to the
@@ -66,11 +70,11 @@ class ResilientRateLimitBackend(IRateLimitBackend):
     limitations. In short: primary healthy → pass-through; primary error →
     breaker opens for ``breaker_cooldown_s`` and calls are served by the
     local fallback; cooldown expiry → exactly one caller probes the primary
-    while concurrent callers stay on the fallback; only that probe's outcome
-    can close (on success) or re-open (on failure) the breaker. Breaker
-    state (``_broken``, ``_broken_until``, ``_probe_inflight``) is plain
-    attributes shared across event loops — the one accepted race is two
-    concurrent probes.
+    while concurrent callers stay on the fallback; only the probe's success
+    closes the breaker, while any primary error (probe or stale) opens or
+    re-arms it. Breaker state (``_broken``, ``_broken_until``,
+    ``_probe_inflight``) is plain attributes shared across event loops — the
+    one accepted race is two concurrent probes.
     """
 
     def __init__(
@@ -102,15 +106,18 @@ class ResilientRateLimitBackend(IRateLimitBackend):
             logger.info("Rate-limit redis backend recovered — resuming cross-bot coordination")
 
     def _on_error(self, exc: Exception, is_probe: bool) -> None:
+        # re-arm the breaker BEFORE releasing the probe slot: once the slot frees,
+        # a racing _route() must already see the fresh cooldown deadline
+        was_broken = self._broken
+        self._broken = True
+        self._broken_until = time.monotonic() + self._breaker_cooldown_s
         if is_probe:
             self._probe_inflight = False
-        if not self._broken:
+        if not was_broken:
             logger.warning(
                 f"Rate-limit redis backend unavailable ({exc!r}) — "
                 f"falling back to local buckets for {self._breaker_cooldown_s:.0f}s"
             )
-        self._broken = True
-        self._broken_until = time.monotonic() + self._breaker_cooldown_s
 
     async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
         use_primary, is_probe = self._route()

--- a/src/qubx/rate_limiting/resilient.py
+++ b/src/qubx/rate_limiting/resilient.py
@@ -1,0 +1,96 @@
+import time
+
+from redis.exceptions import RedisError
+
+from qubx import logger
+
+from .backend import InMemoryBackend, IRateLimitBackend
+
+_BACKEND_ERRORS = (RedisError, OSError)
+
+
+class ResilientRateLimitBackend(IRateLimitBackend):
+    """Composite: primary (redis) with local fallback and a circuit breaker.
+
+    Primary healthy → pass-through. Primary error → breaker opens for
+    breaker_cooldown_s and calls are served by the local fallback (per-bot
+    pacing, no cross-bot coordination). Cooldown expiry → exactly one caller
+    probes the primary; concurrent callers stay on the fallback until the
+    probe resolves. State is plain monotonic floats shared across event
+    loops — races are benign (worst case: two probes).
+    """
+
+    def __init__(
+        self,
+        primary: IRateLimitBackend,
+        fallback: IRateLimitBackend | None = None,
+        breaker_cooldown_s: float = 30.0,
+    ):
+        self._primary = primary
+        self._fallback = fallback or InMemoryBackend()
+        self._breaker_cooldown_s = breaker_cooldown_s
+        self._broken = False
+        self._broken_until = 0.0
+        self._probe_inflight = False
+
+    def _use_primary(self) -> bool:
+        """Route decision for this call; claims the probe slot when one is due."""
+        if not self._broken:
+            return True
+        if self._probe_inflight or time.monotonic() < self._broken_until:
+            return False
+        self._probe_inflight = True
+        return True
+
+    def _on_success(self) -> None:
+        self._probe_inflight = False
+        if self._broken:
+            self._broken = False
+            logger.info("Rate-limit redis backend recovered — resuming cross-bot coordination")
+
+    def _on_error(self, exc: Exception) -> None:
+        self._probe_inflight = False
+        if not self._broken:
+            logger.warning(
+                f"Rate-limit redis backend unavailable ({exc!r}) — "
+                f"falling back to local buckets for {self._breaker_cooldown_s:.0f}s"
+            )
+        self._broken = True
+        self._broken_until = time.monotonic() + self._breaker_cooldown_s
+
+    async def acquire(self, key: str, weight: float, capacity: float, refill_rate: float) -> float:
+        if self._use_primary():
+            try:
+                waited = await self._primary.acquire(key, weight, capacity, refill_rate)
+            except _BACKEND_ERRORS as e:
+                self._on_error(e)
+            else:
+                self._on_success()
+                return waited
+        return await self._fallback.acquire(key, weight, capacity, refill_rate)
+
+    async def get_remaining(self, key: str, capacity: float = 0, refill_rate: float = 0) -> float | None:
+        if self._use_primary():
+            try:
+                remaining = await self._primary.get_remaining(key, capacity, refill_rate)
+            except _BACKEND_ERRORS as e:
+                self._on_error(e)
+            else:
+                self._on_success()
+                return remaining
+        return await self._fallback.get_remaining(key, capacity, refill_rate)
+
+    async def set_remaining(self, key: str, remaining: float, capacity: float = 0, refill_rate: float = 0) -> None:
+        if self._use_primary():
+            try:
+                await self._primary.set_remaining(key, remaining, capacity, refill_rate)
+            except _BACKEND_ERRORS as e:
+                self._on_error(e)
+            else:
+                self._on_success()
+                return
+        await self._fallback.set_remaining(key, remaining, capacity, refill_rate)
+
+    async def close(self) -> None:
+        await self._primary.close()
+        await self._fallback.close()

--- a/src/qubx/state/redis.py
+++ b/src/qubx/state/redis.py
@@ -37,6 +37,11 @@ class RedisStatePersistence(IStatePersistence):
         key_prefix: str = "state",
         ttl_seconds: int | None = None,
         indent: int | None = 2,
+        *,
+        socket_connect_timeout: float = 2.0,
+        socket_timeout: float = 5.0,
+        socket_keepalive: bool = True,
+        health_check_interval: int = 30,
     ):
         """
         Initialize Redis state persistence.
@@ -47,8 +52,21 @@ class RedisStatePersistence(IStatePersistence):
             key_prefix: Prefix for all keys (default: "state")
             ttl_seconds: Optional TTL in seconds for all keys (None = no expiry)
             indent: JSON indentation level for readability (default: 2, None = compact)
+            socket_connect_timeout: Max seconds to wait for a TCP connection to Redis
+            socket_timeout: Max seconds to wait for a socket read/write to Redis
+            socket_keepalive: Enable TCP keepalive on the underlying socket
+            health_check_interval: Seconds between health-check pings on idle connections
         """
-        self._redis = redis.from_url(redis_url)
+        # - bounded-failure client: a dead peer costs seconds, never TCP-retransmission
+        #   minutes (incident 2026-08-19; platform #375). Retry policy lives in the
+        #   SafeStatePersistence wrapper, not here.
+        self._redis = redis.from_url(
+            redis_url,
+            socket_connect_timeout=socket_connect_timeout,
+            socket_timeout=socket_timeout,
+            socket_keepalive=socket_keepalive,
+            health_check_interval=health_check_interval,
+        )
         self._strategy_name = strategy_name
         self._key_prefix = key_prefix
         self._ttl_seconds = ttl_seconds

--- a/src/qubx/state/safe.py
+++ b/src/qubx/state/safe.py
@@ -115,6 +115,10 @@ class SafeStatePersistence(IStatePersistence):
         while True:
             try:
                 self._backend.exists("__qubx_probe__")
+                # - the probe proves backend liveness: seed last-success now so a backend that
+                #   dies after startup but before the first write is still caught by staleness
+                #   monitoring instead of leaving last_success_age() = None forever
+                self._last_success = time.monotonic()
                 logger.info(f"[SafeStatePersistence] backend validated after {attempt + 1} attempt(s)")
                 return
             except Exception as e:

--- a/src/qubx/state/safe.py
+++ b/src/qubx/state/safe.py
@@ -1,0 +1,124 @@
+"""Async wrapper making any IStatePersistence backend safe for the event loop.
+
+Contract (spec 2026-08-19-safe-state-persistence, D2): all writes are buffered
+per-key (latest wins) and flushed by ONE background writer thread; ``load``
+consults the pending buffer first (read-your-writes); no caller ever blocks on
+the network and network errors never raise from ``save``/``delete``.
+"""
+
+import json
+import threading
+import time
+from typing import Any, Callable
+
+from qubx import logger
+from qubx.core.interfaces import IStatePersistence
+
+_TOMBSTONE = object()
+
+
+class SafeStatePersistence(IStatePersistence):
+    def __init__(
+        self,
+        backend: IStatePersistence,
+        *,
+        staleness_threshold_s: float = 60.0,
+        flush_timeout_s: float = 5.0,
+        retry_backoff_s: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0, 16.0, 30.0),
+        sleep_fn: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._backend = backend
+        self.staleness_threshold_s = staleness_threshold_s
+        self._flush_timeout_s = flush_timeout_s
+        self._retry_backoff_s = retry_backoff_s
+        self._sleep = sleep_fn
+
+        self._pending: dict[str, Any] = {}
+        self._cond = threading.Condition()
+        self._stopped = False
+        self._last_success: float | None = None
+        self._consecutive_failures = 0
+        self._last_fail_log = 0.0
+        self._writer = threading.Thread(target=self._run, name="StatePersistenceWriter", daemon=True)
+        self._writer.start()
+
+    # ------------------------------------------------------------------ writes
+    def save(self, key: str, value: Any) -> None:
+        json.dumps(value)  # - eager dry-run: programming errors (TypeError/ValueError) stay loud at the call site
+        with self._cond:
+            self._pending[key] = value
+            self._cond.notify()
+
+    def delete(self, key: str) -> bool:
+        with self._cond:
+            self._pending[key] = _TOMBSTONE
+            self._cond.notify()
+        return True  # optimistic: actual backend result is async
+
+    # ------------------------------------------------------------------- reads
+    def load(self, key: str, default: Any = None) -> Any:
+        with self._cond:
+            if key in self._pending:
+                v = self._pending[key]
+                return default if v is _TOMBSTONE else v
+        return self._backend.load(key, default)
+
+    def exists(self, key: str) -> bool:
+        with self._cond:
+            if key in self._pending:
+                return self._pending[key] is not _TOMBSTONE
+        return self._backend.exists(key)
+
+    # ------------------------------------------------------------------ health
+    def last_success_age(self) -> float | None:
+        return None if self._last_success is None else time.monotonic() - self._last_success
+
+    @property
+    def consecutive_failures(self) -> int:
+        return self._consecutive_failures
+
+    # ------------------------------------------------------------------ writer
+    def _run(self) -> None:
+        while True:
+            with self._cond:
+                while not self._pending and not self._stopped:
+                    self._cond.wait()
+                if not self._pending and self._stopped:
+                    return
+                batch, self._pending = self._pending, {}
+
+            failed: dict[str, Any] = {}
+            for key, value in batch.items():
+                try:
+                    if value is _TOMBSTONE:
+                        self._backend.delete(key)
+                    else:
+                        self._backend.save(key, value)
+                    self._last_success = time.monotonic()
+                    self._consecutive_failures = 0
+                except (TypeError, ValueError):
+                    logger.error(f"[SafeStatePersistence] unserializable value for '{key}' reached writer; dropped")
+                except Exception as e:
+                    failed[key] = value
+                    self._consecutive_failures += 1
+                    now = time.monotonic()
+                    if now - self._last_fail_log >= 30.0:
+                        logger.warning(
+                            f"[SafeStatePersistence] backend write failed ({self._consecutive_failures} in a row): {e}"
+                        )
+                        self._last_fail_log = now
+
+            if failed:
+                with self._cond:
+                    for key, value in failed.items():
+                        self._pending.setdefault(key, value)  # - newer pending values win over the failed batch
+                    if self._stopped:
+                        return  # - do not backoff-sleep during shutdown
+                backoff = self._retry_backoff_s[min(self._consecutive_failures, len(self._retry_backoff_s)) - 1]
+                self._sleep(backoff)
+
+    def stop(self) -> None:
+        with self._cond:
+            self._stopped = True
+            self._cond.notify_all()
+        self._writer.join(timeout=self._flush_timeout_s)

--- a/src/qubx/state/safe.py
+++ b/src/qubx/state/safe.py
@@ -34,8 +34,14 @@ class SafeStatePersistence(IStatePersistence):
         self._sleep = sleep_fn
 
         self._pending: dict[str, Any] = {}
+        # keys currently being flushed by the writer (dequeued from _pending, not yet resolved) -
+        # consulted by load()/exists() so read-your-writes holds for the whole batch-write duration,
+        # not just while a key sits in _pending (fixes the in-flight read gap, spec review F2).
+        self._inflight: dict[str, Any] = {}
         self._cond = threading.Condition()
         self._stopped = False
+        self._stop_event = threading.Event()  # lets stop() interrupt an in-progress backoff wait (fixes F3)
+        self._warned_after_stop = False
         self._last_success: float | None = None
         self._consecutive_failures = 0
         self._last_fail_log = 0.0
@@ -46,14 +52,26 @@ class SafeStatePersistence(IStatePersistence):
     def save(self, key: str, value: Any) -> None:
         json.dumps(value)  # - eager dry-run: programming errors (TypeError/ValueError) stay loud at the call site
         with self._cond:
+            if self._stopped:
+                self._warn_write_after_stop()
+                return
             self._pending[key] = value
             self._cond.notify()
 
     def delete(self, key: str) -> bool:
         with self._cond:
+            if self._stopped:
+                self._warn_write_after_stop()
+                return True  # optimistic per contract; nothing will actually be persisted
             self._pending[key] = _TOMBSTONE
             self._cond.notify()
         return True  # optimistic: actual backend result is async
+
+    def _warn_write_after_stop(self) -> None:
+        # called under self._cond; log once so a busy shutdown path can't spam the log
+        if not self._warned_after_stop:
+            logger.warning("[SafeStatePersistence] save after stop; value will not be persisted")
+            self._warned_after_stop = True
 
     # ------------------------------------------------------------------- reads
     def load(self, key: str, default: Any = None) -> Any:
@@ -61,12 +79,17 @@ class SafeStatePersistence(IStatePersistence):
             if key in self._pending:
                 v = self._pending[key]
                 return default if v is _TOMBSTONE else v
+            if key in self._inflight:
+                v = self._inflight[key]
+                return default if v is _TOMBSTONE else v
         return self._backend.load(key, default)
 
     def exists(self, key: str) -> bool:
         with self._cond:
             if key in self._pending:
                 return self._pending[key] is not _TOMBSTONE
+            if key in self._inflight:
+                return self._inflight[key] is not _TOMBSTONE
         return self._backend.exists(key)
 
     # ------------------------------------------------------------------ health
@@ -75,9 +98,38 @@ class SafeStatePersistence(IStatePersistence):
 
     @property
     def consecutive_failures(self) -> int:
+        """Consecutive *rounds* (batch attempts) with at least one failing key, not failing keys."""
         return self._consecutive_failures
 
     # ------------------------------------------------------------------ writer
+    def _attempt_batch(self, batch: dict[str, Any]) -> tuple[dict[str, Any], bool, Exception | None]:
+        """Flush one batch to the backend. Returns (still-failed subset, round had any failure, last error)."""
+        failed: dict[str, Any] = {}
+        round_failed = False
+        last_error: Exception | None = None
+        for key, value in batch.items():
+            try:
+                if value is _TOMBSTONE:
+                    self._backend.delete(key)
+                else:
+                    self._backend.save(key, value)
+                self._last_success = time.monotonic()
+            except (TypeError, ValueError):
+                logger.error(f"[SafeStatePersistence] unserializable value for '{key}' reached writer; dropped")
+            except Exception as e:
+                failed[key] = value
+                round_failed = True
+                last_error = e
+        return failed, round_failed, last_error
+
+    def _wait_backoff(self, backoff: float) -> None:
+        if self._sleep is time.sleep:
+            # default sleep: wait on the event so stop() can interrupt a long backoff immediately
+            self._stop_event.wait(backoff)
+        else:
+            # an injected sleep_fn (tests) is honored as given; _stopped is re-checked right after
+            self._sleep(backoff)
+
     def _run(self) -> None:
         while True:
             with self._cond:
@@ -86,39 +138,55 @@ class SafeStatePersistence(IStatePersistence):
                 if not self._pending and self._stopped:
                     return
                 batch, self._pending = self._pending, {}
+                self._inflight = batch
 
-            failed: dict[str, Any] = {}
-            for key, value in batch.items():
-                try:
-                    if value is _TOMBSTONE:
-                        self._backend.delete(key)
-                    else:
-                        self._backend.save(key, value)
-                    self._last_success = time.monotonic()
-                    self._consecutive_failures = 0
-                except (TypeError, ValueError):
-                    logger.error(f"[SafeStatePersistence] unserializable value for '{key}' reached writer; dropped")
-                except Exception as e:
-                    failed[key] = value
-                    self._consecutive_failures += 1
-                    now = time.monotonic()
-                    if now - self._last_fail_log >= 30.0:
-                        logger.warning(
-                            f"[SafeStatePersistence] backend write failed ({self._consecutive_failures} in a row): {e}"
-                        )
-                        self._last_fail_log = now
+            failed, round_failed, last_error = self._attempt_batch(batch)
 
-            if failed:
-                with self._cond:
-                    for key, value in failed.items():
-                        self._pending.setdefault(key, value)  # - newer pending values win over the failed batch
-                    if self._stopped:
-                        return  # - do not backoff-sleep during shutdown
-                backoff = self._retry_backoff_s[min(self._consecutive_failures, len(self._retry_backoff_s)) - 1]
-                self._sleep(backoff)
+            with self._cond:
+                # merge failed keys back into _pending BEFORE clearing _inflight so a key is never
+                # visible in neither map (read-your-writes gap, spec review F2)
+                for key, value in failed.items():
+                    self._pending.setdefault(key, value)  # - newer pending values win over the failed batch
+                self._inflight = {}
+                is_stopped = self._stopped
+
+            # count consecutive FAILING ROUNDS, not failing keys (spec review F1: a batch with one
+            # failing key and one succeeding key must not reset to 0 and then backoff-index to -1)
+            self._consecutive_failures = self._consecutive_failures + 1 if round_failed else 0
+
+            if not failed:
+                continue
+
+            if is_stopped:
+                # bounded flush: this attempt (or the one that follows an interrupted backoff wait)
+                # is the single final drain attempt - no more retries, no more backend calls after this.
+                logger.warning(
+                    f"[SafeStatePersistence] stop(): abandoning {len(failed)} unflushed key(s) after "
+                    f"final drain attempt: {sorted(failed)} (last error: {last_error})"
+                )
+                return
+
+            now = time.monotonic()
+            if now - self._last_fail_log >= 30.0:
+                logger.warning(
+                    f"[SafeStatePersistence] backend write failed for {len(failed)} key(s) "
+                    f"({self._consecutive_failures} consecutive failing round(s)): {last_error}"
+                )
+                self._last_fail_log = now
+
+            backoff = self._retry_backoff_s[min(self._consecutive_failures - 1, len(self._retry_backoff_s) - 1)]
+            self._wait_backoff(backoff)
 
     def stop(self) -> None:
         with self._cond:
             self._stopped = True
             self._cond.notify_all()
+        self._stop_event.set()
         self._writer.join(timeout=self._flush_timeout_s)
+        if self._writer.is_alive():
+            with self._cond:
+                n_unflushed = len(self._pending) + len(self._inflight)
+            logger.warning(
+                f"[SafeStatePersistence] stop(): flush timed out after {self._flush_timeout_s}s with "
+                f"{n_unflushed} key(s) still unflushed"
+            )

--- a/src/qubx/state/safe.py
+++ b/src/qubx/state/safe.py
@@ -12,6 +12,7 @@ import time
 from typing import Any, Callable
 
 from qubx import logger
+from qubx.core.exceptions import StatePersistenceUnavailable
 from qubx.core.interfaces import IStatePersistence
 
 _TOMBSTONE = object()
@@ -100,6 +101,35 @@ class SafeStatePersistence(IStatePersistence):
     def consecutive_failures(self) -> int:
         """Consecutive *rounds* (batch attempts) with at least one failing key, not failing keys."""
         return self._consecutive_failures
+
+    def validate_startup(
+        self,
+        deadline_s: float = 60.0,
+        probe_backoff_s: tuple[float, ...] = (0.5, 1.0, 2.0, 4.0, 8.0, 10.0),
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Probe the backend with backoff for up to ``deadline_s``; raise on exhaustion (spec D3)."""
+        start = clock()
+        attempt = 0
+        last_err: Exception | None = None
+        while True:
+            try:
+                self._backend.exists("__qubx_probe__")
+                logger.info(f"[SafeStatePersistence] backend validated after {attempt + 1} attempt(s)")
+                return
+            except Exception as e:
+                last_err = e
+                elapsed = clock() - start
+                if elapsed >= deadline_s:
+                    raise StatePersistenceUnavailable(
+                        f"state persistence unreachable after {elapsed:.0f}s ({attempt + 1} attempts): {last_err}"
+                    ) from last_err
+                backoff = probe_backoff_s[min(attempt, len(probe_backoff_s) - 1)]
+                logger.warning(
+                    f"[SafeStatePersistence] startup probe failed (attempt {attempt + 1}): {e}; retrying in {backoff}s"
+                )
+                self._sleep(backoff)
+                attempt += 1
 
     # ------------------------------------------------------------------ writer
     def _attempt_batch(self, batch: dict[str, Any]) -> tuple[dict[str, Any], bool, Exception | None]:

--- a/src/qubx/utils/runner/factory.py
+++ b/src/qubx/utils/runner/factory.py
@@ -6,11 +6,15 @@ import inspect
 import os
 from typing import Any
 
+import pandas as pd
+
 from qubx import logger
 from qubx.core.interfaces import IAccountViewer, IMetricEmitter, IStatePersistence, IStrategyNotifier, ITradeDataExport
 from qubx.data.storage import IStorage
 from qubx.data.storages.multi import MultiStorage
 from qubx.emitters.composite import CompositeMetricEmitter
+from qubx.state.dummy import DummyStatePersistence
+from qubx.state.safe import SafeStatePersistence
 from qubx.utils.misc import class_import
 from qubx.utils.runner.configs import (
     EmissionConfig,
@@ -469,13 +473,22 @@ def create_state_persistence(
         # Copy parameters (env vars already resolved during config load)
         params: dict[str, Any] = dict(config.parameters)
 
-        # Add strategy_name if not already provided
-        if "strategy_name" not in params:
+        # Add strategy_name if the backend accepts it and it's not already provided
+        if "strategy_name" in inspect.signature(persistence_class).parameters and "strategy_name" not in params:
             params["strategy_name"] = strategy_name
 
         persistence = persistence_class(**params)
         logger.info(f"Created state persistence: {persistence_class_name}")
-        return persistence
+
+        if isinstance(persistence, DummyStatePersistence):
+            return persistence
+
+        # - wrap every real backend (spec D2/D4): async latest-wins writes, read-your-writes,
+        #   fail-fast startup (D3). StatePersistenceUnavailable propagates and kills the runner.
+        interval_s = pd.Timedelta(config.snapshot_interval).total_seconds() if config.snapshot_interval else 0.0
+        safe = SafeStatePersistence(persistence, staleness_threshold_s=max(3.0 * interval_s, 60.0))
+        safe.validate_startup()
+        return safe
 
     except Exception as e:
         logger.error(f"Failed to create state persistence {persistence_class_name}: {e}")

--- a/src/qubx/utils/threading.py
+++ b/src/qubx/utils/threading.py
@@ -22,6 +22,8 @@ class BoundedWorker:
     """
 
     def __init__(self, name: str, maxlen: int, warn_every_s: float = 30.0) -> None:
+        if maxlen < 1:
+            raise ValueError(f"maxlen must be >= 1, got {maxlen}")
         self._name = name
         self._maxlen = maxlen
         self._warn_every_s = warn_every_s

--- a/src/qubx/utils/threading.py
+++ b/src/qubx/utils/threading.py
@@ -1,0 +1,82 @@
+"""Bounded background-work primitives (spec: 2026-08-19-safe-state-persistence).
+
+Absolute imports mean ``import threading`` below resolves to the stdlib even
+though this module shares its name.
+"""
+
+import threading
+import time
+from collections import deque
+from typing import Any, Callable
+
+from qubx import logger
+
+
+class BoundedWorker:
+    """Single daemon worker thread over a drop-oldest bounded queue.
+
+    ``submit`` never blocks and never raises: when the queue is full the OLDEST
+    pending item is dropped (counted, warned at most once per ``warn_every_s``).
+    One worker per instance is deliberate — it preserves FIFO ordering, which
+    redis-stream exports rely on.
+    """
+
+    def __init__(self, name: str, maxlen: int, warn_every_s: float = 30.0) -> None:
+        self._name = name
+        self._maxlen = maxlen
+        self._warn_every_s = warn_every_s
+        self._queue: deque[tuple[Callable[..., Any], tuple, dict]] = deque()
+        self._cond = threading.Condition()
+        self._dropped = 0
+        self._dropped_unreported = 0
+        self._last_warn = 0.0
+        self._stopped = False
+        self._thread = threading.Thread(target=self._run, name=f"BoundedWorker-{name}", daemon=True)
+        self._thread.start()
+
+    @property
+    def dropped(self) -> int:
+        return self._dropped
+
+    @property
+    def queued(self) -> int:
+        with self._cond:
+            return len(self._queue)
+
+    def submit(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        with self._cond:
+            if self._stopped:
+                return
+            if len(self._queue) >= self._maxlen:
+                self._queue.popleft()
+                self._dropped += 1
+                self._dropped_unreported += 1
+                now = time.monotonic()
+                if now - self._last_warn >= self._warn_every_s:
+                    logger.warning(
+                        f"[BoundedWorker:{self._name}] queue full (maxlen={self._maxlen}) — "
+                        f"dropped {self._dropped_unreported} oldest items since last report"
+                    )
+                    self._last_warn = now
+                    self._dropped_unreported = 0
+            self._queue.append((fn, args, kwargs))
+            self._cond.notify()
+
+    def _run(self) -> None:
+        while True:
+            with self._cond:
+                while not self._queue and not self._stopped:
+                    self._cond.wait()
+                if not self._queue and self._stopped:
+                    return
+                fn, args, kwargs = self._queue.popleft()
+            try:
+                fn(*args, **kwargs)
+            except Exception as e:
+                logger.warning(f"[BoundedWorker:{self._name}] task failed: {e}")
+
+    def stop(self, flush_timeout_s: float = 5.0) -> None:
+        with self._cond:
+            self._stopped = True
+            self._cond.notify_all()
+        self._thread.join(timeout=flush_timeout_s)

--- a/tests/qubx/core/context_state_persistence_test.py
+++ b/tests/qubx/core/context_state_persistence_test.py
@@ -103,3 +103,17 @@ def test_stop_flushes_safe_state_persistence(mock_components):
 def test_stop_is_noop_for_dummy_state_persistence(mock_components):
     ctx = _build_context(mock_components, None, MagicMock())  # None -> DummyStatePersistence()
     ctx.stop()  # must not raise (DummyStatePersistence has no stop())
+
+
+class _HealthMonitorWithoutStatePersistenceSupport:
+    """A custom IHealthMonitor that predates set_state_persistence — must not AttributeError
+    at construction when paired with real (SafeStatePersistence-shaped) persistence."""
+
+    def set_status(self, status) -> None:
+        pass
+
+
+def test_construction_does_not_raise_for_health_monitor_missing_set_state_persistence(mock_components):
+    sp = _StubSafePersistence()
+    # must not raise AttributeError even though the monitor has no set_state_persistence
+    _build_context(mock_components, sp, _HealthMonitorWithoutStatePersistenceSupport())

--- a/tests/qubx/core/context_state_persistence_test.py
+++ b/tests/qubx/core/context_state_persistence_test.py
@@ -1,7 +1,8 @@
-"""Task 6 scope extension: StrategyContext wires a SafeStatePersistence (duck-typed via
-last_success_age) into the health monitor at construction, and flushes it (stop()) during
-StrategyContext.stop()'s fault-tolerant cleanup sequence. DummyStatePersistence (no
-last_success_age/stop) must be a no-op on both paths.
+"""StrategyContext wires its state persistence into the health monitor at construction
+(set_state_persistence is part of IHealthMonitor) and flushes it (stop(), part of
+IStatePersistence) during StrategyContext.stop()'s fault-tolerant cleanup sequence.
+Backends that don't track write health (DummyStatePersistence) rely on the interface
+defaults: last_success_age() -> None and a no-op stop().
 
 Mirrors the StrategyContext construction pattern from context_initializer_test.py — the
 same set of manager classes (MarketManager/UniverseManager/SubscriptionManager/
@@ -15,8 +16,9 @@ import pytest
 
 from qubx.core.context import StrategyContext
 from qubx.core.initializer import BasicStrategyInitializer
-from qubx.core.interfaces import IStrategy
+from qubx.core.interfaces import IHealthMonitor, IStrategy
 from qubx.core.lookups import lookup
+from qubx.state import DummyStatePersistence
 
 
 class _MockStrategy(IStrategy):
@@ -24,7 +26,7 @@ class _MockStrategy(IStrategy):
 
 
 class _StubSafePersistence:
-    """Duck-types the SafeStatePersistence surface context.py wires on: last_success_age()
+    """The SafeStatePersistence surface context.py relies on: last_success_age()
     + staleness_threshold_s (health wiring) and stop() (shutdown flush)."""
 
     staleness_threshold_s = 60.0
@@ -87,10 +89,11 @@ def test_safe_persistence_wired_into_health_monitor_on_construction(mock_compone
     health_monitor.set_state_persistence.assert_called_once_with(sp)
 
 
-def test_dummy_persistence_not_wired_into_health_monitor(mock_components):
+def test_dummy_persistence_is_wired_unconditionally(mock_components):
     health_monitor = MagicMock()
-    _build_context(mock_components, None, health_monitor)  # None -> DummyStatePersistence()
-    health_monitor.set_state_persistence.assert_not_called()
+    ctx = _build_context(mock_components, None, health_monitor)  # None -> DummyStatePersistence()
+    health_monitor.set_state_persistence.assert_called_once_with(ctx._state_persistence)
+    assert isinstance(ctx._state_persistence, DummyStatePersistence)
 
 
 def test_stop_flushes_safe_state_persistence(mock_components):
@@ -102,18 +105,18 @@ def test_stop_flushes_safe_state_persistence(mock_components):
 
 def test_stop_is_noop_for_dummy_state_persistence(mock_components):
     ctx = _build_context(mock_components, None, MagicMock())  # None -> DummyStatePersistence()
-    ctx.stop()  # must not raise (DummyStatePersistence has no stop())
+    ctx.stop()  # must not raise (DummyStatePersistence inherits the no-op stop() default)
 
 
-class _HealthMonitorWithoutStatePersistenceSupport:
-    """A custom IHealthMonitor that predates set_state_persistence — must not AttributeError
-    at construction when paired with real (SafeStatePersistence-shaped) persistence."""
+class _MinimalHealthMonitor(IHealthMonitor):
+    """A monitor that implements nothing beyond what IHealthMonitor's interface
+    defaults provide — set_state_persistence must be inherited as a no-op."""
 
     def set_status(self, status) -> None:
         pass
 
 
-def test_construction_does_not_raise_for_health_monitor_missing_set_state_persistence(mock_components):
+def test_construction_works_for_monitor_using_interface_default(mock_components):
     sp = _StubSafePersistence()
-    # must not raise AttributeError even though the monitor has no set_state_persistence
-    _build_context(mock_components, sp, _HealthMonitorWithoutStatePersistenceSupport())
+    # must not raise: set_state_persistence is part of IHealthMonitor with a no-op default
+    _build_context(mock_components, sp, _MinimalHealthMonitor())

--- a/tests/qubx/core/context_state_persistence_test.py
+++ b/tests/qubx/core/context_state_persistence_test.py
@@ -1,0 +1,105 @@
+"""Task 6 scope extension: StrategyContext wires a SafeStatePersistence (duck-typed via
+last_success_age) into the health monitor at construction, and flushes it (stop()) during
+StrategyContext.stop()'s fault-tolerant cleanup sequence. DummyStatePersistence (no
+last_success_age/stop) must be a no-op on both paths.
+
+Mirrors the StrategyContext construction pattern from context_initializer_test.py — the
+same set of manager classes (MarketManager/UniverseManager/SubscriptionManager/
+TradingManager/ProcessingManager) is patched out so construction stays cheap.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from qubx.core.context import StrategyContext
+from qubx.core.initializer import BasicStrategyInitializer
+from qubx.core.interfaces import IStrategy
+from qubx.core.lookups import lookup
+
+
+class _MockStrategy(IStrategy):
+    """Bare strategy — relies on IStrategy's default no-op on_init/on_stop."""
+
+
+class _StubSafePersistence:
+    """Duck-types the SafeStatePersistence surface context.py wires on: last_success_age()
+    + staleness_threshold_s (health wiring) and stop() (shutdown flush)."""
+
+    staleness_threshold_s = 60.0
+
+    def __init__(self) -> None:
+        self.stop_called = False
+
+    def last_success_age(self) -> float | None:
+        return None
+
+    def stop(self) -> None:
+        self.stop_called = True
+
+
+@pytest.fixture
+def mock_components():
+    data_provider = MagicMock()
+    time_provider = MagicMock()
+    time_provider.time.return_value = np.datetime64("2023-01-01", "ns")
+    return {
+        "connectors": {"BINANCE.UM": MagicMock()},
+        "data_provider": data_provider,
+        "account": MagicMock(),
+        "scheduler": MagicMock(),
+        "time_provider": time_provider,
+        "instruments": [lookup.find_symbol("BINANCE.UM", "BTCUSDT")],
+        "logging": MagicMock(),
+        "aux_data_storage": MagicMock(),
+    }
+
+
+def _build_context(mock_components, state_persistence, health_monitor) -> StrategyContext:
+    with (
+        patch("qubx.core.context.MarketManager"),
+        patch("qubx.core.context.UniverseManager"),
+        patch("qubx.core.context.SubscriptionManager"),
+        patch("qubx.core.context.TradingManager"),
+        patch("qubx.core.context.ProcessingManager"),
+    ):
+        return StrategyContext(
+            strategy=_MockStrategy(),
+            connectors=mock_components["connectors"],
+            data_providers=[mock_components["data_provider"]],
+            account_manager=mock_components["account"],
+            scheduler=mock_components["scheduler"],
+            time_provider=mock_components["time_provider"],
+            instruments=mock_components["instruments"],
+            logging=mock_components["logging"],
+            initializer=BasicStrategyInitializer(simulation=True),
+            aux_data_storage=mock_components["aux_data_storage"],
+            state_persistence=state_persistence,
+            health_monitor=health_monitor,
+        )
+
+
+def test_safe_persistence_wired_into_health_monitor_on_construction(mock_components):
+    sp = _StubSafePersistence()
+    health_monitor = MagicMock()
+    _build_context(mock_components, sp, health_monitor)
+    health_monitor.set_state_persistence.assert_called_once_with(sp)
+
+
+def test_dummy_persistence_not_wired_into_health_monitor(mock_components):
+    health_monitor = MagicMock()
+    _build_context(mock_components, None, health_monitor)  # None -> DummyStatePersistence()
+    health_monitor.set_state_persistence.assert_not_called()
+
+
+def test_stop_flushes_safe_state_persistence(mock_components):
+    sp = _StubSafePersistence()
+    ctx = _build_context(mock_components, sp, MagicMock())
+    ctx.stop()
+    assert sp.stop_called is True
+
+
+def test_stop_is_noop_for_dummy_state_persistence(mock_components):
+    ctx = _build_context(mock_components, None, MagicMock())  # None -> DummyStatePersistence()
+    ctx.stop()  # must not raise (DummyStatePersistence has no stop())

--- a/tests/qubx/emitters/metric_emitters_test.py
+++ b/tests/qubx/emitters/metric_emitters_test.py
@@ -589,7 +589,9 @@ class TestQuestDBMetricEmitter:
             emitter = QuestDBMetricEmitter(
                 host="testhost", port=9999, table_name="test_table", tags={"strategy": "test"}
             )
-            mock_sender.from_conf.assert_called_once_with("http::addr=testhost:9999;")
+            mock_sender.from_conf.assert_called_once_with(
+                "http::addr=testhost:9999;request_timeout=5000;retry_timeout=5000;"
+            )
             mock_sender.establish.assert_called_once()
             assert emitter._table_name == "test_table"
             assert emitter._default_tags["strategy"] == "test"
@@ -602,6 +604,9 @@ class TestQuestDBMetricEmitter:
         dt_timestamp = datetime.datetime(2023, 1, 1)
         with patch.object(emitter, "_convert_timestamp", return_value=dt_timestamp):
             emitter.emit("test_metric", 42.0, {"tag1": "value1"}, timestamp)
+
+            # - wait for the background worker thread to complete before asserting
+            emitter._worker.stop(flush_timeout_s=2.0)
 
             # Check that row was called with the correct arguments
             # Only SYMBOL_TAGS go into symbols, everything else (including metric_name) goes into columns
@@ -619,6 +624,9 @@ class TestQuestDBMetricEmitter:
             mock_datetime.now.return_value = mock_now
 
             emitter.emit("test_metric", 42.0, {"tag1": "value1"})
+
+            # - wait for the background worker thread to complete before asserting
+            emitter._worker.stop(flush_timeout_s=2.0)
 
             # Check that row was called with the correct arguments
             # Only SYMBOL_TAGS go into symbols, everything else (including metric_name) goes into columns
@@ -655,8 +663,8 @@ class TestQuestDBMetricEmitter:
             # - should not raise an exception
             emitter.emit("test_metric", 42.0)
 
-            # - wait for background executor thread to complete before asserting
-            emitter._executor.shutdown(wait=True)
+            # - wait for background worker thread to complete before asserting
+            emitter._worker.stop(flush_timeout_s=2.0)
 
             # - row must have been called despite the exception
             mock_sender.row.assert_called_once()
@@ -694,6 +702,8 @@ class TestQuestDBMetricEmitter:
         with patch("pandas.Timestamp.now", return_value=current_time):
             # Second call to notify should flush because current_time - _last_flush >= flush_interval
             emitter.notify(mock_context)
+            # - wait for the background worker thread to complete before asserting
+            emitter._worker.stop(flush_timeout_s=2.0)
             mock_sender.flush.assert_called_once()
 
     def test_emit_signals(self, emitter, mock_sender, mock_signals, mock_account):
@@ -702,7 +712,7 @@ class TestQuestDBMetricEmitter:
 
         # Mock the necessary methods
         with patch.object(emitter, "_convert_timestamp", return_value=datetime.datetime(2023, 1, 1, 12, 0, 0)):
-            with patch.object(emitter._executor, "submit") as mock_submit:
+            with patch.object(emitter._worker, "submit") as mock_submit:
                 emitter.emit_signals(time, mock_signals, mock_account)
 
                 # Should submit a single background task that handles all signals
@@ -738,7 +748,7 @@ class TestQuestDBMetricEmitter:
         emitter.emit_signals(time, [], mock_account)
 
         # Should not submit any tasks
-        with patch.object(emitter._executor, "submit") as mock_submit:
+        with patch.object(emitter._worker, "submit") as mock_submit:
             emitter.emit_signals(time, [], mock_account)
             mock_submit.assert_not_called()
 

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -56,11 +56,14 @@ class FakeSender:
         pass
 
 
-class SyncExecutor:
+class SyncWorker:
+    """Runs submitted work inline — stands in for BoundedWorker so tests can assert
+    synchronously without waiting on a background thread."""
+
     def submit(self, fn, *args, **kwargs):
         fn(*args, **kwargs)
 
-    def shutdown(self, **kwargs):
+    def stop(self, **kwargs):
         pass
 
 
@@ -73,7 +76,7 @@ def emitter(monkeypatch):
     monkeypatch.setattr(qdb_mod, "Sender", MagicMock(from_conf=MagicMock(side_effect=RuntimeError("no net"))))
     em = QuestDBMetricEmitter(host="qdb", tags={"strategy": "bot-1", "run_id": "r-1", "environment": "dev"})
     em._sender = FakeSender()
-    em._executor = SyncExecutor()
+    em._worker = SyncWorker()
     ddl.reset_mock()  # drop the signals/deals DDL calls from __init__
     em._ddl_client_for_test = ddl
     return em

--- a/tests/qubx/emitters/test_questdb_bounded.py
+++ b/tests/qubx/emitters/test_questdb_bounded.py
@@ -1,0 +1,37 @@
+"""Tests for QuestDBMetricEmitter: BoundedWorker + ILP Sender timeouts (spec: 2026-08-19-safe-state-persistence)."""
+
+from unittest.mock import MagicMock, patch
+
+import qubx.emitters.questdb as qdb_mod
+from qubx.emitters.questdb import QuestDBMetricEmitter
+from qubx.utils.threading import BoundedWorker
+
+
+def _make_emitter(**kwargs) -> QuestDBMetricEmitter:
+    """Construct a QuestDBMetricEmitter with QuestDBClient/Sender mocked out (no real network calls).
+
+    Mirrors the fixtures in tests/qubx/emitters/metric_emitters_test.py: QuestDBClient is used
+    directly by _ensure_signals_table_exists/_ensure_deals_table_exists (bypassing the Sender
+    mock), and would otherwise attempt real DNS resolution against host="qdb.local".
+    """
+    mock_client = MagicMock()
+    mock_client.return_value.execute.return_value = None
+    mock_sender = MagicMock()
+    mock_sender.from_conf.return_value = mock_sender
+    mock_sender.establish.return_value = None
+    with patch.object(qdb_mod, "QuestDBClient", mock_client), patch.object(qdb_mod, "Sender", mock_sender):
+        return QuestDBMetricEmitter(host="qdb.local", port=9000, **kwargs)
+
+
+def test_conn_string_has_bounded_timeouts():
+    em = _make_emitter()
+    assert "request_timeout=5000;" in em._conn_str
+    assert "retry_timeout=5000;" in em._conn_str
+    em._worker.stop()
+
+
+def test_uses_bounded_worker():
+    em = _make_emitter(max_queue=123)
+    assert isinstance(em._worker, BoundedWorker)
+    assert em._worker._maxlen == 123
+    em._worker.stop()

--- a/tests/qubx/exporters/test_redis_streams_bounded.py
+++ b/tests/qubx/exporters/test_redis_streams_bounded.py
@@ -1,0 +1,57 @@
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from qubx.exporters.redis_streams import RedisStreamsExporter
+
+
+def _wait(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def _make_exporter(**kwargs):
+    with patch("qubx.exporters.redis_streams.redis.from_url", return_value=MagicMock()) as from_url:
+        exp = RedisStreamsExporter(redis_url="redis://localhost:6379/0", strategy_name="s", **kwargs)
+    return exp, from_url
+
+
+def test_client_has_bounded_failure_defaults():
+    _, from_url = _make_exporter()
+    kwargs = from_url.call_args.kwargs
+    assert kwargs["socket_connect_timeout"] == 2.0
+    assert kwargs["socket_timeout"] == 5.0
+    assert kwargs["socket_keepalive"] is True
+
+
+def test_stream_writes_preserve_fifo_order():
+    exp, _ = _make_exporter()
+    seen: list[int] = []
+    for i in range(50):
+        exp._worker.submit(seen.append, i)
+    exp._worker.stop(flush_timeout_s=2.0)
+    assert seen == list(range(50))
+
+
+def test_queue_bounded_under_hung_backend():
+    exp, _ = _make_exporter(max_queue=5)
+    gate = threading.Event()
+    started = threading.Event()
+
+    def occupy() -> None:
+        started.set()
+        gate.wait(5.0)
+
+    exp._worker.submit(occupy)  # occupy the worker
+    assert _wait(started.is_set)  # ensure it's dequeued (in-flight) before the flood arrives
+    t0 = time.monotonic()
+    for i in range(50):
+        exp._worker.submit(lambda: None)
+    assert time.monotonic() - t0 < 0.5
+    assert exp._worker.dropped >= 44
+    gate.set()
+    exp.stop()

--- a/tests/qubx/health/test_state_staleness.py
+++ b/tests/qubx/health/test_state_staleness.py
@@ -1,8 +1,11 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 
 from qubx.core.basics import ITimeProvider
 from qubx.core.status import ContextStatus, DegradeReason
 from qubx.health.base import BaseHealthMonitor
+from qubx.state import DummyStatePersistence
 
 
 class FixedTime(ITimeProvider):
@@ -52,6 +55,22 @@ def test_no_persistence_wired_is_noop():
     monitor = BaseHealthMonitor(FixedTime())
     monitor.set_status(ContextStatus())
     monitor.check_state_persistence()  # must not raise
+
+
+def test_dummy_persistence_wired_is_inert():
+    """Context wires persistence unconditionally; a backend that doesn't track write
+    health (last_success_age() -> None interface default) must never produce a gauge
+    or a degradation."""
+    monitor = BaseHealthMonitor(FixedTime())
+    status = ContextStatus()
+    monitor.set_status(status)
+    monitor.record_gauge = MagicMock()  # type: ignore[method-assign]
+    monitor.set_state_persistence(DummyStatePersistence())
+
+    monitor.check_state_persistence()
+
+    monitor.record_gauge.assert_not_called()
+    assert not status.info.degradations
 
 
 def test_age_none_before_first_write_is_not_stale():

--- a/tests/qubx/health/test_state_staleness.py
+++ b/tests/qubx/health/test_state_staleness.py
@@ -59,3 +59,23 @@ def test_age_none_before_first_write_is_not_stale():
     sp.age = None
     monitor.check_state_persistence()
     assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+
+
+def test_staleness_is_scoped_to_state_and_never_gates_trading():
+    """A pure persistence outage must never make is_degraded_for(exchange) true —
+    the degradation must be scoped to "state", not context-wide (scope=None)."""
+    monitor, status, sp = _make_monitor()
+
+    sp.age = 120.0
+    monitor.check_state_persistence()
+
+    assert status.info.is_degraded_for("BINANCE.UM") is False
+    state_degradations = [d for d in status.info.degradations if d.reason == DegradeReason.STATE_PERSISTENCE_STALE]
+    assert len(state_degradations) == 1
+    assert state_degradations[0].scope == "state"
+
+    sp.age = 1.0
+    monitor.check_state_persistence()
+
+    assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+    assert status.info.is_degraded_for("BINANCE.UM") is False

--- a/tests/qubx/health/test_state_staleness.py
+++ b/tests/qubx/health/test_state_staleness.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+from qubx.core.basics import ITimeProvider
+from qubx.core.status import ContextStatus, DegradeReason
+from qubx.health.base import BaseHealthMonitor
+
+
+class FixedTime(ITimeProvider):
+    def __init__(self) -> None:
+        self.now = np.datetime64("2026-08-19T00:00:00", "ns")
+
+    def time(self) -> np.datetime64:
+        return self.now
+
+
+class StubSafePersistence:
+    staleness_threshold_s = 60.0
+
+    def __init__(self) -> None:
+        self.age: float | None = 0.0
+
+    def last_success_age(self) -> float | None:
+        return self.age
+
+
+def _make_monitor():
+    monitor = BaseHealthMonitor(FixedTime())
+    status = ContextStatus()
+    monitor.set_status(status)
+    sp = StubSafePersistence()
+    monitor.set_state_persistence(sp)
+    return monitor, status, sp
+
+
+def test_degrades_when_stale_and_clears_on_recovery():
+    monitor, status, sp = _make_monitor()
+
+    sp.age = 10.0
+    monitor.check_state_persistence()
+    assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+
+    sp.age = 120.0
+    monitor.check_state_persistence()
+    assert any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+
+    sp.age = 1.0
+    monitor.check_state_persistence()
+    assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)
+
+
+def test_no_persistence_wired_is_noop():
+    monitor = BaseHealthMonitor(FixedTime())
+    monitor.set_status(ContextStatus())
+    monitor.check_state_persistence()  # must not raise
+
+
+def test_age_none_before_first_write_is_not_stale():
+    monitor, status, sp = _make_monitor()
+    sp.age = None
+    monitor.check_state_persistence()
+    assert not any(d.reason == DegradeReason.STATE_PERSISTENCE_STALE for d in status.info.degradations)

--- a/tests/qubx/rate_limiting/test_manager.py
+++ b/tests/qubx/rate_limiting/test_manager.py
@@ -7,9 +7,12 @@ import pytest
 from qubx import logger
 from qubx.connectors.registry import ConnectorRegistry
 from qubx.rate_limiting import EndpointCosts, ExchangeRateLimitConfig, PoolConfig
+from qubx.rate_limiting.backend import InMemoryBackend
 from qubx.rate_limiting.engine import _UNRESOLVED_SCOPE_ID
 from qubx.rate_limiting.ip_resolver import EgressIPResolver
 from qubx.rate_limiting.manager import RateLimitManager
+from qubx.rate_limiting.redis_backend import RedisBackend
+from qubx.rate_limiting.resilient import ResilientRateLimitBackend
 from qubx.utils.runner.configs import RateLimitingConfig
 
 _EGRESS_IP = "203.0.113.7"  # literal, so no IP discovery (and no network I/O) happens
@@ -104,6 +107,39 @@ class TestAccountScoping:
         assert not key.endswith(":local")
         assert key.endswith(_UNRESOLVED_SCOPE_ID)
         assert _UNRESOLVED_SCOPE_ID.startswith("local_")
+
+
+class TestBackendWiring:
+    """Fix round 1 / F6.3 (review Finding 9.3): `_create_backend` wiring had zero coverage."""
+
+    def test_redis_backend_is_wrapped_in_resilient(self):
+        loop = asyncio.new_event_loop()
+        try:
+            manager = RateLimitManager(
+                RateLimitingConfig(backend="redis", redis_url="redis://localhost:6379/0", egress_ip=_EGRESS_IP), loop
+            )
+            assert isinstance(manager._backend, ResilientRateLimitBackend)
+            assert isinstance(manager._backend._primary, RedisBackend)
+        finally:
+            loop.close()
+
+    def test_local_backend_is_not_wrapped(self):
+        """Negative control: `backend="local"` (the default) must stay a plain InMemoryBackend."""
+        loop = asyncio.new_event_loop()
+        try:
+            manager = RateLimitManager(RateLimitingConfig(backend="local", egress_ip=_EGRESS_IP), loop)
+            assert isinstance(manager._backend, InMemoryBackend)
+        finally:
+            loop.close()
+
+    def test_redis_backend_without_url_falls_back_to_in_memory(self):
+        """`backend="redis"` with no `redis_url` must not attempt a RedisBackend at all."""
+        loop = asyncio.new_event_loop()
+        try:
+            manager = RateLimitManager(RateLimitingConfig(backend="redis", redis_url=None, egress_ip=_EGRESS_IP), loop)
+            assert isinstance(manager._backend, InMemoryBackend)
+        finally:
+            loop.close()
 
 
 class TestEgressIPResolver:

--- a/tests/qubx/rate_limiting/test_redis_client_options.py
+++ b/tests/qubx/rate_limiting/test_redis_client_options.py
@@ -1,0 +1,31 @@
+"""Mirrors tests/qubx/state/test_redis_client_options.py for the rate-limit RedisBackend.
+
+RedisBackend creates its redis client lazily, per event loop, inside
+``_scripts_for_current_loop`` — so these tests must run inside a running loop.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qubx.rate_limiting.redis_backend import RedisBackend
+
+
+@pytest.mark.asyncio
+async def test_client_created_with_bounded_failure_defaults():
+    with patch("redis.asyncio.from_url", return_value=MagicMock()) as from_url:
+        RedisBackend("redis://x")._scripts_for_current_loop()
+    kwargs = from_url.call_args.kwargs
+    assert kwargs["socket_connect_timeout"] == 2.0
+    assert kwargs["socket_timeout"] == 5.0
+    assert kwargs["socket_keepalive"] is True
+    assert kwargs["health_check_interval"] == 30
+    assert kwargs["decode_responses"] is True
+    assert kwargs["single_connection_client"] is True
+
+
+@pytest.mark.asyncio
+async def test_timeouts_overridable():
+    with patch("redis.asyncio.from_url", return_value=MagicMock()) as from_url:
+        RedisBackend("redis://x", socket_timeout=1.5)._scripts_for_current_loop()
+    assert from_url.call_args.kwargs["socket_timeout"] == 1.5

--- a/tests/qubx/rate_limiting/test_resilient.py
+++ b/tests/qubx/rate_limiting/test_resilient.py
@@ -1,0 +1,197 @@
+"""Tests for ResilientRateLimitBackend — redis primary + local fallback + circuit breaker.
+
+No sleeps: breaker timing is forced by assigning ``backend._broken_until`` directly, and the
+single-probe race is forced by blocking the primary on an ``asyncio.Event``.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from qubx.rate_limiting.backend import IRateLimitBackend
+from qubx.rate_limiting.resilient import ResilientRateLimitBackend
+
+
+class FakeBackend(IRateLimitBackend):
+    def __init__(self) -> None:
+        self.acquire_calls = 0
+        self.get_calls = 0
+        self.set_calls = 0
+        self.closed = False
+        self.raise_exc: Exception | None = None
+        self.block_on: asyncio.Event | None = None
+
+    async def acquire(self, key, weight, capacity, refill_rate) -> float:
+        self.acquire_calls += 1
+        if self.block_on is not None:
+            await self.block_on.wait()
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return 0.0
+
+    async def get_remaining(self, key, capacity=0, refill_rate=0):
+        self.get_calls += 1
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return 1.0
+
+    async def set_remaining(self, key, remaining, capacity=0, refill_rate=0) -> None:
+        self.set_calls += 1
+        if self.raise_exc is not None:
+            raise self.raise_exc
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_passthrough_when_primary_healthy():
+    primary, fallback = FakeBackend(), FakeBackend()
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    waited = await resilient.acquire("k", 1.0, 10.0, 5.0)
+    remaining = await resilient.get_remaining("k", 10.0, 5.0)
+    await resilient.set_remaining("k", 5.0, 10.0, 5.0)
+
+    assert waited == 0.0
+    assert remaining == 1.0
+    assert primary.acquire_calls == 1
+    assert primary.get_calls == 1
+    assert primary.set_calls == 1
+    assert fallback.acquire_calls == 0
+    assert fallback.get_calls == 0
+    assert fallback.set_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_error_opens_breaker_and_serves_fallback():
+    primary, fallback = FakeBackend(), FakeBackend()
+    primary.raise_exc = ConnectionError("redis down")
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    waited = await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert waited == 0.0  # served by fallback
+    assert primary.acquire_calls == 1
+    assert fallback.acquire_calls == 1
+    assert resilient._broken is True
+
+    # second call must not touch primary — breaker is open
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert primary.acquire_calls == 1
+    assert fallback.acquire_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_probe_after_cooldown_single_caller():
+    primary, fallback = FakeBackend(), FakeBackend()
+    primary.raise_exc = ConnectionError("redis down")
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # opens breaker
+    assert primary.acquire_calls == 1
+
+    resilient._broken_until = 0.0  # force cooldown expiry
+    primary.raise_exc = None  # primary healed
+
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # probes primary, closes breaker
+    assert primary.acquire_calls == 2
+    assert resilient._broken is False
+
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # breaker closed, hits primary directly
+    assert primary.acquire_calls == 3
+    assert fallback.acquire_calls == 1  # only the original failure
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_stay_local_while_probe_inflight():
+    primary, fallback = FakeBackend(), FakeBackend()
+    primary.raise_exc = ConnectionError("redis down")
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # opens breaker
+    assert primary.acquire_calls == 1
+
+    resilient._broken_until = 0.0  # force cooldown expiry
+    primary.raise_exc = None  # primary healed, but ...
+    primary.block_on = asyncio.Event()  # ... the probe blocks in-flight
+
+    task_a = asyncio.create_task(resilient.acquire("k", 1.0, 10.0, 5.0))
+    await asyncio.sleep(0)  # let A claim the probe slot and start blocking on primary
+    await asyncio.sleep(0)
+    assert primary.acquire_calls == 2  # 1 (initial failure) + 1 (A's in-flight probe)
+    assert resilient._probe_inflight is True
+
+    # B arrives while the probe is in flight — must be served by the fallback
+    waited_b = await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert waited_b == 0.0
+    assert primary.acquire_calls == 2  # unchanged — only A touched primary
+    assert fallback.acquire_calls == 2  # original failure + B
+
+    primary.block_on.set()  # release A
+    await task_a
+    assert resilient._broken is False
+
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # breaker closed now, hits primary
+    assert primary.acquire_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_reopens():
+    primary, fallback = FakeBackend(), FakeBackend()
+    primary.raise_exc = ConnectionError("redis down")
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # opens breaker
+    assert primary.acquire_calls == 1
+
+    resilient._broken_until = 0.0  # force cooldown expiry, primary still broken
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # probes primary again — fails
+    assert primary.acquire_calls == 2
+    assert resilient._broken is True
+
+    # immediate next call must go straight to fallback, no further primary touch
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert primary.acquire_calls == 2
+    assert fallback.acquire_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_follow_policy():
+    primary, fallback = FakeBackend(), FakeBackend()
+    resilient = ResilientRateLimitBackend(primary, fallback)
+    resilient._broken = True
+    resilient._broken_until = time.monotonic() + 30.0
+
+    remaining = await resilient.get_remaining("k", 10.0, 5.0)
+    await resilient.set_remaining("k", 5.0, 10.0, 5.0)
+
+    assert remaining == 1.0  # fallback's canned value
+    assert primary.get_calls == 0
+    assert primary.set_calls == 0
+    assert fallback.get_calls == 1
+    assert fallback.set_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_propagates():
+    primary, fallback = FakeBackend(), FakeBackend()
+    primary.raise_exc = asyncio.CancelledError()
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    with pytest.raises(asyncio.CancelledError):
+        await resilient.acquire("k", 1.0, 10.0, 5.0)
+
+    assert resilient._broken is False
+    assert fallback.acquire_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_close_closes_both():
+    primary, fallback = FakeBackend(), FakeBackend()
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    await resilient.close()
+
+    assert primary.closed is True
+    assert fallback.closed is True

--- a/tests/qubx/rate_limiting/test_resilient.py
+++ b/tests/qubx/rate_limiting/test_resilient.py
@@ -265,3 +265,46 @@ async def test_stale_success_does_not_close_breaker():
     # the next call must go straight to the fallback — no further primary touch
     await resilient.acquire("k", 1.0, 10.0, 5.0)
     assert primary.acquire_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_error_reopens_breaker():
+    """The asymmetric half of the stale-outcome contract: a stale ERROR is still
+    evidence of an unhealthy primary and must re-open the breaker, even right
+    after a successful probe closed it."""
+    primary, fallback = FakeBackend(), FakeBackend()
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    event = asyncio.Event()
+    primary.block_on = event  # call A blocks here while the breaker is still closed
+
+    task_a = asyncio.create_task(resilient.acquire("k", 1.0, 10.0, 5.0))
+    await asyncio.sleep(0)  # let A dispatch to primary and start blocking, while healthy
+    await asyncio.sleep(0)
+    assert primary.acquire_calls == 1
+
+    # call B fails and opens the breaker while A is still in flight
+    primary.block_on = None
+    primary.raise_exc = ConnectionError("redis down")
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert resilient._broken is True
+    assert primary.acquire_calls == 2
+
+    # a healed probe closes the breaker
+    primary.raise_exc = None
+    resilient._broken_until = 0.0
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert resilient._broken is False
+    assert primary.acquire_calls == 3
+
+    # release A into an error: stale, but it re-opens the breaker for a full cooldown
+    primary.raise_exc = ConnectionError("redis down again")
+    event.set()
+    await task_a  # A's acquire is served by the fallback after the error
+    assert resilient._broken is True
+    assert resilient._probe_inflight is False
+
+    # while the fresh cooldown runs, calls stay on the fallback
+    # (A was counted at dispatch as call 1; the count must not move after its stale error)
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert primary.acquire_calls == 3

--- a/tests/qubx/rate_limiting/test_resilient.py
+++ b/tests/qubx/rate_limiting/test_resilient.py
@@ -71,7 +71,9 @@ async def test_error_opens_breaker_and_serves_fallback():
     resilient = ResilientRateLimitBackend(primary, fallback)
 
     waited = await resilient.acquire("k", 1.0, 10.0, 5.0)
-    assert waited == 0.0  # served by fallback
+    assert waited == 0.0
+    # load-bearing assertions: FakeBackend returns 0.0 on both sides, so `waited` alone
+    # doesn't prove routing — the call counters do.
     assert primary.acquire_calls == 1
     assert fallback.acquire_calls == 1
     assert resilient._broken is True
@@ -195,3 +197,71 @@ async def test_close_closes_both():
 
     assert primary.closed is True
     assert fallback.closed is True
+
+
+@pytest.mark.asyncio
+async def test_cancelled_probe_releases_slot():
+    """Fix round 1 / F1 (review Finding 1): a cancelled probe must not wedge the breaker open forever."""
+    primary, fallback = FakeBackend(), FakeBackend()
+    primary.raise_exc = ConnectionError("redis down")
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    await resilient.acquire("k", 1.0, 10.0, 5.0)  # opens breaker
+    assert primary.acquire_calls == 1
+
+    resilient._broken_until = 0.0  # force cooldown expiry
+    primary.raise_exc = None  # primary healed, but ...
+    primary.block_on = asyncio.Event()  # ... the probe blocks in-flight
+
+    probe = asyncio.create_task(resilient.acquire("k", 1.0, 10.0, 5.0))
+    await asyncio.sleep(0)  # let the probe claim the slot and start blocking on primary
+    await asyncio.sleep(0)
+    assert primary.acquire_calls == 2
+    assert resilient._probe_inflight is True
+
+    probe.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await probe
+
+    assert resilient._probe_inflight is False, "cancelled probe leaked the slot — breaker is wedged open"
+    assert resilient._broken is True  # cancellation doesn't heal the breaker by itself
+
+    # the breaker must still be able to recover: force cooldown expiry again and probe once more
+    primary.block_on = None
+    resilient._broken_until = 0.0
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert primary.acquire_calls == 3  # initial failure + cancelled probe + this recovering probe
+    assert resilient._broken is False
+
+
+@pytest.mark.asyncio
+async def test_stale_success_does_not_close_breaker():
+    """Fix round 1 / F2 (review Finding 2): only the probe's own success may close the breaker."""
+    primary, fallback = FakeBackend(), FakeBackend()
+    resilient = ResilientRateLimitBackend(primary, fallback)
+
+    event = asyncio.Event()
+    primary.block_on = event  # call A blocks here while the breaker is still closed
+
+    task_a = asyncio.create_task(resilient.acquire("k", 1.0, 10.0, 5.0))
+    await asyncio.sleep(0)  # let A dispatch to primary and start blocking, while healthy
+    await asyncio.sleep(0)
+    assert primary.acquire_calls == 1
+
+    # call B fails and opens the breaker while A is still in flight
+    primary.block_on = None  # only A's already-captured Event reference blocks
+    primary.raise_exc = ConnectionError("redis down")
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert resilient._broken is True
+    assert primary.acquire_calls == 2
+
+    # release A: it now succeeds, but it was dispatched before the breaker opened —
+    # a stale success carries no evidence redis is healthy and must not close the breaker
+    primary.raise_exc = None
+    event.set()
+    await task_a
+    assert resilient._broken is True
+
+    # the next call must go straight to the fallback — no further primary touch
+    await resilient.acquire("k", 1.0, 10.0, 5.0)
+    assert primary.acquire_calls == 2

--- a/tests/qubx/rate_limiting/test_resilient_integration.py
+++ b/tests/qubx/rate_limiting/test_resilient_integration.py
@@ -1,0 +1,84 @@
+# tests/qubx/rate_limiting/test_resilient_integration.py
+"""Integration: ResilientRateLimitBackend vs a real redis that gets frozen mid-run.
+
+``docker pause`` freezes the server process WITHOUT closing TCP connections —
+the closest reproduction of the 2026-08-19 half-open-socket incident.
+Requires docker; runs only under `-m integration`.
+"""
+import subprocess
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+CONTAINER = f"qubx-rl-itest-redis-{uuid.uuid4().hex[:8]}"
+PORT = 63791
+
+
+@pytest.fixture(scope="module")
+def redis_container():
+    subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", CONTAINER, "-p", f"{PORT}:6379", "redis:7-alpine"],
+        check=True, capture_output=True,
+    )
+    time.sleep(1.0)
+    yield CONTAINER
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+
+
+def _pause():
+    subprocess.run(["docker", "pause", CONTAINER], check=True, capture_output=True)
+
+
+def _unpause():
+    subprocess.run(["docker", "unpause", CONTAINER], check=True, capture_output=True)
+
+
+@pytest.mark.asyncio
+async def test_resilient_backend_survives_a_redis_freeze(redis_container):
+    import redis.asyncio as aioredis
+
+    from qubx.rate_limiting.redis_backend import RedisBackend
+    from qubx.rate_limiting.resilient import ResilientRateLimitBackend
+
+    url = f"redis://localhost:{PORT}/0"
+    backend = ResilientRateLimitBackend(RedisBackend(url, socket_timeout=5.0, socket_connect_timeout=2.0))
+    control = aioredis.from_url(url, decode_responses=True)
+
+    try:
+        # 1. Healthy primary: acquire succeeds via redis, and a control client can see the key.
+        waited = await backend.acquire("ratelimit:itest", 1.0, 10.0, 5.0)
+        assert waited == 0.0
+        assert await control.exists("ratelimit:itest") == 1
+        assert backend._broken is False
+
+        _pause()
+        try:
+            # 2. Frozen primary: the socket timeout bounds the hang, and the breaker opens —
+            #    the call is served by the local fallback, well under the 15-min incident hang.
+            t0 = time.monotonic()
+            await backend.acquire("ratelimit:itest", 1.0, 10.0, 5.0)
+            elapsed = time.monotonic() - t0
+            assert elapsed < 8.0, f"acquire took {elapsed:.2f}s while redis was paused"
+            assert backend._broken is True
+
+            # 3. Breaker open: the next call must not pay the timeout tax again.
+            t1 = time.monotonic()
+            await backend.acquire("ratelimit:itest", 1.0, 10.0, 5.0)
+            assert time.monotonic() - t1 < 0.5
+        finally:
+            _unpause()
+
+        # 4. Recovered primary: force the cooldown to expire and confirm the probe routes
+        #    back to redis (control client observes last_refill advance).
+        before = await control.hget("ratelimit:itest", "last_refill")
+        backend._broken_until = 0.0
+        await backend.acquire("ratelimit:itest", 1.0, 10.0, 5.0)
+        assert backend._broken is False
+        after = await control.hget("ratelimit:itest", "last_refill")
+        assert after is not None and after != before
+    finally:
+        await backend.close()
+        await control.aclose()

--- a/tests/qubx/rate_limiting/test_resilient_integration.py
+++ b/tests/qubx/rate_limiting/test_resilient_integration.py
@@ -21,7 +21,12 @@ PORT = 63791
 def _docker_available() -> bool:
     if shutil.which("docker") is None:
         return False
-    return subprocess.run(["docker", "ps"], capture_output=True).returncode == 0
+    try:
+        # timeout: this runs at collection time on every suite run — a wedged
+        # docker daemon must not hang collection
+        return subprocess.run(["docker", "ps"], capture_output=True, timeout=5).returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
 
 
 pytestmark = [

--- a/tests/qubx/rate_limiting/test_resilient_integration.py
+++ b/tests/qubx/rate_limiting/test_resilient_integration.py
@@ -5,6 +5,7 @@
 the closest reproduction of the 2026-08-19 half-open-socket incident.
 Requires docker; runs only under `-m integration`.
 """
+
 import subprocess
 import time
 import uuid
@@ -21,7 +22,8 @@ PORT = 63791
 def redis_container():
     subprocess.run(
         ["docker", "run", "-d", "--rm", "--name", CONTAINER, "-p", f"{PORT}:6379", "redis:7-alpine"],
-        check=True, capture_output=True,
+        check=True,
+        capture_output=True,
     )
     time.sleep(1.0)
     yield CONTAINER

--- a/tests/qubx/rate_limiting/test_resilient_integration.py
+++ b/tests/qubx/rate_limiting/test_resilient_integration.py
@@ -3,19 +3,43 @@
 
 ``docker pause`` freezes the server process WITHOUT closing TCP connections —
 the closest reproduction of the 2026-08-19 half-open-socket incident.
-Requires docker; runs only under `-m integration`.
+Requires docker; runs only under `-m integration`, and skips (rather than
+erroring) when docker itself is unavailable.
 """
 
+import shutil
 import subprocess
 import time
 import uuid
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 CONTAINER = f"qubx-rl-itest-redis-{uuid.uuid4().hex[:8]}"
 PORT = 63791
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "ps"], capture_output=True).returncode == 0
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _docker_available(), reason="docker is not available in this environment"),
+]
+
+
+def _wait_until_ready(deadline_s: float = 10.0) -> None:
+    """Poll `redis-cli ping` instead of a fixed sleep — a loaded host or a cold image
+    can take longer than a guessed constant to accept connections."""
+    deadline = time.monotonic() + deadline_s
+    while time.monotonic() < deadline:
+        result = subprocess.run(["docker", "exec", CONTAINER, "redis-cli", "ping"], capture_output=True, text=True)
+        if result.returncode == 0 and result.stdout.strip() == "PONG":
+            return
+        time.sleep(0.1)
+    raise RuntimeError(f"redis container {CONTAINER} did not become ready within {deadline_s}s")
 
 
 @pytest.fixture(scope="module")
@@ -25,9 +49,9 @@ def redis_container():
         check=True,
         capture_output=True,
     )
-    time.sleep(1.0)
+    _wait_until_ready()
     yield CONTAINER
-    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)  # works on paused containers too
 
 
 def _pause():

--- a/tests/qubx/state/test_dummy.py
+++ b/tests/qubx/state/test_dummy.py
@@ -2,8 +2,6 @@
 Unit tests for DummyStatePersistence.
 """
 
-import pytest
-
 from qubx.core.interfaces import IStatePersistence
 from qubx.state import DummyStatePersistence
 
@@ -15,6 +13,14 @@ class TestDummyStatePersistence:
         """Test that DummyStatePersistence implements IStatePersistence."""
         persistence = DummyStatePersistence()
         assert isinstance(persistence, IStatePersistence)
+
+    def test_interface_defaults(self):
+        """Write-health tracking and stop() are part of the interface contract;
+        Dummy relies on the defaults: no tracking, no-op stop."""
+        persistence = DummyStatePersistence()
+        assert persistence.last_success_age() is None
+        assert persistence.staleness_threshold_s == 60.0
+        persistence.stop()  # no-op, must not raise
 
     def test_save_does_nothing(self):
         """Test that save is a no-op."""

--- a/tests/qubx/state/test_factory_wrapping.py
+++ b/tests/qubx/state/test_factory_wrapping.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+from qubx.state.dummy import DummyStatePersistence
+from qubx.state.safe import SafeStatePersistence
+from qubx.utils.runner.configs import StatePersistenceConfig
+from qubx.utils.runner.factory import create_state_persistence
+
+
+class InMemoryBackend:
+    def __init__(self, strategy_name: str = "", **kwargs):
+        self.store = {}
+        self.probed = False
+
+    def save(self, key, value):
+        self.store[key] = value
+
+    def load(self, key, default=None):
+        return self.store.get(key, default)
+
+    def delete(self, key):
+        return self.store.pop(key, None) is not None
+
+    def exists(self, key):
+        self.probed = True
+        return key in self.store
+
+
+def test_real_backend_is_wrapped_and_validated():
+    cfg = StatePersistenceConfig(type="RedisStatePersistence", parameters={}, snapshot_interval="5s")
+    with patch("qubx.utils.runner.factory.class_import", return_value=InMemoryBackend):
+        sp = create_state_persistence(cfg, "strat")
+    assert isinstance(sp, SafeStatePersistence)
+    assert sp.staleness_threshold_s == 60.0  # max(3*5s, 60s)
+    sp.stop()
+
+
+def test_threshold_scales_with_long_snapshot_interval():
+    cfg = StatePersistenceConfig(type="RedisStatePersistence", parameters={}, snapshot_interval="1m")
+    with patch("qubx.utils.runner.factory.class_import", return_value=InMemoryBackend):
+        sp = create_state_persistence(cfg, "strat")
+    assert sp.staleness_threshold_s == 180.0  # max(3*60s, 60s)
+    sp.stop()
+
+
+def test_dummy_backend_is_not_wrapped():
+    cfg = StatePersistenceConfig(type="DummyStatePersistence", parameters={})
+    with patch("qubx.utils.runner.factory.class_import", return_value=DummyStatePersistence):
+        sp = create_state_persistence(cfg, "strat")
+    assert isinstance(sp, DummyStatePersistence)
+
+
+def test_none_config_returns_none():
+    assert create_state_persistence(None, "strat") is None

--- a/tests/qubx/state/test_redis_client_options.py
+++ b/tests/qubx/state/test_redis_client_options.py
@@ -1,0 +1,19 @@
+from unittest.mock import MagicMock, patch
+
+from qubx.state.redis import RedisStatePersistence
+
+
+def test_client_created_with_bounded_failure_defaults():
+    with patch("qubx.state.redis.redis.from_url", return_value=MagicMock()) as from_url:
+        RedisStatePersistence(redis_url="redis://localhost:6379/0", strategy_name="s")
+    kwargs = from_url.call_args.kwargs
+    assert kwargs["socket_connect_timeout"] == 2.0
+    assert kwargs["socket_timeout"] == 5.0
+    assert kwargs["socket_keepalive"] is True
+    assert kwargs["health_check_interval"] == 30
+
+
+def test_timeouts_overridable():
+    with patch("qubx.state.redis.redis.from_url", return_value=MagicMock()) as from_url:
+        RedisStatePersistence(redis_url="redis://localhost:6379/0", strategy_name="s", socket_timeout=1.5)
+    assert from_url.call_args.kwargs["socket_timeout"] == 1.5

--- a/tests/qubx/state/test_safe.py
+++ b/tests/qubx/state/test_safe.py
@@ -269,6 +269,10 @@ def test_validate_startup_succeeds_after_transient_failures(backend):
     p = SafeStatePersistence(backend, sleep_fn=lambda s: None)
     p.validate_startup(deadline_s=60.0)
     assert calls["n"] == 3
+    # - probe success seeds last-success so staleness monitoring is never silently absent
+    #   for a backend that dies before the first write
+    age = p.last_success_age()
+    assert age is not None and age < 1.0
     p.stop()
 
 

--- a/tests/qubx/state/test_safe.py
+++ b/tests/qubx/state/test_safe.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from qubx import logger as qubx_logger
+from qubx.core.exceptions import StatePersistenceUnavailable
 from qubx.state.safe import SafeStatePersistence
 
 
@@ -253,3 +254,39 @@ def test_save_after_stop_does_not_raise_and_warns_once(backend):
     assert warn_count == 1  # warned once, not once per call
     time.sleep(0.05)
     assert backend.store == {}  # nothing reaches the (dead) backend
+
+
+def test_validate_startup_succeeds_after_transient_failures(backend):
+    calls = {"n": 0}
+
+    def flaky_exists(key: str) -> bool:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("not yet")
+        return False
+
+    backend.exists = flaky_exists  # type: ignore[assignment]
+    p = SafeStatePersistence(backend, sleep_fn=lambda s: None)
+    p.validate_startup(deadline_s=60.0)
+    assert calls["n"] == 3
+    p.stop()
+
+
+def test_validate_startup_exhausts_budget_and_raises(backend):
+    def always_down(key: str) -> bool:
+        raise ConnectionError("down")
+
+    backend.exists = always_down  # type: ignore[assignment]
+    fake_now = {"t": 0.0}
+    slept: list[float] = []
+
+    def fake_sleep(s: float) -> None:
+        slept.append(s)
+        fake_now["t"] += s
+
+    p = SafeStatePersistence(backend, sleep_fn=fake_sleep)
+    with pytest.raises(StatePersistenceUnavailable):
+        p.validate_startup(deadline_s=60.0, clock=lambda: fake_now["t"])
+    assert slept[:6] == [0.5, 1.0, 2.0, 4.0, 8.0, 10.0]  # spec D3 schedule
+    assert sum(slept) >= 60.0
+    p.stop()

--- a/tests/qubx/state/test_safe.py
+++ b/tests/qubx/state/test_safe.py
@@ -1,0 +1,129 @@
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from qubx.state.safe import SafeStatePersistence
+
+
+class FakeBackend:
+    """Scriptable IStatePersistence backend: can hang (Event) or fail N times."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, Any] = {}
+        self.saves: list[tuple[str, Any]] = []
+        self.gate = threading.Event()
+        self.gate.set()  # open by default
+        self.fail_saves_remaining = 0
+
+    def save(self, key: str, value: Any) -> None:
+        self.gate.wait(10.0)
+        if self.fail_saves_remaining > 0:
+            self.fail_saves_remaining -= 1
+            raise ConnectionError("backend down")
+        self.saves.append((key, value))
+        self.store[key] = value
+
+    def load(self, key: str, default: Any = None) -> Any:
+        self.gate.wait(10.0)
+        return self.store.get(key, default)
+
+    def delete(self, key: str) -> bool:
+        return self.store.pop(key, None) is not None
+
+    def exists(self, key: str) -> bool:
+        return key in self.store
+
+
+def _wait(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+@pytest.fixture
+def backend() -> FakeBackend:
+    return FakeBackend()
+
+
+@pytest.fixture
+def sp(backend):
+    p = SafeStatePersistence(backend, retry_backoff_s=(0.01, 0.02), sleep_fn=lambda s: time.sleep(min(s, 0.02)))
+    yield p
+    backend.gate.set()
+    p.stop()
+
+
+def test_save_returns_instantly_while_backend_hangs(sp, backend):
+    backend.gate.clear()  # backend hangs forever
+    t0 = time.monotonic()
+    sp.save("state", {"a": 1})
+    assert time.monotonic() - t0 < 0.05  # THE loop-liveness invariant
+
+
+def test_unserializable_value_raises_at_call_site(sp):
+    with pytest.raises(TypeError):
+        sp.save("bad", object())
+
+
+def test_write_through_and_last_success_age(sp, backend):
+    assert sp.last_success_age() is None
+    sp.save("k", {"v": 1})
+    assert _wait(lambda: backend.store.get("k") == {"v": 1})
+    assert sp.last_success_age() is not None and sp.last_success_age() < 1.0
+
+
+def test_latest_wins_per_key_while_blocked(sp, backend):
+    backend.gate.clear()
+    sp.save("k", 1)
+    sp.save("k", 2)
+    sp.save("other", "x")
+    backend.gate.set()
+    assert _wait(lambda: backend.store.get("k") == 2 and backend.store.get("other") == "x")
+    assert ("k", 1) not in backend.saves  # the stale intermediate was never written
+
+
+def test_read_your_writes_before_flush(sp, backend):
+    backend.gate.clear()
+    sp.save("k", {"pending": True})
+    assert sp.load("k") == {"pending": True}  # served from pending, no network
+    assert sp.exists("k") is True
+
+
+def test_tombstones(sp, backend):
+    backend.store["k"] = "old"
+    backend.gate.clear()
+    sp.delete("k")
+    assert sp.load("k", default="D") == "D"
+    assert sp.exists("k") is False
+    backend.gate.set()
+    assert _wait(lambda: "k" not in backend.store)
+
+
+def test_failed_batch_remerge_does_not_clobber_newer(sp, backend):
+    backend.fail_saves_remaining = 1
+    sp.save("k", "v1")  # first write attempt fails
+    time.sleep(0.005)
+    sp.save("k", "v2")  # arrives while retry pending
+    assert _wait(lambda: backend.store.get("k") == "v2")
+    assert not _wait(lambda: backend.store.get("k") == "v1", timeout=0.2)
+
+
+def test_stop_flushes_pending(backend):
+    p = SafeStatePersistence(backend, sleep_fn=lambda s: time.sleep(min(s, 0.01)))
+    p.save("final", 42)
+    p.stop()
+    assert backend.store.get("final") == 42
+
+
+def test_load_propagates_backend_errors(sp, backend):
+    def boom(key, default=None):
+        raise ConnectionError("down")
+
+    backend.load = boom  # type: ignore[assignment]
+    with pytest.raises(ConnectionError):
+        sp.load("missing")

--- a/tests/qubx/state/test_safe.py
+++ b/tests/qubx/state/test_safe.py
@@ -1,9 +1,11 @@
+import contextlib
 import threading
 import time
 from typing import Any
 
 import pytest
 
+from qubx import logger as qubx_logger
 from qubx.state.safe import SafeStatePersistence
 
 
@@ -16,8 +18,10 @@ class FakeBackend:
         self.gate = threading.Event()
         self.gate.set()  # open by default
         self.fail_saves_remaining = 0
+        self.entered = threading.Event()  # set as soon as save() is invoked, before it can block on the gate
 
     def save(self, key: str, value: Any) -> None:
+        self.entered.set()
         self.gate.wait(10.0)
         if self.fail_saves_remaining > 0:
             self.fail_saves_remaining -= 1
@@ -43,6 +47,17 @@ def _wait(predicate, timeout=3.0):
             return True
         time.sleep(0.005)
     return False
+
+
+@contextlib.contextmanager
+def _capture_logs():
+    """Capture qubx (loguru) log lines for the duration of the block."""
+    messages: list[str] = []
+    handler_id = qubx_logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    try:
+        yield messages
+    finally:
+        qubx_logger.remove(handler_id)
 
 
 @pytest.fixture
@@ -90,8 +105,24 @@ def test_latest_wins_per_key_while_blocked(sp, backend):
 def test_read_your_writes_before_flush(sp, backend):
     backend.gate.clear()
     sp.save("k", {"pending": True})
-    assert sp.load("k") == {"pending": True}  # served from pending, no network
+    # deterministically pin the read to the harder in-flight window: wait until the writer has actually
+    # dequeued 'k' and entered backend.save() (blocked on the gate) rather than racing on scheduling -
+    # without the _inflight fix this falls through to the (gate-blocked) backend.load() call. On a lucky
+    # scheduling the two independent 10s gate.wait() timeouts (writer's save, this load) can resolve close
+    # enough together that the value still comes back right - but only after blocking the caller for ~10s,
+    # which is precisely the loop-liveness violation this class exists to prevent (spec review F2/F9), so
+    # we assert on latency too, not just on the returned value.
+    assert backend.entered.wait(2.0)
+    t0 = time.monotonic()
+    assert sp.load("k") == {"pending": True}  # served from _inflight, not a stale/blocked backend read
+    assert time.monotonic() - t0 < 0.05  # loop-liveness invariant: never blocks on the network
     assert sp.exists("k") is True
+
+    sp.delete("k")  # a newer write arrives while the stale save is still in flight
+    assert sp.load("k", default="D") == "D"  # newer pending tombstone wins over the stale in-flight value
+    assert sp.exists("k") is False
+
+    backend.gate.set()
 
 
 def test_tombstones(sp, backend):
@@ -127,3 +158,98 @@ def test_load_propagates_backend_errors(sp, backend):
     backend.load = boom  # type: ignore[assignment]
     with pytest.raises(ConnectionError):
         sp.load("missing")
+
+
+def test_backoff_uses_round_count_not_failed_key_count(backend):
+    """spec review F1: a batch with one failing key and one succeeding key must not reset the
+    consecutive-failure counter to 0 (via the succeeding key) and then index backoff[-1] (max tier)
+    on the very first partial failure - it must count failing ROUNDS and use backoff[0]."""
+    backend.fail_saves_remaining = 1  # exactly the first backend.save() call fails, whichever key
+    recorded: list[float] = []
+
+    def recording_sleep(s: float) -> None:
+        recorded.append(s)
+        time.sleep(min(s, 0.02))
+
+    p = SafeStatePersistence(backend, retry_backoff_s=(0.01, 0.02, 0.03), sleep_fn=recording_sleep)
+    try:
+        with p._cond:  # hold the lock so the writer can't dequeue until BOTH keys are buffered together
+            p.save("a", 1)
+            p.save("b", 2)
+        assert _wait(lambda: recorded)  # the round-level backoff was recorded
+        assert recorded[0] == pytest.approx(0.01)  # retry_backoff_s[0], never backoff[-1] (0.03)
+        assert _wait(lambda: backend.store.get("a") == 1 and backend.store.get("b") == 2)
+    finally:
+        p.stop()
+
+
+def test_stop_interrupts_backoff_bounded_final_attempt(backend):
+    """spec review F3: stop() called while the writer is sleeping in a (large) backoff must not wait
+    out the full backoff - it interrupts immediately, the writer makes at most one more bounded
+    final-drain attempt (no further backoff/retries), and abandoned keys are logged (spec review F4a)."""
+    backend.fail_saves_remaining = 10**6  # keep failing forever
+    call_count = {"n": 0}
+    first_attempt = threading.Event()
+    orig_save = backend.save
+
+    def counting_save(key: str, value: Any) -> None:
+        call_count["n"] += 1
+        first_attempt.set()
+        return orig_save(key, value)
+
+    backend.save = counting_save  # type: ignore[assignment]
+
+    # default sleep_fn=time.sleep -> the writer's backoff wait uses the interruptible _stop_event
+    p = SafeStatePersistence(backend, flush_timeout_s=2.0, retry_backoff_s=(30.0,))
+    p.save("k", "v1")
+    assert first_attempt.wait(1.0)  # first (failing) attempt happened; writer now backing off for 30s
+    time.sleep(0.05)  # let the writer settle into the backoff wait
+    n_before = call_count["n"]
+
+    with _capture_logs() as messages:
+        t0 = time.monotonic()
+        p.stop()
+        dt = time.monotonic() - t0
+
+    assert dt < 1.0  # returned fast: the 30s backoff was interrupted, not waited out
+    assert not p._writer.is_alive()  # writer actually exited - never a zombie thread sleeping in the background
+    assert call_count["n"] - n_before <= 1  # at most ONE more attempt after stop was observed
+    assert any("abandoning" in m and "'k'" in m for m in messages)  # abandoned key logged, not silently dropped
+
+
+def test_stop_join_timeout_logs_unflushed_count(backend):
+    """spec review F4b: if the writer is still flushing when the join times out, stop() must not
+    silently swallow that - it logs how many keys are still unflushed."""
+    backend.gate.clear()  # backend call hangs
+    p = SafeStatePersistence(backend, flush_timeout_s=0.05, sleep_fn=lambda s: time.sleep(min(s, 0.01)))
+    p.save("k", 1)
+    assert backend.entered.wait(1.0)  # writer has started the (now-hanging) backend call
+
+    with _capture_logs() as messages:
+        t0 = time.monotonic()
+        p.stop()
+        dt = time.monotonic() - t0
+
+    assert dt < 0.5  # bounded by flush_timeout_s, not an indefinite hang
+    assert p._writer.is_alive()  # writer genuinely still stuck - stop() must not claim otherwise
+    assert any("timed out" in m and "1 key" in m for m in messages)  # unflushed count logged, not swallowed
+
+    backend.gate.set()  # release so the writer (and the process) isn't left hanging
+    assert _wait(lambda: not p._writer.is_alive())
+
+
+def test_save_after_stop_does_not_raise_and_warns_once(backend):
+    """spec review F4c: save()/delete() after stop() must not raise (spec) but also must not silently
+    buffer into a dead queue - warn once, and drop."""
+    p = SafeStatePersistence(backend, sleep_fn=lambda s: time.sleep(min(s, 0.01)))
+    p.stop()
+
+    with _capture_logs() as messages:
+        p.save("late", 1)  # must not raise
+        assert p.delete("late2") is True  # still optimistic True per contract
+        p.save("late3", 3)  # second post-stop write - warning must not repeat
+
+    warn_count = sum(1 for m in messages if "save after stop" in m)
+    assert warn_count == 1  # warned once, not once per call
+    time.sleep(0.05)
+    assert backend.store == {}  # nothing reaches the (dead) backend

--- a/tests/qubx/state/test_safe_integration.py
+++ b/tests/qubx/state/test_safe_integration.py
@@ -1,0 +1,95 @@
+# tests/qubx/state/test_safe_integration.py
+"""Integration: SafeStatePersistence vs a real redis that gets frozen mid-run.
+
+``docker pause`` freezes the server process WITHOUT closing TCP connections —
+the closest reproduction of the 2026-08-19 half-open-socket incident.
+Requires docker; runs only under `-m integration`.
+"""
+import json
+import subprocess
+import time
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+CONTAINER = f"qubx-test-redis-{uuid.uuid4().hex[:8]}"
+PORT = 63790
+
+
+@pytest.fixture(scope="module")
+def redis_container():
+    subprocess.run(
+        ["docker", "run", "-d", "--rm", "--name", CONTAINER, "-p", f"{PORT}:6379", "redis:7-alpine"],
+        check=True, capture_output=True,
+    )
+    time.sleep(1.0)
+    yield CONTAINER
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+
+
+def _pause():
+    subprocess.run(["docker", "pause", CONTAINER], check=True, capture_output=True)
+
+
+def _unpause():
+    subprocess.run(["docker", "unpause", CONTAINER], check=True, capture_output=True)
+
+
+def test_event_loop_liveness_through_redis_freeze(redis_container):
+    from qubx.state.redis import RedisStatePersistence
+    from qubx.state.safe import SafeStatePersistence
+
+    backend = RedisStatePersistence(
+        redis_url=f"redis://localhost:{PORT}/0", strategy_name="itest", socket_timeout=1.0, socket_connect_timeout=1.0
+    )
+    sp = SafeStatePersistence(backend, retry_backoff_s=(0.5, 1.0))
+    sp.validate_startup(deadline_s=10.0)
+
+    sp.save("k", {"phase": 1})
+    deadline = time.monotonic() + 5.0
+    while sp.last_success_age() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert sp.last_success_age() is not None
+
+    _pause()
+    try:
+        t0 = time.monotonic()
+        sp.save("k", {"phase": 2})           # must return instantly despite frozen server
+        assert time.monotonic() - t0 < 0.05
+        assert sp.load("k") == {"phase": 2}  # read-your-writes while frozen
+        time.sleep(3.0)
+        assert sp.last_success_age() > 2.0   # staleness visibly grows
+    finally:
+        _unpause()
+
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        if json.loads(backend._redis.get("state:itest:k") or "null") == {"phase": 2}:
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("pending write was not flushed after recovery")
+    sp.stop()
+
+
+def test_cold_start_against_frozen_redis_fails_fast(redis_container):
+    from qubx.core.exceptions import StatePersistenceUnavailable
+    from qubx.state.redis import RedisStatePersistence
+    from qubx.state.safe import SafeStatePersistence
+
+    _pause()
+    try:
+        backend = RedisStatePersistence(
+            redis_url=f"redis://localhost:{PORT}/0", strategy_name="itest2",
+            socket_timeout=1.0, socket_connect_timeout=1.0,
+        )
+        sp = SafeStatePersistence(backend)
+        t0 = time.monotonic()
+        with pytest.raises(StatePersistenceUnavailable):
+            sp.validate_startup(deadline_s=5.0)
+        assert time.monotonic() - t0 < 15.0  # bounded, not TCP-retransmission minutes
+        sp.stop()
+    finally:
+        _unpause()

--- a/tests/qubx/utils/test_bounded_worker.py
+++ b/tests/qubx/utils/test_bounded_worker.py
@@ -1,0 +1,63 @@
+import threading
+import time
+
+from qubx.utils.threading import BoundedWorker
+
+
+def _wait(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_executes_in_fifo_order_and_stop_flushes():
+    out: list[int] = []
+    w = BoundedWorker("t1", maxlen=100)
+    for i in range(20):
+        w.submit(out.append, i)
+    w.stop(flush_timeout_s=2.0)
+    assert out == list(range(20))
+
+
+def test_submit_never_blocks_and_drops_oldest_when_full():
+    gate = threading.Event()
+    started = threading.Event()
+    out: list[int] = []
+
+    def task(i: int) -> None:
+        started.set()
+        gate.wait(5.0)
+        out.append(i)
+
+    w = BoundedWorker("t2", maxlen=3)
+    w.submit(task, 0)
+    assert _wait(started.is_set)  # ensure item 0 is dequeued (in-flight) before the rest arrive
+    t0 = time.monotonic()
+    for i in range(1, 10):  # 1 in-flight (blocked on gate), 3 queued max, rest dropped-oldest
+        w.submit(task, i)
+    assert time.monotonic() - t0 < 0.5  # submit never blocked
+    assert _wait(lambda: w.dropped >= 6)
+    gate.set()
+    w.stop(flush_timeout_s=2.0)
+    # the in-flight item plus the LAST 3 queued survive; older ones were dropped
+    assert out[0] == 0 and out[-3:] == [7, 8, 9]
+    assert w.dropped == 6
+
+
+def test_task_exception_does_not_kill_worker():
+    out: list[str] = []
+    w = BoundedWorker("t3", maxlen=10)
+    w.submit(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    w.submit(out.append, "alive")
+    w.stop(flush_timeout_s=2.0)
+    assert out == ["alive"]
+
+
+def test_submit_after_stop_is_noop():
+    w = BoundedWorker("t4", maxlen=10)
+    w.stop()
+    w.submit(lambda: None)  # must not raise
+    assert w.queued == 0

--- a/tests/qubx/utils/test_bounded_worker.py
+++ b/tests/qubx/utils/test_bounded_worker.py
@@ -1,6 +1,8 @@
 import threading
 import time
 
+import pytest
+
 from qubx.utils.threading import BoundedWorker
 
 
@@ -61,3 +63,13 @@ def test_submit_after_stop_is_noop():
     w.stop()
     w.submit(lambda: None)  # must not raise
     assert w.queued == 0
+
+
+def test_construction_rejects_non_positive_maxlen():
+    # submit() must never raise; a degenerate maxlen (e.g. 0, which makes every submit an
+    # eviction of an empty queue) is a programming error and must be caught loudly at construction
+    # instead, not surfaced as an IndexError out of submit().
+    with pytest.raises(ValueError):
+        BoundedWorker("t5", maxlen=0)
+    with pytest.raises(ValueError):
+        BoundedWorker("t6", maxlen=-1)


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-08-19-safe-state-persistence-design.md — see spec for the incident analysis and decisions (D1-D4).

- SafeStatePersistence: async per-key latest-wins writes, read-your-writes, fail-fast 60s startup validation (StatePersistenceUnavailable), bounded flush on stop
- Redis clients (state + streams exporter): socket/connect timeouts, keepalive, health checks
- BoundedWorker replaces unbounded ThreadPoolExecutors in RedisStreamsExporter (also fixes XADD reordering) and QuestDBMetricEmitter; QuestDB Sender gains request/retry timeouts
- Health: DegradeReason.STATE_PERSISTENCE_STALE + state_persistence_lag gauge

Closes the qubx side of xLydianSoftware/xlydian-platform#375 (epic #374, incident 2026-08-19).

Note: branch is based on `main` (not `dev`) — `dev` currently lacks the ctx-status/health subsystem (PR #360) this work integrates with.

---
## Rollout notes (from final review)
- **`emit_health: true`** is required in a bot's `health:` config for the new `state_persistence_lag` gauge to reach QuestDB (the in-bot half of platform #379's staleness alerting). Default is false.
- **`ctx.stop()` may take up to ~15s worst-case** (bounded flushes: emitter + exporter + persistence, 5s each) where teardown was previously instant — verify pod `terminationGracePeriodSeconds` covers this on the platform.
- `max_workers` was **removed** (not deprecated) from `RedisStreamsExporter` / `QuestDBMetricEmitter` constructors — no ecosystem config passes it (verified); any that did would now fail loudly at startup, which is intended.
- 16 minor findings triaged as ship-as-follow-up during review (see branch ledger / follow-up issue); none affect correctness of the mainline paths.

---
## Increment 2 (2026-08-19): interface-contract cleanup + resilient rate-limit backend

**Interface cleanup** (`642c45bd`): `last_success_age()` / `staleness_threshold_s` / `stop()` are now part of the `IStatePersistence` Protocol (inert defaults: `None` / 60s / no-op), and `set_state_persistence` is part of `IHealthMonitor` — the `hasattr` duck-typing in `StrategyContext` and `BaseHealthMonitor` is gone; context wires and flushes persistence unconditionally.

**Resilient redis rate-limit backend** (spec section "Rate-limit backend resilience", decisions RL-D1–D4): the redis token-bucket backend shares the incident's root cause and is enabled for **every platform-deployed bot** via control-api's `redis-ratelimit` default preset (same `REDIS_URL` as state persistence) — a redis outage silently stalled every rate-limited order/REST path for ~15 min per socket death.

- `RedisBackend` async client gains the same socket timeouts (`connect=2s`, `socket=5s`, keepalive, health checks) — safe: all commands are fast Lua evals.
- New `ResilientRateLimitBackend` composite: redis primary + local `InMemoryBackend` fallback (same per-key bucket params) behind a 30s circuit breaker — trading never blocks on rate-limit redis. After cooldown exactly one call probes redis (probe slot released on every exit path incl. cancellation; only the probe's success closes the breaker, any error re-arms it); concurrent callers stay local.
- `close()` joined the `IRateLimitBackend` contract (no-op default). Wiring is transparent: `RateLimitManager._create_backend` wraps redis automatically — **no config or platform changes needed**.
- Observability: WARNING on fallback engage / INFO on recovery (transition-only). No new metrics; a redis outage already surfaces via `state_persistence_stale`.
- Accepted + documented limitations: uncoordinated per-bot pacing during fallback (contained by in-process 429 gates + ccxt throttler); in-band probe can hold the slot for a legitimate bucket wait; partial primary waits discarded on failure (over-throttles, never under).
- Tests: 15 unit tests (incl. Event-synchronized probe-concurrency, probe-cancellation, stale-success/stale-error regressions, manager wiring) + docker-`pause` integration test (half-open socket: fallback in <8s, breaker skips the timeout tax, recovery to redis on unpause). Reviewed over 3 rounds (opus), clean.
