### PR TITLE
fix(ccxt): bound every blocking wait in the connector and make it loop-thread safe

### DIFF
--- a/src/qubx/connectors/ccxt/connection_manager.py
+++ b/src/qubx/connectors/ccxt/connection_manager.py
@@ -3,14 +3,6 @@ Connection management for CCXT data provider.
 
 This module handles WebSocket connections, retry logic, and stream lifecycle management,
 separating connection concerns from subscription state and data handling.
-
-BACKPORT HAZARD (v1.7.0 and earlier): `SubscriptionManager.lock` is safe on main only because
-no code path acquires it from the exchange event loop thread. v1.7.0's
-`CcxtAccountProcessor._subscribe_instruments` calls `SubscriptionManager.commit()` inside a
-coroutine submitted with `self._loop.submit` (`account.py:431`), i.e. ON the loop. Backporting
-the lock without first moving that `commit()` off-loop turns an off-loop `_wait` into a bounded
-stall of the whole exchange loop (~cleanup_timeout per stream, per subscription type). Move the
-poller's `commit()` off the loop in the same backport commit.
 """
 
 import asyncio
@@ -82,9 +74,8 @@ class ConnectionManager:
         self._subscription_manager = subscription_manager
         self._cleanup_timeout = cleanup_timeout
 
-        # Stream state management. A plain dict on purpose: the orchestrator inserts a key before
-        # it submits the stream task and stop_stream pops it, so membership means "this stream is
-        # meant to be running". A defaultdict would silently re-create a popped key on read.
+        # Plain dict on purpose: membership means "this stream is meant to be running", and a
+        # defaultdict would silently re-create a popped key on read.
         self._is_stream_enabled: dict[str, bool] = {}
         self._stream_to_unsubscriber: dict[str, Callable[[], Awaitable[None]]] = {}
 
@@ -121,11 +112,10 @@ class ConnectionManager:
         """
         Listen to a WebSocket stream with error handling and retry logic.
 
-        This coroutine only ever READS the stream registry. The orchestrator arms the enabled flag
-        and the unsubscriber under the subscription lock before submitting this task, so a
-        stop_stream that pops them is final: `concurrent.Future.cancel()` returning True does not
-        prevent an already-queued first step from running, and a task that writes the flag on that
-        step would resurrect a stopped stream and make is_connected() lie forever.
+        Only ever READS the stream registry: the orchestrator arms the enabled flag and the
+        unsubscriber before submitting this task. A task that wrote the flag on its first step
+        would resurrect a stream `stop_stream` already popped, because cancelling a queued future
+        does not stop that first step from running.
 
         Args:
             subscriber: Async function that handles the stream data
@@ -133,6 +123,8 @@ class ConnectionManager:
             channel: Control channel for data flow
             stream_name: Unique name for this stream
         """
+        # "Listening to" is matched literally by the BotExchangeRecreationWedged Loki alert in
+        # xlydian-platform (k8s/apps/*/loki.yaml). Do not reword this line.
         logger.info(f"<yellow>{self._exchange_id}</yellow> Listening to {stream_name}")
 
         n_retry = 0
@@ -232,20 +224,18 @@ class ConnectionManager:
         logger.debug(f"Stopping stream: {stream_name}, wait={wait}")
 
         if wait and self._on_exchange_loop_thread():
-            # Blocking here would park the exchange loop on a coroutine that only that same loop
-            # can run - the self-deadlock that froze a live bot for 18 days on 2026-07-28. Never
-            # raise for this: callers up the synchronous subscription pipeline treat an exception
-            # as a fault and would kill their own poller.
+            # Blocking here would park the exchange loop on a coroutine only that loop can run.
+            # Degrade rather than raise: callers up the synchronous subscription pipeline treat an
+            # exception as a fault and would kill their own poller.
             logger.info(
                 f"[{self._exchange_id}] stop_stream({stream_name}) called from the exchange loop thread - "
                 "degrading to non-blocking cleanup"
             )
             wait = False
 
-        # Tear the registry down before any blocking wait: a wait that times out must not leave a
+        # Tear the registry down before any blocking wait, so a wait that times out cannot leave a
         # half-removed stream behind. Popping _is_stream_enabled is the stop signal the listen loop
-        # reads - it treats a missing key as False without reinserting it, so the dict holds exactly
-        # the live streams and is_connected() cannot report a stopped stream as connected.
+        # reads, and it is what is_connected() reports on.
         stream_future = self._stream_to_coro.pop(stream_name, None)
         unsubscriber = self._stream_to_unsubscriber.pop(stream_name, None)
         self._is_stream_enabled.pop(stream_name, None)
@@ -262,10 +252,9 @@ class ConnectionManager:
             unsub_task = self._loop.submit(unsubscriber())
             if wait and self._wait(unsub_task, f"unsubscriber for {stream_name}"):
                 # Grace period so the venue acks the unsubscribe before a new subscription reuses
-                # the same hashes. Plain wall-clock - the guarantee is elapsed time, and routing it
-                # through the loop only adds a second thing that can block. Skipped entirely when
-                # the unsubscribe wait timed out: no ack is coming, and waiting again for a loop
-                # that is already not answering just doubles the stall.
+                # the same hashes. Plain wall-clock, not routed through the loop, which would add a
+                # second thing that can block. Skipped when the unsubscribe wait timed out: no ack
+                # is coming from a loop that is already not answering.
                 time.sleep(1)
         else:
             logger.debug(f"No unsubscriber found for {stream_name}")
@@ -384,9 +373,8 @@ class ConnectionManager:
         including when it completed by raising, which callers treat as "the loop answered".
         """
         # A future from asyncio.run_coroutine_threadsafe goes PENDING -> FINISHED/CANCELLED and is
-        # NEVER in RUNNING state, so the `while future.running()` poll this replaced executed zero
-        # iterations, its timeout WARNING was unreachable, and every call fell into an unbounded
-        # result(). Do not reintroduce running() here.
+        # never RUNNING, so a `while future.running()` poll never loops and any timeout built on it
+        # is dead code. Do not reintroduce running() here.
         try:
             future.result(timeout=self._cleanup_timeout)
         except concurrent.futures.TimeoutError:

--- a/src/qubx/connectors/ccxt/connection_manager.py
+++ b/src/qubx/connectors/ccxt/connection_manager.py
@@ -7,7 +7,6 @@ separating connection concerns from subscription state and data handling.
 
 import asyncio
 import concurrent.futures
-import time
 from asyncio.exceptions import CancelledError
 from collections import defaultdict
 from typing import Awaitable, Callable
@@ -56,6 +55,9 @@ class ConnectionManager:
     - Implement retry logic and error handling
     - Manage stream lifecycle (start, stop, cleanup)
     - Coordinate with SubscriptionManager for state updates
+
+    Invariant: nothing here may block a thread on the exchange event loop without a bound, and
+    nothing running *on* that loop may block waiting for it.
     """
 
     def __init__(
@@ -83,6 +85,16 @@ class ConnectionManager:
     def _loop(self) -> AsyncThreadLoop:
         """Get current AsyncThreadLoop from exchange manager."""
         return AsyncThreadLoop(self._exchange_manager.exchange.asyncio_loop)
+
+    def _on_exchange_loop_thread(self) -> bool:
+        """True when the caller is running *on* the exchange event loop.
+
+        Anything that blocks waiting for that loop from this thread deadlocks the loop on itself.
+        """
+        try:
+            return asyncio.get_running_loop() is self._exchange_manager.exchange.asyncio_loop
+        except RuntimeError:
+            return False
 
     def set_subscription_manager(self, subscription_manager: SubscriptionManager) -> None:
         """Set the subscription manager for state coordination."""
@@ -211,30 +223,41 @@ class ConnectionManager:
 
         logger.debug(f"Stopping stream: {stream_name}, wait={wait}")
 
-        self._is_stream_enabled[stream_name] = False
+        if wait and self._on_exchange_loop_thread():
+            # Blocking here would park the exchange loop on a coroutine that only that same loop
+            # can run - the self-deadlock that froze a live bot for 18 days on 2026-07-28. Never
+            # raise for this: callers up the synchronous subscription pipeline treat an exception
+            # as a fault and would kill their own poller.
+            logger.info(
+                f"[{self._exchange_id}] stop_stream({stream_name}) called from the exchange loop thread - "
+                "degrading to non-blocking cleanup"
+            )
+            wait = False
 
-        stream_future = self.get_stream_future(stream_name)
-        if stream_future:
+        # Tear the registry down before any blocking wait: a wait that times out must not leave a
+        # half-removed stream behind. Popping _is_stream_enabled is the stop signal the listen loop
+        # reads - the defaultdict yields False for a missing key.
+        stream_future = self._stream_to_coro.pop(stream_name, None)
+        unsubscriber = self._stream_to_unsubscriber.pop(stream_name, None)
+        self._is_stream_enabled.pop(stream_name, None)
+
+        if stream_future is not None:
             stream_future.cancel()
             if wait:
                 self._wait(stream_future, stream_name)
         else:
             logger.warning(f"[CONNECTION] No stream future found for {stream_name}")
 
-        unsubscriber = self.get_stream_unsubscriber(stream_name)
-        if unsubscriber:
+        if unsubscriber is not None:
             logger.debug(f"Calling unsubscriber for {stream_name}")
             unsub_task = self._loop.submit(unsubscriber())
             if wait:
                 self._wait(unsub_task, f"unsubscriber for {stream_name}")
-                # Wait for 1 second just in case
-                self._loop.submit(asyncio.sleep(1)).result()
+                # Grace period so the venue acks the unsubscribe before a new subscription reuses
+                # the same hashes. Bounded like every other wait here.
+                self._wait(self._loop.submit(asyncio.sleep(1)), f"unsubscribe grace period for {stream_name}")
         else:
             logger.debug(f"No unsubscriber found for {stream_name}")
-
-        self._is_stream_enabled.pop(stream_name, None)
-        self._stream_to_coro.pop(stream_name, None)
-        self._stream_to_unsubscriber.pop(stream_name, None)
 
     def register_stream_future(self, stream_name: str, future: concurrent.futures.Future) -> None:
         """
@@ -334,21 +357,29 @@ class ConnectionManager:
             stream_name: Name of the stream for logging
         """
         try:
-            future.result()  # Retrieve result to handle any exceptions
-        except Exception:
-            pass  # Silent handling to prevent "Future exception was never retrieved"
+            future.result(timeout=0)  # the future is done here, this only re-raises
+        except concurrent.futures.CancelledError:
+            return
+        except BaseException as e:  # noqa: BLE001 - a done-callback must never propagate onto the loop
+            if self._is_stream_enabled.get(stream_name, False):
+                logger.warning(f"[{self._exchange_id}] {stream_name} stopped while still subscribed: {e!r}")
+            else:
+                logger.debug(f"[{self._exchange_id}] {stream_name} finished with {e!r}")
 
     def _wait(self, future: concurrent.futures.Future, context: str) -> None:
         """Wait for future completion with timeout and exception handling."""
-        start_wait = time.time()
-        while future.running() and (time.time() - start_wait) < self._cleanup_timeout:
-            time.sleep(0.1)
-
-        if future.running():
-            logger.warning(f"[{self._exchange_id}] {context} still running after {self._cleanup_timeout}s timeout")
-        else:
-            # Always retrieve result to handle exceptions properly and prevent "Future exception was never retrieved"
-            try:
-                future.result()  # This will raise any exception that occurred
-            except Exception:
-                pass  # Silent handling during cleanup - UnsubscribeError is expected
+        # A future from asyncio.run_coroutine_threadsafe goes PENDING -> FINISHED/CANCELLED and is
+        # NEVER in RUNNING state, so the `while future.running()` poll this replaced executed zero
+        # iterations, its timeout WARNING was unreachable, and every call fell into an unbounded
+        # result(). Do not reintroduce running() here.
+        try:
+            future.result(timeout=self._cleanup_timeout)
+        except concurrent.futures.TimeoutError:
+            # Must precede `except Exception` - TimeoutError is an Exception subclass. The abandoned
+            # coroutine keeps running on the loop; we only stop waiting for it.
+            logger.warning(
+                f"[{self._exchange_id}] {context} did not complete in {self._cleanup_timeout}s - abandoning it"
+            )
+            future.cancel()
+        except Exception as e:
+            logger.debug(f"[{self._exchange_id}] {context} finished with {e!r}")

--- a/src/qubx/connectors/ccxt/connection_manager.py
+++ b/src/qubx/connectors/ccxt/connection_manager.py
@@ -130,7 +130,7 @@ class ConnectionManager:
         n_retry = 0
         connection_established = False
 
-        while channel.control.is_set() and self._is_stream_enabled[stream_name]:
+        while channel.control.is_set() and self._is_stream_enabled.get(stream_name, False):
             try:
                 await subscriber()
                 n_retry = 0  # Reset retry counter on success
@@ -141,7 +141,7 @@ class ConnectionManager:
                     connection_established = True
 
                 # Check if stream was disabled during subscriber execution
-                if not self._is_stream_enabled[stream_name]:
+                if not self._is_stream_enabled.get(stream_name, False):
                     break
 
             except CcxtSymbolNotRecognized:
@@ -188,7 +188,7 @@ class ConnectionManager:
                 continue
             except Exception as e:
                 # Unexpected errors
-                if not channel.control.is_set() or not self._is_stream_enabled[stream_name]:
+                if not channel.control.is_set() or not self._is_stream_enabled.get(stream_name, False):
                     # Channel closed or stream disabled, exit gracefully
                     break
 
@@ -236,7 +236,8 @@ class ConnectionManager:
 
         # Tear the registry down before any blocking wait: a wait that times out must not leave a
         # half-removed stream behind. Popping _is_stream_enabled is the stop signal the listen loop
-        # reads - the defaultdict yields False for a missing key.
+        # reads - it treats a missing key as False without reinserting it, so the dict holds exactly
+        # the live streams and is_connected() cannot report a stopped stream as connected.
         stream_future = self._stream_to_coro.pop(stream_name, None)
         unsubscriber = self._stream_to_unsubscriber.pop(stream_name, None)
         self._is_stream_enabled.pop(stream_name, None)

--- a/src/qubx/connectors/ccxt/connection_manager.py
+++ b/src/qubx/connectors/ccxt/connection_manager.py
@@ -3,12 +3,20 @@ Connection management for CCXT data provider.
 
 This module handles WebSocket connections, retry logic, and stream lifecycle management,
 separating connection concerns from subscription state and data handling.
+
+BACKPORT HAZARD (v1.7.0 and earlier): `SubscriptionManager.lock` is safe on main only because
+no code path acquires it from the exchange event loop thread. v1.7.0's
+`CcxtAccountProcessor._subscribe_instruments` calls `SubscriptionManager.commit()` inside a
+coroutine submitted with `self._loop.submit` (`account.py:431`), i.e. ON the loop. Backporting
+the lock without first moving that `commit()` off-loop turns an off-loop `_wait` into a bounded
+stall of the whole exchange loop (~cleanup_timeout per stream, per subscription type). Move the
+poller's `commit()` off the loop in the same backport commit.
 """
 
 import asyncio
 import concurrent.futures
+import time
 from asyncio.exceptions import CancelledError
-from collections import defaultdict
 from typing import Awaitable, Callable
 
 from ccxt import (
@@ -74,8 +82,10 @@ class ConnectionManager:
         self._subscription_manager = subscription_manager
         self._cleanup_timeout = cleanup_timeout
 
-        # Stream state management
-        self._is_stream_enabled: dict[str, bool] = defaultdict(lambda: False)
+        # Stream state management. A plain dict on purpose: the orchestrator inserts a key before
+        # it submits the stream task and stop_stream pops it, so membership means "this stream is
+        # meant to be running". A defaultdict would silently re-create a popped key on read.
+        self._is_stream_enabled: dict[str, bool] = {}
         self._stream_to_unsubscriber: dict[str, Callable[[], Awaitable[None]]] = {}
 
         # Connection tracking
@@ -107,26 +117,24 @@ class ConnectionManager:
         channel: CtrlChannel,
         subscription_type: str,
         stream_name: str,
-        unsubscriber: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         """
         Listen to a WebSocket stream with error handling and retry logic.
+
+        This coroutine only ever READS the stream registry. The orchestrator arms the enabled flag
+        and the unsubscriber under the subscription lock before submitting this task, so a
+        stop_stream that pops them is final: `concurrent.Future.cancel()` returning True does not
+        prevent an already-queued first step from running, and a task that writes the flag on that
+        step would resurrect a stopped stream and make is_connected() lie forever.
 
         Args:
             subscriber: Async function that handles the stream data
             exchange: CCXT exchange instance
             channel: Control channel for data flow
             stream_name: Unique name for this stream
-            unsubscriber: Optional cleanup function for graceful unsubscription
         """
         logger.info(f"<yellow>{self._exchange_id}</yellow> Listening to {stream_name}")
 
-        # Register unsubscriber for cleanup
-        if unsubscriber is not None:
-            self._stream_to_unsubscriber[stream_name] = unsubscriber
-
-        # Enable the stream
-        self._is_stream_enabled[stream_name] = True
         n_retry = 0
         connection_established = False
 
@@ -252,11 +260,13 @@ class ConnectionManager:
         if unsubscriber is not None:
             logger.debug(f"Calling unsubscriber for {stream_name}")
             unsub_task = self._loop.submit(unsubscriber())
-            if wait:
-                self._wait(unsub_task, f"unsubscriber for {stream_name}")
+            if wait and self._wait(unsub_task, f"unsubscriber for {stream_name}"):
                 # Grace period so the venue acks the unsubscribe before a new subscription reuses
-                # the same hashes. Bounded like every other wait here.
-                self._wait(self._loop.submit(asyncio.sleep(1)), f"unsubscribe grace period for {stream_name}")
+                # the same hashes. Plain wall-clock - the guarantee is elapsed time, and routing it
+                # through the loop only adds a second thing that can block. Skipped entirely when
+                # the unsubscribe wait timed out: no ack is coming, and waiting again for a loop
+                # that is already not answering just doubles the stall.
+                time.sleep(1)
         else:
             logger.debug(f"No unsubscriber found for {stream_name}")
 
@@ -367,8 +377,12 @@ class ConnectionManager:
             else:
                 logger.debug(f"[{self._exchange_id}] {stream_name} finished with {e!r}")
 
-    def _wait(self, future: concurrent.futures.Future, context: str) -> None:
-        """Wait for future completion with timeout and exception handling."""
+    def _wait(self, future: concurrent.futures.Future, context: str) -> bool:
+        """Wait for future completion with timeout and exception handling.
+
+        Returns False iff the wait timed out (the coroutine was abandoned), True otherwise -
+        including when it completed by raising, which callers treat as "the loop answered".
+        """
         # A future from asyncio.run_coroutine_threadsafe goes PENDING -> FINISHED/CANCELLED and is
         # NEVER in RUNNING state, so the `while future.running()` poll this replaced executed zero
         # iterations, its timeout WARNING was unreachable, and every call fell into an unbounded
@@ -382,5 +396,7 @@ class ConnectionManager:
                 f"[{self._exchange_id}] {context} did not complete in {self._cleanup_timeout}s - abandoning it"
             )
             future.cancel()
+            return False
         except Exception as e:
             logger.debug(f"[{self._exchange_id}] {context} finished with {e!r}")
+        return True

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -251,7 +251,13 @@ class CcxtConnector(ChannelEmitter):
         Always bounded, and routed through ``run_sync`` so being called from the exchange loop's
         own thread raises instead of parking that loop on itself.
         """
-        return self._loop.run_sync(coro, timeout=DEFAULT_VENUE_CALL_TIMEOUT_SECONDS if timeout is None else timeout)
+        try:
+            return self._loop.run_sync(coro, timeout=DEFAULT_VENUE_CALL_TIMEOUT_SECONDS if timeout is None else timeout)
+        except RuntimeError:
+            # The loop-thread guard (or a closed loop) rejected before the coroutine was ever
+            # awaited; close it so it does not surface as "coroutine was never awaited".
+            coro.close()
+            raise
 
     async def _acquire_endpoint_budget(self, endpoint: str) -> None:
         """Charge whatever budget this endpoint draws beyond IP weight, which the throttle already took."""

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -104,6 +104,9 @@ from .utils import (
 # venue call it is treated as a venue verdict and emitted.)
 # How often the connector re-reads the venue's configured / maximum leverage.
 LEVERAGE_REFRESH_INTERVAL_S = 3600.0
+# Default bound for the synchronous venue calls below. An unbounded wait on the exchange
+# loop from the strategy/account thread is the deadlock this connector must never allow.
+DEFAULT_VENUE_CALL_TIMEOUT_SECONDS = 15.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -229,7 +232,7 @@ class CcxtConnector(ChannelEmitter):
 
     def _log_spawn_error(self, future: Any) -> None:
         try:
-            exc = future.exception()
+            exc = future.exception()  # unbounded-result-ok: done-callback, the future is finished
         except Exception:  # noqa: BLE001 — cancelled/loop-teardown; nothing to surface
             return
         if exc is not None:
@@ -244,8 +247,11 @@ class CcxtConnector(ChannelEmitter):
         Used by the synchronous leverage / margin / disconnect paths. Factored
         out (mirroring ``_spawn``) so tests can drive the coroutine without a
         real loop/thread boundary.
+
+        Always bounded, and routed through ``run_sync`` so being called from the exchange loop's
+        own thread raises instead of parking that loop on itself.
         """
-        return self._loop.submit(coro).result(timeout=timeout)
+        return self._loop.run_sync(coro, timeout=DEFAULT_VENUE_CALL_TIMEOUT_SECONDS if timeout is None else timeout)
 
     async def _acquire_endpoint_budget(self, endpoint: str) -> None:
         """Charge whatever budget this endpoint draws beyond IP weight, which the throttle already took."""

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -133,56 +133,60 @@ class CcxtDataProvider(IDataProvider):
             # In case of no instruments, do nothing, unsubscribe should handle this case
             return
 
-        # Delegate to subscription manager for state management
-        _updated_instruments = self._subscription_manager.add_subscription(subscription_type, instruments, reset)
+        # The instrument set and the stream that serves it must move together - see
+        # SubscriptionManager.lock.
+        with self._subscription_manager.lock:
+            # Delegate to subscription manager for state management
+            _updated_instruments = self._subscription_manager.add_subscription(subscription_type, instruments, reset)
 
-        # Get handler from factory
-        _sub_type, _params = DataType.from_str(subscription_type)
-        handler = self._data_type_handler_factory.get_handler(_sub_type)
-        if handler is None:
-            raise ValueError(f"{self._exchange_id}: Subscription type {subscription_type} is not supported")
+            # Get handler from factory
+            _sub_type, _params = DataType.from_str(subscription_type)
+            handler = self._data_type_handler_factory.get_handler(_sub_type)
+            if handler is None:
+                raise ValueError(f"{self._exchange_id}: Subscription type {subscription_type} is not supported")
 
-        # Delegate to orchestrator for complex subscription logic (clean facade pattern)
-        self._subscription_orchestrator.execute_subscription(
-            subscription_type=subscription_type,
-            instruments=_updated_instruments,
-            handler=handler,
-            exchange=self._exchange_manager.exchange,
-            channel=self.channel,
-            **_params,
-        )
+            # Delegate to orchestrator for complex subscription logic (clean facade pattern)
+            self._subscription_orchestrator.execute_subscription(
+                subscription_type=subscription_type,
+                instruments=_updated_instruments,
+                handler=handler,
+                exchange=self._exchange_manager.exchange,
+                channel=self.channel,
+                **_params,
+            )
 
     def unsubscribe(self, subscription_type: str, instruments: list[Instrument]) -> None:
         """Unsubscribe from instruments and handle partial/complete unsubscription."""
-        # Get current instruments before removal (check both active and pending)
-        current_instruments = set(self._subscription_manager.get_subscribed_instruments(subscription_type))
+        with self._subscription_manager.lock:
+            # Get current instruments before removal (check both active and pending)
+            current_instruments = set(self._subscription_manager.get_subscribed_instruments(subscription_type))
 
-        # Early exit if no subscription exists
-        if not current_instruments:
-            logger.debug(f"No active subscription for {subscription_type}")
-            return
+            # Early exit if no subscription exists
+            if not current_instruments:
+                logger.debug(f"No active subscription for {subscription_type}")
+                return
 
-        # Remove instruments from subscription manager
-        self._subscription_manager.remove_subscription(subscription_type, instruments)
+            # Remove instruments from subscription manager
+            self._subscription_manager.remove_subscription(subscription_type, instruments)
 
-        # Get remaining instruments after removal
-        remaining_instruments = set(self._subscription_manager.get_subscribed_instruments(subscription_type))
+            # Get remaining instruments after removal
+            remaining_instruments = set(self._subscription_manager.get_subscribed_instruments(subscription_type))
 
-        if not remaining_instruments:
-            # Complete unsubscription - no instruments left
-            config = SubscriptionConfiguration(
-                subscription_type=subscription_type,
-                channel=self.channel,
-                stream_name=f"cleanup_{subscription_type}",
-            )
-            self._subscription_orchestrator.execute_unsubscription(config)
-        elif remaining_instruments != current_instruments:
-            # Partial unsubscription - resubscribe with remaining instruments
-            logger.info(
-                f"Partial unsubscription for {subscription_type}, resubscribing with {len(remaining_instruments)} instruments"
-            )
-            # important to update subscription manager
-            self.subscribe(subscription_type, list(remaining_instruments), reset=True)
+            if not remaining_instruments:
+                # Complete unsubscription - no instruments left
+                config = SubscriptionConfiguration(
+                    subscription_type=subscription_type,
+                    channel=self.channel,
+                    stream_name=f"cleanup_{subscription_type}",
+                )
+                self._subscription_orchestrator.execute_unsubscription(config)
+            elif remaining_instruments != current_instruments:
+                # Partial unsubscription - resubscribe with remaining instruments
+                logger.info(
+                    f"Partial unsubscription for {subscription_type}, resubscribing with {len(remaining_instruments)} instruments"
+                )
+                # important to update subscription manager
+                self.subscribe(subscription_type, list(remaining_instruments), reset=True)
 
     def get_subscriptions(self, instrument: Instrument | None = None) -> list[str]:
         """Get list of active subscription types (delegated to subscription manager)."""

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -133,9 +133,7 @@ class CcxtDataProvider(IDataProvider):
             # In case of no instruments, do nothing, unsubscribe should handle this case
             return
 
-        # The instrument set and the stream that serves it must move together - see
-        # SubscriptionManager.lock.
-        with self._subscription_manager.lock:
+        with self._subscription_manager.transition():
             # Delegate to subscription manager for state management
             _updated_instruments = self._subscription_manager.add_subscription(subscription_type, instruments, reset)
 
@@ -157,7 +155,7 @@ class CcxtDataProvider(IDataProvider):
 
     def unsubscribe(self, subscription_type: str, instruments: list[Instrument]) -> None:
         """Unsubscribe from instruments and handle partial/complete unsubscription."""
-        with self._subscription_manager.lock:
+        with self._subscription_manager.transition():
             # Get current instruments before removal (check both active and pending)
             current_instruments = set(self._subscription_manager.get_subscribed_instruments(subscription_type))
 

--- a/src/qubx/connectors/ccxt/data.py
+++ b/src/qubx/connectors/ccxt/data.py
@@ -19,6 +19,8 @@ from .subscription_manager import SubscriptionManager
 from .subscription_orchestrator import SubscriptionOrchestrator
 from .warmup_service import WarmupService
 
+MARKETS_LOAD_TIMEOUT_SECONDS = 60.0
+
 
 class CcxtDataProvider(IDataProvider):
     time_provider: ITimeProvider
@@ -227,7 +229,8 @@ class CcxtDataProvider(IDataProvider):
         # initial set_universe (in paper mode no account processor loads them). ccxt
         # caches markets, so this is idempotent with the account processor's load.
         try:
-            self._loop.submit(self._exchange_manager.exchange.load_markets()).result()
+            # Bounded: a hang here wedges startup with no diagnostic at all.
+            self._loop.run_sync(self._exchange_manager.exchange.load_markets(), timeout=MARKETS_LOAD_TIMEOUT_SECONDS)
             logger.info(
                 f"<yellow>{self._exchange_id}</yellow> Markets loaded "
                 f"({len(self._exchange_manager.exchange.markets or {})})"

--- a/src/qubx/connectors/ccxt/exchanges/base.py
+++ b/src/qubx/connectors/ccxt/exchanges/base.py
@@ -36,7 +36,7 @@ class CcxtFuturePatchMixin:
             task = asyncio.create_task(coro)
             
             def callback(done):
-                complete, _ = done.result()
+                complete, _ = done.result()  # unbounded-result-ok: asyncio Future has no timeout param
                 # Check for exceptions
                 exceptions = []
                 cancelled = False
@@ -44,7 +44,7 @@ class CcxtFuturePatchMixin:
                     if f.cancelled():
                         cancelled = True
                     else:
-                        err = f.exception()
+                        err = f.exception()  # unbounded-result-ok: asyncio Future, already complete
                         if err:
                             exceptions.append(err)
                 
@@ -59,7 +59,7 @@ class CcxtFuturePatchMixin:
                 elif cancelled:
                     future.cancel()
                 else:
-                    first_result = list(complete)[0].result()
+                    first_result = list(complete)[0].result()  # unbounded-result-ok: asyncio Future
                     future.set_result(first_result)
             
             task.add_done_callback(callback)

--- a/src/qubx/connectors/ccxt/handlers/base.py
+++ b/src/qubx/connectors/ccxt/handlers/base.py
@@ -66,13 +66,11 @@ class BaseDataTypeHandler(IDataTypeHandler):
 
     Handles common CCXT operations and provides helper methods for data conversion.
 
-    Convention for `prepare_subscription` implementations: bind `exchange =
-    self._exchange_manager.exchange` ONCE at prepare time and close over that local, instead of
-    reading `self._exchange_manager.exchange` inside the subscriber/unsubscriber closures.
-    Exchange recreation swaps the attribute, so a late-bound unsubscriber is aimed at an exchange
-    the stream was never established on and can only ever time out. (Late binding IS correct in
-    `warmup` / `get_historical_ohlc`, which are one-shot REST calls that should use whatever
-    exchange is current, and in the `open_interest` REST poller, which has no unsubscriber.)
+    Convention for `prepare_subscription`: bind `exchange = self._exchange_manager.exchange` once
+    at prepare time and close over that local. Exchange recreation swaps the attribute, so a
+    late-bound unsubscriber targets an exchange the stream was never established on and can only
+    time out. One-shot REST paths (`warmup`, `get_historical_ohlc`, the open_interest poller) read
+    the attribute late on purpose - they should follow recreation.
     """
 
     def __init__(self, data_provider, exchange_manager: ExchangeManager, exchange_id: str):

--- a/src/qubx/connectors/ccxt/handlers/base.py
+++ b/src/qubx/connectors/ccxt/handlers/base.py
@@ -65,6 +65,14 @@ class BaseDataTypeHandler(IDataTypeHandler):
     Base implementation providing common functionality for data type handlers.
 
     Handles common CCXT operations and provides helper methods for data conversion.
+
+    Convention for `prepare_subscription` implementations: bind `exchange =
+    self._exchange_manager.exchange` ONCE at prepare time and close over that local, instead of
+    reading `self._exchange_manager.exchange` inside the subscriber/unsubscriber closures.
+    Exchange recreation swaps the attribute, so a late-bound unsubscriber is aimed at an exchange
+    the stream was never established on and can only ever time out. (Late binding IS correct in
+    `warmup` / `get_historical_ohlc`, which are one-shot REST calls that should use whatever
+    exchange is current, and in the `open_interest` REST poller, which has no unsubscriber.)
     """
 
     def __init__(self, data_provider, exchange_manager: ExchangeManager, exchange_id: str):

--- a/src/qubx/connectors/ccxt/handlers/funding_rate.py
+++ b/src/qubx/connectors/ccxt/handlers/funding_rate.py
@@ -40,9 +40,6 @@ class FundingRateDataHandler(BaseDataTypeHandler):
         Both funding_rate and funding_payment subscriptions use the same underlying
         WebSocket stream and emit both data types when appropriate.
         """
-        # Bind the exchange here, not inside the closures: recreation swaps
-        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
-        # a different exchange than the one the stream was established on.
         exchange = self._exchange_manager.exchange
         # Convert to CCXT symbols
         symbols = [instrument_to_ccxt_symbol(instr) for instr in instruments]

--- a/src/qubx/connectors/ccxt/handlers/funding_rate.py
+++ b/src/qubx/connectors/ccxt/handlers/funding_rate.py
@@ -40,6 +40,10 @@ class FundingRateDataHandler(BaseDataTypeHandler):
         Both funding_rate and funding_payment subscriptions use the same underlying
         WebSocket stream and emit both data types when appropriate.
         """
+        # Bind the exchange here, not inside the closures: recreation swaps
+        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
+        # a different exchange than the one the stream was established on.
+        exchange = self._exchange_manager.exchange
         # Convert to CCXT symbols
         symbols = [instrument_to_ccxt_symbol(instr) for instr in instruments]
         if _params.pop("__all__", False):
@@ -49,9 +53,9 @@ class FundingRateDataHandler(BaseDataTypeHandler):
             """Unified subscriber that handles both funding rates and payments."""
             try:
                 if _params:
-                    funding_rates = await self._exchange_manager.exchange.watch_funding_rates(symbols, _params)  # type: ignore
+                    funding_rates = await exchange.watch_funding_rates(symbols, _params)  # type: ignore
                 else:
-                    funding_rates = await self._exchange_manager.exchange.watch_funding_rates(symbols)  # type: ignore
+                    funding_rates = await exchange.watch_funding_rates(symbols)  # type: ignore
 
                 current_time = self._data_provider.time_provider.time()
 
@@ -59,7 +63,7 @@ class FundingRateDataHandler(BaseDataTypeHandler):
                 if funding_rates:
                     for symbol, info in funding_rates.items():
                         try:
-                            instrument = ccxt_find_instrument(symbol, self._exchange_manager.exchange)
+                            instrument = ccxt_find_instrument(symbol, exchange)
                             funding_rate = ccxt_convert_funding_rate(info)
 
                             channel.send((instrument, DataType.FUNDING_RATE, funding_rate, False))
@@ -78,7 +82,7 @@ class FundingRateDataHandler(BaseDataTypeHandler):
 
         async def cleanup_funding():
             """Simple cleanup - just call exchange unwatch if available."""
-            unwatch_func = getattr(self._exchange_manager.exchange, "un_watch_funding_rates", None)
+            unwatch_func = getattr(exchange, "un_watch_funding_rates", None)
             if unwatch_func and callable(unwatch_func):
                 try:
                     unwatch_result = unwatch_func()

--- a/src/qubx/connectors/ccxt/handlers/liquidation.py
+++ b/src/qubx/connectors/ccxt/handlers/liquidation.py
@@ -40,19 +40,21 @@ class LiquidationDataHandler(BaseDataTypeHandler):
         Returns:
             SubscriptionConfiguration with subscriber and unsubscriber functions
         """
+        # Bind the exchange here, not inside the closures: recreation swaps
+        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
+        # a different exchange than the one the stream was established on.
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}
 
         async def watch_liquidation(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
-            liquidations = await self._exchange_manager.exchange.watch_liquidations_for_symbols(symbols)
+            liquidations = await exchange.watch_liquidations_for_symbols(symbols)
 
             for liquidation in liquidations:
                 try:
                     exch_symbol = liquidation["symbol"]
-                    instrument = ccxt_find_instrument(
-                        exch_symbol, self._exchange_manager.exchange, _symbol_to_instrument
-                    )
+                    instrument = ccxt_find_instrument(exch_symbol, exchange, _symbol_to_instrument)
                     liquidation_event = ccxt_convert_liquidation(liquidation)
 
                     channel.send((instrument, sub_type, liquidation_event, False))
@@ -63,9 +65,7 @@ class LiquidationDataHandler(BaseDataTypeHandler):
 
         async def un_watch_liquidation(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
-            unwatch = getattr(self._exchange_manager.exchange, "un_watch_liquidations_for_symbols", lambda _: None)(
-                symbols
-            )
+            unwatch = getattr(exchange, "un_watch_liquidations_for_symbols", lambda _: None)(symbols)
             if unwatch is not None:
                 await unwatch
 

--- a/src/qubx/connectors/ccxt/handlers/liquidation.py
+++ b/src/qubx/connectors/ccxt/handlers/liquidation.py
@@ -40,9 +40,6 @@ class LiquidationDataHandler(BaseDataTypeHandler):
         Returns:
             SubscriptionConfiguration with subscriber and unsubscriber functions
         """
-        # Bind the exchange here, not inside the closures: recreation swaps
-        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
-        # a different exchange than the one the stream was established on.
         exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}

--- a/src/qubx/connectors/ccxt/handlers/ohlc.py
+++ b/src/qubx/connectors/ccxt/handlers/ohlc.py
@@ -206,9 +206,6 @@ class OhlcDataHandler(BaseDataTypeHandler):
         """
         Prepare bulk OHLCV subscriptions when exchange supports bulk watching.
         """
-        # Bind the exchange here, not inside the closures: recreation swaps
-        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
-        # a different exchange than the one the stream was established on.
         exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}

--- a/src/qubx/connectors/ccxt/handlers/ohlc.py
+++ b/src/qubx/connectors/ccxt/handlers/ohlc.py
@@ -206,6 +206,10 @@ class OhlcDataHandler(BaseDataTypeHandler):
         """
         Prepare bulk OHLCV subscriptions when exchange supports bulk watching.
         """
+        # Bind the exchange here, not inside the closures: recreation swaps
+        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
+        # a different exchange than the one the stream was established on.
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}
         _exchange_timeframe = self._data_provider._get_exch_timeframe(timeframe)
@@ -213,13 +217,11 @@ class OhlcDataHandler(BaseDataTypeHandler):
         async def watch_ohlcv(instruments_batch: list[Instrument]):
             _symbol_timeframe_pairs = [[_instr_to_ccxt_symbol[i], _exchange_timeframe] for i in instruments_batch]
             try:
-                ohlcv = await self._exchange_manager.exchange.watch_ohlcv_for_symbols(_symbol_timeframe_pairs)
+                ohlcv = await exchange.watch_ohlcv_for_symbols(_symbol_timeframe_pairs)
 
                 # ohlcv is symbol -> timeframe -> list[timestamp, open, high, low, close, volume]
                 for exch_symbol, _data in ohlcv.items():
-                    instrument = ccxt_find_instrument(
-                        exch_symbol, self._exchange_manager.exchange, _symbol_to_instrument
-                    )
+                    instrument = ccxt_find_instrument(exch_symbol, exchange, _symbol_to_instrument)
                     for _, ohlcvs in _data.items():
                         for oh in ohlcvs:
                             # Use private processing method to avoid duplication
@@ -252,11 +254,11 @@ class OhlcDataHandler(BaseDataTypeHandler):
 
         async def un_watch_ohlcv(instruments_batch: list[Instrument]):
             symbol_timeframe_pairs = [[_instr_to_ccxt_symbol[i], _exchange_timeframe] for i in instruments_batch]
-            if hasattr(self._exchange_manager.exchange, "un_watch_ohlcv_for_symbols"):
+            if hasattr(exchange, "un_watch_ohlcv_for_symbols"):
                 try:
                     # Wrap the unsubscription call with timeout to prevent hanging
                     result = await asyncio.wait_for(
-                        self._exchange_manager.exchange.un_watch_ohlcv_for_symbols(symbol_timeframe_pairs), timeout=5.0
+                        exchange.un_watch_ohlcv_for_symbols(symbol_timeframe_pairs), timeout=5.0
                     )
                     logger.debug(
                         f"<yellow>{self._exchange_id}</yellow> Successfully unsubscribed from {len(instruments_batch)} instruments"
@@ -292,6 +294,7 @@ class OhlcDataHandler(BaseDataTypeHandler):
         Creates separate subscriber functions for each instrument to enable independent
         WebSocket streams without waiting for all instruments.
         """
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _exchange_timeframe = self._data_provider._get_exch_timeframe(timeframe)
 
@@ -307,7 +310,7 @@ class OhlcDataHandler(BaseDataTypeHandler):
                     while True:
                         try:
                             # Watch OHLCV for single instrument
-                            ohlcv_data = await self._exchange_manager.exchange.watch_ohlcv(symbol, _exchange_timeframe)
+                            ohlcv_data = await exchange.watch_ohlcv(symbol, _exchange_timeframe)
 
                             # Process the OHLCV data using private method
                             if ohlcv_data:
@@ -329,14 +332,12 @@ class OhlcDataHandler(BaseDataTypeHandler):
             individual_subscribers[instrument] = create_individual_subscriber()
 
             # Create individual unsubscriber if exchange supports it
-            if hasattr(self._exchange_manager.exchange, "un_watch_ohlcv") and callable(
-                getattr(self._exchange_manager.exchange, "un_watch_ohlcv", None)
-            ):
+            if hasattr(exchange, "un_watch_ohlcv") and callable(getattr(exchange, "un_watch_ohlcv", None)):
 
                 def create_individual_unsubscriber(symbol=ccxt_symbol, exchange_id=self._exchange_id):
                     async def individual_unsubscriber():
                         try:
-                            _unwatch = getattr(self._exchange_manager.exchange, "un_watch_ohlcv")
+                            _unwatch = getattr(exchange, "un_watch_ohlcv")
                             await _unwatch(symbol, _exchange_timeframe)
                         except Exception as e:
                             logger.error(f"<yellow>{exchange_id}</yellow> Error unsubscribing OHLCV for {symbol}: {e}")

--- a/src/qubx/connectors/ccxt/handlers/open_interest.py
+++ b/src/qubx/connectors/ccxt/handlers/open_interest.py
@@ -73,6 +73,10 @@ class OpenInterestDataHandler(BaseDataTypeHandler):
         # Track if this is the first poll for initial data
         first_poll = True
 
+        # Deliberately late-bound (`self._exchange_manager.exchange` read inside the closures):
+        # this is a REST poller with no unsubscriber, so it should always use the current
+        # exchange. See BaseDataTypeHandler - the WS handlers bind at prepare time instead.
+
         async def poll_open_interest_once():
             """Single polling operation - called repeatedly by _listen_to_stream"""
             nonlocal first_poll

--- a/src/qubx/connectors/ccxt/handlers/open_interest.py
+++ b/src/qubx/connectors/ccxt/handlers/open_interest.py
@@ -73,9 +73,8 @@ class OpenInterestDataHandler(BaseDataTypeHandler):
         # Track if this is the first poll for initial data
         first_poll = True
 
-        # Deliberately late-bound (`self._exchange_manager.exchange` read inside the closures):
-        # this is a REST poller with no unsubscriber, so it should always use the current
-        # exchange. See BaseDataTypeHandler - the WS handlers bind at prepare time instead.
+        # Late binding is deliberate here: a REST poller with no unsubscriber should follow
+        # exchange recreation. WS handlers bind at prepare time instead - see BaseDataTypeHandler.
 
         async def poll_open_interest_once():
             """Single polling operation - called repeatedly by _listen_to_stream"""

--- a/src/qubx/connectors/ccxt/handlers/orderbook.py
+++ b/src/qubx/connectors/ccxt/handlers/orderbook.py
@@ -118,9 +118,6 @@ class OrderBookDataHandler(BaseDataTypeHandler):
         depth: int,
     ) -> SubscriptionConfiguration:
         """Prepare subscription configuration for multiple instruments using bulk API."""
-        # Bind the exchange here, not inside the closures: recreation swaps
-        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
-        # a different exchange than the one the stream was established on.
         exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}

--- a/src/qubx/connectors/ccxt/handlers/orderbook.py
+++ b/src/qubx/connectors/ccxt/handlers/orderbook.py
@@ -118,19 +118,21 @@ class OrderBookDataHandler(BaseDataTypeHandler):
         depth: int,
     ) -> SubscriptionConfiguration:
         """Prepare subscription configuration for multiple instruments using bulk API."""
+        # Bind the exchange here, not inside the closures: recreation swaps
+        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
+        # a different exchange than the one the stream was established on.
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}
         _limit = self._orderbook_limit
-        _unwatch_accepts_limit = "limit" in inspect.signature(
-            self._exchange_manager.exchange.un_watch_order_book_for_symbols
-        ).parameters
+        _unwatch_accepts_limit = "limit" in inspect.signature(exchange.un_watch_order_book_for_symbols).parameters
 
         async def watch_orderbook(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
-            ccxt_ob = await self._exchange_manager.exchange.watch_order_book_for_symbols(symbols, limit=_limit)
+            ccxt_ob = await exchange.watch_order_book_for_symbols(symbols, limit=_limit)
 
             exch_symbol = ccxt_ob["symbol"]
-            instrument = ccxt_find_instrument(exch_symbol, self._exchange_manager.exchange, _symbol_to_instrument)
+            instrument = ccxt_find_instrument(exch_symbol, exchange, _symbol_to_instrument)
 
             # Use private processing method to avoid duplication
             self._process_orderbook(ccxt_ob, instrument, sub_type, channel, depth, tick_size_pct)
@@ -138,9 +140,9 @@ class OrderBookDataHandler(BaseDataTypeHandler):
         async def un_watch_orderbook(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
             if _unwatch_accepts_limit:
-                await self._exchange_manager.exchange.un_watch_order_book_for_symbols(symbols, limit=_limit)
+                await exchange.un_watch_order_book_for_symbols(symbols, limit=_limit)
             else:
-                await self._exchange_manager.exchange.un_watch_order_book_for_symbols(symbols)
+                await exchange.un_watch_order_book_for_symbols(symbols)
 
         return SubscriptionConfiguration(
             subscription_type=sub_type,
@@ -166,11 +168,14 @@ class OrderBookDataHandler(BaseDataTypeHandler):
         WebSocket streams without waiting for all instruments. This follows the same
         pattern as the OHLC handler for proper individual stream management.
         """
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _limit = self._orderbook_limit
-        _unwatch_single_accepts_limit = "limit" in inspect.signature(
-            self._exchange_manager.exchange.un_watch_order_book
-        ).parameters if hasattr(self._exchange_manager.exchange, "un_watch_order_book") else False
+        _unwatch_single_accepts_limit = (
+            "limit" in inspect.signature(exchange.un_watch_order_book).parameters
+            if hasattr(exchange, "un_watch_order_book")
+            else False
+        )
 
         individual_subscribers = {}
         individual_unsubscribers = {}
@@ -183,7 +188,7 @@ class OrderBookDataHandler(BaseDataTypeHandler):
                 async def individual_subscriber():
                     try:
                         # Watch orderbook for single instrument
-                        ccxt_ob = await self._exchange_manager.exchange.watch_order_book(symbol, limit=_limit)
+                        ccxt_ob = await exchange.watch_order_book(symbol, limit=_limit)
 
                         # Use private processing method to avoid duplication
                         self._process_orderbook(ccxt_ob, inst, sub_type, channel, depth, tick_size_pct)
@@ -199,7 +204,7 @@ class OrderBookDataHandler(BaseDataTypeHandler):
             individual_subscribers[instrument] = create_individual_subscriber()
 
             # Create individual unsubscriber if exchange supports it
-            un_watch_method = getattr(self._exchange_manager.exchange, "un_watch_order_book", None)
+            un_watch_method = getattr(exchange, "un_watch_order_book", None)
             if un_watch_method is not None and callable(un_watch_method):
 
                 def create_individual_unsubscriber(
@@ -210,9 +215,9 @@ class OrderBookDataHandler(BaseDataTypeHandler):
                     async def individual_unsubscriber():
                         try:
                             if accepts_limit:
-                                await self._exchange_manager.exchange.un_watch_order_book(symbol, limit=_limit)
+                                await exchange.un_watch_order_book(symbol, limit=_limit)
                             else:
-                                await self._exchange_manager.exchange.un_watch_order_book(symbol)
+                                await exchange.un_watch_order_book(symbol)
                         except Exception as e:
                             logger.error(
                                 f"<yellow>{exchange_id}</yellow> Error unsubscribing orderbook for {symbol}: {e}"

--- a/src/qubx/connectors/ccxt/handlers/quote.py
+++ b/src/qubx/connectors/ccxt/handlers/quote.py
@@ -53,9 +53,6 @@ class QuoteDataHandler(BaseDataTypeHandler):
                 stream_name=name,
             )
 
-        # Bind the exchange here, not inside the closures: recreation swaps
-        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
-        # a different exchange than the one the stream was established on.
         exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}

--- a/src/qubx/connectors/ccxt/handlers/quote.py
+++ b/src/qubx/connectors/ccxt/handlers/quote.py
@@ -53,15 +53,19 @@ class QuoteDataHandler(BaseDataTypeHandler):
                 stream_name=name,
             )
 
+        # Bind the exchange here, not inside the closures: recreation swaps
+        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
+        # a different exchange than the one the stream was established on.
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}
 
         async def watch_quote(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
-            ccxt_tickers: dict[str, dict] = await self._exchange_manager.exchange.watch_bids_asks(symbols)
+            ccxt_tickers: dict[str, dict] = await exchange.watch_bids_asks(symbols)
 
             for exch_symbol, ccxt_ticker in ccxt_tickers.items():
-                instrument = ccxt_find_instrument(exch_symbol, self._exchange_manager.exchange, _symbol_to_instrument)
+                instrument = ccxt_find_instrument(exch_symbol, exchange, _symbol_to_instrument)
                 quote = ccxt_convert_ticker(ccxt_ticker)
 
                 if not (
@@ -85,10 +89,10 @@ class QuoteDataHandler(BaseDataTypeHandler):
 
         async def un_watch_quote(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
-            if hasattr(self._exchange_manager.exchange, "un_watch_bids_asks"):
-                await getattr(self._exchange_manager.exchange, "un_watch_bids_asks")(symbols)
+            if hasattr(exchange, "un_watch_bids_asks"):
+                await getattr(exchange, "un_watch_bids_asks")(symbols)
             else:
-                await self._exchange_manager.exchange.un_watch_tickers(symbols)
+                await exchange.un_watch_tickers(symbols)
 
         # Return subscription configuration instead of calling _listen_to_stream directly
         return SubscriptionConfiguration(

--- a/src/qubx/connectors/ccxt/handlers/trade.py
+++ b/src/qubx/connectors/ccxt/handlers/trade.py
@@ -85,9 +85,6 @@ class TradeDataHandler(BaseDataTypeHandler):
         instruments: set[Instrument],
     ) -> SubscriptionConfiguration:
         """Prepare subscription configuration for multiple instruments using bulk API."""
-        # Bind the exchange here, not inside the closures: recreation swaps
-        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
-        # a different exchange than the one the stream was established on.
         exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}

--- a/src/qubx/connectors/ccxt/handlers/trade.py
+++ b/src/qubx/connectors/ccxt/handlers/trade.py
@@ -85,22 +85,26 @@ class TradeDataHandler(BaseDataTypeHandler):
         instruments: set[Instrument],
     ) -> SubscriptionConfiguration:
         """Prepare subscription configuration for multiple instruments using bulk API."""
+        # Bind the exchange here, not inside the closures: recreation swaps
+        # `exchange_manager.exchange`, and an unsubscriber resolved at call time would be aimed at
+        # a different exchange than the one the stream was established on.
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
         _symbol_to_instrument = {_instr_to_ccxt_symbol[i]: i for i in instruments}
 
         async def watch_trades(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
-            trades = await self._exchange_manager.exchange.watch_trades_for_symbols(symbols)
+            trades = await exchange.watch_trades_for_symbols(symbols)
 
             exch_symbol = trades[0]["symbol"]
-            instrument = ccxt_find_instrument(exch_symbol, self._exchange_manager.exchange, _symbol_to_instrument)
+            instrument = ccxt_find_instrument(exch_symbol, exchange, _symbol_to_instrument)
 
             # Use private processing method to avoid duplication
             self._process_trade(trades, instrument, sub_type, channel)
 
         async def un_watch_trades(instruments_batch: list[Instrument]):
             symbols = [_instr_to_ccxt_symbol[i] for i in instruments_batch]
-            await self._exchange_manager.exchange.un_watch_trades_for_symbols(symbols)
+            await exchange.un_watch_trades_for_symbols(symbols)
 
         return SubscriptionConfiguration(
             subscription_type=sub_type,
@@ -124,6 +128,7 @@ class TradeDataHandler(BaseDataTypeHandler):
         WebSocket streams without waiting for all instruments. This follows the same
         pattern as the orderbook handler for proper individual stream management.
         """
+        exchange = self._exchange_manager.exchange
         _instr_to_ccxt_symbol = {i: instrument_to_ccxt_symbol(i) for i in instruments}
 
         individual_subscribers = {}
@@ -137,7 +142,7 @@ class TradeDataHandler(BaseDataTypeHandler):
                 async def individual_subscriber():
                     try:
                         # Watch trades for single instrument
-                        trades = await self._exchange_manager.exchange.watch_trades(symbol)
+                        trades = await exchange.watch_trades(symbol)
 
                         # Use private processing method to avoid duplication
                         self._process_trade(trades, inst, sub_type, channel)
@@ -153,13 +158,13 @@ class TradeDataHandler(BaseDataTypeHandler):
             individual_subscribers[instrument] = create_individual_subscriber()
 
             # Create individual unsubscriber if exchange supports it
-            un_watch_method = getattr(self._exchange_manager.exchange, "un_watch_trades", None)
+            un_watch_method = getattr(exchange, "un_watch_trades", None)
             if un_watch_method is not None and callable(un_watch_method):
 
                 def create_individual_unsubscriber(symbol=ccxt_symbol, exchange_id=self._exchange_id):
                     async def individual_unsubscriber():
                         try:
-                            await self._exchange_manager.exchange.un_watch_trades(symbol)
+                            await exchange.un_watch_trades(symbol)
                         except Exception as e:
                             logger.error(f"<yellow>{exchange_id}</yellow> Error unsubscribing trades for {symbol}: {e}")
 

--- a/src/qubx/connectors/ccxt/subscription_manager.py
+++ b/src/qubx/connectors/ccxt/subscription_manager.py
@@ -5,6 +5,7 @@ This module handles the lifecycle and state tracking of data subscriptions,
 separating subscription concerns from connection management and data handling.
 """
 
+import threading
 from collections import defaultdict
 from typing import Dict, List, Set
 
@@ -23,6 +24,13 @@ class SubscriptionManager:
     """
 
     def __init__(self):
+        # Held across a whole subscription transition - computing the new instrument set, stopping
+        # the old stream and installing the new name is one read-modify-write, and the stale-data
+        # watchdog thread and the strategy thread both run it. Per-method locking is not enough.
+        # Reentrant: unsubscribe resubscribes the remainder, and a handler may unsubscribe while
+        # preparing.
+        self.lock = threading.RLock()
+
         # Active subscriptions (connection established and receiving data)
         self._subscriptions: dict[str, set[Instrument]] = defaultdict(set)
 

--- a/src/qubx/connectors/ccxt/subscription_manager.py
+++ b/src/qubx/connectors/ccxt/subscription_manager.py
@@ -24,11 +24,12 @@ class SubscriptionManager:
     """
 
     def __init__(self):
-        # Held across a whole subscription transition - computing the new instrument set, stopping
-        # the old stream and installing the new name is one read-modify-write, and the stale-data
-        # watchdog thread and the strategy thread both run it. Per-method locking is not enough.
-        # Reentrant: unsubscribe resubscribes the remainder, and a handler may unsubscribe while
-        # preparing.
+        # Held across a whole subscription transition: computing the new instrument set, stopping
+        # the old stream and installing the new name is one read-modify-write, driven concurrently
+        # by the strategy thread and the stale-data watchdog. Reentrant because unsubscribe
+        # resubscribes the remainder and a handler may unsubscribe while preparing.
+        # INVARIANT: never acquire it from the exchange event loop thread - holders block on that
+        # loop (stream teardown, unsubscribe), so taking it on-loop parks the loop on itself.
         self.lock = threading.RLock()
 
         # Active subscriptions (connection established and receiving data)

--- a/src/qubx/connectors/ccxt/subscription_manager.py
+++ b/src/qubx/connectors/ccxt/subscription_manager.py
@@ -7,7 +7,8 @@ separating subscription concerns from connection management and data handling.
 
 import threading
 from collections import defaultdict
-from typing import Dict, List, Set
+from contextlib import contextmanager
+from typing import Dict, Iterator, List, Set
 
 from qubx.core.basics import DataType, Instrument
 
@@ -24,13 +25,9 @@ class SubscriptionManager:
     """
 
     def __init__(self):
-        # Held across a whole subscription transition: computing the new instrument set, stopping
-        # the old stream and installing the new name is one read-modify-write, driven concurrently
-        # by the strategy thread and the stale-data watchdog. Reentrant because unsubscribe
-        # resubscribes the remainder and a handler may unsubscribe while preparing.
-        # INVARIANT: never acquire it from the exchange event loop thread - holders block on that
-        # loop (stream teardown, unsubscribe), so taking it on-loop parks the loop on itself.
-        self.lock = threading.RLock()
+        # Reentrant: unsubscribe resubscribes the remainder, and a handler may unsubscribe while
+        # preparing a subscription.
+        self._transition_lock = threading.RLock()
 
         # Active subscriptions (connection established and receiving data)
         self._subscriptions: dict[str, set[Instrument]] = defaultdict(set)
@@ -49,6 +46,20 @@ class SubscriptionManager:
 
         # Individual stream mappings: {subscription_type: {instrument: stream_name}}
         self._individual_streams: dict[str, dict[Instrument, str]] = defaultdict(dict)
+
+    @contextmanager
+    def transition(self) -> Iterator[None]:
+        """Serialise a whole subscription transition against this manager's state.
+
+        Computing the new instrument set, stopping the old stream and installing the new name is
+        one read-modify-write, and the strategy thread and the stale-data watchdog both drive it.
+        Interleaving them strands a live stream that nothing ever stop-requests.
+
+        INVARIANT: never enter this from the exchange event loop thread. Holders block on that loop
+        (stream teardown, unsubscribe), so taking it on-loop parks the loop on itself.
+        """
+        with self._transition_lock:
+            yield
 
     def add_subscription(
         self, subscription_type: str, instruments: list[Instrument], reset: bool = False

--- a/src/qubx/connectors/ccxt/subscription_orchestrator.py
+++ b/src/qubx/connectors/ccxt/subscription_orchestrator.py
@@ -197,9 +197,8 @@ class SubscriptionOrchestrator:
         # 4. Register new stream with subscription manager
         self._subscription_manager.set_subscription_name(subscription_type, subscription_config.stream_name)
 
-        # 5. Arm the stream registry BEFORE submitting, still under the subscription lock.
-        #    listen_to_stream only reads the enabled flag, so this is what makes a later
-        #    stop_stream pop final - see ConnectionManager.listen_to_stream.
+        # 5. Arm the stream registry before submitting: listen_to_stream only reads the enabled
+        #    flag, which is what makes a later stop_stream pop final.
         self._arm_stream(subscription_config.stream_name, subscription_config.unsubscriber_func)
 
         # 6. Create and start new subscription task

--- a/src/qubx/connectors/ccxt/subscription_orchestrator.py
+++ b/src/qubx/connectors/ccxt/subscription_orchestrator.py
@@ -197,14 +197,19 @@ class SubscriptionOrchestrator:
         # 4. Register new stream with subscription manager
         self._subscription_manager.set_subscription_name(subscription_type, subscription_config.stream_name)
 
-        # 5. Create and start new subscription task
+        # 5. Arm the stream registry BEFORE submitting, still under the subscription lock.
+        #    listen_to_stream only reads the enabled flag, so this is what makes a later
+        #    stop_stream pop final - see ConnectionManager.listen_to_stream.
+        self._arm_stream(subscription_config.stream_name, subscription_config.unsubscriber_func)
+
+        # 6. Create and start new subscription task
         subscription_task = self._create_subscription_task(
             subscription_config=subscription_config,
             exchange=exchange,
         )
         future = self._loop.submit(subscription_task())
 
-        # 6. Register with connection manager
+        # 7. Register with connection manager
         self._connection_manager.register_stream_future(subscription_config.stream_name, future)
 
     def _start_instrument_streams(
@@ -246,6 +251,12 @@ class SubscriptionOrchestrator:
                     futures[instrument] = existing_streams[instrument]
                     continue
 
+            # Arm the registry before submitting - see _start_bulk_stream step 5.
+            self._arm_stream(
+                instrument_stream_name,
+                (subscription_config.instrument_unsubscribers or {}).get(instrument),
+            )
+
             # Start the individual stream
             task_coroutine = self._create_instrument_subscription_task(
                 instrument=instrument,
@@ -268,6 +279,12 @@ class SubscriptionOrchestrator:
 
         # Store individual stream mapping for future resubscriptions
         self._subscription_manager.set_individual_streams(subscription_type, futures)
+
+    def _arm_stream(self, stream_name: str, unsubscriber: Callable[[], Awaitable[None]] | None) -> None:
+        """Register a stream as enabled (and its unsubscriber) before its task is submitted."""
+        self._connection_manager.enable_stream(stream_name)
+        if unsubscriber is not None:
+            self._connection_manager.set_stream_unsubscriber(stream_name, unsubscriber)
 
     def _stop_individual_streams(self, streams: dict[Instrument, str]) -> None:
         """Stop individual streams for the given instruments."""
@@ -334,7 +351,6 @@ class SubscriptionOrchestrator:
                 channel=subscription_config.channel,
                 subscription_type=subscription_config.subscription_type,
                 stream_name=subscription_config.stream_name,
-                unsubscriber=subscription_config.unsubscriber_func,
             )
             logger.info(f"listen_to_stream finished for stream {subscription_config.stream_name}")
 
@@ -353,10 +369,6 @@ class SubscriptionOrchestrator:
         assert subscriber is not None
         assert subscription_config.channel is not None, "Channel must be set before creating task"
 
-        unsubscriber = None
-        if subscription_config.instrument_unsubscribers:
-            unsubscriber = subscription_config.instrument_unsubscribers.get(instrument)
-
         # Create subscription task for this instrument
         async def subscription_task():
             assert subscription_config.channel is not None, "Channel must be set before creating task"
@@ -366,7 +378,6 @@ class SubscriptionOrchestrator:
                 channel=subscription_config.channel,
                 subscription_type=subscription_config.subscription_type,
                 stream_name=stream_name,
-                unsubscriber=unsubscriber,
             )
             logger.info(f"listen_to_stream finished for stream {stream_name}")
 

--- a/src/qubx/connectors/ccxt/subscription_orchestrator.py
+++ b/src/qubx/connectors/ccxt/subscription_orchestrator.py
@@ -74,7 +74,7 @@ class SubscriptionOrchestrator:
             logger.debug(f"<yellow>{self._exchange_id}</yellow> No instruments to subscribe to for {subscription_type}")
             return
 
-        with self._subscription_manager.lock:
+        with self._subscription_manager.transition():
             # Prepare subscription configuration
             subscription_config = self._prepare_subscription_config(
                 subscription_type,
@@ -92,7 +92,7 @@ class SubscriptionOrchestrator:
 
     def execute_unsubscription(self, subscription_config: SubscriptionConfiguration):
         """Clean up existing subscription if it exists."""
-        with self._subscription_manager.lock:
+        with self._subscription_manager.transition():
             subscription_type = subscription_config.subscription_type
 
             # For bulk subscriptions, use the main stream name

--- a/src/qubx/connectors/ccxt/subscription_orchestrator.py
+++ b/src/qubx/connectors/ccxt/subscription_orchestrator.py
@@ -74,51 +74,53 @@ class SubscriptionOrchestrator:
             logger.debug(f"<yellow>{self._exchange_id}</yellow> No instruments to subscribe to for {subscription_type}")
             return
 
-        # Prepare subscription configuration
-        subscription_config = self._prepare_subscription_config(
-            subscription_type,
-            instruments,
-            handler,
-            channel,
-            **subscriber_params,
-        )
+        with self._subscription_manager.lock:
+            # Prepare subscription configuration
+            subscription_config = self._prepare_subscription_config(
+                subscription_type,
+                instruments,
+                handler,
+                channel,
+                **subscriber_params,
+            )
 
-        # Start subscription (unsubscription handled internally based on mode)
-        self._start_subscription(
-            subscription_config=subscription_config,
-            exchange=exchange,
-        )
+            # Start subscription (unsubscription handled internally based on mode)
+            self._start_subscription(
+                subscription_config=subscription_config,
+                exchange=exchange,
+            )
 
     def execute_unsubscription(self, subscription_config: SubscriptionConfiguration):
         """Clean up existing subscription if it exists."""
-        subscription_type = subscription_config.subscription_type
+        with self._subscription_manager.lock:
+            subscription_type = subscription_config.subscription_type
 
-        # For bulk subscriptions, use the main stream name
-        if not subscription_config.use_instrument_streams:
-            existing_stream_name = self._subscription_manager.get_subscription_stream(subscription_type)
-            new_stream_name = subscription_config.stream_name
+            # For bulk subscriptions, use the main stream name
+            if not subscription_config.use_instrument_streams:
+                existing_stream_name = self._subscription_manager.get_subscription_stream(subscription_type)
+                new_stream_name = subscription_config.stream_name
 
-            # Skip unsubscription if stream names match (same instruments)
-            if existing_stream_name == new_stream_name:
-                logger.debug(
-                    f"[{self._exchange_id}] Reusing existing {subscription_type} stream: {existing_stream_name}"
-                )
-                return  # Skip unsubscription - reuse existing stream
-
-            # Different instruments - proceed with cleanup
-            if existing_stream_name:
-                stream_future = self._connection_manager.get_stream_future(existing_stream_name)
-                if stream_future:
+                # Skip unsubscription if stream names match (same instruments)
+                if existing_stream_name == new_stream_name:
                     logger.debug(
-                        f"[{self._exchange_id}] Canceling existing {subscription_type} subscription: {existing_stream_name}"
+                        f"[{self._exchange_id}] Reusing existing {subscription_type} stream: {existing_stream_name}"
                     )
-                    self._connection_manager.stop_stream(existing_stream_name)
-        else:
-            # For individual subscriptions, stop all individual streams
-            individual_streams = self._subscription_manager.get_individual_streams(subscription_type)
-            self._stop_individual_streams(individual_streams)
+                    return  # Skip unsubscription - reuse existing stream
 
-        self._subscription_manager.clear_subscription_state(subscription_type)
+                # Different instruments - proceed with cleanup
+                if existing_stream_name:
+                    stream_future = self._connection_manager.get_stream_future(existing_stream_name)
+                    if stream_future:
+                        logger.debug(
+                            f"[{self._exchange_id}] Canceling existing {subscription_type} subscription: {existing_stream_name}"
+                        )
+                        self._connection_manager.stop_stream(existing_stream_name)
+            else:
+                # For individual subscriptions, stop all individual streams
+                individual_streams = self._subscription_manager.get_individual_streams(subscription_type)
+                self._stop_individual_streams(individual_streams)
+
+            self._subscription_manager.clear_subscription_state(subscription_type)
 
     def _prepare_subscription_config(
         self,

--- a/src/qubx/control/builtin.py
+++ b/src/qubx/control/builtin.py
@@ -585,10 +585,9 @@ def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
         for exch, by_type in rates.items()
     }
 
-    # - seconds since the last event of each (exchange, type). This is the freshness signal an
-    #   external watchdog needs: `connected` only says a stream is enabled, not that data arrives.
-    #   NaT is reported as None rather than a NaN age: this payload is JSON-serialised with
-    #   allow_nan=False, so a single NaN would 500 the health endpoint and blind the probe.
+    # - seconds since the last event of each (exchange, type): `connected` only says a stream is
+    #   enabled, not that data arrives. NaT maps to None, not a NaN age - this payload is
+    #   JSON-serialised with allow_nan=False, so one NaN would 500 the whole health endpoint.
     now = ctx.time()
 
     def _age(t) -> float | None:

--- a/src/qubx/control/builtin.py
+++ b/src/qubx/control/builtin.py
@@ -3,7 +3,6 @@
 from collections import defaultdict
 from typing import Callable
 
-import numpy as np
 import pandas as pd
 
 from qubx.core.basics import DataType, Instrument, MarketType, Signal
@@ -585,21 +584,6 @@ def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
         for exch, by_type in rates.items()
     }
 
-    # - seconds since the last event of each (exchange, type): `connected` only says a stream is
-    #   enabled, not that data arrives. NaT maps to None, not a NaN age - this payload is
-    #   JSON-serialised with allow_nan=False, so one NaN would 500 the whole health endpoint.
-    now = ctx.time()
-
-    def _age(t) -> float | None:
-        if t is None or np.isnat(np.datetime64(t)):
-            return None
-        return round(float((now - t) / np.timedelta64(1, "s")), 2)
-
-    last_event_ages_s = {
-        exch: {event_type: _age(t) for event_type, t in health.get_last_event_times_by_exchange(exch).items()}
-        for exch in exchanges
-    }
-
     info = ctx.status
     return ActionResult(
         status="ok",
@@ -613,7 +597,6 @@ def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
             "queue_size": health.get_queue_size(),
             "data_latencies_ms": latencies,
             "event_frequency": frequency,
-            "last_event_ages_s": last_event_ages_s,
         },
     )
 

--- a/src/qubx/control/builtin.py
+++ b/src/qubx/control/builtin.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 from typing import Callable
 
+import numpy as np
 import pandas as pd
 
 from qubx.core.basics import DataType, Instrument, MarketType, Signal
@@ -584,6 +585,22 @@ def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
         for exch, by_type in rates.items()
     }
 
+    # - seconds since the last event of each (exchange, type). This is the freshness signal an
+    #   external watchdog needs: `connected` only says a stream is enabled, not that data arrives.
+    #   NaT is reported as None rather than a NaN age: this payload is JSON-serialised with
+    #   allow_nan=False, so a single NaN would 500 the health endpoint and blind the probe.
+    now = ctx.time()
+
+    def _age(t) -> float | None:
+        if t is None or np.isnat(np.datetime64(t)):
+            return None
+        return round(float((now - t) / np.timedelta64(1, "s")), 2)
+
+    last_event_ages_s = {
+        exch: {event_type: _age(t) for event_type, t in health.get_last_event_times_by_exchange(exch).items()}
+        for exch in exchanges
+    }
+
     info = ctx.status
     return ActionResult(
         status="ok",
@@ -597,6 +614,7 @@ def _get_health(ctx: IStrategyContext, **kwargs) -> ActionResult:
             "queue_size": health.get_queue_size(),
             "data_latencies_ms": latencies,
             "event_frequency": frequency,
+            "last_event_ages_s": last_event_ages_s,
         },
     )
 

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -9,8 +9,6 @@ from collections import defaultdict
 from types import FunctionType
 from typing import Any, Callable
 
-import numpy as np
-
 from qubx import logger
 from qubx.core.account_manager import AccountManager
 from qubx.core.account_manager.reducer import ApplyResult
@@ -1450,10 +1448,11 @@ class ProcessingManager(IProcessingManager):
         snapshot = {
             "timestamp": str(self._time_provider.time()),
             "exchanges": exchanges_snapshot,
-            # Seconds since the last event of each type. A fresh snapshot only proves this thread is
-            # running; these ages prove data is still arriving. `None` for a type never seen, so a
-            # warming-up bot is not reported as infinitely stale.
-            "data_ages_s": {exchange: self._last_event_ages(exchange) for exchange in exchanges},
+            # When each event type last arrived. A fresh `timestamp` only proves this thread is
+            # running; these prove data is still arriving. Same format as `timestamp`, so the reader
+            # computes freshness at read time rather than trusting an age measured here. `None` for
+            # a type never seen, so a warming-up bot is not read as infinitely stale.
+            "last_event_times": {exchange: self._last_event_times(exchange) for exchange in exchanges},
         }
 
         try:
@@ -1461,12 +1460,11 @@ class ProcessingManager(IProcessingManager):
         except Exception as e:
             logger.warning(f"Failed to save state snapshot: {e}")
 
-    def _last_event_ages(self, exchange: str) -> dict[str, float | None]:
-        now = self._time_provider.time()
-        ages: dict[str, float | None] = {}
+    def _last_event_times(self, exchange: str) -> dict[str, str | None]:
+        times: dict[str, str | None] = {}
         for event_type, last in self._health_monitor.get_last_event_times_by_exchange(exchange).items():
-            ages[event_type] = None if last is None else round(float((now - last) / np.timedelta64(1, "s")), 2)
-        return ages
+            times[event_type] = None if last is None else str(last)
+        return times
 
     def _handle_error(self, instrument: Instrument | None, event_type: str, error: BaseErrorEvent) -> None:
         self._strategy.on_error(self._context, error)

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -103,6 +103,13 @@ def validate_account_callback_signatures(strategy: IStrategy) -> None:
             )
 
 
+# Feeds that arrive on venue events rather than continuously: their age measures the market, not the
+# connection, so reporting it invites a staleness alert that fires on every quiet period. Qubx
+# already excludes funding payments from latency percentiles for the same reason
+# (health/base.py DATA_FEED_LATENCY_EXCLUDE); liquidations are just as bursty.
+_EVENT_DRIVEN_TYPES = frozenset({DataType.FUNDING_PAYMENT, DataType.LIQUIDATION})
+
+
 class ProcessingManager(IProcessingManager):
     MAX_NUMBER_OF_STRATEGY_FAILURES: int = 10
     DATA_READY_TIMEOUT: td_64 = td_64(60, "s")
@@ -1448,10 +1455,9 @@ class ProcessingManager(IProcessingManager):
         snapshot = {
             "timestamp": str(self._time_provider.time()),
             "exchanges": exchanges_snapshot,
-            # When each event type last arrived. A fresh `timestamp` only proves this thread is
-            # running; these prove data is still arriving. Same format as `timestamp`, so the reader
-            # computes freshness at read time rather than trusting an age measured here. `None` for
-            # a type never seen, so a warming-up bot is not read as infinitely stale.
+            # When each continuous feed last arrived. A fresh `timestamp` only proves this thread
+            # is running; these prove data is still arriving. Same format as `timestamp`, so the
+            # reader computes freshness at read time rather than trusting an age measured here.
             "last_event_times": {exchange: self._last_event_times(exchange) for exchange in exchanges},
         }
 
@@ -1460,11 +1466,12 @@ class ProcessingManager(IProcessingManager):
         except Exception as e:
             logger.warning(f"Failed to save state snapshot: {e}")
 
-    def _last_event_times(self, exchange: str) -> dict[str, str | None]:
-        times: dict[str, str | None] = {}
-        for event_type, last in self._health_monitor.get_last_event_times_by_exchange(exchange).items():
-            times[event_type] = None if last is None else str(last)
-        return times
+    def _last_event_times(self, exchange: str) -> dict[str, str]:
+        return {
+            event_type: str(last)
+            for event_type, last in self._health_monitor.get_last_event_times_by_exchange(exchange).items()
+            if event_type not in _EVENT_DRIVEN_TYPES
+        }
 
     def _handle_error(self, instrument: Instrument | None, event_type: str, error: BaseErrorEvent) -> None:
         self._strategy.on_error(self._context, error)

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -9,6 +9,8 @@ from collections import defaultdict
 from types import FunctionType
 from typing import Any, Callable
 
+import numpy as np
+
 from qubx import logger
 from qubx.core.account_manager import AccountManager
 from qubx.core.account_manager.reducer import ApplyResult
@@ -1448,12 +1450,23 @@ class ProcessingManager(IProcessingManager):
         snapshot = {
             "timestamp": str(self._time_provider.time()),
             "exchanges": exchanges_snapshot,
+            # Seconds since the last event of each type. A fresh snapshot only proves this thread is
+            # running; these ages prove data is still arriving. `None` for a type never seen, so a
+            # warming-up bot is not reported as infinitely stale.
+            "data_ages_s": {exchange: self._last_event_ages(exchange) for exchange in exchanges},
         }
 
         try:
             self._context.persistence.save("state", snapshot)
         except Exception as e:
             logger.warning(f"Failed to save state snapshot: {e}")
+
+    def _last_event_ages(self, exchange: str) -> dict[str, float | None]:
+        now = self._time_provider.time()
+        ages: dict[str, float | None] = {}
+        for event_type, last in self._health_monitor.get_last_event_times_by_exchange(exchange).items():
+            ages[event_type] = None if last is None else round(float((now - last) / np.timedelta64(1, "s")), 2)
+        return ages
 
     def _handle_error(self, instrument: Instrument | None, event_type: str, error: BaseErrorEvent) -> None:
         self._strategy.on_error(self._context, error)

--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -452,7 +452,10 @@ class SubscriptionManager(ISubscriptionManager):
         exch_sub_to_stale_instr = defaultdict(lambda: defaultdict(set))
         for data_type in ["quote", "orderbook", "trade"]:
             for data_provider in self._data_providers:
-                if data_provider.is_simulation or not data_provider.is_connected():
+                # Deliberately NOT skipped on `not is_connected()`: a wedged CCXT provider drops its
+                # stream-enabled flag before it blocks, so it reports not-connected exactly when this
+                # watchdog is needed most - that self-disarmed the last recovery path on 2026-07-28.
+                if data_provider.is_simulation:
                     continue
                 instruments = data_provider.get_subscribed_instruments(data_type)
                 for instrument in instruments:

--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -455,15 +455,15 @@ class SubscriptionManager(ISubscriptionManager):
     def _monitor_subscription_status(self) -> None:
         exch_sub_to_stale_instr = defaultdict(lambda: defaultdict(set))
         for data_provider in self._data_providers:
-            # Deliberately NOT skipped on `not is_connected()`: a wedged CCXT provider drops its
+            # Must NOT be gated on `is_connected()`: a wedged CCXT provider drops its
             # stream-enabled flag before it blocks, so it reports not-connected exactly when this
-            # watchdog is needed most - that self-disarmed the last recovery path on 2026-07-28.
+            # watchdog is needed - gating here disarms the last recovery path.
             if data_provider.is_simulation:
                 continue
-            # Iterate the provider's OWN keys rather than the bare base types: a fleet bot is
-            # subscribed as "orderbook(0, 1)", and get_subscribed_instruments/unsubscribe/subscribe
-            # are all exact-key lookups, so asking for "orderbook" collects nothing and recovery
-            # early-returns. Health is keyed by base type, the provider by full key - carry both.
+            # Iterate the provider's OWN subscription keys, not the bare base types: a subscription
+            # may carry parameters ("orderbook(0, 1)") and get_subscribed_instruments / subscribe /
+            # unsubscribe are all exact-key lookups, so "orderbook" would match nothing. Health is
+            # keyed by base type, the provider by full key - carry both.
             for sub in data_provider.get_subscriptions():
                 base_type = DataType.from_str(sub)[0]
                 if base_type not in _WATCHDOG_DATA_TYPES:

--- a/src/qubx/core/mixins/subscription.py
+++ b/src/qubx/core/mixins/subscription.py
@@ -22,6 +22,10 @@ from .utils import EXCHANGE_MAPPINGS
 # and applied on the ProcessorThread.
 SUBSCRIPTION_SWAP_EVENT = "subscription_swap"
 
+# Data types the stale-data watchdog polices. Base types: a subscription may carry parameters
+# ("orderbook(0, 1)"), and only the base type has a staleness threshold in the health monitor.
+_WATCHDOG_DATA_TYPES = frozenset({DataType.QUOTE, DataType.ORDERBOOK, DataType.TRADE})
+
 
 @dataclass(frozen=True, slots=True)
 class _CommitPlan:
@@ -450,17 +454,23 @@ class SubscriptionManager(ISubscriptionManager):
 
     def _monitor_subscription_status(self) -> None:
         exch_sub_to_stale_instr = defaultdict(lambda: defaultdict(set))
-        for data_type in ["quote", "orderbook", "trade"]:
-            for data_provider in self._data_providers:
-                # Deliberately NOT skipped on `not is_connected()`: a wedged CCXT provider drops its
-                # stream-enabled flag before it blocks, so it reports not-connected exactly when this
-                # watchdog is needed most - that self-disarmed the last recovery path on 2026-07-28.
-                if data_provider.is_simulation:
+        for data_provider in self._data_providers:
+            # Deliberately NOT skipped on `not is_connected()`: a wedged CCXT provider drops its
+            # stream-enabled flag before it blocks, so it reports not-connected exactly when this
+            # watchdog is needed most - that self-disarmed the last recovery path on 2026-07-28.
+            if data_provider.is_simulation:
+                continue
+            # Iterate the provider's OWN keys rather than the bare base types: a fleet bot is
+            # subscribed as "orderbook(0, 1)", and get_subscribed_instruments/unsubscribe/subscribe
+            # are all exact-key lookups, so asking for "orderbook" collects nothing and recovery
+            # early-returns. Health is keyed by base type, the provider by full key - carry both.
+            for sub in data_provider.get_subscriptions():
+                base_type = DataType.from_str(sub)[0]
+                if base_type not in _WATCHDOG_DATA_TYPES:
                     continue
-                instruments = data_provider.get_subscribed_instruments(data_type)
-                for instrument in instruments:
-                    if self._health_monitor.is_stale(instrument, data_type):
-                        exch_sub_to_stale_instr[data_provider.exchange()][data_type].add(instrument)
+                for instrument in data_provider.get_subscribed_instruments(sub):
+                    if self._health_monitor.is_stale(instrument, str(base_type)):
+                        exch_sub_to_stale_instr[data_provider.exchange()][sub].add(instrument)
 
         if not exch_sub_to_stale_instr:
             return
@@ -471,14 +481,14 @@ class SubscriptionManager(ISubscriptionManager):
             )
             logger.info("[1/4] Unsubscribing stale instruments..")
             data_provider = self._get_data_provider(exchange)
-            # - unsubscribe stale instruments
-            for data_type, stale_instruments in sub_to_stale_instr.items():
-                data_provider.unsubscribe(data_type, stale_instruments)
+            # - unsubscribe stale instruments (full subscription key, not the base type)
+            for sub, stale_instruments in sub_to_stale_instr.items():
+                data_provider.unsubscribe(sub, stale_instruments)
             logger.info("[2/4] Waiting for 3 seconds before resubscribing..")
             # - wait for 3 seconds before resubscribing
             time.sleep(3)
             logger.info("[3/4] Resubscribing stale instruments..")
             # - resubscribe stale instruments
-            for data_type, stale_instruments in sub_to_stale_instr.items():
-                data_provider.subscribe(data_type, stale_instruments)
+            for sub, stale_instruments in sub_to_stale_instr.items():
+                data_provider.subscribe(sub, stale_instruments)
             logger.info("[4/4] Resubscription complete")

--- a/src/qubx/health/base.py
+++ b/src/qubx/health/base.py
@@ -355,7 +355,9 @@ class BaseHealthMonitor(IHealthMonitor):
     def get_last_event_times_by_exchange(self, exchange: str) -> dict[str, dt_64]:
         """Get all last event times for a specific exchange."""
         result = {}
-        for (instrument, event_type), event_time in self._last_event_time.items():
+        # Snapshot: the processor thread writes this dict on every event, and this is read from the
+        # stale monitor and the control server.
+        for (instrument, event_type), event_time in list(self._last_event_time.items()):
             if instrument.exchange == exchange:
                 if event_type not in result:
                     result[event_type] = event_time

--- a/tests/qubx/connectors/ccxt/test_connection_manager.py
+++ b/tests/qubx/connectors/ccxt/test_connection_manager.py
@@ -5,13 +5,12 @@ Tests the WebSocket connection handling, retry logic, and stream lifecycle
 management functionality in isolation.
 """
 
-import asyncio
 import concurrent.futures
 from asyncio.exceptions import CancelledError
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from ccxt import BadSymbol, ExchangeClosedByUser, ExchangeError, ExchangeNotAvailable, NetworkError
+from ccxt import BadSymbol, ExchangeClosedByUser, NetworkError
 
 from qubx.connectors.ccxt.connection_manager import ConnectionManager
 from qubx.connectors.ccxt.exceptions import CcxtSymbolNotRecognized
@@ -111,6 +110,7 @@ class TestConnectionManager:
         mock_ctrl_channel.control.is_set.return_value = False  # Will exit the loop immediately
         stream_name = "test_stream"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         # Execute
         await connection_manager.listen_to_stream(
@@ -140,6 +140,7 @@ class TestConnectionManager:
 
         stream_name = "test_stream"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             # Execute
@@ -168,6 +169,7 @@ class TestConnectionManager:
 
         stream_name = "test_stream"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             # Execute
@@ -199,6 +201,7 @@ class TestConnectionManager:
 
         stream_name = "test_stream"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         # Execute
         await connection_manager.listen_to_stream(
@@ -224,6 +227,7 @@ class TestConnectionManager:
 
         stream_name = "test_stream"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         # Execute
         await connection_manager.listen_to_stream(
@@ -249,6 +253,7 @@ class TestConnectionManager:
 
         stream_name = "ohlc:200:DGBUSDT"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             await connection_manager.listen_to_stream(
@@ -282,6 +287,7 @@ class TestConnectionManager:
 
         stream_name = "funding_payment:200:DGBUSDT"
         subscription_type = "funding_payment"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             await connection_manager.listen_to_stream(
@@ -307,6 +313,7 @@ class TestConnectionManager:
 
         stream_name = "test_stream"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         # Execute
         await connection_manager.listen_to_stream(
@@ -320,30 +327,29 @@ class TestConnectionManager:
         # Should exit gracefully after one call
         assert mock_subscriber.call_count == 1
 
-    async def test_listen_to_stream_with_unsubscriber(self, connection_manager, mock_async_loop):
-        """Test stream listening registers unsubscriber."""
+    async def test_listen_to_stream_registers_nothing(self, connection_manager, mock_async_loop):
+        """listen_to_stream must only READ the registry - see the resurrection regression tests."""
         # Setup
         mock_subscriber = AsyncMock()
-        mock_unsubscriber = AsyncMock()
         mock_exchange = MagicMock()
         mock_ctrl_channel = MagicMock()
-        mock_ctrl_channel.control.is_set.return_value = False  # Exit immediately
+        mock_ctrl_channel.control.is_set.return_value = True
 
         stream_name = "test_stream"
         subscription_type = "ohlc"
 
-        # Execute
+        # Execute - nobody armed this stream, so the listen loop must not run at all
         await connection_manager.listen_to_stream(
             subscriber=mock_subscriber,
             exchange=mock_exchange,
             channel=mock_ctrl_channel,
             subscription_type=subscription_type,
             stream_name=stream_name,
-            unsubscriber=mock_unsubscriber,
         )
 
-        # Verify unsubscriber was registered
-        assert connection_manager.get_stream_unsubscriber(stream_name) is mock_unsubscriber
+        mock_subscriber.assert_not_called()
+        assert connection_manager._is_stream_enabled == {}
+        assert connection_manager._stream_to_unsubscriber == {}
 
     def test_stop_stream_with_unsubscriber(self, connection_manager):
         """Test stopping stream calls unsubscriber."""
@@ -456,6 +462,7 @@ class TestConnectionManager:
 
         stream_name = "test_stream"
         subscription_type = "ohlc"
+        connection_manager.enable_stream(stream_name)  # the orchestrator arms it before submitting
 
         with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             # Execute

--- a/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
+++ b/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
@@ -413,3 +413,44 @@ class TestEnabledStreamRegistry:
         assert manager._is_stream_enabled == {}
         assert manager._stream_to_unsubscriber == {}
         assert subscriber_ran.is_set() is False
+
+
+class TestRejectedVenueCallDoesNotLeakItsCoroutine:
+    """CcxtConnector._run_sync's guard rejects before awaiting, so it must close the coroutine.
+
+    Otherwise every rejected on-loop venue call leaves an un-awaited coroutine behind, which
+    surfaces as a RuntimeWarning whenever the GC happens to get to it.
+    """
+
+    def test_run_sync_closes_the_coroutine_when_the_guard_rejects(self):
+        import inspect
+        from types import SimpleNamespace
+
+        from qubx.connectors.ccxt.connector import CcxtConnector
+        from qubx.utils.misc import AsyncThreadLoop, BackgroundEventLoop
+
+        loop = BackgroundEventLoop(name="guard-reject-test")
+        try:
+            stub = SimpleNamespace(_loop=AsyncThreadLoop(loop.loop))
+            run_sync = CcxtConnector._run_sync.__get__(stub, CcxtConnector)
+            captured: dict[str, object] = {}
+
+            async def venue_call():  # pragma: no cover - must never be awaited
+                return "unreachable"
+
+            async def on_loop() -> None:
+                # Built here, exactly as the real callers do, then handed to _run_sync.
+                coro = venue_call()
+                captured["coro"] = coro
+                try:
+                    run_sync(coro, timeout=1.0)
+                except RuntimeError as e:
+                    captured["error"] = e
+
+            loop.submit(on_loop()).result(timeout=5.0)
+
+            assert "error" in captured, "the loop-thread guard should have rejected the on-loop call"
+            state = inspect.getcoroutinestate(captured["coro"])
+            assert state == inspect.CORO_CLOSED, f"_run_sync left the rejected coroutine {state}, want CORO_CLOSED"
+        finally:
+            loop.stop()

--- a/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
+++ b/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
@@ -6,7 +6,6 @@ test instead of hanging CI forever.
 """
 
 import asyncio
-import concurrent.futures
 import threading
 import time
 from types import SimpleNamespace
@@ -265,6 +264,50 @@ class TestStopStreamIsBounded:
         assert called.wait(2.0)
 
 
+class TestUnsubscribeGracePeriod:
+    """The 1s grace lets the venue ack the unsubscribe before a new subscription reuses the same
+    hashes. It is a pure wall-clock guarantee, and it is worthless once the unsubscribe wait has
+    already timed out - the ack is not coming and waiting again doubles the worst-case stall."""
+
+    def test_no_grace_period_when_the_unsubscribe_wait_timed_out(self, exchange_manager, bg_loop):
+        manager = make_manager(exchange_manager, cleanup_timeout=0.3)
+        stream_name = "orderbook(0, 1):9:timeout-no-grace"
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, _hang_forever)
+
+        slept: list[float] = []
+        with patch("qubx.connectors.ccxt.connection_manager.time.sleep", slept.append):
+            with patch("qubx.connectors.ccxt.connection_manager.logger", MagicMock()) as log:
+                run_with_deadline(lambda: manager.stop_stream(stream_name, wait=True), 3.0)
+                warnings = " ".join(str(c) for c in log.warning.call_args_list)
+
+        assert slept == []
+        assert "grace period" not in warnings
+
+    def test_the_grace_period_is_a_plain_sleep_when_the_unsubscribe_completed(self, exchange_manager, bg_loop):
+        manager = make_manager(exchange_manager, cleanup_timeout=0.3)
+        stream_name = "orderbook(0, 1):9:grace"
+
+        async def quick_unsubscriber() -> None:
+            return None
+
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, quick_unsubscriber)
+
+        slept: list[float] = []
+        with patch("qubx.connectors.ccxt.connection_manager.time.sleep", slept.append):
+            with patch("qubx.connectors.ccxt.connection_manager.logger", MagicMock()) as log:
+                run_with_deadline(lambda: manager.stop_stream(stream_name, wait=True), 3.0)
+                warnings = " ".join(str(c) for c in log.warning.call_args_list)
+
+        # - routed through the loop, a healthy 1s grace is itself "abandoned" whenever
+        #   cleanup_timeout < 1s, which is a lie in the log and proves nothing about the venue
+        assert slept == [1]
+        assert "grace period" not in warnings
+
+
 class TestLoopThreadDetection:
     def test_detects_the_exchange_loop_thread(self, manager, bg_loop):
         async def check() -> bool:
@@ -294,8 +337,10 @@ def test_cleanup_timeout_is_actually_used(exchange_manager, bg_loop):
 
     elapsed = run_with_deadline(lambda: manager._wait(future, "timing check"), 3.0)
 
-    assert 0.4 < elapsed < 1.5
-    assert isinstance(concurrent.futures.TimeoutError(), Exception)
+    # Upper bound deliberately loose: this is the only wall-clock assert in the file and a loaded
+    # CI runner can add seconds of scheduling delay. It only needs to catch "the timeout is dead
+    # code again", i.e. an unbounded wait.
+    assert 0.4 < elapsed < 2.5
 
 
 class TestEnabledStreamRegistry:
@@ -318,7 +363,8 @@ class TestEnabledStreamRegistry:
             while not popped.is_set():
                 await asyncio.sleep(0.01)
 
-        future = bg_loop.submit(manager.listen_to_stream(subscriber, MagicMock(), channel, "trade", stream_name, None))
+        manager.enable_stream(stream_name)  # the orchestrator arms the flag before submitting
+        future = bg_loop.submit(manager.listen_to_stream(subscriber, MagicMock(), channel, "trade", stream_name))
         assert running.wait(2.0)
         assert manager._is_stream_enabled.get(stream_name) is True
 
@@ -328,3 +374,42 @@ class TestEnabledStreamRegistry:
         assert wait_until(future.done, 2.0)
         assert stream_name not in manager._is_stream_enabled
         assert manager._is_stream_enabled == {}
+
+    def test_a_task_that_starts_after_the_pop_does_not_resurrect_the_stream(self, manager, bg_loop):
+        """The other half of the race: the stream task takes its FIRST step after stop_stream popped.
+
+        `stop_stream` pops the registry before it cancels/waits, and cancelling a
+        `run_coroutine_threadsafe` future does not reliably prevent the coroutine's synchronous
+        prefix from running (the chained `task.cancel()` lands behind an already-queued
+        `Task.__step`). While that prefix wrote the enabled flag and the unsubscriber, a stopped
+        stream came back to life: `is_connected()` reported True off a dead stream forever and the
+        entry leaked. The prefix must only READ the flag.
+        """
+        stream_name = "trade:2:start-after-pop"
+        channel = MagicMock()
+        channel.control.is_set.return_value = True
+        subscriber_ran = threading.Event()
+        release_loop = threading.Event()
+
+        async def subscriber() -> None:
+            subscriber_ran.set()
+            await asyncio.sleep(0.01)
+
+        # Park the loop so the submitted task cannot start before the pop below.
+        bg_loop.loop.call_soon_threadsafe(release_loop.wait)
+        time.sleep(0.1)
+
+        manager.enable_stream(stream_name)  # the orchestrator arms the flag before submitting
+        manager.set_stream_unsubscriber(stream_name, _ping)
+        future = bg_loop.submit(manager.listen_to_stream(subscriber, MagicMock(), channel, "trade", stream_name))
+
+        # ... exactly what stop_stream does first, while the task is still queued
+        manager._is_stream_enabled.pop(stream_name, None)
+        manager._stream_to_unsubscriber.pop(stream_name, None)
+
+        release_loop.set()
+        assert wait_until(future.done, 2.0), "the stream task should exit immediately on a popped flag"
+
+        assert manager._is_stream_enabled == {}
+        assert manager._stream_to_unsubscriber == {}
+        assert subscriber_ran.is_set() is False

--- a/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
+++ b/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
@@ -296,3 +296,35 @@ def test_cleanup_timeout_is_actually_used(exchange_manager, bg_loop):
 
     assert 0.4 < elapsed < 1.5
     assert isinstance(concurrent.futures.TimeoutError(), Exception)
+
+
+class TestEnabledStreamRegistry:
+    """`_is_stream_enabled` is what CcxtDataProvider.is_connected() reads, so it must hold exactly
+    the live streams - an entry left behind for a stopped stream is a false-healthy signal."""
+
+    def test_the_stop_signal_read_does_not_resurrect_a_popped_stream(self, manager, bg_loop):
+        """stop_stream pops the flag while the listen loop is still in flight; the loop's next read
+        of it must not put the key back (`defaultdict.__getitem__` on a missing key inserts)."""
+        stream_name = "trade:2:registry"
+        channel = MagicMock()
+        channel.control.is_set.return_value = True
+        running = threading.Event()
+        popped = threading.Event()
+
+        async def subscriber() -> None:
+            running.set()
+            # Park inside the subscriber so the pop lands mid-iteration, exactly as it does when
+            # stop_stream races a subscriber that is about to return with data.
+            while not popped.is_set():
+                await asyncio.sleep(0.01)
+
+        future = bg_loop.submit(manager.listen_to_stream(subscriber, MagicMock(), channel, "trade", stream_name, None))
+        assert running.wait(2.0)
+        assert manager._is_stream_enabled.get(stream_name) is True
+
+        manager._is_stream_enabled.pop(stream_name, None)  # the first thing stop_stream does
+        popped.set()
+
+        assert wait_until(future.done, 2.0)
+        assert stream_name not in manager._is_stream_enabled
+        assert manager._is_stream_enabled == {}

--- a/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
+++ b/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
@@ -1,0 +1,298 @@
+"""Regression tests for the 2026-07-28 ccxt connector deadlock.
+
+Every test here uses a REAL background event loop: the bug is a thread/loop interaction and mocks
+cannot reproduce it. Every blocking call is run behind a hard deadline so a regression fails the
+test instead of hanging CI forever.
+"""
+
+import asyncio
+import concurrent.futures
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qubx.connectors.ccxt.connection_manager import ConnectionManager
+from qubx.connectors.ccxt.subscription_manager import SubscriptionManager
+from qubx.utils.misc import BackgroundEventLoop
+
+
+def run_with_deadline(fn, timeout: float) -> float:
+    """Run ``fn`` on a daemon thread and fail the test if it does not return in ``timeout``."""
+    outcome: dict[str, BaseException] = {}
+
+    def _run() -> None:
+        try:
+            fn()
+        except BaseException as e:  # noqa: BLE001 - re-raised on the test thread below
+            outcome["error"] = e
+
+    thread = threading.Thread(target=_run, daemon=True, name="deadline-runner")
+    started = time.monotonic()
+    thread.start()
+    thread.join(timeout)
+    elapsed = time.monotonic() - started
+
+    if thread.is_alive():
+        pytest.fail(f"call did not return within {timeout}s - unbounded wait regression")
+    if "error" in outcome:
+        raise outcome["error"]
+    return elapsed
+
+
+def wait_until(predicate, timeout: float = 5.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+async def _hang_forever() -> None:
+    await asyncio.Event().wait()
+
+
+async def _ping() -> str:
+    return "pong"
+
+
+def _drain(loop: BackgroundEventLoop) -> None:
+    """Cancel whatever is still parked on the loop and stop it without ever blocking teardown."""
+
+    async def cancel_all() -> None:
+        current = asyncio.current_task()
+        for task in asyncio.all_tasks():
+            if task is not current:
+                task.cancel()
+
+    try:
+        loop.submit(cancel_all()).result(timeout=2.0)
+        time.sleep(0.05)
+    except Exception:
+        pass
+    # BackgroundEventLoop.stop() joins its thread unbounded, and a loop these tests deliberately
+    # wedge never runs call_soon_threadsafe - stopping it off-thread keeps a regression a failing
+    # test rather than a hung CI job. The loop thread is a daemon, so leaving it is harmless.
+    stopper = threading.Thread(target=loop.stop, daemon=True, name="loop-stopper")
+    stopper.start()
+    stopper.join(2.0)
+
+
+@pytest.fixture
+def bg_loop():
+    loop = BackgroundEventLoop("DeadlockTestLoop")
+    yield loop
+    _drain(loop)
+
+
+@pytest.fixture
+def exchange_manager(bg_loop):
+    return SimpleNamespace(exchange=SimpleNamespace(asyncio_loop=bg_loop.loop), rate_limiter=None)
+
+
+def make_manager(exchange_manager, **kwargs) -> ConnectionManager:
+    params = dict(
+        exchange_id="TEST.F",
+        exchange_manager=exchange_manager,
+        subscription_manager=SubscriptionManager(),
+        cleanup_timeout=0.3,
+    )
+    params.update(kwargs)
+    return ConnectionManager(**params)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def manager(exchange_manager):
+    return make_manager(exchange_manager)
+
+
+class TestWaitIsBounded:
+    def test_future_from_run_coroutine_threadsafe_is_never_running(self, bg_loop):
+        """Documents the semantics the old `while future.running()` poll got wrong."""
+        future = bg_loop.submit(_hang_forever())
+        time.sleep(0.1)
+
+        assert future.running() is False
+        assert future.done() is False
+
+        future.cancel()
+
+    def test_wait_is_bounded_when_coroutine_never_completes(self, manager, bg_loop):
+        future = bg_loop.submit(_hang_forever())
+        time.sleep(0.05)
+
+        elapsed = run_with_deadline(lambda: manager._wait(future, "hanging coroutine"), 2.0)
+
+        assert elapsed < 2.0
+        assert wait_until(future.cancelled)
+
+    def test_wait_swallows_expected_cleanup_errors(self, manager, bg_loop):
+        async def raising() -> None:
+            raise RuntimeError("UnsubscribeError-like failure")
+
+        future = bg_loop.submit(raising())
+
+        # - must not propagate: UnsubscribeError and friends are expected during teardown
+        run_with_deadline(lambda: manager._wait(future, "failing unsubscriber"), 2.0)
+
+    def test_wait_returns_immediately_for_a_cancelled_future(self, manager, bg_loop):
+        future = bg_loop.submit(_hang_forever())
+        time.sleep(0.05)
+        future.cancel()
+
+        elapsed = run_with_deadline(lambda: manager._wait(future, "cancelled stream"), 2.0)
+
+        assert elapsed < 0.3
+
+
+class TestStopStreamIsBounded:
+    def test_stop_stream_wait_true_returns_when_unsubscriber_hangs(self, manager, bg_loop):
+        stream_name = "orderbook(0, 1):47:hanging"
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, _hang_forever)
+
+        elapsed = run_with_deadline(lambda: manager.stop_stream(stream_name, wait=True), 3.0)
+
+        assert elapsed < 3.0
+        assert manager.is_stream_enabled(stream_name) is False
+        assert manager.get_stream_future(stream_name) is None
+        assert manager.get_stream_unsubscriber(stream_name) is None
+
+    def test_stop_stream_clears_registry_even_when_the_wait_times_out(self, manager, bg_loop):
+        stream_name = "orderbook(0, 1):48:hanging"
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, _hang_forever)
+
+        run_with_deadline(lambda: manager.stop_stream(stream_name, wait=True), 3.0)
+
+        assert stream_name not in manager._is_stream_enabled
+        assert stream_name not in manager._stream_to_coro
+        assert stream_name not in manager._stream_to_unsubscriber
+
+    def test_registry_is_torn_down_before_the_blocking_waits(self, manager, bg_loop):
+        """Teardown must precede the waits, or a timeout leaves a half-removed stream behind.
+
+        Observed from inside the unsubscriber, i.e. *while* stop_stream is still blocked - checking
+        after it returns passes under either ordering.
+        """
+        stream_name = "orderbook(0, 1):48:ordering"
+        seen: dict[str, bool] = {}
+
+        async def observing_unsubscriber() -> None:
+            seen["coro"] = stream_name in manager._stream_to_coro
+            seen["unsub"] = stream_name in manager._stream_to_unsubscriber
+            seen["wanted"] = stream_name in manager._is_stream_enabled
+            await asyncio.Event().wait()
+
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, observing_unsubscriber)
+
+        run_with_deadline(lambda: manager.stop_stream(stream_name, wait=True), 3.0)
+
+        assert wait_until(lambda: "coro" in seen)
+        assert seen == {"coro": False, "unsub": False, "wanted": False}
+
+    def test_stop_stream_from_loop_thread_does_not_deadlock(self, exchange_manager, bg_loop):
+        """Reproduction of the 00:02:28 self-deadlock that froze okx-am-agg for 18 days.
+
+        Production-ish cleanup_timeout on purpose: with a short one an un-degraded path still
+        returns quickly and the test would pass while the exchange loop is frozen for seconds.
+        """
+        manager = make_manager(exchange_manager, cleanup_timeout=5.0)
+        stream_name = "orderbook(0, 1):47:self-deadlock"
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, _hang_forever)
+
+        elapsed: dict[str, float] = {}
+
+        async def stop_from_the_loop() -> None:
+            started = time.monotonic()
+            manager.stop_stream(stream_name)  # wait=True, the production default
+            elapsed["seconds"] = time.monotonic() - started
+
+        with patch("qubx.connectors.ccxt.connection_manager.logger", MagicMock()) as log:
+            stopping = bg_loop.submit(stop_from_the_loop())
+            # - the loop must stay responsive *while* stop_stream runs on it: on the broken version
+            #   it is parked on itself and this ping never gets a turn
+            assert bg_loop.submit(_ping()).result(timeout=2.0) == "pong"
+            stopping.result(timeout=5.0)
+            degraded = " ".join(str(c) for c in log.info.call_args_list)
+
+        assert elapsed["seconds"] < 1.0
+        assert "degrading to non-blocking cleanup" in degraded
+        # - and the unsubscriber was still scheduled, fire-and-forget
+        assert manager.get_stream_unsubscriber(stream_name) is None
+
+    def test_stop_stream_from_loop_thread_never_raises(self, exchange_manager, bg_loop):
+        """Raising would propagate into callers that treat it as a fault and stop their poller."""
+        manager = make_manager(exchange_manager, cleanup_timeout=5.0)
+        stream_name = "quote:3:no-raise"
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, _hang_forever)
+
+        async def stop_from_the_loop() -> str:
+            manager.stop_stream(stream_name)
+            return "returned"
+
+        assert bg_loop.submit(stop_from_the_loop()).result(timeout=5.0) == "returned"
+
+    def test_the_degraded_path_still_schedules_the_unsubscriber(self, exchange_manager, bg_loop):
+        """Degrading must not silently drop the venue-side unsubscribe."""
+        manager = make_manager(exchange_manager, cleanup_timeout=5.0)
+        stream_name = "quote:3:degraded-unsub"
+        called = threading.Event()
+
+        async def unsubscriber() -> None:
+            called.set()
+
+        manager.enable_stream(stream_name)
+        manager.register_stream_future(stream_name, bg_loop.submit(_hang_forever()))
+        manager.set_stream_unsubscriber(stream_name, unsubscriber)
+
+        async def stop_from_the_loop() -> None:
+            manager.stop_stream(stream_name)
+
+        bg_loop.submit(stop_from_the_loop()).result(timeout=5.0)
+
+        assert called.wait(2.0)
+
+
+class TestLoopThreadDetection:
+    def test_detects_the_exchange_loop_thread(self, manager, bg_loop):
+        async def check() -> bool:
+            return manager._on_exchange_loop_thread()
+
+        assert bg_loop.submit(check()).result(timeout=2.0) is True
+
+    def test_off_loop_thread_is_not_flagged(self, manager):
+        assert manager._on_exchange_loop_thread() is False
+
+    def test_a_different_loop_is_not_flagged(self, manager):
+        other = BackgroundEventLoop("OtherLoop")
+        try:
+
+            async def check() -> bool:
+                return manager._on_exchange_loop_thread()
+
+            assert other.submit(check()).result(timeout=2.0) is False
+        finally:
+            _drain(other)
+
+
+def test_cleanup_timeout_is_actually_used(exchange_manager, bg_loop):
+    """The old poll loop made `cleanup_timeout` dead code; it must bound the wait now."""
+    manager = make_manager(exchange_manager, cleanup_timeout=0.5)
+    future = bg_loop.submit(_hang_forever())
+
+    elapsed = run_with_deadline(lambda: manager._wait(future, "timing check"), 3.0)
+
+    assert 0.4 < elapsed < 1.5
+    assert isinstance(concurrent.futures.TimeoutError(), Exception)

--- a/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
+++ b/tests/qubx/connectors/ccxt/test_connection_manager_deadlock.py
@@ -1,8 +1,8 @@
-"""Regression tests for the 2026-07-28 ccxt connector deadlock.
+"""Regression tests for the ccxt connector self-deadlock.
 
-Every test here uses a REAL background event loop: the bug is a thread/loop interaction and mocks
-cannot reproduce it. Every blocking call is run behind a hard deadline so a regression fails the
-test instead of hanging CI forever.
+Every test uses a REAL background event loop: the bug is a thread/loop interaction and mocks cannot
+reproduce it. Every blocking call runs behind a hard deadline so a regression fails the test
+instead of hanging CI forever.
 """
 
 import asyncio
@@ -198,7 +198,7 @@ class TestStopStreamIsBounded:
         assert seen == {"coro": False, "unsub": False, "wanted": False}
 
     def test_stop_stream_from_loop_thread_does_not_deadlock(self, exchange_manager, bg_loop):
-        """Reproduction of the 00:02:28 self-deadlock that froze okx-am-agg for 18 days.
+        """stop_stream called *on* the exchange loop must not park that loop on itself.
 
         Production-ish cleanup_timeout on purpose: with a short one an un-degraded path still
         returns quickly and the test would pass while the exchange loop is frozen for seconds.
@@ -266,8 +266,8 @@ class TestStopStreamIsBounded:
 
 class TestUnsubscribeGracePeriod:
     """The 1s grace lets the venue ack the unsubscribe before a new subscription reuses the same
-    hashes. It is a pure wall-clock guarantee, and it is worthless once the unsubscribe wait has
-    already timed out - the ack is not coming and waiting again doubles the worst-case stall."""
+    hashes. Pure wall-clock, and skipped once the unsubscribe wait has already timed out - no ack
+    is coming and waiting again doubles the worst-case stall."""
 
     def test_no_grace_period_when_the_unsubscribe_wait_timed_out(self, exchange_manager, bg_loop):
         manager = make_manager(exchange_manager, cleanup_timeout=0.3)
@@ -378,12 +378,10 @@ class TestEnabledStreamRegistry:
     def test_a_task_that_starts_after_the_pop_does_not_resurrect_the_stream(self, manager, bg_loop):
         """The other half of the race: the stream task takes its FIRST step after stop_stream popped.
 
-        `stop_stream` pops the registry before it cancels/waits, and cancelling a
-        `run_coroutine_threadsafe` future does not reliably prevent the coroutine's synchronous
-        prefix from running (the chained `task.cancel()` lands behind an already-queued
-        `Task.__step`). While that prefix wrote the enabled flag and the unsubscriber, a stopped
-        stream came back to life: `is_connected()` reported True off a dead stream forever and the
-        entry leaked. The prefix must only READ the flag.
+        Cancelling a `run_coroutine_threadsafe` future does not reliably prevent that first step
+        from running - the chained `task.cancel()` lands behind an already-queued `Task.__step`.
+        So the coroutine must only READ the flag; writing it there resurrects a stopped stream and
+        `is_connected()` reports True off a dead one forever.
         """
         stream_name = "trade:2:start-after-pop"
         channel = MagicMock()

--- a/tests/qubx/connectors/ccxt/test_data_provider.py
+++ b/tests/qubx/connectors/ccxt/test_data_provider.py
@@ -332,8 +332,8 @@ def test_stale_recovery_does_not_collapse_bulk_subscription_set(data_provider):
 def test_a_concurrent_universe_change_cannot_interleave_with_a_transition(data_provider):
     """The stale-data watchdog thread and the strategy thread both drive subscriptions. Computing
     the instrument set and rebuilding the stream that serves it is one read-modify-write: a churn
-    that lands in the middle of it rebuilds from a half-updated set, which was observed emptying a
-    subscription type outright ("No active subscription for ...") with no resubscribe to follow.
+    landing in the middle rebuilds from a half-updated set and can empty a subscription type
+    outright, with no resubscribe to follow.
     """
     instruments = [_make_instrument(i) for i in range(6)]
     parked = threading.Event()

--- a/tests/qubx/connectors/ccxt/test_data_provider.py
+++ b/tests/qubx/connectors/ccxt/test_data_provider.py
@@ -1,11 +1,12 @@
 """Simple unit tests for CcxtDataProvider focusing on core functionality."""
 
 import asyncio
+import concurrent.futures
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 
-from qubx.connectors.ccxt.data import CcxtDataProvider
+from qubx.connectors.ccxt.data import MARKETS_LOAD_TIMEOUT_SECONDS, CcxtDataProvider
 from qubx.connectors.ccxt.handlers.ohlc import OhlcDataHandler
 from qubx.connectors.plugin import BuildContext
 from qubx.core.basics import CtrlChannel, Instrument, MarketType
@@ -193,31 +194,30 @@ class TestBasicFunctionality:
                 data_provider.get_ohlc(btc_instrument, "1m", 10)
 
     def test_start_loads_markets(self, data_provider):
-        """start() should eagerly load markets via the async loop."""
+        """start() should eagerly load markets via the async loop, with a timeout."""
         data_provider._exchange_manager.exchange.load_markets = Mock(return_value="markets_coro")
         data_provider._exchange_manager.exchange.markets = {"BTC/USDT:USDT": {}}
 
-        # - _loop is a property; patch it so submit(...).result() is fully mocked
+        # - _loop is a property; patch it so run_sync(...) is fully mocked
         mock_loop = Mock()
         with patch.object(type(data_provider), "_loop", new_callable=PropertyMock, return_value=mock_loop):
             data_provider.start()
 
-        # - load_markets coroutine must have been created and submitted to the loop
+        # - load_markets coroutine must have been created and run on the loop, bounded
         data_provider._exchange_manager.exchange.load_markets.assert_called_once()
-        mock_loop.submit.assert_called_once_with("markets_coro")
-        mock_loop.submit.return_value.result.assert_called_once()
+        mock_loop.run_sync.assert_called_once_with("markets_coro", timeout=MARKETS_LOAD_TIMEOUT_SECONDS)
 
     def test_start_swallows_load_markets_error(self, data_provider):
-        """start() must not raise if markets load fails (listing checks fail-open)."""
+        """start() must not raise if markets load fails or times out (listing checks fail-open)."""
         mock_loop = Mock()
-        mock_loop.submit.return_value.result.side_effect = Exception("boom")
+        mock_loop.run_sync.side_effect = concurrent.futures.TimeoutError()
         data_provider._exchange_manager.exchange.load_markets = Mock(return_value="markets_coro")
 
         with patch.object(type(data_provider), "_loop", new_callable=PropertyMock, return_value=mock_loop):
             # - should not raise
             data_provider.start()
 
-        mock_loop.submit.return_value.result.assert_called_once()
+        mock_loop.run_sync.assert_called_once()
 
     def test_close_calls_exchange_close(self, data_provider):
         """Test that close method calls exchange close."""

--- a/tests/qubx/connectors/ccxt/test_data_provider.py
+++ b/tests/qubx/connectors/ccxt/test_data_provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import concurrent.futures
+import threading
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
@@ -326,6 +327,47 @@ def test_stale_recovery_does_not_collapse_bulk_subscription_set(data_provider):
 
             # Provider state should also reflect the full desired set.
             assert len(data_provider.get_subscribed_instruments("quote")) == 40
+
+
+def test_a_concurrent_universe_change_cannot_interleave_with_a_transition(data_provider):
+    """The stale-data watchdog thread and the strategy thread both drive subscriptions. Computing
+    the instrument set and rebuilding the stream that serves it is one read-modify-write: a churn
+    that lands in the middle of it rebuilds from a half-updated set, which was observed emptying a
+    subscription type outright ("No active subscription for ...") with no resubscribe to follow.
+    """
+    instruments = [_make_instrument(i) for i in range(6)]
+    parked = threading.Event()
+    release = threading.Event()
+
+    def park(**kwargs):
+        if not parked.is_set():
+            parked.set()
+            release.wait(2.0)
+
+    with patch.object(data_provider._data_type_handler_factory, "get_handler", return_value=Mock()):
+        with patch.object(data_provider._subscription_orchestrator, "execute_subscription", side_effect=park):
+            first = threading.Thread(target=lambda: data_provider.subscribe("quote", instruments), daemon=True)
+            first.start()
+            assert parked.wait(5.0), "the first transition never started"
+
+            churn_done = threading.Event()
+
+            def churn():
+                data_provider.unsubscribe("quote", instruments[:2])
+                churn_done.set()
+
+            second = threading.Thread(target=churn, daemon=True)
+            second.start()
+
+            assert not churn_done.wait(0.3), (
+                "a universe change mutated the subscription set while another transition was mid-flight"
+            )
+
+            release.set()
+            assert churn_done.wait(5.0)
+            first.join(5.0)
+            second.join(5.0)
+            assert not first.is_alive() and not second.is_alive()
 
 
 class TestDelegation:

--- a/tests/qubx/connectors/ccxt/test_no_unbounded_result.py
+++ b/tests/qubx/connectors/ccxt/test_no_unbounded_result.py
@@ -1,0 +1,114 @@
+"""Lint gate: no unbounded blocking wait anywhere under `qubx/connectors/ccxt/`.
+
+A single timeout-less `concurrent.futures.Future.result()` on the exchange event loop froze a live
+bot for 18 days. This makes the pattern unrepresentable rather than merely fixed.
+
+Covered: `.result(...)`, `.exception(...)` and `run_sync(...)` — the three ways this package blocks
+a thread on the exchange loop. A literal `None` timeout counts as unbounded, because that is what
+`Future.result(timeout=None)` actually does. Not covered (and not currently used here to wait on the
+exchange loop): `Event.wait`, `Thread.join`, `concurrent.futures.wait`.
+
+A call that genuinely cannot take a timeout (an already-resolved asyncio Future, whose `result()`
+has no timeout parameter at all) must say so with an explicit `unbounded-result-ok:` comment on its
+line.
+"""
+
+import ast
+import pathlib
+
+import qubx.connectors.ccxt as ccxt_package
+
+CCXT_ROOT = pathlib.Path(ccxt_package.__file__).parent
+OPT_OUT_MARKER = "unbounded-result-ok"
+BLOCKING_ATTRS = ("result", "exception")
+
+
+def _is_none_literal(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _is_bounded(node: ast.Call) -> bool:
+    """A call is bounded when it is given a timeout that is not a literal ``None``."""
+    for kw in node.keywords:
+        if kw.arg == "timeout":
+            return not _is_none_literal(kw.value)
+    if node.args:
+        return not _is_none_literal(node.args[0])
+    return False
+
+
+def _called_name(node: ast.Call) -> str | None:
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    return None
+
+
+def _unbounded_calls(path: pathlib.Path) -> list[tuple[int, str]]:
+    source = path.read_text()
+    lines = source.splitlines()
+    findings = []
+    for node in ast.walk(ast.parse(source, filename=str(path))):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _called_name(node)
+        if name == "run_sync":
+            # run_sync's own timeout defaults to None, so an omitted timeout is unbounded too.
+            bounded = any(kw.arg == "timeout" and not _is_none_literal(kw.value) for kw in node.keywords)
+        elif name in BLOCKING_ATTRS:
+            bounded = _is_bounded(node)
+        else:
+            continue
+        if bounded:
+            continue
+        # A multi-line call reports at its first line; scan the whole span for the opt-out.
+        span = lines[node.lineno - 1 : (node.end_lineno or node.lineno)]
+        if any(OPT_OUT_MARKER in line for line in span):
+            continue
+        findings.append((node.end_lineno or node.lineno, lines[node.lineno - 1].strip()))
+    return findings
+
+
+def test_no_unbounded_waits_in_ccxt_connector():
+    offenders = []
+    for path in sorted(CCXT_ROOT.rglob("*.py")):
+        for lineno, line in _unbounded_calls(path):
+            offenders.append(f"{path.relative_to(CCXT_ROOT.parents[2])}:{lineno}: {line}")
+
+    assert not offenders, (
+        "unbounded blocking waits found - pass a timeout, or annotate the call with "
+        f"`# {OPT_OUT_MARKER}: <reason>` if the future genuinely cannot take one:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_gate_actually_detects_the_pattern(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "def f(future, other, third, fourth, loop, coro):\n"
+        "    future.result()\n"
+        "    other.result(5)\n"
+        "    third.result(timeout=1)\n"
+        "    fourth.result(timeout=None)\n"
+        "    future.result(None)\n"
+        "    future.exception()\n"
+        "    logger.exception(err)\n"
+        "    loop.run_sync(coro)\n"
+        "    loop.run_sync(coro, timeout=None)\n"
+        "    loop.run_sync(coro, timeout=3)\n"
+        f"    future.result()  # {OPT_OUT_MARKER}: already done\n"
+    )
+
+    assert [lineno for lineno, _ in _unbounded_calls(sample)] == [2, 5, 6, 7, 9, 10]
+
+
+def test_the_gate_finds_the_opt_out_on_a_multiline_call(tmp_path):
+    sample = tmp_path / "multiline.py"
+    sample.write_text(
+        "def f(loop, coro):\n"
+        f"    return loop.submit(  # {OPT_OUT_MARKER}: reason\n"
+        "        coro\n"
+        "    ).result()\n"
+    )
+
+    assert _unbounded_calls(sample) == []

--- a/tests/qubx/connectors/ccxt/test_no_unbounded_result.py
+++ b/tests/qubx/connectors/ccxt/test_no_unbounded_result.py
@@ -1,7 +1,7 @@
 """Lint gate: no unbounded blocking wait anywhere under `qubx/connectors/ccxt/`.
 
-A single timeout-less `concurrent.futures.Future.result()` on the exchange event loop froze a live
-bot for 18 days. This makes the pattern unrepresentable rather than merely fixed.
+A single timeout-less `concurrent.futures.Future.result()` waiting on the exchange event loop can
+freeze a bot indefinitely. This gate makes the pattern unrepresentable rather than merely fixed.
 
 Covered: `.result(...)`, `.exception(...)` and `run_sync(...)` — the three ways this package blocks
 a thread on the exchange loop. A literal `None` timeout counts as unbounded, because that is what

--- a/tests/qubx/connectors/ccxt/test_orderbook_handler.py
+++ b/tests/qubx/connectors/ccxt/test_orderbook_handler.py
@@ -568,3 +568,69 @@ class TestOrderBookHandlerEdgeCases:
         # Should re-raise the exception for connection manager to handle
         with pytest.raises(Exception, match="Connection failed"):
             await btc_subscriber()
+
+
+class TestExchangeIsCapturedAtPrepareTime:
+    """Recreation swaps `exchange_manager.exchange` under a live subscription.
+
+    Closures that resolve it at call time would aim an unsubscriber at an exchange the stream was
+    never established on, so the venue never acks and the wait runs to its timeout.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bulk_unsubscriber_targets_the_exchange_it_was_prepared_on(
+        self, mock_data_provider, mock_exchange_with_bulk_support, orderbook_channel, btc_instrument
+    ):
+        handler = OrderBookDataHandler(
+            data_provider=mock_data_provider,
+            exchange_manager=mock_exchange_with_bulk_support,
+            exchange_id="test",
+        )
+        config = handler.prepare_subscription(
+            name="test_stream",
+            sub_type=DataType.ORDERBOOK,
+            channel=orderbook_channel,
+            instruments={btc_instrument},
+        )
+        original = mock_exchange_with_bulk_support.exchange
+
+        recreated = Mock()
+        recreated.has = {"watchOrderBookForSymbols": True}
+        recreated.un_watch_order_book_for_symbols = AsyncMock()
+        recreated.name = "binance"
+        mock_exchange_with_bulk_support.exchange = recreated
+
+        assert config.unsubscriber_func is not None
+        await config.unsubscriber_func()
+
+        original.un_watch_order_book_for_symbols.assert_awaited_once()
+        recreated.un_watch_order_book_for_symbols.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_individual_unsubscriber_targets_the_exchange_it_was_prepared_on(
+        self, mock_data_provider, mock_exchange_without_bulk_support, orderbook_channel, btc_instrument
+    ):
+        handler = OrderBookDataHandler(
+            data_provider=mock_data_provider,
+            exchange_manager=mock_exchange_without_bulk_support,
+            exchange_id="test",
+        )
+        config = handler.prepare_subscription(
+            name="test_stream",
+            sub_type=DataType.ORDERBOOK,
+            channel=orderbook_channel,
+            instruments={btc_instrument},
+        )
+        original = mock_exchange_without_bulk_support.exchange
+
+        recreated = Mock()
+        recreated.has = {"watchOrderBookForSymbols": False}
+        recreated.un_watch_order_book = AsyncMock()
+        recreated.name = "binance"
+        mock_exchange_without_bulk_support.exchange = recreated
+
+        assert config.instrument_unsubscribers is not None
+        await config.instrument_unsubscribers[btc_instrument]()
+
+        original.un_watch_order_book.assert_awaited_once()
+        recreated.un_watch_order_book.assert_not_awaited()

--- a/tests/qubx/connectors/ccxt/test_subscription_orchestrator.py
+++ b/tests/qubx/connectors/ccxt/test_subscription_orchestrator.py
@@ -477,7 +477,7 @@ class TestIndividualSubscriptions:
 class TestConcurrentTransitions:
     """The stale-data watchdog thread and the strategy thread both drive subscriptions for the
     same (exchange, data_type), and `_sub_to_name` is the only handle to a started bulk stream.
-    An interleaved read-stop-swap used to leave one stream live with nothing left to stop it.
+    An interleaved read-stop-swap must not leave a stream live with nothing left to stop it.
     """
 
     @staticmethod
@@ -593,9 +593,9 @@ class TestConcurrentTransitions:
 class TestStreamRegistryIsArmedBeforeSubmit:
     """The orchestrator - not the stream coroutine - owns the enabled flag and the unsubscriber.
 
-    `listen_to_stream` used to write both on its first (synchronous) step, which runs on the
-    exchange loop. A `stop_stream` that popped them while the task was merely queued was then
-    silently undone, leaving `is_connected()` reporting True off a dead stream forever.
+    If the coroutine wrote them on its first (synchronous, on-loop) step, a `stop_stream` that
+    popped them while the task was merely queued would be silently undone, leaving
+    `is_connected()` reporting True off a dead stream.
     """
 
     def _config_factory(self, unsubscriber):

--- a/tests/qubx/connectors/ccxt/test_subscription_orchestrator.py
+++ b/tests/qubx/connectors/ccxt/test_subscription_orchestrator.py
@@ -590,6 +590,95 @@ class TestConcurrentTransitions:
         assert done.wait(5.0), "reentrant unsubscription deadlocked the subscription transition"
 
 
+class TestStreamRegistryIsArmedBeforeSubmit:
+    """The orchestrator - not the stream coroutine - owns the enabled flag and the unsubscriber.
+
+    `listen_to_stream` used to write both on its first (synchronous) step, which runs on the
+    exchange loop. A `stop_stream` that popped them while the task was merely queued was then
+    silently undone, leaving `is_connected()` reporting True off a dead stream forever.
+    """
+
+    def _config_factory(self, unsubscriber):
+        def mock_prepare(name, sub_type, channel, instruments, **kwargs):
+            return SubscriptionConfiguration(
+                subscription_type=sub_type,
+                channel=None,
+                subscriber_func=AsyncMock(),
+                unsubscriber_func=unsubscriber,
+                stream_name=name,
+            )
+
+        return mock_prepare
+
+    def test_bulk_stream_is_enabled_before_its_task_is_submitted(
+        self, orchestrator, connection_manager, btc_instrument, mock_exchange, ctrl_channel
+    ):
+        seen_at_submit = {}
+        original_submit = orchestrator._loop.submit.side_effect
+
+        def submit(coro):
+            name = orchestrator._subscription_manager.get_subscription_stream("orderbook(0, 1)")
+            seen_at_submit["enabled"] = connection_manager.is_stream_enabled(name)
+            seen_at_submit["unsubscriber"] = connection_manager.get_stream_unsubscriber(name)
+            return original_submit(coro)
+
+        orchestrator._loop.submit = Mock(side_effect=submit)
+
+        unsubscriber = AsyncMock()
+        handler = Mock()
+        handler.prepare_subscription.side_effect = self._config_factory(unsubscriber)
+
+        orchestrator.execute_subscription(
+            subscription_type="orderbook(0, 1)",
+            instruments={btc_instrument},
+            handler=handler,
+            exchange=mock_exchange,
+            channel=ctrl_channel,
+        )
+
+        assert seen_at_submit["enabled"] is True
+        assert seen_at_submit["unsubscriber"] is unsubscriber
+
+    def test_individual_streams_are_enabled_before_their_tasks_are_submitted(
+        self, orchestrator, connection_manager, btc_instrument, eth_instrument, mock_exchange, ctrl_channel
+    ):
+        unsubscribers = {btc_instrument: AsyncMock(), eth_instrument: AsyncMock()}
+        seen_at_submit = []
+        original_submit = orchestrator._loop.submit.side_effect
+
+        def submit(coro):
+            seen_at_submit.append(dict(connection_manager._is_stream_enabled))
+            return original_submit(coro)
+
+        orchestrator._loop.submit = Mock(side_effect=submit)
+
+        def mock_prepare(name, sub_type, channel, instruments, **kwargs):
+            return SubscriptionConfiguration(
+                subscription_type=sub_type,
+                channel=None,
+                instrument_subscribers={i: AsyncMock() for i in instruments},
+                instrument_unsubscribers=unsubscribers,
+            )
+
+        handler = Mock()
+        handler.prepare_subscription.side_effect = mock_prepare
+
+        orchestrator.execute_subscription(
+            subscription_type="trade",
+            instruments={btc_instrument, eth_instrument},
+            handler=handler,
+            exchange=mock_exchange,
+            channel=ctrl_channel,
+        )
+
+        # each submit already sees its own stream armed
+        assert len(seen_at_submit) == 2
+        assert seen_at_submit[0] == {"BTCUSDT:trade": True} or seen_at_submit[0] == {"ETHUSDT:trade": True}
+        assert len(seen_at_submit[1]) == 2
+        assert connection_manager.get_stream_unsubscriber("BTCUSDT:trade") is unsubscribers[btc_instrument]
+        assert connection_manager.get_stream_unsubscriber("ETHUSDT:trade") is unsubscribers[eth_instrument]
+
+
 class TestEdgeCases:
     """Test edge cases and error conditions."""
 

--- a/tests/qubx/connectors/ccxt/test_subscription_orchestrator.py
+++ b/tests/qubx/connectors/ccxt/test_subscription_orchestrator.py
@@ -6,6 +6,7 @@ including resubscription behavior and cleanup.
 """
 
 import concurrent.futures
+import threading
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -471,6 +472,122 @@ class TestIndividualSubscriptions:
             c for c in connection_manager.stop_stream.call_args_list if c.kwargs.get("wait") is False
         ]
         assert len(calls_with_wait_false) >= 1
+
+
+class TestConcurrentTransitions:
+    """The stale-data watchdog thread and the strategy thread both drive subscriptions for the
+    same (exchange, data_type), and `_sub_to_name` is the only handle to a started bulk stream.
+    An interleaved read-stop-swap used to leave one stream live with nothing left to stop it.
+    """
+
+    @staticmethod
+    def _bulk_handler():
+        handler = Mock()
+
+        def prepare(name, sub_type, channel, instruments, **kwargs):
+            return SubscriptionConfiguration(
+                subscription_type=sub_type,
+                channel=channel,
+                subscriber_func=AsyncMock(),
+                stream_name=name,
+            )
+
+        handler.prepare_subscription.side_effect = prepare
+        return handler
+
+    def test_interleaved_resubscriptions_leave_no_orphan_stream(
+        self, orchestrator, btc_instrument, eth_instrument, sol_instrument, mock_exchange, ctrl_channel
+    ):
+        connection_manager = orchestrator._connection_manager
+        handler = self._bulk_handler()
+
+        started: list[str] = []
+        stop_requested: list[str] = []
+        first_stop_entered = threading.Event()
+        second_transition_done = threading.Event()
+
+        original_register = connection_manager.register_stream_future
+
+        def register(stream_name, future):
+            started.append(stream_name)
+            original_register(stream_name, future)
+
+        def stop_stream(stream_name, wait=True):
+            stop_requested.append(stream_name)
+            connection_manager._stream_to_coro.pop(stream_name, None)
+            connection_manager._stream_to_unsubscriber.pop(stream_name, None)
+            connection_manager._is_stream_enabled.pop(stream_name, None)
+            if not first_stop_entered.is_set():
+                first_stop_entered.set()
+                # Hold this transition open so the other thread gets a chance to interleave.
+                # Bounded: once transitions are serialized the other thread cannot run yet.
+                second_transition_done.wait(0.5)
+
+        connection_manager.register_stream_future = register  # type: ignore[method-assign]
+        connection_manager.stop_stream = stop_stream  # type: ignore[method-assign]
+
+        def subscribe(instruments):
+            orchestrator.execute_subscription(
+                subscription_type="trade",
+                instruments=instruments,
+                handler=handler,
+                exchange=mock_exchange,
+                channel=ctrl_channel,
+            )
+
+        subscribe({btc_instrument, eth_instrument})
+
+        watchdog = threading.Thread(target=lambda: subscribe({btc_instrument}), daemon=True)
+        watchdog.start()
+        assert first_stop_entered.wait(5.0), "the watchdog thread never entered its transition"
+
+        subscribe({btc_instrument, eth_instrument, sol_instrument})
+        second_transition_done.set()
+        watchdog.join(5.0)
+        assert not watchdog.is_alive()
+
+        assert len(started) == 3
+        current = orchestrator._subscription_manager.get_subscription_stream("trade")
+        orphans = [name for name in started if name != current and name not in stop_requested]
+        assert orphans == [], f"streams started and never stop-requested: {orphans}"
+
+    def test_handler_that_unsubscribes_while_preparing_does_not_deadlock(
+        self, orchestrator, btc_instrument, mock_exchange, ctrl_channel
+    ):
+        """QuoteDataHandler unsubscribes from inside prepare_subscription when the venue has no
+        watchBidsAsks, which reenters the orchestrator on the same thread."""
+        handler = Mock()
+
+        def prepare(name, sub_type, channel, instruments, **kwargs):
+            orchestrator.execute_unsubscription(
+                SubscriptionConfiguration(
+                    subscription_type=sub_type, channel=channel, stream_name=f"cleanup_{sub_type}"
+                )
+            )
+            return SubscriptionConfiguration(
+                subscription_type=sub_type,
+                channel=channel,
+                subscriber_func=AsyncMock(),
+                stream_name=name,
+            )
+
+        handler.prepare_subscription.side_effect = prepare
+
+        done = threading.Event()
+
+        def run():
+            orchestrator.execute_subscription(
+                subscription_type="quote",
+                instruments={btc_instrument},
+                handler=handler,
+                exchange=mock_exchange,
+                channel=ctrl_channel,
+            )
+            done.set()
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        assert done.wait(5.0), "reentrant unsubscription deadlocked the subscription transition"
 
 
 class TestEdgeCases:

--- a/tests/qubx/control/test_builtin.py
+++ b/tests/qubx/control/test_builtin.py
@@ -1,7 +1,4 @@
-import json
 from unittest.mock import MagicMock
-
-import numpy as np
 
 from qubx.control.builtin import BUILTIN_ACTIONS, _refresh_instrument_service
 
@@ -190,34 +187,6 @@ class TestGetHealth:
         assert "connected" in result.data
         assert "queue_size" in result.data
         assert "data_latencies_ms" in result.data
-
-    def test_reports_last_event_ages_in_seconds(self):
-        ctx = _make_mock_ctx()
-        now = np.datetime64("2026-04-05T10:00:00", "ns")
-        ctx.time.return_value = now
-        ctx.health.get_last_event_times_by_exchange.return_value = {
-            "orderbook": now - np.timedelta64(1500, "ms"),
-            "trade": now - np.timedelta64(42, "s"),
-        }
-
-        _, handler = BUILTIN_ACTIONS["get_health"]
-        result = handler(ctx)
-
-        assert result.data["last_event_ages_s"]["BINANCE.UM"] == {"orderbook": 1.5, "trade": 42.0}
-
-    def test_a_never_seen_event_type_is_none_not_nan(self):
-        """The payload is JSON-serialised with allow_nan=False, so a NaN age would 500 the whole
-        health endpoint."""
-        ctx = _make_mock_ctx()
-        now = np.datetime64("2026-04-05T10:00:00", "ns")
-        ctx.time.return_value = now
-        ctx.health.get_last_event_times_by_exchange.return_value = {"quote": np.datetime64("NaT", "ns")}
-
-        _, handler = BUILTIN_ACTIONS["get_health"]
-        result = handler(ctx)
-
-        assert result.data["last_event_ages_s"]["BINANCE.UM"] == {"quote": None}
-        json.dumps(result.data["last_event_ages_s"], allow_nan=False)
 
 
 class TestGetOrders:

--- a/tests/qubx/control/test_builtin.py
+++ b/tests/qubx/control/test_builtin.py
@@ -206,8 +206,8 @@ class TestGetHealth:
         assert result.data["last_event_ages_s"]["BINANCE.UM"] == {"orderbook": 1.5, "trade": 42.0}
 
     def test_a_never_seen_event_type_is_none_not_nan(self):
-        """The payload is JSON-serialised with allow_nan=False - a NaN age 500s the endpoint the
-        platform watchdog polls, i.e. blinds the probe this signal exists for."""
+        """The payload is JSON-serialised with allow_nan=False, so a NaN age would 500 the whole
+        health endpoint."""
         ctx = _make_mock_ctx()
         now = np.datetime64("2026-04-05T10:00:00", "ns")
         ctx.time.return_value = now

--- a/tests/qubx/control/test_builtin.py
+++ b/tests/qubx/control/test_builtin.py
@@ -1,4 +1,7 @@
+import json
 from unittest.mock import MagicMock
+
+import numpy as np
 
 from qubx.control.builtin import BUILTIN_ACTIONS, _refresh_instrument_service
 
@@ -187,6 +190,34 @@ class TestGetHealth:
         assert "connected" in result.data
         assert "queue_size" in result.data
         assert "data_latencies_ms" in result.data
+
+    def test_reports_last_event_ages_in_seconds(self):
+        ctx = _make_mock_ctx()
+        now = np.datetime64("2026-04-05T10:00:00", "ns")
+        ctx.time.return_value = now
+        ctx.health.get_last_event_times_by_exchange.return_value = {
+            "orderbook": now - np.timedelta64(1500, "ms"),
+            "trade": now - np.timedelta64(42, "s"),
+        }
+
+        _, handler = BUILTIN_ACTIONS["get_health"]
+        result = handler(ctx)
+
+        assert result.data["last_event_ages_s"]["BINANCE.UM"] == {"orderbook": 1.5, "trade": 42.0}
+
+    def test_a_never_seen_event_type_is_none_not_nan(self):
+        """The payload is JSON-serialised with allow_nan=False - a NaN age 500s the endpoint the
+        platform watchdog polls, i.e. blinds the probe this signal exists for."""
+        ctx = _make_mock_ctx()
+        now = np.datetime64("2026-04-05T10:00:00", "ns")
+        ctx.time.return_value = now
+        ctx.health.get_last_event_times_by_exchange.return_value = {"quote": np.datetime64("NaT", "ns")}
+
+        _, handler = BUILTIN_ACTIONS["get_health"]
+        result = handler(ctx)
+
+        assert result.data["last_event_ages_s"]["BINANCE.UM"] == {"quote": None}
+        json.dumps(result.data["last_event_ages_s"], allow_nan=False)
 
 
 class TestGetOrders:

--- a/tests/qubx/core/mixins/state_snapshot_test.py
+++ b/tests/qubx/core/mixins/state_snapshot_test.py
@@ -1,0 +1,53 @@
+"""The state snapshot carries per-exchange data ages.
+
+A fresh snapshot only proves the thread writing it is running. A bot whose thread is alive while its
+market-data feed is dead writes fresh snapshots the whole time — the ages are what make that visible.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from qubx.core.mixins.processing import ProcessingManager
+
+
+class TestSnapshotDataAges:
+    def _manager(self, now, last_event_times):
+        m = ProcessingManager.__new__(ProcessingManager)
+        m._time_provider = MagicMock()
+        m._time_provider.time.return_value = now
+        m._health_monitor = MagicMock()
+        m._health_monitor.get_last_event_times_by_exchange.return_value = last_event_times
+        return m
+
+    def test_ages_are_seconds_since_the_last_event(self):
+        now = np.datetime64("2026-04-05T10:00:00", "ns")
+        m = self._manager(now, {"orderbook": now - np.timedelta64(1500, "ms"), "trade": now - np.timedelta64(42, "s")})
+
+        assert m._last_event_ages("BINANCE.UM") == {"orderbook": 1.5, "trade": 42.0}
+
+    def test_a_never_seen_event_type_is_none_not_a_huge_age(self):
+        """A warming-up bot has no events yet; reporting that as infinitely stale would page on
+        every start."""
+        now = np.datetime64("2026-04-05T10:00:00", "ns")
+        m = self._manager(now, {"orderbook": None})
+
+        assert m._last_event_ages("BINANCE.UM") == {"orderbook": None}
+
+    def test_a_wedged_feed_shows_a_growing_age(self):
+        """The 2026-08-18 shape: the writing thread is alive, so the snapshot is fresh, but no data
+        has arrived for minutes."""
+        now = np.datetime64("2026-04-05T10:00:00", "ns")
+        m = self._manager(now, {"orderbook": now - np.timedelta64(11, "m")})
+
+        assert m._last_event_ages("BINANCE.UM") == {"orderbook": 660.0}
+
+    def test_ages_are_json_serialisable(self):
+        """The snapshot is json.dumps'd by the persistence layer; a numpy float would raise."""
+        import json
+
+        now = np.datetime64("2026-04-05T10:00:00", "ns")
+        m = self._manager(now, {"orderbook": now - np.timedelta64(3, "s"), "trade": None})
+
+        assert json.loads(json.dumps(m._last_event_ages("BINANCE.UM"))) == {"orderbook": 3.0, "trade": None}

--- a/tests/qubx/core/mixins/state_snapshot_test.py
+++ b/tests/qubx/core/mixins/state_snapshot_test.py
@@ -26,11 +26,19 @@ class TestSnapshotLastEventTimes:
 
         assert m._last_event_times("BINANCE.UM") == {"orderbook": str(ob), "trade": str(tr)}
 
-    def test_a_never_seen_type_is_none(self):
-        """A warming-up bot has no events yet; a sentinel age would page on every start."""
-        m = self._manager({"orderbook": None})
+    def test_event_driven_feeds_are_excluded(self):
+        """funding_payment and liquidation arrive on venue events, so their age measures the market,
+        not the connection. Reporting them would page on every quiet period."""
+        t = np.datetime64("2026-04-05T10:00:00", "ns")
+        m = self._manager({"orderbook": t, "funding_payment": t, "liquidation": t})
 
-        assert m._last_event_times("BINANCE.UM") == {"orderbook": None}
+        assert set(m._last_event_times("BINANCE.UM")) == {"orderbook"}
+
+    def test_a_type_never_seen_is_simply_absent(self):
+        """A warming-up bot has no events yet; the reader sees no entry rather than a sentinel."""
+        m = self._manager({})
+
+        assert m._last_event_times("BINANCE.UM") == {}
 
     def test_timestamps_match_the_snapshot_timestamp_format(self):
         """The reader parses these with the same parser it uses for the snapshot's own timestamp."""
@@ -44,6 +52,6 @@ class TestSnapshotLastEventTimes:
         import json
 
         t = np.datetime64("2026-04-05T10:00:00", "ns")
-        m = self._manager({"orderbook": t, "trade": None})
+        m = self._manager({"orderbook": t})
 
-        assert json.loads(json.dumps(m._last_event_times("BINANCE.UM"))) == {"orderbook": str(t), "trade": None}
+        assert json.loads(json.dumps(m._last_event_times("BINANCE.UM"))) == {"orderbook": str(t)}

--- a/tests/qubx/core/mixins/state_snapshot_test.py
+++ b/tests/qubx/core/mixins/state_snapshot_test.py
@@ -1,53 +1,49 @@
-"""The state snapshot carries per-exchange data ages.
+"""The state snapshot records when each data type last arrived.
 
-A fresh snapshot only proves the thread writing it is running. A bot whose thread is alive while its
-market-data feed is dead writes fresh snapshots the whole time — the ages are what make that visible.
+A fresh snapshot timestamp only proves the thread writing it is running. A bot whose thread is alive
+while its market-data feed is dead writes fresh snapshots the whole time — these are what make that
+visible. Timestamps rather than ages, so the reader measures freshness when it reads.
 """
 
 from unittest.mock import MagicMock
 
 import numpy as np
-import pytest
 
 from qubx.core.mixins.processing import ProcessingManager
 
 
-class TestSnapshotDataAges:
-    def _manager(self, now, last_event_times):
+class TestSnapshotLastEventTimes:
+    def _manager(self, last_event_times):
         m = ProcessingManager.__new__(ProcessingManager)
-        m._time_provider = MagicMock()
-        m._time_provider.time.return_value = now
         m._health_monitor = MagicMock()
         m._health_monitor.get_last_event_times_by_exchange.return_value = last_event_times
         return m
 
-    def test_ages_are_seconds_since_the_last_event(self):
-        now = np.datetime64("2026-04-05T10:00:00", "ns")
-        m = self._manager(now, {"orderbook": now - np.timedelta64(1500, "ms"), "trade": now - np.timedelta64(42, "s")})
+    def test_records_when_each_type_last_arrived(self):
+        ob = np.datetime64("2026-04-05T09:59:58.500", "ns")
+        tr = np.datetime64("2026-04-05T09:59:18", "ns")
+        m = self._manager({"orderbook": ob, "trade": tr})
 
-        assert m._last_event_ages("BINANCE.UM") == {"orderbook": 1.5, "trade": 42.0}
+        assert m._last_event_times("BINANCE.UM") == {"orderbook": str(ob), "trade": str(tr)}
 
-    def test_a_never_seen_event_type_is_none_not_a_huge_age(self):
-        """A warming-up bot has no events yet; reporting that as infinitely stale would page on
-        every start."""
-        now = np.datetime64("2026-04-05T10:00:00", "ns")
-        m = self._manager(now, {"orderbook": None})
+    def test_a_never_seen_type_is_none(self):
+        """A warming-up bot has no events yet; a sentinel age would page on every start."""
+        m = self._manager({"orderbook": None})
 
-        assert m._last_event_ages("BINANCE.UM") == {"orderbook": None}
+        assert m._last_event_times("BINANCE.UM") == {"orderbook": None}
 
-    def test_a_wedged_feed_shows_a_growing_age(self):
-        """The 2026-08-18 shape: the writing thread is alive, so the snapshot is fresh, but no data
-        has arrived for minutes."""
-        now = np.datetime64("2026-04-05T10:00:00", "ns")
-        m = self._manager(now, {"orderbook": now - np.timedelta64(11, "m")})
+    def test_timestamps_match_the_snapshot_timestamp_format(self):
+        """The reader parses these with the same parser it uses for the snapshot's own timestamp."""
+        t = np.datetime64("2026-04-05T10:00:00.123456789", "ns")
+        m = self._manager({"orderbook": t})
 
-        assert m._last_event_ages("BINANCE.UM") == {"orderbook": 660.0}
+        got = m._last_event_times("BINANCE.UM")["orderbook"]
+        assert got == "2026-04-05T10:00:00.123456789"
 
-    def test_ages_are_json_serialisable(self):
-        """The snapshot is json.dumps'd by the persistence layer; a numpy float would raise."""
+    def test_is_json_serialisable(self):
         import json
 
-        now = np.datetime64("2026-04-05T10:00:00", "ns")
-        m = self._manager(now, {"orderbook": now - np.timedelta64(3, "s"), "trade": None})
+        t = np.datetime64("2026-04-05T10:00:00", "ns")
+        m = self._manager({"orderbook": t, "trade": None})
 
-        assert json.loads(json.dumps(m._last_event_ages("BINANCE.UM"))) == {"orderbook": 3.0, "trade": None}
+        assert json.loads(json.dumps(m._last_event_times("BINANCE.UM"))) == {"orderbook": str(t), "trade": None}

--- a/tests/qubx/core/subscription_test.py
+++ b/tests/qubx/core/subscription_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, call
 
 import pytest
 
+from qubx.connectors.ccxt.subscription_manager import SubscriptionManager as CcxtSubscriptionManager
 from qubx.core.basics import DataType, Instrument
 from qubx.core.interfaces import StrategyState
 from qubx.core.lookups import lookup
@@ -242,10 +243,19 @@ class TestSubscriptionStuff:
 class TestSubscriptionWatchdog:
     """The stale-instrument watchdog is the last independent recovery path.
 
-    It used to skip any provider reporting not-connected, and a wedged CCXT provider reports
-    exactly that (stop_stream clears the stream-enabled flag before it blocks), so the watchdog
-    disarmed itself in the 2026-07-28 freeze.
+    Two ways it disarmed itself:
+      * it skipped any provider reporting not-connected, and a wedged CCXT provider reports exactly
+        that (stop_stream clears the stream-enabled flag before it blocks) - the 2026-07-28 freeze;
+      * it looked instruments up by the bare base type ("orderbook"), while the fleet subscribes as
+        "orderbook(0, 1)" and every provider lookup is an exact-key match - so it collected zero
+        instruments and never even consulted is_stale.
+
+    These tests drive a REAL ccxt SubscriptionManager keyed with the parameterised type. A mocked
+    provider keyed on "orderbook" passes under both the broken and the fixed lookup, which is how
+    the second bug shipped. (That state class is plain Python - importing it pulls in no ccxt.)
     """
+
+    BASE_SUB = DataType.ORDERBOOK[0, 1]  # "orderbook(0, 1)" - what the platform actually subscribes
 
     def _manager(self, data_provider, health_monitor):
         time_provider = Mock()
@@ -254,12 +264,18 @@ class TestSubscriptionWatchdog:
         state.is_on_warmup_finished_called = True
         return SubscriptionManager(time_provider, [data_provider], health_monitor, state, monitor_interval_seconds=1e6)
 
-    def _provider(self, instrument, connected: bool):
+    def _provider(self, instrument, connected: bool, sub_type: str | None = None):
+        """A provider whose subscription queries go through the real CcxtSubscriptionManager."""
+        state = CcxtSubscriptionManager()
+        state.add_subscription(sub_type or self.BASE_SUB, [instrument])
+        state.mark_subscription_active(sub_type or self.BASE_SUB)
+
         provider = Mock()
         provider.is_simulation = False
         provider.is_connected.return_value = connected
         provider.exchange.return_value = "BINANCE.UM"
-        provider.get_subscribed_instruments.side_effect = lambda dt: [instrument] if dt == "orderbook" else []
+        provider.get_subscriptions.side_effect = state.get_subscriptions
+        provider.get_subscribed_instruments.side_effect = state.get_subscribed_instruments
         return provider
 
     def _stale_health(self):
@@ -275,8 +291,47 @@ class TestSubscriptionWatchdog:
 
         manager._monitor_subscription_status()
 
-        provider.unsubscribe.assert_called_once_with("orderbook", {instrument})
-        provider.subscribe.assert_called_once_with("orderbook", {instrument})
+        provider.unsubscribe.assert_called_once_with(self.BASE_SUB, {instrument})
+        provider.subscribe.assert_called_once_with(self.BASE_SUB, {instrument})
+
+    def test_staleness_is_checked_against_the_base_type(self):
+        """Health thresholds and last-event times are keyed by base type, the provider by full key."""
+        instrument = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instrument is not None
+        provider = self._provider(instrument, connected=True)
+        health = self._stale_health()
+        manager = self._manager(provider, health)
+
+        manager._monitor_subscription_status()
+
+        health.is_stale.assert_called_once_with(instrument, "orderbook")
+
+    def test_fresh_instruments_are_left_alone(self):
+        instrument = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instrument is not None
+        provider = self._provider(instrument, connected=True)
+        health = Mock()
+        health.is_stale.return_value = False
+        manager = self._manager(provider, health)
+
+        manager._monitor_subscription_status()
+
+        provider.unsubscribe.assert_not_called()
+        provider.subscribe.assert_not_called()
+
+    def test_unwatched_data_types_are_ignored(self):
+        """Only quote/orderbook/trade have staleness thresholds; ohlc must not be touched."""
+        instrument = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instrument is not None
+        provider = self._provider(instrument, connected=True, sub_type=DataType.OHLC["1m"])
+        health = Mock()
+        health.is_stale.return_value = True
+        manager = self._manager(provider, health)
+
+        manager._monitor_subscription_status()
+
+        health.is_stale.assert_not_called()
+        provider.unsubscribe.assert_not_called()
 
     def test_simulation_providers_are_still_skipped(self):
         instrument = lookup.find_symbol("BINANCE.UM", "BTCUSDT")

--- a/tests/qubx/core/subscription_test.py
+++ b/tests/qubx/core/subscription_test.py
@@ -241,18 +241,15 @@ class TestSubscriptionStuff:
 
 
 class TestSubscriptionWatchdog:
-    """The stale-instrument watchdog is the last independent recovery path.
+    """The stale-instrument watchdog is the last independent recovery path. Two things disarm it:
 
-    Two ways it disarmed itself:
-      * it skipped any provider reporting not-connected, and a wedged CCXT provider reports exactly
-        that (stop_stream clears the stream-enabled flag before it blocks) - the 2026-07-28 freeze;
-      * it looked instruments up by the bare base type ("orderbook"), while the fleet subscribes as
-        "orderbook(0, 1)" and every provider lookup is an exact-key match - so it collected zero
-        instruments and never even consulted is_stale.
+      * skipping providers that report not-connected - a wedged CCXT provider reports exactly that,
+        since stop_stream clears the stream-enabled flag before it blocks;
+      * looking instruments up by the bare base type ("orderbook") while the subscription key is
+        parameterised ("orderbook(0, 1)") and every provider lookup is an exact-key match.
 
-    These tests drive a REAL ccxt SubscriptionManager keyed with the parameterised type. A mocked
-    provider keyed on "orderbook" passes under both the broken and the fixed lookup, which is how
-    the second bug shipped. (That state class is plain Python - importing it pulls in no ccxt.)
+    These tests drive a REAL ccxt SubscriptionManager keyed with the parameterised type: a mocked
+    provider keyed on "orderbook" passes under both the broken and the fixed lookup.
     """
 
     BASE_SUB = DataType.ORDERBOOK[0, 1]  # "orderbook(0, 1)" - what the platform actually subscribes

--- a/tests/qubx/core/subscription_test.py
+++ b/tests/qubx/core/subscription_test.py
@@ -237,3 +237,55 @@ class TestSubscriptionStuff:
             | {(DataType.TRADE, i): "10m" for i in instruments}
         )
         self.mock_broker.warmup.assert_called_once_with(expected_warmup)
+
+
+class TestSubscriptionWatchdog:
+    """The stale-instrument watchdog is the last independent recovery path.
+
+    It used to skip any provider reporting not-connected, and a wedged CCXT provider reports
+    exactly that (stop_stream clears the stream-enabled flag before it blocks), so the watchdog
+    disarmed itself in the 2026-07-28 freeze.
+    """
+
+    def _manager(self, data_provider, health_monitor):
+        time_provider = Mock()
+        time_provider.time.return_value = 0.0
+        state = StrategyState()
+        state.is_on_warmup_finished_called = True
+        return SubscriptionManager(time_provider, [data_provider], health_monitor, state, monitor_interval_seconds=1e6)
+
+    def _provider(self, instrument, connected: bool):
+        provider = Mock()
+        provider.is_simulation = False
+        provider.is_connected.return_value = connected
+        provider.exchange.return_value = "BINANCE.UM"
+        provider.get_subscribed_instruments.side_effect = lambda dt: [instrument] if dt == "orderbook" else []
+        return provider
+
+    def _stale_health(self):
+        health = Mock()
+        health.is_stale.side_effect = lambda instr, dt: dt == "orderbook"
+        return health
+
+    def test_a_disconnected_provider_is_still_checked_and_recovered(self):
+        instrument = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instrument is not None
+        provider = self._provider(instrument, connected=False)
+        manager = self._manager(provider, self._stale_health())
+
+        manager._monitor_subscription_status()
+
+        provider.unsubscribe.assert_called_once_with("orderbook", {instrument})
+        provider.subscribe.assert_called_once_with("orderbook", {instrument})
+
+    def test_simulation_providers_are_still_skipped(self):
+        instrument = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instrument is not None
+        provider = self._provider(instrument, connected=True)
+        provider.is_simulation = True
+        manager = self._manager(provider, self._stale_health())
+
+        manager._monitor_subscription_status()
+
+        provider.unsubscribe.assert_not_called()
+        provider.subscribe.assert_not_called()


### PR DESCRIPTION
## The bug

`ConnectionManager._wait` waited on a future by polling `future.running()`:

```python
while future.running() and elapsed < self._cleanup_timeout: time.sleep(0.1)
if future.running(): logger.warning("... still running after 3.0s")
else:                future.result()          # ← no timeout
```

A `concurrent.futures.Future` returned by `asyncio.run_coroutine_threadsafe` goes
**PENDING → FINISHED** and is **never** in `RUNNING` state. So the poll loop ran zero iterations,
`cleanup_timeout` was dead code, the timeout WARNING was unreachable — it appears nowhere in 137 days
of production logs — and every call fell into an **unbounded** `future.result()`.

## Why that froze a bot for 18 days

`stop_stream` is synchronous and thread-blocking, but what it waits for is a coroutine on the
exchange event loop. On 2026-07-28 a coroutine *already running on that loop* reached it through the
subscription pipeline, so the loop blocked on itself. Market data stopped instantly.

That alone would have been survivable — but `ProcessingManager.__process_data` calls
`@synchronized commit()` on **every** market-data event, and that lock is shared across instances, so
one blocked thread stopped the entire strategy: no heartbeats, no metrics, no orders.

Ten minutes later the staleness watchdog did the right thing — detected `orderbook(620s)`, recreated
the exchange, started resubscribing. Resubscribing unsubscribes first, which hit the same unbounded
wait, so the watchdog thread died too. `Resubscribing to orderbook(0, 1) with 48 instruments` is the
last line the process ever logged. The pod stayed `Running`/`Ready` with 0 restarts and nothing
alerted.

It recurred on 2026-08-18 on two OKX bots at once. Exposure is `(OKX | Binance) × orderbook` —
Kraken's `quote` unsubscriber is a ccxt stub that raises `NotSupported` instantly, which is why
Kraken bots have recreated ~1,665 times and never wedged.

## The change

**13 source files, +164/−82.** Every hunk is one of six things.

**1. `_wait` is bounded** — `future.result(timeout=…)`, with `TimeoutError` caught *before*
`Exception` (it is a subclass, so the order is load-bearing), a warning naming the context, and a
cancel. This is the bug.

**2. `stop_stream` is safe on the loop thread** — new `_on_exchange_loop_thread()`; when called from
the exchange loop it degrades to non-blocking cleanup instead of parking the loop on itself. It
never *raises* for this: callers up the synchronous subscription pipeline treat an exception as a
fault and would kill their own poller.

**3. Registry teardown moved before the waits** — so a wait that times out cannot leave a
half-removed stream behind.

**4. The remaining unbounded `.result()` calls are bounded** — the grace `asyncio.sleep`,
`load_markets` (`data.py`), and the synchronous venue calls (`connector.py`, now routed through
`run_sync`, which already carries its own same-thread guard).

**5. Handlers capture the exchange at prepare time** — the subscriber/unsubscriber closures resolved
`exchange_manager.exchange` at *call* time. Recreation swaps that attribute under a live
subscription, so an unsubscriber could be aimed at an exchange the stream was never established on;
the venue never acks and the wait runs to its timeout. All six WS handlers now bind the exchange once
in `prepare_subscription`. (`open_interest` is a REST poller with no unsubscriber round-trip and is
deliberately left late-binding, so its next poll picks up the new exchange.)

**6. The watchdog can actually reach its subscriptions** (`core/mixins/subscription.py`) — it skipped
any provider reporting `not is_connected()`, but `stop_stream` clears that flag *before* it blocks, so
a wedged provider reported not-connected exactly when the watchdog was needed most. It also looked up
subscriptions by base type (`orderbook`) while the fleet subscribes as `orderbook(0, 1)`, an exact-key
lookup that collected nothing. It now resolves full keys from the provider, checks staleness against
the base type (which is how the health monitor is keyed), and hands the full key back to
`unsubscribe`/`subscribe`.

**7. Subscription transitions are serialised** (`subscription_manager.py` + call sites) — computing the
new instrument set, stopping the old stream and installing the new name is one read-modify-write, and
both the stale-data watchdog thread and the strategy thread run it. Interleaving them left a live
duplicate WebSocket subscription that nothing ever stop-requested; an end-to-end run reproduced it 3/3.

Holding a lock across `stop_stream` is safe only because of (1) and (2): every wait inside is bounded,
and an on-loop caller degrades instead of blocking. `mark_subscription_active` is the only call the
exchange loop makes into this state, and is deliberately left unlocked.

**8. Stream registration is armed before the task is submitted** (`subscription_orchestrator.py`) —
`listen_to_stream`'s synchronous prefix used to register the enabled flag and unsubscriber itself,
re-inserting them after `stop_stream` had popped them, because cancelling a future does not stop a task
whose first step is already queued. `is_connected()` could then report a dead stream as connected.
Arming now happens in the orchestrator inside the lock, `listen_to_stream` only reads, and
`_is_stream_enabled` is a plain `dict` so the invariant is structural.

Two one-liners round it out: `_handle_stream_completion` logs instead of `except Exception: pass`, and
`get_last_event_times_by_exchange` snapshots the dict it iterates (the processor thread mutates it on
every event, so the stale monitor could crash with `dictionary changed size during iteration`).

The state snapshot gains **last event times** — when each data type last arrived, per exchange, in
the same format as the snapshot's own timestamp. A fresh snapshot only proves the thread writing it
is running; a bot whose thread is alive while its feed is dead writes fresh snapshots the whole
time. One signal now covers both shapes: the snapshot stops advancing when the thread blocks, and
these stop advancing when only the feed dies.

Timestamps rather than ages, so the reader measures freshness when it reads rather than trusting an
age the bot computed seconds earlier — and consumers reuse the parser they already have for
`timestamp`. A type never seen is simply absent, so a warming-up bot is not read as infinitely stale.

Event-driven feeds — funding payments and liquidations — are excluded: their age measures the market,
not the connection, and a funding feed is hours old for most of every cycle by design. Qubx already
excludes funding payments from latency percentiles for the same reason.

The platform already reads this snapshot every few seconds, so the reading reaches metrics, history
and the UI with no new poller.

## Verification

726 tests in the touched suites, 2804 in the full unit suite, ruff clean. Every regression test was
confirmed to fail on `origin/main` for the right reason.

`test_no_unbounded_result.py` is an AST gate: the build fails on any `.result()` without a timeout
under `connectors/ccxt/`, with an `# unbounded-result-ok: <reason>` escape for `asyncio.Future`, which
takes no timeout parameter. That is what stops the pattern coming back.

`test_connection_manager_deadlock.py` uses real background event loops — mocks cannot reproduce this
bug — with a hard deadline on every blocking call so a regression fails rather than hangs CI.

Beyond unit tests, a **differential end-to-end run against Binance UM testnet** (paper, no emission, no
notifiers, no external sinks) drove four fault scenarios against this branch and against `origin/main`.
On `origin/main` all four freeze with the incident's signature — the control server answering in 1–3 ms
with **zero** HTTP failures while the strategy's event counter is perfectly flat. On this branch all
four survive. The decisive case is an on-loop resubscribe: `origin/main` emits neither `Listening to …`
nor `listen_to_stream finished` — the two lines whose absence was the 2026-07-28 signature — while this
branch emits both, 2 ms after the injected call.

The strongest evidence needs no fault injection at all. Running **non-paper** against testnet builds a
real authenticated `CcxtConnector` that shares the exchange loop with the market-data streams
(confirmed at runtime: `same_loop_as_data_provider: true`). Calling its own
`get_max_instrument_notional` → `_fetch_leverage_row` → `_run_sync` **from that loop** — production
code, nothing monkeypatched, and one of the call sites this PR changed:

| | this branch | `origin/main` |
|---|---|---|
| result | returns in 0.003 s, logs `run_sync called from the target loop's own thread — would deadlock` | **never returns** |
| loop ticks afterwards | advancing | **frozen for the rest of the run** |
| shutdown | clean, rc=0 | **SIGKILL, rc=137** |

All six changed handlers were exercised. In the recreation scenario `origin/main` wedges its fan-out on
the first unresponsive unsubscriber and leaves **four** streams dead-but-still-reported-enabled; this
branch rebuilds all six and leaves none.

Note that all three pre-existing `stop_stream` tests passed `wait=False`, i.e. **the path that fired in
production was untested**.

## Backporting to v1.7.0 needs one extra change

v1.7.0 still calls `SubscriptionManager.commit()` from a coroutine on the exchange loop
(`account.py:431`; removed on `main`). Backporting (7) unchanged would put a lock acquire on the loop
thread while off-loop threads hold it across bounded waits — bounded stalls rather than a freeze, but a
real regression. The backport must pair with moving that call off-loop.

## Merging this does not reach the fleet

Bots resolve qubx from their release ZIP's `uv.lock`, not from `qubx_image_tag` — the bot that froze
reported image `1.1.3.dev22` while running **qubx 1.7.0**. The path is: release → re-pin in the
strategy's `pyproject.toml`/`uv.lock` → `xrelease` → `xl bot update`.

Worth scheduling deliberately: the 2026-08-15 restart cost 229 fills in 3m40s at 72.5% taker, turning
over 1.45× equity.

## Known residuals

- The exchange loop can still wedge on the unbounded acquire in `rate_limiting/redis_backend.py`,
  which this PR does not touch and which is the suspected trigger of the 2026-08-18 recurrence.
- `SubscriptionManager.lock` is itself an on-loop blocking site the loop-thread guard does not cover.
  Strictly better than the unconditional deadlock it replaces, but it has only been exercised
  uncontended.
- The account-side watchdog still self-disarms: `_ws_ready` stays `True` on a wedged loop
  (`connector.py`), so `AccountManager`'s reconnect never fires. Pre-existing, same class as the
  defect that let the incident run 18 days, and out of scope here.
- `get_max_instrument_notional` returns `inf` when both venue reads fail — pre-existing and unchanged,
  but this PR makes that path reachable where it previously deadlocked. Worth its own fix.

Platform-side detection: xLydianSoftware/xlydian-platform#405