### PR TITLE
fix(emitters): stop QuestDB tables growing a column per strategy tag

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -2621,6 +2621,7 @@ class IMetricEmitter:
         tags: dict[str, Any] | None = None,
         timestamp: dt_64 | None = None,
         instrument: Instrument | None = None,
+        force_emit: bool = False,
     ) -> None:
         """
         Emit a metric.
@@ -2632,6 +2633,8 @@ class IMetricEmitter:
             timestamp: Optional timestamp for the metric (may be ignored by some implementations)
             instrument: Optional instrument associated with the metric. If provided, symbol and exchange
                       will be added to the tags.
+            force_emit: Emit even during warmup. For values that carry their own historical
+                      timestamp, such as funding payments replayed from the warmup window.
         """
         pass
 

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -718,7 +718,7 @@ class ProcessingManager(IProcessingManager):
             self._exporter.export_signals(self._time_provider.time(), signals, self._account_manager)
 
         # - emit signals to metric emitters if available
-        if self._context.emitter is not None and signals:
+        if self._context.emitter is not None and signals and not self._context.is_warmup_in_progress:
             self._context.emitter.emit_signals(
                 self._time_provider.time(), signals, self._account_manager, _targets_from_trackers
             )
@@ -1636,7 +1636,7 @@ class ProcessingManager(IProcessingManager):
             logger.exception("universe manager on_alter_position raised")
             self._emit_error_metric("downstream_fill_errors", consumer="on_alter_position")
 
-        if self._context.emitter is not None:
+        if self._context.emitter is not None and not self._context.is_warmup_in_progress:
             try:
                 self._context.emitter.emit_deals(
                     time=self._time_provider.time(),

--- a/src/qubx/emitters/base.py
+++ b/src/qubx/emitters/base.py
@@ -116,10 +116,22 @@ class BaseMetricEmitter(IMetricEmitter):
             timestamp: Optional timestamp for the metric (defaults to current time)
             instrument: Optional instrument to add symbol and exchange tags from
         """
+        if self.is_warmup:
+            return
         if self._context is not None and timestamp is None:
             timestamp = self._context.time()
         merged_tags = self._merge_tags(tags, instrument)
         self._emit_impl(name, float(value), merged_tags, timestamp)
+
+    @property
+    def is_warmup(self) -> bool:
+        """
+        True while the warmup replay is running.
+
+        Warmup rebinds this emitter to a simulated context whose clock sits in the past, so
+        anything emitted from it lands in the store timestamped hours before it was written.
+        """
+        return self._context is not None and self._context.is_warmup_in_progress
 
     def set_context(self, context: IStrategyContext) -> None:
         """
@@ -252,7 +264,7 @@ class BaseMetricEmitter(IMetricEmitter):
         Args:
             context: The strategy context to get statistics from
         """
-        if not context.is_live_or_warmup:
+        if not context.is_live or context.is_warmup_in_progress:
             return
 
         # Convert to pandas timestamp for easier time calculations

--- a/src/qubx/emitters/base.py
+++ b/src/qubx/emitters/base.py
@@ -105,6 +105,7 @@ class BaseMetricEmitter(IMetricEmitter):
         tags: dict[str, Any] | None = None,
         timestamp: dt_64 | None = None,
         instrument: Instrument | None = None,
+        force_emit: bool = False,
     ) -> None:
         """
         Emit a metric with the given name, value, and optional tags.
@@ -115,8 +116,10 @@ class BaseMetricEmitter(IMetricEmitter):
             tags: Optional dictionary of tags/labels to include with the metric
             timestamp: Optional timestamp for the metric (defaults to current time)
             instrument: Optional instrument to add symbol and exchange tags from
+            force_emit: Emit even during warmup. For values carrying their own historical
+                timestamp, such as funding payments replayed from the warmup window.
         """
-        if self.is_warmup:
+        if self.is_warmup and not force_emit:
             return
         if self._context is not None and timestamp is None:
             timestamp = self._context.time()

--- a/src/qubx/emitters/prometheus.py
+++ b/src/qubx/emitters/prometheus.py
@@ -184,6 +184,7 @@ class PrometheusMetricEmitter(BaseMetricEmitter):
         tags: dict[str, Any] | None = None,
         timestamp: dt_64 | None = None,
         instrument: Instrument | None = None,
+        force_emit: bool = False,
         metric_type: MetricType = "gauge",
     ) -> None:
         """
@@ -194,6 +195,8 @@ class PrometheusMetricEmitter(BaseMetricEmitter):
             value: Value of the metric
             tags: Dictionary of tags/labels for the metric
             timestamp: Optional timestamp for the metric (ignored in Prometheus)
+            force_emit: Accepted for interface compatibility; Prometheus scrapes the current
+                gauge value and has no warmup gate to bypass
             metric_type: Type of metric (gauge, counter, summary)
         """
         # Merge tags with instrument decomposed into symbol/exchange/asset/quote
@@ -354,4 +357,3 @@ class PrometheusMetricEmitter(BaseMetricEmitter):
                 )
             except Exception as e:
                 logger.warning(f"[PrometheusMetricEmitter] Failed final push to gateway: {e}")
-

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -5,6 +5,7 @@ This module provides an implementation of IMetricEmitter that exports metrics to
 """
 
 import datetime
+import json
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, cast
@@ -21,6 +22,11 @@ from qubx.utils.questdb import QuestDBClient
 from qubx.utils.time import to_timedelta
 
 
+def _json_scalar(value: Any) -> Any:
+    # - numpy scalars are not JSON-serialisable; anything else falls back to its text form
+    return value.item() if isinstance(value, np.generic) else str(value)
+
+
 class QuestDBMetricEmitter(BaseMetricEmitter):
     """
     Emits metrics to QuestDB using the QuestDB ingress client.
@@ -30,6 +36,55 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
 
     SYMBOL_TAGS = ["symbol", "exchange", "type", "environment", "strategy", "event_type"]
     RECORD_COLUMN_TYPES = {"DOUBLE", "LONG", "STRING", "BOOLEAN", "TIMESTAMP", "SYMBOL"}
+
+    # - the schema of each reserved table, used both to create it and to decide which tags may
+    #   become columns. A tag that is not declared here goes to `custom` instead of widening the
+    #   table for every bot writing to the same server.
+    SCOPE_COLUMNS = {
+        "strategy": "SYMBOL",
+        "environment": "SYMBOL",
+        "run_id": "VARCHAR",
+        "bot_id": "SYMBOL INDEX",
+        "instance_id": "VARCHAR",
+        "is_live": "BOOLEAN",
+    }
+    INSTRUMENT_COLUMNS = {"symbol": "SYMBOL", "exchange": "SYMBOL", "asset": "VARCHAR", "quote": "VARCHAR"}
+    # - only the metrics table carries `custom`; signals and deals receive a fixed tag set
+    METRICS_COLUMNS = {
+        "timestamp": "TIMESTAMP",
+        "metric_name": "SYMBOL INDEX",
+        "value": "DOUBLE",
+        "type": "SYMBOL",
+        **INSTRUMENT_COLUMNS,
+        **SCOPE_COLUMNS,
+        "custom": "VARCHAR",
+    }
+    SIGNALS_COLUMNS = {
+        "timestamp": "TIMESTAMP",
+        "signal": "DOUBLE",
+        "price": "DOUBLE",
+        "stop": "DOUBLE",
+        "take": "DOUBLE",
+        "reference_price": "DOUBLE",
+        "target_leverage": "DOUBLE",
+        "group_name": "SYMBOL",
+        "comment": "STRING",
+        "is_service": "BOOLEAN",
+        **INSTRUMENT_COLUMNS,
+        **SCOPE_COLUMNS,
+    }
+    DEALS_COLUMNS = {
+        "timestamp": "TIMESTAMP",
+        "amount": "DOUBLE",
+        "price": "DOUBLE",
+        "aggressive": "BOOLEAN",
+        "fee_amount": "DOUBLE",
+        "fee_currency": "SYMBOL",
+        "deal_id": "STRING",
+        "order_id": "STRING",
+        **INSTRUMENT_COLUMNS,
+        **SCOPE_COLUMNS,
+    }
 
     def __init__(
         self,
@@ -79,9 +134,9 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._declared_symbols: dict[str, set[str]] = {}
         self._warned_undeclared: set[str] = set()
 
-        # Create signals table if it doesn't exist
-        self._ensure_signals_table_exists()
-        self._ensure_deals_table_exists()
+        self._declare_table(self._table_name, self.METRICS_COLUMNS, "DAY")
+        self._declare_table(self._signals_table_name, self.SIGNALS_COLUMNS, "WEEK")
+        self._declare_table(self._deals_table_name, self.DEALS_COLUMNS, "WEEK")
 
     def notify(self, context: IStrategyContext) -> None:
         super().notify(context)
@@ -200,9 +255,13 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             if self._sender is None:
                 return
 
-            # Prepare symbols (tags) and columns (values)
-            symbols = self._pop_symbols(tags)
-            columns: dict = {"metric_name": name, "value": round(value, 5), **tags}
+            symbols, tag_columns, custom = self._split_tags(self._table_name, tags)
+            columns: dict = {
+                "metric_name": name,
+                "value": round(value, 5),
+                **tag_columns,
+                **self._custom_column(custom),
+            }
 
             # Use the provided timestamp if available, otherwise use current time
             dt_timestamp = self._convert_timestamp(timestamp) if timestamp is not None else datetime.datetime.now()
@@ -222,59 +281,47 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             _sender = None
         return _sender
 
-    def _ensure_signals_table_exists(self) -> None:
-        """Ensure the signals table exists with the correct schema."""
+    def _declare_table(self, table: str, columns: dict[str, str], partition_by: str) -> None:
+        """
+        Create a reserved table and record its schema.
+
+        The recorded schema is what `_split_tags` filters against, so a table whose DDL could
+        not be applied still filters against the declaration rather than accepting everything.
+        """
+        self._declared_columns[table] = set(columns)
+        self._declared_symbols[table] = {n for n, t in columns.items() if t.startswith("SYMBOL")}
+        cols_sql = ", ".join(f'"{n}" {t}' for n, t in columns.items())
+        ddl = f'CREATE TABLE IF NOT EXISTS "{table}" ({cols_sql}) TIMESTAMP(timestamp) PARTITION BY {partition_by} WAL;'
         try:
-            # Use the PostgreSQL interface (port 8812) for DDL operations
-            client = QuestDBClient(host=self._host, port=8812)
-
-            create_table_sql = f"""
-            CREATE TABLE IF NOT EXISTS "{self._signals_table_name}" (
-                timestamp TIMESTAMP,
-                symbol SYMBOL,
-                exchange SYMBOL,
-                signal DOUBLE,
-                price DOUBLE,
-                stop DOUBLE,
-                take DOUBLE,
-                reference_price DOUBLE,
-                target_leverage DOUBLE,
-                group_name SYMBOL,
-                comment STRING,
-                is_service BOOLEAN
-            ) TIMESTAMP(timestamp) PARTITION BY WEEK;
-            """
-
-            client.execute(create_table_sql)
-            logger.info(f"[QuestDBMetricEmitter] Ensured signals table '{self._signals_table_name}' exists")
+            QuestDBClient(host=self._host, port=8812).execute(ddl)
+            logger.info(f"[QuestDBMetricEmitter] Ensured table '{table}' exists")
         except Exception as e:
-            logger.error(f"[QuestDBMetricEmitter] Failed to create signals table: {e}")
+            logger.error(f"[QuestDBMetricEmitter] Failed to create table '{table}': {e}")
 
-    def _ensure_deals_table_exists(self) -> None:
-        """Ensure the signals table exists with the correct schema."""
-        try:
-            # Use the PostgreSQL interface (port 8812) for DDL operations
-            client = QuestDBClient(host=self._host, port=8812)
+    def _split_tags(self, table: str, tags: dict[str, Any]) -> tuple[dict[str, str], dict[str, Any], dict[str, Any]]:
+        """
+        Sort tags into ILP symbol fields, real columns, and the `custom` bag.
 
-            create_table_sql = f"""
-            CREATE TABLE IF NOT EXISTS "{self._deals_table_name}" (
-                timestamp TIMESTAMP,
-                symbol SYMBOL,
-                exchange SYMBOL,
-                amount DOUBLE,
-                price DOUBLE,
-                aggressive BOOLEAN,
-                fee_amount DOUBLE,
-                fee_currency SYMBOL,
-                deal_id STRING,
-                order_id STRING
-            ) TIMESTAMP(timestamp) PARTITION BY WEEK;
-            """
+        An undeclared tag would otherwise become a new column under ILP auto-create, permanently
+        and for every bot writing to the same table.
+        """
+        allowed = self._declared_columns.get(table, set())
+        symbols = self._declared_symbols.get(table, set())
+        keys = tags.keys()
+        return (
+            {k: str(tags[k]) for k in keys & symbols},
+            {k: tags[k] for k in (keys & allowed) - symbols},
+            {k: tags[k] for k in keys - allowed},
+        )
 
-            client.execute(create_table_sql)
-            logger.info(f"[QuestDBMetricEmitter] Ensured signals table '{self._signals_table_name}' exists")
-        except Exception as e:
-            logger.error(f"[QuestDBMetricEmitter] Failed to create signals table: {e}")
+    @staticmethod
+    def _custom_column(custom: dict[str, Any]) -> dict[str, str]:
+        """
+        Render leftover tags as JSON, or nothing at all when there are none.
+        """
+        if not custom:
+            return {}
+        return {"custom": json.dumps(custom, sort_keys=True, default=_json_scalar)}
 
     def emit_signals(
         self,
@@ -452,7 +499,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
 
                 # Use _merge_tags to get properly merged tags
                 merged_tags = self._merge_tags({}, signal.instrument)
-                symbols = self._pop_symbols(merged_tags)
+                symbols, tag_columns, _ = self._split_tags(self._signals_table_name, merged_tags)
 
                 columns = {
                     "signal": float(signal.signal),
@@ -465,7 +512,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
                     # "options": json.dumps(signal.options) if signal.options else "{}",
                     "is_service": bool(signal.is_service),
                     "group_name": signal.group if signal.group else "",
-                    **merged_tags,
+                    **tag_columns,
                 }
 
                 # Convert timestamp - signal.time is always dt_64, no need to check for string
@@ -491,7 +538,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             for deal in deals:
                 # Use _merge_tags to get properly merged tags
                 merged_tags = self._merge_tags({}, instrument)
-                symbols = self._pop_symbols(merged_tags)
+                symbols, tag_columns, _ = self._split_tags(self._deals_table_name, merged_tags)
 
                 columns = {
                     "amount": float(deal.amount),
@@ -501,7 +548,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
                     "fee_currency": deal.fee_currency if deal.fee_currency is not None else None,
                     "deal_id": deal.trade_id,
                     "order_id": deal.order_id,
-                    **merged_tags,
+                    **tag_columns,
                 }
 
                 # Convert timestamp - signal.time is always dt_64, no need to check for string
@@ -512,10 +559,3 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
 
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to emit deals to QuestDB: {e}")
-
-    def _pop_symbols(self, tags: dict[str, str]) -> dict[str, str]:
-        symbols = {}
-        for symbol_name in self.SYMBOL_TAGS:
-            if symbol_name in tags:
-                symbols[symbol_name] = tags.pop(symbol_name)
-        return symbols

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -73,6 +73,30 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         **INSTRUMENT_COLUMNS,
         **SCOPE_COLUMNS,
     }
+    # - health/base.py tags every row with type=health plus reason+scope on degradations and
+    #   exchange+event_type on latencies
+    HEALTH_COLUMNS = {
+        "timestamp": "TIMESTAMP",
+        "metric_name": "SYMBOL INDEX",
+        "value": "DOUBLE",
+        "type": "SYMBOL",
+        "exchange": "SYMBOL",
+        "event_type": "SYMBOL",
+        "reason": "SYMBOL",
+        "scope": "SYMBOL",
+        **SCOPE_COLUMNS,
+    }
+    # - rate_limiting/engine.py tags every row with exchange, pool, scope, type
+    RATE_LIMITS_COLUMNS = {
+        "timestamp": "TIMESTAMP",
+        "metric_name": "SYMBOL INDEX",
+        "value": "DOUBLE",
+        "type": "SYMBOL",
+        "exchange": "SYMBOL",
+        "pool": "SYMBOL",
+        "scope": "SYMBOL",
+        **SCOPE_COLUMNS,
+    }
     DEALS_COLUMNS = {
         "timestamp": "TIMESTAMP",
         "amount": "DOUBLE",
@@ -93,6 +117,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         table_name: str = "qubx.metrics",
         signals_table_name: str = "qubx.signals",
         deals_table_name: str = "qubx.deals",
+        health_table_name: str = "qubx.health",
+        rate_limits_table_name: str = "qubx.rate_limits",
         stats_to_emit: list[str] | None = None,
         stats_interval: str = "1m",
         flush_interval: str = "5s",
@@ -107,6 +133,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             port: QuestDB server port
             table_name: Name of the table to store metrics in
             signals_table_name: Name of the table to store signals in
+            health_table_name: Name of the table to store type=health metrics in
+            rate_limits_table_name: Name of the table to store type=rate_limit metrics in
             stats_to_emit: Optional list of specific stats to emit
             stats_interval: Interval for emitting strategy stats (default: "1m")
             tags: Dictionary of default tags/labels to include with all metrics
@@ -122,6 +150,9 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._table_name = table_name
         self._signals_table_name = signals_table_name
         self._deals_table_name = deals_table_name
+        # - streams with their own tag set get their own table, so those tags stay real columns
+        #   there instead of being NULL on every other row of the shared one
+        self._tables_by_type = {"health": health_table_name, "rate_limit": rate_limits_table_name}
         self._conn_str = f"http::addr={host}:{port};"
         self._flush_interval = to_timedelta(flush_interval)
         self._sender = self._try_get_sender()
@@ -137,6 +168,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._declare_table(self._table_name, self.METRICS_COLUMNS, "DAY")
         self._declare_table(self._signals_table_name, self.SIGNALS_COLUMNS, "WEEK")
         self._declare_table(self._deals_table_name, self.DEALS_COLUMNS, "WEEK")
+        self._declare_table(health_table_name, self.HEALTH_COLUMNS, "DAY")
+        self._declare_table(rate_limits_table_name, self.RATE_LIMITS_COLUMNS, "DAY")
 
     def notify(self, context: IStrategyContext) -> None:
         super().notify(context)
@@ -255,19 +288,20 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             if self._sender is None:
                 return
 
-            symbols, tag_columns, custom = self._split_tags(self._table_name, tags)
+            table = self._tables_by_type.get(tags.get("type", ""), self._table_name)
+            symbols, tag_columns, custom = self._split_tags(table, tags)
             columns: dict = {
                 "metric_name": name,
                 "value": round(value, 5),
                 **tag_columns,
-                **self._custom_column(custom),
+                **self._custom_column(table, custom),
             }
 
             # Use the provided timestamp if available, otherwise use current time
             dt_timestamp = self._convert_timestamp(timestamp) if timestamp is not None else datetime.datetime.now()
 
             # Send the row to QuestDB
-            self._sender.row(self._table_name, symbols=symbols, columns=columns, at=dt_timestamp)
+            self._sender.row(table, symbols=symbols, columns=columns, at=dt_timestamp)
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to emit metric {name} to QuestDB: {e}")
 
@@ -314,12 +348,11 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             {k: tags[k] for k in keys - allowed},
         )
 
-    @staticmethod
-    def _custom_column(custom: dict[str, Any]) -> dict[str, str]:
+    def _custom_column(self, table: str, custom: dict[str, Any]) -> dict[str, str]:
         """
-        Render leftover tags as JSON, or nothing at all when there are none.
+        Render leftover tags as JSON. Only qubx.metrics declares `custom`.
         """
-        if not custom:
+        if not custom or "custom" not in self._declared_columns.get(table, set()):
             return {}
         return {"custom": json.dumps(custom, sort_keys=True, default=_json_scalar)}
 

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -28,6 +28,16 @@ DEALS_TABLE = "qubx.deals"
 HEALTH_TABLE = "qubx.health"
 RATE_LIMITS_TABLE = "qubx.rate_limits"
 
+# - retention per reserved table. metrics/signals/deals match what production already carries, so
+#   deploying does not change retention there; health and rate_limits are new and would otherwise
+#   grow without bound.
+METRICS_TTL = "30 days"
+SIGNALS_TTL = "14 weeks"
+DEALS_TTL = "14 weeks"
+HEALTH_TTL = "30 days"
+RATE_LIMITS_TTL = "30 days"
+DEFAULT_USER_TTL = "52 weeks"
+
 
 def _json_scalar(value: Any) -> Any:
     # - numpy scalars are not JSON-serialisable; anything else falls back to its text form
@@ -179,11 +189,11 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._declared_symbols: dict[str, set[str]] = {}
         self._warned_undeclared: set[str] = set()
 
-        self._declare_table(self._metrics_table_name, self.METRICS_COLUMNS, "DAY")
-        self._declare_table(self._signals_table_name, self.SIGNALS_COLUMNS, "WEEK")
-        self._declare_table(self._deals_table_name, self.DEALS_COLUMNS, "WEEK")
-        self._declare_table(health_table_name, self.HEALTH_COLUMNS, "DAY")
-        self._declare_table(rate_limits_table_name, self.RATE_LIMITS_COLUMNS, "DAY")
+        self._declare_table(self._metrics_table_name, self.METRICS_COLUMNS, "DAY", METRICS_TTL)
+        self._declare_table(self._signals_table_name, self.SIGNALS_COLUMNS, "WEEK", SIGNALS_TTL)
+        self._declare_table(self._deals_table_name, self.DEALS_COLUMNS, "WEEK", DEALS_TTL)
+        self._declare_table(health_table_name, self.HEALTH_COLUMNS, "DAY", HEALTH_TTL)
+        self._declare_table(rate_limits_table_name, self.RATE_LIMITS_COLUMNS, "DAY", RATE_LIMITS_TTL)
 
         # - these five have a fixed schema; a strategy table may not target them
         self._reserved_tables = frozenset(
@@ -340,9 +350,9 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             _sender = None
         return _sender
 
-    def _declare_table(self, table: str, columns: dict[str, str], partition_by: str) -> None:
+    def _declare_table(self, table: str, columns: dict[str, str], partition_by: str, max_ttl: str) -> None:
         """
-        Create a reserved table and record its schema.
+        Create a reserved table, record its schema, and set its retention.
 
         The recorded schema is what `_split_tags` filters against, so a table whose DDL could
         not be applied still filters against the declaration rather than accepting everything.
@@ -352,10 +362,25 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         cols_sql = ", ".join(f'"{n}" {t}' for n, t in columns.items())
         ddl = f'CREATE TABLE IF NOT EXISTS "{table}" ({cols_sql}) TIMESTAMP(timestamp) PARTITION BY {partition_by} WAL;'
         try:
-            QuestDBClient(host=self._host, port=8812).execute(ddl)
+            client = QuestDBClient(host=self._host, port=8812)
+            client.execute(ddl)
+            self._set_retention(client, table, max_ttl)
             logger.info(f"[QuestDBMetricEmitter] Ensured table '{table}' exists")
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to create table '{table}': {e}")
+
+    def _set_retention(self, client: QuestDBClient, table: str, max_ttl: str) -> None:
+        """
+        Set retention on a table, whether it was just created or already existed.
+
+        Idempotent and ~2ms, so it runs unconditionally rather than reading the current value
+        back first. QuestDB rejects a TTL finer than the partition size and leaves the table
+        untouched when it does — it owns that rule, so it is not repeated here.
+        """
+        try:
+            client.execute(f'ALTER TABLE "{table}" SET TTL {max_ttl}')
+        except Exception as e:
+            logger.warning(f"[QuestDBMetricEmitter] '{table}': TTL {max_ttl!r} not applied: {e}")
 
     def _refuse_reserved(self, table: str) -> None:
         """
@@ -434,8 +459,14 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         symbol_columns: Sequence[str] = (),
         dedup_keys: Sequence[str] | None = None,
         partition_by: str = "DAY",
+        max_ttl: str | None = DEFAULT_USER_TTL,
     ) -> None:
-        """Create a strategy-owned table with explicit types (spec: strategy-tables §2.0)."""
+        """
+        Create a strategy-owned table with explicit types (spec: strategy-tables §2.0).
+
+        `max_ttl` is applied whether the table was just created or already existed. Pass None
+        to leave retention alone.
+        """
         try:
             self._refuse_reserved(table)
             if isinstance(symbol_columns, str):
@@ -461,7 +492,10 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
                 quoted_keys = ", ".join(f'"{k}"' for k in dedup_keys)
                 ddl += f" DEDUP UPSERT KEYS({quoted_keys})"
             ddl += ";"
-            QuestDBClient(host=self._host, port=8812).execute(ddl)
+            client = QuestDBClient(host=self._host, port=8812)
+            client.execute(ddl)
+            if max_ttl:
+                self._set_retention(client, table, max_ttl)
             self._declared_columns[table] = set(decl)
             self._declared_symbols[table] = {n for n, t in decl.items() if t == "SYMBOL"}
             logger.info(f"[QuestDBMetricEmitter] Ensured table '{table}' exists")

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -21,6 +21,13 @@ from qubx.emitters.base import BaseMetricEmitter
 from qubx.utils.questdb import QuestDBClient
 from qubx.utils.time import to_timedelta
 
+# - tables the emitter owns; a strategy table may not target them
+METRICS_TABLE = "qubx.metrics"
+SIGNALS_TABLE = "qubx.signals"
+DEALS_TABLE = "qubx.deals"
+HEALTH_TABLE = "qubx.health"
+RATE_LIMITS_TABLE = "qubx.rate_limits"
+
 
 def _json_scalar(value: Any) -> Any:
     # - numpy scalars are not JSON-serialisable; anything else falls back to its text form
@@ -114,11 +121,11 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self,
         host: str = "localhost",
         port: int = 9000,
-        table_name: str = "qubx.metrics",
-        signals_table_name: str = "qubx.signals",
-        deals_table_name: str = "qubx.deals",
-        health_table_name: str = "qubx.health",
-        rate_limits_table_name: str = "qubx.rate_limits",
+        metrics_table_name: str = METRICS_TABLE,
+        signals_table_name: str = SIGNALS_TABLE,
+        deals_table_name: str = DEALS_TABLE,
+        health_table_name: str = HEALTH_TABLE,
+        rate_limits_table_name: str = RATE_LIMITS_TABLE,
         stats_to_emit: list[str] | None = None,
         stats_interval: str = "1m",
         flush_interval: str = "5s",
@@ -131,7 +138,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         Args:
             host: QuestDB server host
             port: QuestDB server port
-            table_name: Name of the table to store metrics in
+            metrics_table_name: Name of the table to store metrics in
             signals_table_name: Name of the table to store signals in
             health_table_name: Name of the table to store type=health metrics in
             rate_limits_table_name: Name of the table to store type=rate_limit metrics in
@@ -147,7 +154,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
 
         self._host = host
         self._port = port
-        self._table_name = table_name
+        self._metrics_table_name = metrics_table_name
         self._signals_table_name = signals_table_name
         self._deals_table_name = deals_table_name
         # - streams with their own tag set get their own table, so those tags stay real columns
@@ -165,11 +172,22 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         self._declared_symbols: dict[str, set[str]] = {}
         self._warned_undeclared: set[str] = set()
 
-        self._declare_table(self._table_name, self.METRICS_COLUMNS, "DAY")
+        self._declare_table(self._metrics_table_name, self.METRICS_COLUMNS, "DAY")
         self._declare_table(self._signals_table_name, self.SIGNALS_COLUMNS, "WEEK")
         self._declare_table(self._deals_table_name, self.DEALS_COLUMNS, "WEEK")
         self._declare_table(health_table_name, self.HEALTH_COLUMNS, "DAY")
         self._declare_table(rate_limits_table_name, self.RATE_LIMITS_COLUMNS, "DAY")
+
+        # - these five have a fixed schema; a strategy table may not target them
+        self._reserved_tables = frozenset(
+            {
+                self._metrics_table_name,
+                self._signals_table_name,
+                self._deals_table_name,
+                health_table_name,
+                rate_limits_table_name,
+            }
+        )
 
     def notify(self, context: IStrategyContext) -> None:
         super().notify(context)
@@ -288,7 +306,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             if self._sender is None:
                 return
 
-            table = self._tables_by_type.get(tags.get("type", ""), self._table_name)
+            table = self._tables_by_type.get(tags.get("type", ""), self._metrics_table_name)
             symbols, tag_columns, custom = self._split_tags(table, tags)
             columns: dict = {
                 "metric_name": name,
@@ -331,6 +349,13 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             logger.info(f"[QuestDBMetricEmitter] Ensured table '{table}' exists")
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to create table '{table}': {e}")
+
+    def _refuse_reserved(self, table: str) -> None:
+        """
+        Reject a strategy table that targets one of the emitter's own tables.
+        """
+        if table in self._reserved_tables:
+            raise ValueError(f"'{table}' is reserved by the emitter and has a fixed schema")
 
     def _split_tags(self, table: str, tags: dict[str, Any]) -> tuple[dict[str, str], dict[str, Any], dict[str, Any]]:
         """
@@ -405,6 +430,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
     ) -> None:
         """Create a strategy-owned table with explicit types (spec: strategy-tables §2.0)."""
         try:
+            self._refuse_reserved(table)
             if isinstance(symbol_columns, str):
                 raise ValueError(f"symbol_columns must be a sequence of names, not a bare string: {symbol_columns!r}")
             decl: dict[str, str] = {"timestamp": "TIMESTAMP"}
@@ -451,6 +477,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         if self._sender is None:
             return
         try:
+            self._refuse_reserved(table)
             if isinstance(symbol_columns, str):
                 raise ValueError(f"symbol_columns must be a sequence of names, not a bare string: {symbol_columns!r}")
             if self._context is not None and timestamp is None:

--- a/src/qubx/utils/runner/textual/app.py
+++ b/src/qubx/utils/runner/textual/app.py
@@ -21,7 +21,16 @@ from qubx.cli.theme import QUBX_DARK
 from .handlers import KernelEventHandler
 from .init_code import generate_init_code, generate_mock_init_code
 from .kernel import IPyKernel
-from .widgets import AccountSummary, CommandInput, DebugLog, OrdersTable, PositionsTable, QuotesTable, ReplOutput
+from .widgets import (
+    AccountSummary,
+    CommandInput,
+    DebugLog,
+    LogLevelFilter,
+    OrdersTable,
+    PositionsTable,
+    QuotesTable,
+    ReplOutput,
+)
 
 
 class TextualStrategyApp(App[None]):
@@ -32,12 +41,16 @@ class TextualStrategyApp(App[None]):
 
     BINDINGS = [
         Binding("ctrl+l", "clear_repl", "Clear REPL", show=True),
-        Binding("ctrl+c", "interrupt", "Interrupt", show=True),
+        # - not ctrl+c: Textual's Screen binds that to copy_text, and an App binding shadows it,
+        #   which leaves selected text with no way to reach the clipboard
+        Binding("ctrl+k", "interrupt", "Interrupt", show=True),
         Binding("p", "toggle_positions", "Positions", show=True),
         Binding("o", "toggle_orders", "Orders", show=True),
         Binding("m", "toggle_market", "Market", show=True),
         # Binding("d", "toggle_debug", "Debug", show=True),
-        Binding("q", "quit", "Quit", show=True),
+        # - ctrl+q, not a bare q: terminals send plain characters on startup handshakes
+        #   (VS Code's init string among them) and a bare binding quits the app
+        Binding("ctrl+q", "quit", "Quit", show=True),
     ]
 
     def __init__(
@@ -267,6 +280,7 @@ class TextualStrategyApp(App[None]):
             with Horizontal(id="main-container"):
                 # Output on the left
                 with Vertical(id="output-container"):
+                    yield LogLevelFilter(id="log-filter")
                     self.output = ReplOutput(id="output", max_lines=10000)
                     yield self.output
                 # Vertical layout for positions/orders stacked up/down on the right
@@ -321,6 +335,12 @@ class TextualStrategyApp(App[None]):
     def action_clear_repl(self) -> None:
         """Clear the output."""
         self.output.clear_output()
+
+    def on_log_level_filter_changed(self, message: LogLevelFilter.Changed) -> None:
+        """
+        Re-render the log pane with the levels that are still switched on.
+        """
+        self.output.apply_levels(message.enabled)
 
     async def action_interrupt(self) -> None:
         """Send interrupt signal to the kernel."""

--- a/src/qubx/utils/runner/textual/init_code.py
+++ b/src/qubx/utils/runner/textual/init_code.py
@@ -203,12 +203,17 @@ def _account_summary():
     \"\"\"Collect per-exchange account summary (total capital, leverage).\"\"\"
     summary = []
     try:
+        # - Position.pnl is unrealized + realized, and realized already carries cumulative funding
+        pnl_by_exchange = {{}}
+        for instr, pos in ctx.get_positions().items():
+            pnl_by_exchange[instr.exchange] = pnl_by_exchange.get(instr.exchange, 0.0) + pos.pnl
         for exch in ctx.exchanges:
             summary.append({{
                 "exchange": exch,
                 "total_capital": _sanitize_number(round(ctx.get_total_capital(exch), 2)),
                 "net_leverage": _sanitize_number(round(ctx.get_net_leverage(exch), 4)),
                 "gross_leverage": _sanitize_number(round(ctx.get_gross_leverage(exch), 4)),
+                "pnl": _sanitize_number(round(pnl_by_exchange.get(exch, 0.0), 2)),
             }})
     except Exception:
         pass
@@ -257,7 +262,7 @@ config_file = Path('{config_path_str}')
 account_file = Path('{account_path_str}') if '{account_path_str}' != 'None' else None
 
 # Add project to system path
-{'add_project_to_system_path()  # dev mode: adds ~/projects' if dev else '# dev mode disabled - ~/projects not added'}
+{"add_project_to_system_path()  # dev mode: adds ~/projects" if dev else "# dev mode disabled - ~/projects not added"}
 add_project_to_system_path(config_file.parent)
 
 # Run the strategy

--- a/src/qubx/utils/runner/textual/styles.tcss
+++ b/src/qubx/utils/runner/textual/styles.tcss
@@ -70,7 +70,8 @@ Footer {
     width: 1fr;
     border: solid $border-green;
     background: $background;
-    padding: 1;
+    /* - no top padding: the log filter bar docks flush against the border */
+    padding: 0 1 1 1;
 }
 
 #output-container:focus-within {

--- a/src/qubx/utils/runner/textual/widgets/__init__.py
+++ b/src/qubx/utils/runner/textual/widgets/__init__.py
@@ -3,9 +3,20 @@
 from .account_summary import AccountSummary
 from .command_input import CommandInput
 from .debug_log import DebugLog, TextualLogHandler
+from .log_filter import LogLevelFilter
 from .orders_table import OrdersTable
 from .positions_table import PositionsTable
 from .quotes_table import QuotesTable
 from .repl_output import ReplOutput
 
-__all__ = ["AccountSummary", "ReplOutput", "PositionsTable", "OrdersTable", "QuotesTable", "CommandInput", "DebugLog", "TextualLogHandler"]
+__all__ = [
+    "AccountSummary",
+    "ReplOutput",
+    "PositionsTable",
+    "OrdersTable",
+    "QuotesTable",
+    "CommandInput",
+    "DebugLog",
+    "TextualLogHandler",
+    "LogLevelFilter",
+]

--- a/src/qubx/utils/runner/textual/widgets/account_summary.py
+++ b/src/qubx/utils/runner/textual/widgets/account_summary.py
@@ -52,12 +52,23 @@ class AccountSummary(Widget):
             parts.append(
                 f"[bold]{exch}[/bold]  "
                 f"Capital: [cyan]${capital:,.2f}[/cyan]  "
+                f"PnL: {self._money(item.get('pnl', 0.0))}  "
                 f"Net: [green]{net_lev:+.3f}x[/green]  "
                 f"Gross: [yellow]{gross_lev:.3f}x[/yellow]"
             )
 
+        total_pnl = sum(item.get("pnl", 0.0) for item in summary)
+        if len(summary) > 1:
+            parts.insert(0, f"[bold]TOTAL[/bold] PnL: {self._money(total_pnl)}")
+
         content = self.query_one("#account-summary-content", Static)
         content.update("    ".join(parts))
+
+    @staticmethod
+    def _money(value: float) -> str:
+        colour = "green" if value > 0 else ("red" if value < 0 else "white")
+        sign = "-" if value < 0 else ""
+        return f"[{colour}]{sign}${abs(value):,.2f}[/{colour}]"
 
     def update_status(self, status: dict | None) -> None:
         """Update the context-status chip.

--- a/src/qubx/utils/runner/textual/widgets/log_filter.py
+++ b/src/qubx/utils/runner/textual/widgets/log_filter.py
@@ -1,0 +1,78 @@
+"""
+Clickable level toggles for the log pane: [E][W][I][D].
+
+Loguru writes the level into the line itself (``{ts} [ ERROR ] module | ...``), so filtering
+is done on the rendered text rather than on log records — the pane receives the kernel's
+stdout, not a logging stream.
+"""
+
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widgets import Static
+
+# - buckets in the order they are shown; the letter is what the toggle displays
+LEVELS: tuple[tuple[str, str], ...] = (
+    ("ERROR", "E"),
+    ("WARNING", "W"),
+    ("INFO", "I"),
+    ("DEBUG", "D"),
+)
+
+
+class LogLevelFilter(Horizontal):
+    """
+    A row of level toggles. Emits `Changed` with the levels that remain enabled.
+    """
+
+    DEFAULT_CSS = """
+    LogLevelFilter {
+        height: 1;
+        dock: top;
+        background: $panel;
+    }
+    LogLevelFilter > Static {
+        width: 4;
+        height: 1;
+        content-align: center middle;
+    }
+    LogLevelFilter > Static.on { color: $success; text-style: bold; }
+    LogLevelFilter > Static.off { color: $text-disabled; }
+    LogLevelFilter > #log-filter-label { width: auto; color: $text-muted; }
+    
+    """
+
+    class Changed(Message):
+        """Posted when a level is toggled."""
+
+        def __init__(self, enabled: set[str]) -> None:
+            super().__init__()
+            self.enabled = enabled
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._enabled: set[str] = {name for name, _ in LEVELS}
+
+    def compose(self):
+        yield Static("Filter: ", id="log-filter-label")
+        for name, letter in LEVELS:
+            # - markup=False: "[E]" is a valid Textual markup tag and renders as nothing
+            yield Static(f"[{letter}]", id=f"log-filter-{name.lower()}", classes="on", markup=False)
+
+    @property
+    def enabled(self) -> set[str]:
+        return set(self._enabled)
+
+    def on_click(self, event) -> None:
+        widget = event.widget
+        if widget is None or not (wid := widget.id) or not wid.startswith("log-filter-"):
+            return
+        name = wid.removeprefix("log-filter-").upper()
+        if name not in {n for n, _ in LEVELS}:
+            return
+        if name in self._enabled:
+            self._enabled.discard(name)
+            widget.set_classes("off")
+        else:
+            self._enabled.add(name)
+            widget.set_classes("on")
+        self.post_message(self.Changed(self.enabled))

--- a/src/qubx/utils/runner/textual/widgets/repl_output.py
+++ b/src/qubx/utils/runner/textual/widgets/repl_output.py
@@ -2,12 +2,23 @@
 
 RichLog (not TextArea): renders Rich/ANSI color for the kernel log stream — a TextArea is a
 plain-text editor and drops the color from ``Text.from_ansi(...)``. Output-only, append-only;
-RichLog handles max-line trimming and smart auto-scroll (follows the tail only when scrolled to it).
+RichLog handles max-line trimming; the tail-following below is ours — RichLog's own auto_scroll
+jumps to the end unconditionally.
 """
+
+import re
+from collections import deque
 
 from rich.text import Text
 from textual.binding import Binding
 from textual.widgets import RichLog
+
+from qubx.utils.runner.textual.widgets.log_filter import LEVELS
+
+# - loguru writes "{ts} [ LEVEL ] module | ..."; TEXT-level lines carry no prefix at all.
+#   Bounded so a bracketed word inside a message body cannot be mistaken for the level.
+_LEVEL_RE = re.compile(r"^.{0,40}?\[\s*([A-Z]+)\s*\]")
+_FILTERABLE = {name for name, _ in LEVELS}
 
 
 class ReplOutput(RichLog):
@@ -25,6 +36,9 @@ class ReplOutput(RichLog):
     """
 
     def __init__(self, max_lines: int = 10000, *args, **kwargs):
+        # - every line is kept so a level can be switched back on without losing history
+        self._buffer: deque[tuple[str | None, str | Text]] = deque(maxlen=max_lines)
+        self._enabled: set[str] | None = None  # None = show everything
         # drop TextArea-era kwargs that RichLog doesn't accept / we set explicitly
         kwargs.pop("markup", None)
         kwargs.pop("wrap", None)
@@ -35,16 +49,56 @@ class ReplOutput(RichLog):
             wrap=True,
             markup=False,  # content arrives as Rich Text / plain str, not markup strings
             highlight=False,
-            auto_scroll=True,  # follow the tail when the user is at the bottom
+            auto_scroll=False,  # - per-write, in `write`, so scrolling up is not undone
             **kwargs,
         )
 
     def write(self, content: str | Text, *args, **kwargs):
-        """Append a line, rendering Rich/ANSI color. Extra args ignored for call-site compatibility."""
-        return super().write(content)
+        """
+        Append a line, rendering Rich/ANSI color. Extra args ignored for call-site compatibility.
+
+        RichLog's own `auto_scroll` jumps to the tail on every write, which drags the view back
+        down while you are reading further up. Follow the tail only while already at it.
+        """
+        level = self._level_of(content)
+        self._buffer.append((level, content))
+        if not self._shown(level):
+            return self
+        return super().write(content, scroll_end=self.is_vertical_scroll_end)
+
+    @staticmethod
+    def _level_of(content: str | Text) -> str | None:
+        """
+        The level a line reports, or None for output that carries no log prefix.
+        """
+        m = _LEVEL_RE.match(content.plain if isinstance(content, Text) else str(content))
+        return m.group(1) if m else None
+
+    def _shown(self, level: str | None) -> bool:
+        """
+        Only the four toggleable levels can be hidden.
+
+        Unprefixed output (TEXT, tracebacks, kernel stdout) and levels with no toggle of their
+        own (CRITICAL, SUCCESS) always show — a filter must never swallow a critical error.
+        """
+        if self._enabled is None or level is None or level not in _FILTERABLE:
+            return True
+        return level in self._enabled
+
+    def apply_levels(self, enabled: set[str]) -> None:
+        """
+        Re-render the buffer with only `enabled` levels visible.
+        """
+        self._enabled = set(enabled)
+        self.clear()
+        for level, content in self._buffer:
+            if self._shown(level):
+                super().write(content, scroll_end=False)
+        self.scroll_end(animate=False)
 
     def clear_output(self):
         """Clear all output."""
+        self._buffer.clear()
         self.clear()
 
     def action_scroll_to_end(self) -> None:

--- a/tests/qubx/emitters/metric_emitters_test.py
+++ b/tests/qubx/emitters/metric_emitters_test.py
@@ -82,6 +82,8 @@ class TestBaseMetricEmitter:
         mock.get_gross_leverage.return_value = 0.7
         mock.instruments = ["BTC-USD", "ETH-USD"]
         mock.is_simulation = False
+        mock.is_live = True
+        mock.is_warmup_in_progress = False
         mock.time.return_value = pd.Timestamp("2023-01-01 00:00:00").to_numpy()
 
         # Mock positions
@@ -677,6 +679,8 @@ class TestQuestDBMetricEmitter:
         # Create a mock context
         mock_context = MagicMock(spec=IStrategyContext)
         mock_context.is_simulation = False
+        mock_context.is_live = True
+        mock_context.is_warmup_in_progress = False
         mock_context.time.return_value = pd.Timestamp("2023-01-01 12:00:00").to_numpy()
 
         # First call to notify should set _last_flush

--- a/tests/qubx/emitters/metric_emitters_test.py
+++ b/tests/qubx/emitters/metric_emitters_test.py
@@ -605,10 +605,10 @@ class TestQuestDBMetricEmitter:
         with patch.object(emitter, "_convert_timestamp", return_value=dt_timestamp):
             emitter.emit("test_metric", 42.0, {"tag1": "value1"}, timestamp)
 
-            # Check that row was called with the correct arguments
-            # Only SYMBOL_TAGS go into symbols, everything else (including metric_name) goes into columns
+            # Declared SYMBOL columns go into symbols; an undeclared tag goes into `custom`
+            # rather than becoming a new column on the shared table
             expected_symbols = {"strategy": "test"}
-            expected_columns = {"metric_name": "test_metric", "value": 42.0, "tag1": "value1"}
+            expected_columns = {"metric_name": "test_metric", "value": 42.0, "custom": '{"tag1": "value1"}'}
             mock_sender.row.assert_called_once_with(
                 "qubx.metrics", symbols=expected_symbols, columns=expected_columns, at=dt_timestamp
             )
@@ -622,10 +622,10 @@ class TestQuestDBMetricEmitter:
 
             emitter.emit("test_metric", 42.0, {"tag1": "value1"})
 
-            # Check that row was called with the correct arguments
-            # Only SYMBOL_TAGS go into symbols, everything else (including metric_name) goes into columns
+            # Declared SYMBOL columns go into symbols; an undeclared tag goes into `custom`
+            # rather than becoming a new column on the shared table
             expected_symbols = {"strategy": "test"}
-            expected_columns = {"metric_name": "test_metric", "value": 42.0, "tag1": "value1"}
+            expected_columns = {"metric_name": "test_metric", "value": 42.0, "custom": '{"tag1": "value1"}'}
             mock_sender.row.assert_called_once_with(
                 "qubx.metrics", symbols=expected_symbols, columns=expected_columns, at=mock_now
             )

--- a/tests/qubx/emitters/metric_emitters_test.py
+++ b/tests/qubx/emitters/metric_emitters_test.py
@@ -589,11 +589,11 @@ class TestQuestDBMetricEmitter:
             from qubx.emitters.questdb import QuestDBMetricEmitter
 
             emitter = QuestDBMetricEmitter(
-                host="testhost", port=9999, table_name="test_table", tags={"strategy": "test"}
+                host="testhost", port=9999, metrics_table_name="test_table", tags={"strategy": "test"}
             )
             mock_sender.from_conf.assert_called_once_with("http::addr=testhost:9999;")
             mock_sender.establish.assert_called_once()
-            assert emitter._table_name == "test_table"
+            assert emitter._metrics_table_name == "test_table"
             assert emitter._default_tags["strategy"] == "test"
 
     def test_emit(self, emitter, mock_sender):

--- a/tests/qubx/emitters/questdb_schema_test.py
+++ b/tests/qubx/emitters/questdb_schema_test.py
@@ -1,0 +1,110 @@
+"""
+The QuestDB emitter must not widen its tables.
+
+Any tag it does not declare would otherwise become a permanent column under ILP
+auto-create, for every bot writing to the same server.
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qubx.emitters.questdb import QuestDBMetricEmitter
+
+
+@pytest.fixture
+def emitter():
+    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient"):
+        em = QuestDBMetricEmitter(tags={"strategy": "s", "environment": "prod"})
+    em._sender = MagicMock()
+    return em
+
+
+def _row(emitter) -> tuple[str, dict, dict]:
+    call = emitter._sender.row.call_args
+    return call.args[0], call.kwargs["symbols"], call.kwargs["columns"]
+
+
+def test_undeclared_tags_go_to_custom(emitter):
+    emitter._emit_to_questdb(
+        "spread", 1.5, {"strategy": "s", "type": "stats", "pair": "ADA:A:B", "lookback": "30d"}, None
+    )
+
+    table, symbols, columns = _row(emitter)
+    assert table == "qubx.metrics"
+    assert symbols == {"strategy": "s", "type": "stats"}
+    assert columns["custom"] == '{"lookback": "30d", "pair": "ADA:A:B"}'
+    assert "pair" not in columns and "lookback" not in columns
+
+
+def test_custom_is_absent_when_every_tag_is_declared(emitter):
+    emitter._emit_to_questdb("total_capital", 1.0, {"strategy": "s", "type": "stats"}, None)
+
+    _, _, columns = _row(emitter)
+    assert "custom" not in columns
+
+
+def test_health_rows_go_to_the_health_table(emitter):
+    emitter._emit_to_questdb(
+        "context_degradation", 1.0, {"type": "health", "reason": "QUEUE_LAG", "scope": "BINANCE.UM"}, None
+    )
+
+    table, symbols, columns = _row(emitter)
+    assert table == "qubx.health"
+    assert symbols["reason"] == "QUEUE_LAG"
+    assert symbols["scope"] == "BINANCE.UM"
+    assert "custom" not in columns  # - the health table does not declare it
+
+
+def test_rate_limit_rows_go_to_their_own_table(emitter):
+    emitter._emit_to_questdb(
+        "rate_limit.utilization",
+        0.42,
+        {"type": "rate_limit", "exchange": "binance.pm", "pool": "orders", "scope": "account"},
+        None,
+    )
+
+    table, symbols, _ = _row(emitter)
+    assert table == "qubx.rate_limits"
+    assert symbols["pool"] == "orders"
+    assert symbols["scope"] == "account"
+
+
+def test_pool_and_scope_never_reach_the_metrics_table(emitter):
+    # - they are rate-limit tags; on qubx.metrics they would be NULL on every other row
+    assert "pool" not in QuestDBMetricEmitter.METRICS_COLUMNS
+    assert "scope" not in QuestDBMetricEmitter.METRICS_COLUMNS
+    assert "event_type" not in QuestDBMetricEmitter.METRICS_COLUMNS
+
+
+def test_signals_and_deals_do_not_declare_custom():
+    assert "custom" not in QuestDBMetricEmitter.SIGNALS_COLUMNS
+    assert "custom" not in QuestDBMetricEmitter.DEALS_COLUMNS
+    assert "custom" in QuestDBMetricEmitter.METRICS_COLUMNS
+
+
+def test_timestamp_is_the_designated_column_of_every_reserved_table():
+    for schema in (
+        QuestDBMetricEmitter.METRICS_COLUMNS,
+        QuestDBMetricEmitter.SIGNALS_COLUMNS,
+        QuestDBMetricEmitter.DEALS_COLUMNS,
+        QuestDBMetricEmitter.HEALTH_COLUMNS,
+        QuestDBMetricEmitter.RATE_LIMITS_COLUMNS,
+    ):
+        assert next(iter(schema)) == "timestamp"
+
+
+def test_unknown_type_falls_back_to_the_metrics_table(emitter):
+    emitter._emit_to_questdb("proba", 0.7, {"type": "prediction", "predictor": "m1"}, None)
+
+    table, _, columns = _row(emitter)
+    assert table == "qubx.metrics"
+    assert columns["custom"] == '{"predictor": "m1"}'
+
+
+def test_timestamp_is_passed_through(emitter):
+    ts = datetime.datetime(2026, 8, 20, 1, 11, 0)
+    emitter._emit_to_questdb("total_capital", 1.0, {"type": "stats"}, ts)
+
+    assert emitter._sender.row.call_args.kwargs["at"] == ts

--- a/tests/qubx/emitters/questdb_schema_test.py
+++ b/tests/qubx/emitters/questdb_schema_test.py
@@ -108,3 +108,24 @@ def test_timestamp_is_passed_through(emitter):
     emitter._emit_to_questdb("total_capital", 1.0, {"type": "stats"}, ts)
 
     assert emitter._sender.row.call_args.kwargs["at"] == ts
+
+
+def test_ensure_table_refuses_a_reserved_name(emitter):
+    with patch("qubx.emitters.questdb.QuestDBClient") as client:
+        emitter.ensure_table("qubx.metrics", columns={"v": "DOUBLE"})
+
+    client.assert_not_called()
+
+
+def test_emit_record_refuses_a_reserved_name(emitter):
+    emitter.emit_record("qubx.health", {"v": 1.0})
+
+    emitter._sender.row.assert_not_called()
+
+
+def test_a_strategy_table_is_still_accepted(emitter):
+    with patch("qubx.emitters.questdb.QuestDBClient") as client:
+        emitter.ensure_table("loe.execution", columns={"v": "DOUBLE"})
+
+    client.assert_called_once()
+    assert "loe.execution" in emitter._declared_columns

--- a/tests/qubx/emitters/questdb_schema_test.py
+++ b/tests/qubx/emitters/questdb_schema_test.py
@@ -129,3 +129,23 @@ def test_a_strategy_table_is_still_accepted(emitter):
 
     client.assert_called_once()
     assert "loe.execution" in emitter._declared_columns
+
+
+def test_retention_is_set_on_the_reserved_tables(emitter):
+    # - health and rate_limits are new tables and would otherwise grow without bound
+    from qubx.emitters.questdb import DEALS_TTL, HEALTH_TTL, METRICS_TTL, RATE_LIMITS_TTL, SIGNALS_TTL
+
+    assert (METRICS_TTL, HEALTH_TTL, RATE_LIMITS_TTL) == ("30 days", "30 days", "30 days")
+    assert (SIGNALS_TTL, DEALS_TTL) == ("14 weeks", "14 weeks")
+
+
+def test_set_retention_survives_a_ttl_questdb_rejects(emitter):
+    """
+    A TTL finer than the partition is refused by QuestDB; the table must still be usable.
+    """
+    client = MagicMock()
+    client.execute.side_effect = Exception("TTL value must be an integer multiple of partition size")
+
+    emitter._set_retention(client, "some.table", "10 days")  # - must not raise
+
+    client.execute.assert_called_once_with('ALTER TABLE "some.table" SET TTL 10 days')

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -26,13 +26,21 @@ class TestCompositeForwarding:
     def test_forwards_to_children(self):
         child_a, child_b = MagicMock(spec=IMetricEmitter), MagicMock(spec=IMetricEmitter)
         comp = CompositeMetricEmitter([child_a, child_b])
-        comp.ensure_table("frab.trades", {"net_pnl": "DOUBLE"}, symbol_columns=("pair",), dedup_keys=("timestamp", "trade_id"))
+        comp.ensure_table(
+            "frab.trades", {"net_pnl": "DOUBLE"}, symbol_columns=("pair",), dedup_keys=("timestamp", "trade_id")
+        )
         comp.emit_record("frab.trades", {"net_pnl": 1.5}, symbol_columns=("pair",))
         for child in (child_a, child_b):
             child.ensure_table.assert_called_once_with(
-                "frab.trades", {"net_pnl": "DOUBLE"}, symbol_columns=("pair",), dedup_keys=("timestamp", "trade_id"), partition_by="DAY"
+                "frab.trades",
+                {"net_pnl": "DOUBLE"},
+                symbol_columns=("pair",),
+                dedup_keys=("timestamp", "trade_id"),
+                partition_by="DAY",
             )
-            child.emit_record.assert_called_once_with("frab.trades", {"net_pnl": 1.5}, symbol_columns=("pair",), timestamp=None)
+            child.emit_record.assert_called_once_with(
+                "frab.trades", {"net_pnl": 1.5}, symbol_columns=("pair",), timestamp=None
+            )
 
     def test_child_error_is_isolated(self):
         bad, good = MagicMock(spec=IMetricEmitter), MagicMock(spec=IMetricEmitter)
@@ -82,6 +90,16 @@ def emitter(monkeypatch):
     return em
 
 
+def _create_sql(emitter) -> str:
+    """
+    The CREATE statement, not the ALTER ... SET TTL that follows it.
+    """
+    for call in emitter._ddl_client_for_test.execute.call_args_list:
+        if call[0][0].lstrip().upper().startswith("CREATE"):
+            return call[0][0]
+    raise AssertionError("no CREATE statement was executed")
+
+
 class TestEnsureTable:
     def test_generates_create_table_with_scope_columns_and_dedup(self, emitter):
         emitter.ensure_table(
@@ -90,7 +108,7 @@ class TestEnsureTable:
             symbol_columns=("pair", "asset"),
             dedup_keys=("timestamp", "trade_id"),
         )
-        ddl_sql = emitter._ddl_client_for_test.execute.call_args[0][0]
+        ddl_sql = _create_sql(emitter)
         assert 'CREATE TABLE IF NOT EXISTS "frab.trades"' in ddl_sql
         assert '"timestamp" TIMESTAMP' in ddl_sql
         # scope columns injected: strategy/environment are SYMBOL_TAGS -> SYMBOL, run_id STRING, is_live BOOLEAN
@@ -114,7 +132,7 @@ class TestEnsureTable:
             {"net_pnl": "DOUBLE"},
             symbol_columns=("run_id", "pair"),
         )
-        ddl_sql = emitter._ddl_client_for_test.execute.call_args[0][0]
+        ddl_sql = _create_sql(emitter)
         # run_id is a reserved scope column (STRING) -> symbol_columns must not flip it to SYMBOL
         assert '"run_id" STRING' in ddl_sql
         assert '"pair" SYMBOL' in ddl_sql

--- a/tests/qubx/emitters/warmup_gate_test.py
+++ b/tests/qubx/emitters/warmup_gate_test.py
@@ -66,3 +66,39 @@ def test_strategy_stats_are_suppressed_during_warmup():
     em.notify(ctx)
 
     assert em.get_dataframe().empty
+
+
+def test_undeclared_tags_are_folded_into_custom():
+    """
+    A strategy tag must not become a column on the shared table.
+    """
+    from unittest.mock import patch
+
+    from qubx.emitters.questdb import QuestDBMetricEmitter
+
+    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient"):
+        em = QuestDBMetricEmitter(table_name="qubx.metrics", tags={"strategy": "s"})
+
+    symbols, columns, custom = em._split_tags(
+        "qubx.metrics",
+        {"strategy": "s", "symbol": "BTCUSDT", "is_live": True, "pair": "ADA:A:B", "lookback": "30d"},
+    )
+
+    assert symbols == {"strategy": "s", "symbol": "BTCUSDT"}
+    assert columns == {"is_live": True}
+    assert custom == {"pair": "ADA:A:B", "lookback": "30d"}
+    assert em._custom_column(custom) == {"custom": '{"lookback": "30d", "pair": "ADA:A:B"}'}
+
+
+def test_custom_is_omitted_when_there_are_no_extra_tags():
+    from unittest.mock import patch
+
+    from qubx.emitters.questdb import QuestDBMetricEmitter
+
+    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient"):
+        em = QuestDBMetricEmitter(table_name="qubx.metrics", tags={"strategy": "s"})
+
+    _, _, custom = em._split_tags("qubx.metrics", {"strategy": "s", "type": "stats"})
+
+    assert custom == {}
+    assert em._custom_column(custom) == {}

--- a/tests/qubx/emitters/warmup_gate_test.py
+++ b/tests/qubx/emitters/warmup_gate_test.py
@@ -66,39 +66,3 @@ def test_strategy_stats_are_suppressed_during_warmup():
     em.notify(ctx)
 
     assert em.get_dataframe().empty
-
-
-def test_undeclared_tags_are_folded_into_custom():
-    """
-    A strategy tag must not become a column on the shared table.
-    """
-    from unittest.mock import patch
-
-    from qubx.emitters.questdb import QuestDBMetricEmitter
-
-    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient"):
-        em = QuestDBMetricEmitter(table_name="qubx.metrics", tags={"strategy": "s"})
-
-    symbols, columns, custom = em._split_tags(
-        "qubx.metrics",
-        {"strategy": "s", "symbol": "BTCUSDT", "is_live": True, "pair": "ADA:A:B", "lookback": "30d"},
-    )
-
-    assert symbols == {"strategy": "s", "symbol": "BTCUSDT"}
-    assert columns == {"is_live": True}
-    assert custom == {"pair": "ADA:A:B", "lookback": "30d"}
-    assert em._custom_column(custom) == {"custom": '{"lookback": "30d", "pair": "ADA:A:B"}'}
-
-
-def test_custom_is_omitted_when_there_are_no_extra_tags():
-    from unittest.mock import patch
-
-    from qubx.emitters.questdb import QuestDBMetricEmitter
-
-    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient"):
-        em = QuestDBMetricEmitter(table_name="qubx.metrics", tags={"strategy": "s"})
-
-    _, _, custom = em._split_tags("qubx.metrics", {"strategy": "s", "type": "stats"})
-
-    assert custom == {}
-    assert em._custom_column(custom) == {}

--- a/tests/qubx/emitters/warmup_gate_test.py
+++ b/tests/qubx/emitters/warmup_gate_test.py
@@ -66,3 +66,16 @@ def test_strategy_stats_are_suppressed_during_warmup():
     em.notify(ctx)
 
     assert em.get_dataframe().empty
+
+
+def test_force_emit_gets_through_the_warmup_gate():
+    # - funding payments replayed from the warmup window carry their own historical timestamp
+    em = InMemoryMetricEmitter()
+    em.set_context(_context(is_simulation=True, is_warmup=True, time="2026-08-18 15:03:00"))
+
+    em.emit("position_pnl", 1.0)
+    em.emit("funding_payment", 0.0001, timestamp=dt_64(pd.Timestamp("2026-08-18 16:00:00")), force_emit=True)
+
+    df = em.get_dataframe()
+    assert list(df["name"]) == ["funding_payment"]
+    assert list(df["timestamp"]) == [pd.Timestamp("2026-08-18 16:00:00")]

--- a/tests/qubx/emitters/warmup_gate_test.py
+++ b/tests/qubx/emitters/warmup_gate_test.py
@@ -1,0 +1,68 @@
+"""
+Warmup must not reach the metric store.
+
+Warmup rebinds the live emitter to a simulated context whose clock sits in the warmup
+window, so anything emitted there lands timestamped hours before it was written.
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from qubx.core.basics import dt_64
+from qubx.core.interfaces import IStrategyContext
+from qubx.emitters.inmemory import InMemoryMetricEmitter
+
+
+def _context(is_simulation: bool, is_warmup: bool, time: str) -> MagicMock:
+    ctx = MagicMock(spec=IStrategyContext)
+    ctx.is_simulation = is_simulation
+    ctx.is_live = not is_simulation
+    ctx.is_warmup_in_progress = is_warmup
+    ctx.is_live_or_warmup = (not is_simulation) or is_warmup
+    ctx.time.return_value = dt_64(pd.Timestamp(time))
+    return ctx
+
+
+def test_emit_is_suppressed_during_warmup():
+    em = InMemoryMetricEmitter()
+    em.set_context(_context(is_simulation=True, is_warmup=True, time="2026-08-18 15:03:00"))
+
+    em.emit("position_pnl", 1.0)
+
+    assert em.get_dataframe().empty
+
+
+def test_emit_resumes_once_warmup_finishes():
+    em = InMemoryMetricEmitter()
+    live = _context(is_simulation=False, is_warmup=False, time="2026-08-18 22:38:00")
+    em.set_context(_context(is_simulation=True, is_warmup=True, time="2026-08-18 15:03:00"))
+
+    em.emit("position_pnl", 1.0)
+    em.set_context(live)
+    em.emit("position_pnl", 2.0)
+
+    df = em.get_dataframe()
+    assert list(df["value"]) == [2.0]
+    assert list(df["timestamp"]) == [pd.Timestamp("2026-08-18 22:38:00")]
+
+
+def test_emit_still_works_in_a_plain_simulation():
+    # - a backtest is is_simulation without warmup; InMemoryMetricEmitter is used for research there
+    em = InMemoryMetricEmitter()
+    em.set_context(_context(is_simulation=True, is_warmup=False, time="2021-06-01 00:00:00"))
+
+    em.emit("position_pnl", 3.0)
+
+    assert list(em.get_dataframe()["value"]) == [3.0]
+
+
+def test_strategy_stats_are_suppressed_during_warmup():
+    em = InMemoryMetricEmitter(stats_interval="1Sec")
+    ctx = _context(is_simulation=True, is_warmup=True, time="2026-08-18 15:03:00")
+    em.notify(ctx)
+    ctx.time.return_value = dt_64(pd.Timestamp("2026-08-18 15:04:00"))
+
+    em.notify(ctx)
+
+    assert em.get_dataframe().empty

--- a/tests/qubx/utils/runner/textual_app/test_app.py
+++ b/tests/qubx/utils/runner/textual_app/test_app.py
@@ -63,7 +63,11 @@ async def test_app_bindings(tmp_path):
 
     print(f"\nBindings: {list(zip(binding_keys, binding_actions))}")
 
-    assert "q" in binding_keys, "Should have quit binding"
+    # - quit and interrupt are ctrl-prefixed: a bare key fires on terminal startup handshakes,
+    #   and ctrl+c has to stay free for Textual's copy_text
+    assert "ctrl+q" in binding_keys, "Should have quit binding"
+    assert "ctrl+k" in binding_keys, "Should have interrupt binding"
+    assert "ctrl+c" not in binding_keys, "ctrl+c must stay free for Textual's copy_text"
     assert "p" in binding_keys, "Should have positions binding"
     assert "o" in binding_keys, "Should have orders binding"
     assert "m" in binding_keys, "Should have market binding"


### PR DESCRIPTION
Every tag a strategy passed to `ctx.emitter.emit()` became a permanent column on the shared
`qubx.metrics` table, for every bot writing to that server. Prod has **29 columns**, nebula 20, a
local instance 13 — same emitter, three schemas, only 11 names in common. Eight of prod's columns
exist so that 2 of 20 bots can tag a spread leg.

Measured over 24h on prod (235.7M rows, 95 GB, 20 bots, 8.8M rows/day):

| column | rows | who writes it |
|---|---|---|
| `pair`, `long_exchange`, `short_exchange`, `long_symbol`, `short_symbol`, `side`, `long`, `short` | 92k–563k | 2 bots of 20 |
| `pool`, `scope` | 542k | rate-limit engine |
| `event_type` | 100k | health monitor |
| `lookback` | 419k | 2 bots of 20 |
| `predictor` | 2.4k | one strategy |

## What changed

- **Declared schemas.** `qubx.metrics` had no `CREATE TABLE` anywhere in Qubx — it was built entirely
  by ILP inference. It now has one, as do signals and deals. The schema is a single dict used both
  for the DDL and for the tag filter, so the two cannot drift.
- **Unknown tags go to one `custom` VARCHAR as JSON**, queryable with `json_extract` (verified on
  QuestDB 8.2.3 and 9.2.4). Note the DDL alone does not stop drift: `qubx.signals` declares 12
  columns and prod's table has 20, because the emitter spliced `**merged_tags` into the column dict
  regardless. The filter is the fix.
- **`type=health` → `qubx.health`** and **`type=rate_limit` → `qubx.rate_limits`** (long format).
  Those two streams own `event_type`, `reason`, `pool` and `scope`, which drop to zero non-null rows
  in `qubx.metrics`, and take 8.4% of daily volume with them.
- **No emission during warmup.** Warmup rebinds the live emitter to a simulated context, so its rows
  landed stamped hours in the past — measured on prod at 715k rows/day, 8.1% of traffic, one run
  writing 296,142 rows stamped up to 7h35m before it started. `force_emit=True` lets a caller opt
  back in for values carrying their own historical timestamp.
- **The five emitter tables are reserved** against `ensure_table`/`emit_record`; both would otherwise
  have overwritten the declared schema the tag filter reads. Refusal is logged, never raised.
- `table_name` → `metrics_table_name`. No config anywhere sets it (checked all 20 xrelease configs).

## Verified on a paper bot

frab `v11_dynamic_bhpl` copy against a local QuestDB, 80,711 rows: `qubx.metrics` went 13 → 15
columns, both additions declared, zero leaked. 18,420 rows carried `custom`. `qubx.health` and
`qubx.rate_limits` filled with their own columns. `is_live=false` appeared only on the two metrics
explicitly marked `force_emit`.

## Known consequence on prod

`CREATE TABLE IF NOT EXISTS` is a no-op against the existing 29-column table. So on deploy:

- the 14 columns we stop writing stay physically present and empty out under the 30-day TTL
- `custom` does not exist yet and arrives by ILP auto-create on the first write
- **any Grafana panel reading `pool`, `scope`, `event_type`, `pair` or `side` off `qubx.metrics`
  stops getting new data.** I could not see Grafana to identify which panels those are — worth
  checking before merge.

Adding a declared-but-missing column deliberately would need an `ALTER` path in `ensure_table`,
which does not exist today. Left out of this PR.

## Also included

One TUI commit (`fc47afaa`), unrelated to the emitter: bare `q` quit the app on VS Code's terminal
init string; `ctrl+c` was bound to interrupt and shadowed Textual's `copy_text`; the log pane jumped
to the tail on every write. Adds a `Filter: [E][W][I][D]` bar and a PnL readout.

## Tests

`1041 passed, 5 skipped`. New tests in `tests/qubx/emitters/questdb_schema_test.py` and
`warmup_gate_test.py`, each checked to fail without its change. `just style-check` fails identically
three commits before this branch — pre-existing findings in unrelated files.
