### PR TITLE
ci: pass GITHUB_TOKEN to the git-cliff release-notes step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,6 +356,11 @@ jobs:
           version: "latest"
 
       - name: Generate release notes
+        env:
+          # cliff.toml has [remote.github] enrichment (PR links, usernames); without a
+          # token git-cliff calls the GitHub API unauthenticated and 403s on shared
+          # runner IPs (broke the v3.3.0 release notes, run 32263898098)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv tool install git-cliff
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")


### PR DESCRIPTION
The v3.3.0 release run (32263898098) failed at "Generate release notes": `cliff.toml` has `[remote.github]` enrichment (PR links, usernames), so git-cliff calls the GitHub API — unauthenticated, which 403s intermittently on shared runner IPs. Earlier releases passed on IP luck; v3.3.0's notes were recovered via a job rerun.

One-line fix: export `GITHUB_TOKEN` to the step (git-cliff picks it up natively).

Note: merging this cuts a v3.3.1 patch release (next-version.sh bumps patch for any commit type) with code identical to v3.3.0 — harmless, or batch it with the next real change.