### PR TITLE
fix(ccxt): OKX — dead book stream, refused stops, algo orders, cancels and leverage reads

### DIFF
--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -553,14 +553,19 @@ class CcxtConnector(ChannelEmitter):
         """Venue-specific triage of one failed cancel attempt (mirrors the
         ``_extract_venue_figures`` seam): ``"retry"`` when the venue may still produce a
         definitive answer, ``"reject"`` on a definitive refusal, ``"gone"`` when the order
-        provably no longer exists at the venue. The base impl matches Binance's error
-        strings; venue subclasses override.
+        provably no longer exists at the venue. The base impl reads ccxt's typed errors and
+        falls back to Binance's error strings; venue subclasses override.
 
         ``acked`` = the order had a venue id (so it WAS accepted). An "unknown order" then
         means it is already gone (filled/expired/canceled), not the submit/cancel race —
         retrying is pointless. Without an ack it IS the race (the order may appear shortly).
         """
         msg = str(err).lower()
+        if isinstance(err, ccxt.OrderNotFound):
+            # - ccxt's per-venue error-code map is the authority on "not there any more", and its
+            #   wording often misses the strings below: OKX 51400 reads "Order cancellation failed
+            #   as the order has been filled, canceled or does not exist."
+            return "gone" if acked else "retry"
         if "unknown order" in msg or "order does not exist" in msg or "order not found" in msg:
             return "gone" if acked else "retry"
         if isinstance(err, ccxt.OperationRejected):

--- a/src/qubx/connectors/ccxt/exchanges/okx/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/connector.py
@@ -7,6 +7,8 @@ Adds the OKX-specific behavior on top of the generic ``CcxtConnector``:
   ``watch_my_trades`` stream. The base runs both concurrently — status events ride
   with ``fill=None`` and each trade arrives as a ``DealEvent``; the AccountManager
   correlates them by trade id (see the two-stream base docstring).
+- **Third stream for the algo book**: trigger/conditional orders are pushed on OKX's
+  "orders-algo" channel, not "orders" — see ``_account_streams``.
 - **Balance extraction**: ccxt's OKX balance mapping is wrong for the framework — see
   ``_convert_balances``.
 - **Venue account figures**: OKX's trading-balance payload carries account-level
@@ -22,7 +24,8 @@ balance refresh.
 """
 
 import re
-from typing import Any
+from functools import partial
+from typing import Any, Coroutine
 
 from qubx.core.basics import FRAMEWORK_CID_PREFIX, Balance
 
@@ -58,6 +61,26 @@ class OkxCcxtConnector(_TwoStreamCcxtConnector):
     # producer and classifier can never drift. Residual caveat: an external cid that
     # happens to start with "qubx" reads as RECOVERED (unavoidable given the charset).
     cid_framework_prefix = _OKX_CLIENT_ID_RE.sub("", FRAMEWORK_CID_PREFIX)
+
+    def _account_streams(self) -> list[Coroutine[Any, Any, None]]:
+        """
+        Watch the algo book as well: OKX streams trigger/conditional orders on their own channel.
+
+        ``watch_orders`` covers channel "orders" only, so a stop's terminal state never arrives
+        over the socket and the order sits in PENDING_CANCEL until the next order-bearing
+        snapshot resolves it — measured at 43s on a live close. ccxt subscribes to
+        "orders-algo" when the watch is asked for trigger orders.
+        """
+        streams = super()._account_streams()
+        streams.append(
+            self._run_ws_loop(
+                watch=partial(self._em.exchange.watch_orders, params={"trigger": True}),
+                handle=self._handle_ws_order,
+                stream="orders_algo",
+                mark_ready=False,
+            )
+        )
+        return streams
 
     def _convert_balances(self, raw_balance: dict[str, Any]) -> list[Balance]:
         """Use OKX ``cashBal``/``frozenBal`` per currency from the raw response.

--- a/src/qubx/connectors/ccxt/exchanges/okx/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/connector.py
@@ -27,9 +27,11 @@ import re
 from functools import partial
 from typing import Any, Coroutine
 
-from qubx.core.basics import FRAMEWORK_CID_PREFIX, Balance
+from qubx import logger
+from qubx.core.basics import FRAMEWORK_CID_PREFIX, Balance, Instrument
 
-from ...utils import info_float
+from ...connector import _LeverageInfo
+from ...utils import info_float, instrument_to_ccxt_symbol
 from .._two_stream import _TwoStreamCcxtConnector
 
 _OKX_CLIENT_ID_RE = re.compile(r"[^a-zA-Z0-9]")
@@ -81,6 +83,55 @@ class OkxCcxtConnector(_TwoStreamCcxtConnector):
             )
         )
         return streams
+
+    def get_instrument_leverage(self, instrument: Instrument) -> float | None:
+        """
+        Ask OKX for the configured leverage when no position carries it.
+
+        The base reads ``fetch_leverages`` — which okx does not have — and then the position
+        row, so a flat instrument reports nothing. ``fetch_leverage`` is per symbol and per
+        margin mode; ccxt asks for cross unless told otherwise, which is the mode
+        ``set_leverage`` writes by default.
+        """
+        leverage = super().get_instrument_leverage(instrument)
+        if leverage is not None:
+            return leverage
+        symbol = instrument_to_ccxt_symbol(instrument)
+        try:
+            row = self._run_sync(self._em.exchange.fetch_leverage(symbol))
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"[{self.exchange_name}] fetch_leverage for {instrument.symbol}: {e}")
+            return None
+        value = row.get("longLeverage") or row.get("shortLeverage") if row else None
+        return float(value) if value is not None else None
+
+    def get_max_instrument_leverage(self, instrument: Instrument) -> float | None:
+        """
+        Read the venue cap per instrument: OKX publishes tiers one market at a time.
+
+        The base serves this from the poller's cache, which is filled by
+        ``fetch_leverage_tiers`` — again absent on okx, so the cap was always None and every
+        leverage request went to the venue unclamped. The result is kept in the same cache, so
+        one read per instrument covers the process.
+        """
+        cached = super().get_max_instrument_leverage(instrument)
+        if cached is not None:
+            return cached
+        symbol = instrument_to_ccxt_symbol(instrument)
+        try:
+            tiers = self._run_sync(self._em.exchange.fetch_market_leverage_tiers(symbol))
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"[{self.exchange_name}] leverage tiers for {instrument.symbol}: {e}")
+            return None
+        levels = [t["maxLeverage"] for t in (tiers or []) if t.get("maxLeverage") is not None]
+        if not levels:
+            return None
+        maximum = int(max(levels))
+        held = self._leverage_cache.get(symbol)
+        self._leverage_cache[symbol] = _LeverageInfo(
+            configured=held.configured if held is not None else None, maximum=maximum
+        )
+        return float(maximum)
 
     def _convert_balances(self, raw_balance: dict[str, Any]) -> list[Balance]:
         """Use OKX ``cashBal``/``frozenBal`` per currency from the raw response.

--- a/src/qubx/connectors/ccxt/exchanges/okx/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/connector.py
@@ -84,53 +84,77 @@ class OkxCcxtConnector(_TwoStreamCcxtConnector):
         )
         return streams
 
-    def get_instrument_leverage(self, instrument: Instrument) -> float | None:
+    async def _read_configured_leverage(self, symbol: str) -> int | None:
         """
-        Ask OKX for the configured leverage when no position carries it.
+        One symbol's configured leverage from OKX's own endpoint.
 
-        The base reads ``fetch_leverages`` — which okx does not have — and then the position
-        row, so a flat instrument reports nothing. ``fetch_leverage`` is per symbol and per
-        margin mode; ccxt asks for cross unless told otherwise, which is the mode
-        ``set_leverage`` writes by default.
+        ccxt asks for cross margin mode unless told otherwise, which is the mode
+        ``set_leverage`` writes by default, so read and write agree.
         """
+        try:
+            row = await self._em.exchange.fetch_leverage(symbol)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"[{self.exchange_name}] fetch_leverage {symbol}: {e}")
+            return None
+        value = (row.get("longLeverage") or row.get("shortLeverage")) if row else None
+        return int(value) if value is not None else None
+
+    async def _read_max_leverage(self, symbol: str) -> int | None:
+        """One symbol's venue cap: OKX publishes tiers one market at a time."""
+        try:
+            tiers = await self._em.exchange.fetch_market_leverage_tiers(symbol)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"[{self.exchange_name}] leverage tiers {symbol}: {e}")
+            return None
+        levels = [t["maxLeverage"] for t in (tiers or []) if t.get("maxLeverage") is not None]
+        return int(max(levels)) if levels else None
+
+    def _store(self, symbol: str, configured: int | None = None, maximum: int | None = None) -> None:
+        held = self._leverage_cache.get(symbol)
+        self._leverage_cache[symbol] = _LeverageInfo(
+            configured=configured if configured is not None else (held.configured if held else None),
+            maximum=maximum if maximum is not None else (held.maximum if held else None),
+        )
+
+    async def _refresh_leverage_cache(self) -> None:
+        """
+        Refresh the symbols the cache already holds, one at a time.
+
+        The base sweep reads ``fetch_leverages`` and ``fetch_leverage_tiers``; okx has neither,
+        so it fills nothing and every getter falls through to a venue round trip — measured at
+        0.93s per ``get_instrument_leverage`` against 16us on Binance, where the sweep works.
+        Entries land here on first ask, and this keeps them as fresh as the hourly sweep does
+        elsewhere.
+        """
+        for symbol in list(self._leverage_cache):
+            self._store(
+                symbol,
+                configured=await self._read_configured_leverage(symbol),
+                maximum=await self._read_max_leverage(symbol),
+            )
+
+    def get_instrument_leverage(self, instrument: Instrument) -> float | None:
+        """Read it from OKX when the cache and the position row have nothing, and keep it."""
         leverage = super().get_instrument_leverage(instrument)
         if leverage is not None:
             return leverage
         symbol = instrument_to_ccxt_symbol(instrument)
-        try:
-            row = self._run_sync(self._em.exchange.fetch_leverage(symbol))
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"[{self.exchange_name}] fetch_leverage for {instrument.symbol}: {e}")
+        configured = self._run_sync(self._read_configured_leverage(symbol))
+        if configured is None:
             return None
-        value = row.get("longLeverage") or row.get("shortLeverage") if row else None
-        return float(value) if value is not None else None
+        self._store(symbol, configured=configured)
+        return float(configured)
 
     def get_max_instrument_leverage(self, instrument: Instrument) -> float | None:
-        """
-        Read the venue cap per instrument: OKX publishes tiers one market at a time.
-
-        The base serves this from the poller's cache, which is filled by
-        ``fetch_leverage_tiers`` — again absent on okx, so the cap was always None and every
-        leverage request went to the venue unclamped. The result is kept in the same cache, so
-        one read per instrument covers the process.
-        """
+        """Read the venue cap per symbol and keep it: the base's source does not exist here."""
         cached = super().get_max_instrument_leverage(instrument)
         if cached is not None:
             return cached
         symbol = instrument_to_ccxt_symbol(instrument)
-        try:
-            tiers = self._run_sync(self._em.exchange.fetch_market_leverage_tiers(symbol))
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"[{self.exchange_name}] leverage tiers for {instrument.symbol}: {e}")
+        maximum = self._run_sync(self._read_max_leverage(symbol))
+        if maximum is None:
             return None
-        levels = [t["maxLeverage"] for t in (tiers or []) if t.get("maxLeverage") is not None]
-        if not levels:
-            return None
-        maximum = int(max(levels))
-        held = self._leverage_cache.get(symbol)
-        self._leverage_cache[symbol] = _LeverageInfo(
-            configured=held.configured if held is not None else None, maximum=maximum
-        )
+        self._store(symbol, maximum=maximum)
         return float(maximum)
 
     def _convert_balances(self, raw_balance: dict[str, Any]) -> list[Balance]:

--- a/src/qubx/connectors/ccxt/exchanges/okx/okx.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/okx.py
@@ -30,6 +30,73 @@ class OkxFutures(CcxtFuturePatchMixin, cxp.okx):
             },
         )
 
+    def create_order_request(self, symbol: str, type, side, amount: float, price=None, params={}):
+        return super().create_order_request(symbol, type, side, amount, price, self._route_protective_stop(params))
+
+    @staticmethod
+    def _route_protective_stop(params: dict) -> dict:
+        """
+        Send a reduce-only stop as OKX's conditional algo order instead of a trigger order.
+
+        OKX answers 51205 "Reduce Only is not available." to ``reduceOnly`` on
+        ``ordType=trigger`` and accepts it on ``ordType=conditional`` — measured live, same
+        account, instrument and size, one parameter apart. ccxt picks the algo type from the
+        parameter name, so moving the level onto ``stopLossPrice`` yields ``slTriggerPx`` with
+        ``slOrdPx=-1``, i.e. close at market when the level trades.
+        """
+        level = params.get("triggerPrice", params.get("stopPrice"))
+        if level is None or not params.get("reduceOnly"):
+            return params
+        rerouted = {k: v for k, v in params.items() if k not in ("triggerPrice", "stopPrice")}
+        rerouted["stopLossPrice"] = level
+        return rerouted
+
+    async def fetch_open_orders(self, symbol: str | None = None, since=None, limit=None, params={}) -> list:
+        """
+        List both algo types when the caller asks for trigger orders.
+
+        OKX's pending-algo endpoint takes a single ``ordType`` and ccxt defaults it to
+        "trigger", so a reduce-only stop — which goes out as "conditional" — would be absent
+        from every snapshot and read as an order the framework does not know about.
+        """
+        wants_trigger = self.safe_value_2(params, "stop", "trigger")
+        if not wants_trigger or self.safe_string(params, "ordType") is not None:
+            return await super().fetch_open_orders(symbol, since, limit, params)
+        orders = []
+        for ord_type in ("trigger", "conditional"):
+            orders.extend(await super().fetch_open_orders(symbol, since, limit, {**params, "ordType": ord_type}))
+        return orders
+
+    def parse_order(self, order: dict, market=None) -> dict:
+        """
+        Report OKX algo orders as the framework's stop types, with the trigger as their price.
+
+        ccxt hands the raw ``ordType`` back as the order type, so an algo order reads as
+        "trigger"/"conditional" — neither is an ``OrderType``, and a cancel routed by order
+        type then misses the venue's algo book entirely. A conditional also leaves ccxt's
+        ``triggerPrice`` empty because that field is read from ``triggerPx`` only.
+        """
+        parsed = super().parse_order(order, market)
+        if self.safe_string(order, "ordType") not in ("trigger", "conditional", "oco"):
+            return parsed
+        limit_price = self.safe_string_2(order, "orderPx", "slOrdPx")
+        parsed["type"] = "stop_market" if limit_price in (None, "", "-1") else "stop_limit"
+        if parsed.get("triggerPrice") is None:
+            parsed["triggerPrice"] = self.safe_number_n(order, ["triggerPx", "slTriggerPx", "tpTriggerPx"])
+        return parsed
+
+    def orderbook_checksum_message(self, symbol: str | None) -> str:
+        """
+        Build the checksum-failure message even when ccxt could not resolve the symbol.
+
+        ccxt's snapshot branch calls ``handle_order_book_message`` without a market and the
+        per-item payload carries no ``instId``, so a checksum mismatch on a snapshot resolves
+        the symbol to None and the base implementation raises TypeError while building the
+        error. That exception skips the subscription cleanup and the waiter is never rejected,
+        so the stream stalls with nothing raised to the connection manager.
+        """
+        return super().orderbook_checksum_message(symbol if symbol is not None else self.id)
+
     def open(self):
         if self.asyncio_loop is None:
             if sys.version_info >= (3, 7):

--- a/src/qubx/connectors/ccxt/exchanges/okx/okx.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/okx.py
@@ -26,6 +26,22 @@ class OkxFutures(CcxtFuturePatchMixin, cxp.okx):
                 "options": {
                     "defaultType": "swap",
                     "positionSide": "net",
+                    # - OKX sends `checksum: 0` on every books message. Measured 2026-08-21 on
+                    #   wss://ws.okx.com:8443/ws/v5/public, BTC-USDT-SWAP and ETH-USDT-SWAP,
+                    #   snapshot and updates alike:
+                    #       action=snapshot checksum=0 seqId=335226848531 prevSeqId=-1
+                    #       action=update   checksum=0 seqId=335226848654 prevSeqId=335226848531
+                    #   A crc32 is never 0, so ccxt's check fails on the first update after the
+                    #   snapshot, always. Building the payload from the venue's own raw strings
+                    #   gives the same 846098866 as ccxt's rendering of it — the book is fine,
+                    #   there is simply nothing to compare against. Below ccxt 4.5.55 that failure
+                    #   ends the stream for good: the error reaches the connection manager, its
+                    #   retry re-awaits the same watch and never returns (twice on the prod
+                    #   reversals config, dead 1.4s after subscribing, quotes frozen six minutes
+                    #   later). ccxt deleted the check in 4.5.55; this carries that to older
+                    #   builds and is a no-op on newer ones. seqId/prevSeqId continuity still runs
+                    #   and is the real guard on this stream.
+                    "watchOrderBook": {"checksum": False},
                 },
             },
         )

--- a/src/qubx/connectors/ccxt/exchanges/okx/okx.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/okx.py
@@ -85,6 +85,18 @@ class OkxFutures(CcxtFuturePatchMixin, cxp.okx):
             parsed["triggerPrice"] = self.safe_number_n(order, ["triggerPx", "slTriggerPx", "tpTriggerPx"])
         return parsed
 
+    def handle_order_book_message(self, client, message, orderbook, messageHash, market=None):
+        """
+        Give ccxt the market it does not pass on the snapshot path.
+
+        The per-item payload carries no ``instId`` — that sits in ``arg`` — and ccxt's snapshot
+        branch calls this without a market, so the symbol resolves to None. It is needed to drop
+        the stale book on a checksum failure, and to build the error at all.
+        """
+        if market is None and orderbook is not None:
+            market = self.markets.get(orderbook.get("symbol"))
+        return super().handle_order_book_message(client, message, orderbook, messageHash, market)
+
     def orderbook_checksum_message(self, symbol: str | None) -> str:
         """
         Build the checksum-failure message even when ccxt could not resolve the symbol.

--- a/src/qubx/connectors/ccxt/utils.py
+++ b/src/qubx/connectors/ccxt/utils.py
@@ -90,16 +90,23 @@ def ccxt_status_to_order_status(raw: str | None, info: dict[str, Any] | None = N
     ``info.status`` — that refinement is applied before mapping. A genuinely unknown
     status is logged (so it surfaces) and mapped to the non-terminal ``ACCEPTED``: it
     is never fabricated into a terminal state, and AM's reconcile heals the true one.
+    An absent status maps the same way but only at debug level — a submit ack legitimately
+    carries none on some venues.
     """
     status = (raw or "").lower()
     # For an open order, prefer the venue-specific info.status (it may say partially_filled).
     if status == "open" and info is not None:
         status = str(info.get("status", status)).lower()
     mapped = _CCXT_STATUS_MAP.get(status)
-    if mapped is None:
+    if mapped is not None:
+        return mapped
+    if status:
         logger.warning(f"Unknown ccxt order status '{raw}' (refined '{status}'); defaulting to ACCEPTED")
-        return OrderStatus.ACCEPTED
-    return mapped
+    else:
+        # - a submit ack carries no state on some venues (OKX answers with ordId/sCode only),
+        #   so an absent status is the expected shape there rather than something to flag
+        logger.debug("Venue order payload carries no status; defaulting to ACCEPTED")
+    return OrderStatus.ACCEPTED
 
 
 def ccxt_convert_order_info(

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_writes.py
@@ -1186,3 +1186,35 @@ class TestOrderRateLimiting:
         assert isinstance(sent[0], OrderRejectedEvent)
 
 
+class TestCancelErrorClassification:
+    """
+    An acked order the venue says is not there is "gone" — cancel is done, not rejected.
+    ccxt's per-venue code map is what knows this (OKX 51400/51401/51402/51603 all map to
+    OrderNotFound); its wording does not match the venue-string fallbacks. Before this,
+    an OKX close retried the cancel for 32s and then reported CANCEL_REJECTED with
+    "order is STILL ALIVE at the venue" for an order that had already been cancelled.
+    """
+
+    OKX_51400 = (
+        'okx {"code":"1","data":[{"algoClOrdId":"","algoId":"3852136948044693504","clOrdId":"",'
+        '"sCode":"51400","sMsg":"Order cancellation failed as the order has been filled, canceled '
+        'or does not exist.","tag":""}],"msg":""}'
+    )
+
+    def test_acked_order_not_found_is_gone(self) -> None:
+        conn, _, _ = _make_connector()
+        assert conn._classify_cancel_error(ccxt.OrderNotFound(self.OKX_51400), acked=True) == "gone"
+
+    def test_unacked_order_not_found_still_retries(self) -> None:
+        # - without a venue id it is the submit/cancel race: the order may appear shortly
+        conn, _, _ = _make_connector()
+        assert conn._classify_cancel_error(ccxt.OrderNotFound(self.OKX_51400), acked=False) == "retry"
+
+    def test_the_okx_message_alone_does_not_match_the_string_fallbacks(self) -> None:
+        # - so the typed check is what does the work here, not the wording
+        conn, _, _ = _make_connector()
+        assert conn._classify_cancel_error(ccxt.ExchangeError(self.OKX_51400), acked=True) == "retry"
+
+    def test_binance_wording_still_classifies(self) -> None:
+        conn, _, _ = _make_connector()
+        assert conn._classify_cancel_error(ccxt.ExchangeError("Unknown order sent."), acked=True) == "gone"

--- a/tests/qubx/connectors/ccxt/test_okx_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_okx_exchange.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import Mock
 
+import ccxt
 import ccxt.pro as cxp
 import pytest
 from ccxt.base.errors import ChecksumError
@@ -286,3 +287,83 @@ class TestAlgoOrderStream:
     def test_algo_orders_go_through_the_same_handler(self, monkeypatch):
         streams = self._recorded_streams(monkeypatch)
         assert streams[-1]["handle"].__func__ is streams[0]["handle"].__func__
+
+
+class _FakeWsClient:
+    """The two things ccxt's orderbook error path touches on a client."""
+
+    def __init__(self, message_hash: str):
+        self.subscriptions = {message_hash: True}
+        self.rejected: list = []
+        self.resolved: list = []
+
+    def reject(self, error, message_hash=None):
+        self.rejected.append(error)
+
+    def resolve(self, result, message_hash=None):
+        self.resolved.append(result)
+
+
+def _snapshot(checksum: int) -> dict:
+    return {
+        "arg": {"channel": "books", "instId": "BTC-USDT-SWAP"},
+        "action": "snapshot",
+        "data": [
+            {
+                "asks": [["78000.1", "1", "0", "1"]],
+                "bids": [["77999.9", "2", "0", "1"]],
+                "ts": "1787305636893",
+                "checksum": checksum,
+                "seqId": 1,
+                "prevSeqId": -1,
+            }
+        ],
+    }
+
+
+class TestOrderBookChecksumFailure:
+    """
+    Prod, 2026-08-04: a ping-pong timeout, then the reconnect's first snapshot failed its
+    checksum and ccxt raised TypeError while building the error message. The raise happens
+    before the cleanup, so the subscription was never dropped and the waiter never rejected —
+    the stream went quiet with nothing raised to the connection manager.
+
+    ccxt's snapshot branch passes no market and the payload has no instId, so the symbol
+    resolves to None. Both master and 4.5.50 still do this.
+    """
+
+    MESSAGE_HASH = "books:BTC/USDT:USDT"
+
+    def test_the_base_class_raises_typeerror_instead_of_the_checksum_error(self):
+        exchange = cxp.okx()
+        exchange.set_markets([_swap_market()])
+        with pytest.raises(TypeError):
+            exchange.handle_order_book(_FakeWsClient(self.MESSAGE_HASH), _snapshot(checksum=1))
+
+    def test_a_bad_checksum_rejects_the_waiter(self, offline_okx):
+        client = _FakeWsClient(self.MESSAGE_HASH)
+        offline_okx.handle_order_book(client, _snapshot(checksum=1))
+        assert len(client.rejected) == 1
+        assert isinstance(client.rejected[0], ChecksumError)
+
+    def test_a_bad_checksum_drops_the_subscription_and_the_stale_book(self, offline_okx):
+        client = _FakeWsClient(self.MESSAGE_HASH)
+        offline_okx.handle_order_book(client, _snapshot(checksum=1))
+        assert self.MESSAGE_HASH not in client.subscriptions
+        assert "BTC/USDT:USDT" not in offline_okx.orderbooks
+
+    def test_the_error_is_retried_by_the_connection_manager(self):
+        # - ChecksumError is a NetworkError, which listen_to_stream retries; the TypeError was
+        #   not raised out of the watch at all, so nothing retried
+        assert issubclass(ChecksumError, ccxt.NetworkError)
+
+    def test_a_good_snapshot_keeps_the_book(self, offline_okx):
+        client = _FakeWsClient(self.MESSAGE_HASH)
+        offline_okx.handle_order_book(client, _snapshot(checksum=1))
+        good = _snapshot(checksum=1)
+        payload = "77999.9:2:78000.1:1"
+        good["data"][0]["checksum"] = offline_okx.crc32(payload, True)
+        client = _FakeWsClient(self.MESSAGE_HASH)
+        offline_okx.handle_order_book(client, good)
+        assert client.rejected == []
+        assert "BTC/USDT:USDT" in offline_okx.orderbooks

--- a/tests/qubx/connectors/ccxt/test_okx_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_okx_exchange.py
@@ -1,7 +1,7 @@
 """Tests for OKX exchange registration and custom class."""
 
 import asyncio
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import ccxt
 import ccxt.pro as cxp
@@ -371,9 +371,10 @@ class TestOrderBookChecksumFailure:
 
 class TestLeverageReads:
     """
-    ccxt's okx has no `fetchLeverages` and no `fetchLeverageTiers` — the two whole-universe
-    calls the base connector's poller uses — so the venue cap was always None and a flat
-    instrument reported no configured leverage. Both exist per symbol.
+    ccxt's okx has neither `fetchLeverages` nor `fetchLeverageTiers` — the two whole-universe
+    calls the base poller uses — so its cache stayed empty and every getter fell through to a
+    venue round trip. Measured 2026-08-21: get_instrument_leverage took 0.93s per call on OKX
+    against 16us on Binance, where the poller fills the same cache for 872 symbols.
     """
 
     @staticmethod
@@ -387,8 +388,19 @@ class TestLeverageReads:
             exchange_manager=exchange_manager,
             data_provider=Mock(),
         )
-        connector._run_sync = lambda coro, timeout=None: coro
+        connector._run_sync = lambda coro, timeout=None: asyncio.new_event_loop().run_until_complete(coro)
         return connector
+
+    @staticmethod
+    def _exchange(**overrides) -> Mock:
+        exchange = Mock()
+        exchange.has = {}
+        exchange.fetch_positions = AsyncMock(return_value=[])
+        exchange.fetch_leverage = AsyncMock(return_value={"longLeverage": 5, "shortLeverage": 5})
+        exchange.fetch_market_leverage_tiers = AsyncMock(return_value=[{"maxLeverage": 125}, {"maxLeverage": 50}])
+        for k, v in overrides.items():
+            setattr(exchange, k, v)
+        return exchange
 
     @staticmethod
     def _instrument() -> Instrument:
@@ -403,40 +415,47 @@ class TestLeverageReads:
             tick_size=0.1,
             lot_size=0.01,
             min_size=0.01,
-            contract_size=0.01,
         )
 
-    def test_venue_cap_read_per_symbol(self):
-        exchange = Mock()
-        exchange.has = {}
-        exchange.fetch_market_leverage_tiers = Mock(
-            return_value=[{"maxLeverage": 125}, {"maxLeverage": 50}, {"maxLeverage": 10}]
-        )
-        connector = self._connector(exchange)
-        assert connector.get_max_instrument_leverage(self._instrument()) == 125.0
-        exchange.fetch_market_leverage_tiers.assert_called_once_with("BTC/USDT:USDT")
-
-    def test_venue_cap_is_cached_after_the_first_read(self):
-        exchange = Mock()
-        exchange.has = {}
-        exchange.fetch_market_leverage_tiers = Mock(return_value=[{"maxLeverage": 125}])
-        connector = self._connector(exchange)
-        instrument = self._instrument()
-        connector.get_max_instrument_leverage(instrument)
-        connector.get_max_instrument_leverage(instrument)
-        assert exchange.fetch_market_leverage_tiers.call_count == 1
-
-    def test_venue_cap_survives_a_failing_read(self):
-        exchange = Mock()
-        exchange.has = {}
-        exchange.fetch_market_leverage_tiers = Mock(side_effect=ccxt.NotSupported("nope"))
-        assert self._connector(exchange).get_max_instrument_leverage(self._instrument()) is None
-
-    def test_configured_leverage_falls_back_to_fetch_leverage(self):
-        exchange = Mock()
-        exchange.has = {}
-        exchange.fetch_positions = Mock(return_value=[])
-        exchange.fetch_leverage = Mock(return_value={"longLeverage": 5, "shortLeverage": 5})
+    def test_configured_leverage_read_per_symbol(self):
+        exchange = self._exchange()
         connector = self._connector(exchange)
         assert connector.get_instrument_leverage(self._instrument()) == 5.0
-        exchange.fetch_leverage.assert_called_once_with("BTC/USDT:USDT")
+        exchange.fetch_leverage.assert_awaited_once_with("BTC/USDT:USDT")
+
+    def test_venue_cap_read_per_symbol(self):
+        exchange = self._exchange()
+        connector = self._connector(exchange)
+        assert connector.get_max_instrument_leverage(self._instrument()) == 125.0
+        exchange.fetch_market_leverage_tiers.assert_awaited_once_with("BTC/USDT:USDT")
+
+    def test_the_second_read_costs_no_venue_call(self):
+        exchange = self._exchange()
+        connector = self._connector(exchange)
+        instrument = self._instrument()
+        for _ in range(3):
+            connector.get_instrument_leverage(instrument)
+            connector.get_max_instrument_leverage(instrument)
+        assert exchange.fetch_leverage.await_count == 1
+        assert exchange.fetch_market_leverage_tiers.await_count == 1
+
+    def test_a_failing_read_returns_none_and_caches_nothing(self):
+        exchange = self._exchange(fetch_market_leverage_tiers=AsyncMock(side_effect=ccxt.NotSupported("nope")))
+        connector = self._connector(exchange)
+        assert connector.get_max_instrument_leverage(self._instrument()) is None
+        assert connector._leverage_cache == {}
+
+    def test_the_poller_refreshes_what_the_cache_holds(self):
+        exchange = self._exchange()
+        connector = self._connector(exchange)
+        connector.get_instrument_leverage(self._instrument())
+        exchange.fetch_leverage = AsyncMock(return_value={"longLeverage": 7, "shortLeverage": 7})
+        asyncio.new_event_loop().run_until_complete(connector._refresh_leverage_cache())
+        cached = connector._leverage_cache["BTC/USDT:USDT"]
+        assert (cached.configured, cached.maximum) == (7, 125)
+
+    def test_the_poller_reads_nothing_when_the_cache_is_empty(self):
+        exchange = self._exchange()
+        connector = self._connector(exchange)
+        asyncio.new_event_loop().run_until_complete(connector._refresh_leverage_cache())
+        assert exchange.fetch_leverage.await_count == 0

--- a/tests/qubx/connectors/ccxt/test_okx_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_okx_exchange.py
@@ -337,20 +337,37 @@ class TestOrderBookChecksumFailure:
     def test_the_base_class_raises_typeerror_instead_of_the_checksum_error(self):
         exchange = cxp.okx()
         exchange.set_markets([_swap_market()])
+        self._checksums_on(exchange)
         with pytest.raises(TypeError):
             exchange.handle_order_book(_FakeWsClient(self.MESSAGE_HASH), _snapshot(checksum=1))
 
+    @staticmethod
+    def _checksums_on(exchange) -> None:
+        # - OkxFutures ships with them off (see TestOrderBookChecksumDisabled); these two
+        #   cover the guard for anyone who turns them back on, and for other venues
+        exchange.options["watchOrderBook"]["checksum"] = True
+
     def test_a_bad_checksum_rejects_the_waiter(self, offline_okx):
+        self._checksums_on(offline_okx)
         client = _FakeWsClient(self.MESSAGE_HASH)
         offline_okx.handle_order_book(client, _snapshot(checksum=1))
         assert len(client.rejected) == 1
         assert isinstance(client.rejected[0], ChecksumError)
 
     def test_a_bad_checksum_drops_the_subscription_and_the_stale_book(self, offline_okx):
+        self._checksums_on(offline_okx)
         client = _FakeWsClient(self.MESSAGE_HASH)
         offline_okx.handle_order_book(client, _snapshot(checksum=1))
         assert self.MESSAGE_HASH not in client.subscriptions
         assert "BTC/USDT:USDT" not in offline_okx.orderbooks
+
+    def test_by_default_a_bad_checksum_is_ignored(self, offline_okx):
+        # - what keeps the stream alive: nothing is raised, nothing is torn down
+        client = _FakeWsClient(self.MESSAGE_HASH)
+        offline_okx.handle_order_book(client, _snapshot(checksum=1))
+        assert client.rejected == []
+        assert self.MESSAGE_HASH in client.subscriptions
+        assert "BTC/USDT:USDT" in offline_okx.orderbooks
 
     def test_the_error_is_retried_by_the_connection_manager(self):
         # - ChecksumError is a NetworkError, which listen_to_stream retries; the TypeError was
@@ -459,3 +476,25 @@ class TestLeverageReads:
         connector = self._connector(exchange)
         asyncio.new_event_loop().run_until_complete(connector._refresh_leverage_cache())
         assert exchange.fetch_leverage.await_count == 0
+
+
+class TestOrderBookChecksumDisabled:
+    """
+    OKX sends `checksum: 0` on every books message (measured 2026-08-21, BTC and ETH swaps,
+    snapshot and updates), and a crc32 is never 0 — so ccxt's check fails on the first update
+    after the snapshot, always. Below ccxt 4.5.55 that ended the stream 1.4s after subscribing
+    on the prod reversals config: the error reached the connection manager, whose retry
+    re-awaits the same watch and never returns. ccxt deleted the check in 4.5.55.
+    """
+
+    def test_okx_futures_turns_the_checksum_off(self):
+        assert OkxFutures().describe()["options"]["watchOrderBook"]["checksum"] is False
+
+    def test_the_base_class_leaves_it_on(self):
+        # - so the override cannot quietly stop mattering on a ccxt that still checksums
+        base = cxp.okx().describe()["options"].get("watchOrderBook", {})
+        assert base.get("checksum", True) is not False
+
+    def test_the_book_depth_is_untouched(self):
+        options = OkxFutures().describe()["options"]["watchOrderBook"]
+        assert options.get("depth") == cxp.okx().describe()["options"].get("watchOrderBook", {}).get("depth")

--- a/tests/qubx/connectors/ccxt/test_okx_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_okx_exchange.py
@@ -1,0 +1,288 @@
+"""Tests for OKX exchange registration and custom class."""
+
+import asyncio
+from unittest.mock import Mock
+
+import ccxt.pro as cxp
+import pytest
+from ccxt.base.errors import ChecksumError
+
+from qubx import logger
+from qubx.connectors.ccxt.exchanges import EXCHANGE_ALIASES, OkxFutures
+from qubx.connectors.ccxt.exchanges.okx.connector import OkxCcxtConnector
+from qubx.connectors.ccxt.utils import ccxt_status_to_order_status
+from qubx.core.basics import OrderStatus
+from qubx.core.basics import CtrlChannel
+
+
+def run(coro):
+    # NOT asyncio.run: that clears the thread's current event loop on exit, breaking
+    # later tests in the same worker that rely on asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _swap_market() -> dict:
+    """Minimal OKX perpetual market dict that satisfies ccxt's lookups."""
+    return {
+        "id": "BTC-USDT-SWAP",
+        "symbol": "BTC/USDT:USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": False,
+        "margin": False,
+        "swap": True,
+        "future": False,
+        "option": False,
+        "contract": True,
+        "linear": True,
+        "inverse": False,
+        "subType": "linear",
+        "active": True,
+        "taker": 0.0005,
+        "maker": 0.0002,
+        "contractSize": 0.01,
+        "expiry": None,
+        "expiryDatetime": None,
+        "strike": None,
+        "optionType": None,
+        "precision": {"amount": 0.01, "price": 0.1},
+        "limits": {
+            "amount": {"min": 0.01, "max": None},
+            "price": {"min": None, "max": None},
+            "cost": {"min": None, "max": None},
+        },
+        "info": {},
+        "created": None,
+    }
+
+
+@pytest.fixture
+def offline_okx():
+    exchange = OkxFutures()
+    exchange.set_markets([_swap_market()])
+    return exchange
+
+
+class TestOkxRegistration:
+    def test_exchange_alias_exists(self):
+        assert EXCHANGE_ALIASES["okx.f"] == "okx_futures"
+
+    def test_custom_class_registered_in_ccxt(self):
+        assert cxp.okx_futures is OkxFutures
+        assert "okx_futures" in cxp.exchanges
+
+    def test_defaults_to_swap_in_net_mode(self):
+        options = OkxFutures().describe()["options"]
+        assert options["defaultType"] == "swap"
+        assert options["positionSide"] == "net"
+
+
+class TestOrderbookChecksumMessage:
+    """
+    A checksum mismatch on a book SNAPSHOT reaches ccxt with symbol=None, because its snapshot
+    branch passes no market and the payload carries no instId. The base implementation
+    concatenates the symbol and raises TypeError, which skips the subscription cleanup and
+    leaves the waiter unresolved — the stream then stalls with nothing raised.
+    """
+
+    def test_base_raises_on_missing_symbol(self):
+        with pytest.raises(TypeError):
+            cxp.okx().orderbook_checksum_message(None)
+
+    def test_message_survives_missing_symbol(self):
+        message = OkxFutures().orderbook_checksum_message(None)
+        assert "okx" in message
+
+    def test_message_keeps_the_symbol_when_present(self):
+        assert "BTC/USDT:USDT" in OkxFutures().orderbook_checksum_message("BTC/USDT:USDT")
+
+    def test_error_is_constructible_without_a_symbol(self):
+        exchange = OkxFutures()
+        assert isinstance(ChecksumError(exchange.orderbook_checksum_message(None)), ChecksumError)
+
+
+class TestProtectiveStopRouting:
+    """
+    Measured live on 2026-08-21, same account/instrument/size, one parameter apart:
+    ``triggerPrice`` + ``reduceOnly`` -> 51205 "Reduce Only is not available.";
+    ``stopLossPrice`` + ``reduceOnly`` -> accepted. So a reduce-only stop has to go out as
+    OKX's conditional algo type, which ccxt selects by the parameter name.
+    """
+
+    def test_reduce_only_stop_becomes_a_conditional_order(self, offline_okx):
+        request = offline_okx.create_order_request(
+            "BTC/USDT:USDT", "market", "sell", 0.12, None, {"triggerPrice": 62256.1, "reduceOnly": True}
+        )
+        assert request["ordType"] == "conditional"
+        assert request["slTriggerPx"] == "62256.1"
+        assert request["slOrdPx"] == "-1"
+        assert "triggerPx" not in request
+
+    def test_plain_stop_stays_a_trigger_order(self, offline_okx):
+        request = offline_okx.create_order_request(
+            "BTC/USDT:USDT", "market", "sell", 0.12, None, {"triggerPrice": 62256.1}
+        )
+        assert request["ordType"] == "trigger"
+        assert request["triggerPx"] == "62256.1"
+
+    def test_a_reduce_only_order_without_a_level_is_untouched(self, offline_okx):
+        params = {"reduceOnly": True}
+        assert offline_okx._route_protective_stop(params) == params
+
+    def test_the_caller_params_are_not_mutated(self, offline_okx):
+        params = {"triggerPrice": 62256.1, "reduceOnly": True}
+        offline_okx._route_protective_stop(params)
+        assert params["triggerPrice"] == 62256.1
+
+
+class TestAlgoOrderParsing:
+    """
+    ccxt returns the raw ``ordType`` as the order type, so an algo order reads as
+    "trigger"/"conditional" — neither is an OrderType, and the connector routes a cancel to
+    the algo book by order type. A conditional also leaves ccxt's triggerPrice empty.
+    """
+
+    def _parse(self, exchange, raw: dict) -> dict:
+        return exchange.parse_order({"instId": "BTC-USDT-SWAP", "side": "sell", "sz": "0.12", **raw})
+
+    def test_conditional_reads_as_stop_market_with_its_trigger(self, offline_okx):
+        parsed = self._parse(offline_okx, {"ordType": "conditional", "slTriggerPx": "62256.1", "slOrdPx": "-1"})
+        assert parsed["type"] == "stop_market"
+        assert parsed["triggerPrice"] == 62256.1
+
+    def test_conditional_with_a_limit_price_reads_as_stop_limit(self, offline_okx):
+        parsed = self._parse(offline_okx, {"ordType": "conditional", "slTriggerPx": "62256.1", "slOrdPx": "62200"})
+        assert parsed["type"] == "stop_limit"
+
+    def test_trigger_reads_as_stop_market(self, offline_okx):
+        parsed = self._parse(offline_okx, {"ordType": "trigger", "triggerPx": "62256.1", "orderPx": "-1"})
+        assert parsed["type"] == "stop_market"
+        assert parsed["triggerPrice"] == 62256.1
+
+    def test_a_regular_order_is_left_alone(self, offline_okx):
+        parsed = self._parse(offline_okx, {"ordType": "limit", "px": "73000"})
+        assert parsed["type"] == "limit"
+
+
+class TestTriggerOrderListing:
+    """
+    Qubx's snapshot asks for trigger orders with ``params={"trigger": True}``. ccxt turns that
+    into OKX's pending-algo call with ``ordType="trigger"`` — one type only — so a conditional
+    stop would never be listed and reconcile would not see it.
+    """
+
+    @staticmethod
+    def _record_calls(monkeypatch) -> list:
+        calls = []
+
+        async def stub(self, symbol=None, since=None, limit=None, params={}):
+            calls.append(params)
+            return [{"id": params.get("ordType", "regular")}]
+
+        monkeypatch.setattr(cxp.okx, "fetch_open_orders", stub)
+        return calls
+
+    def test_trigger_request_asks_for_both_algo_types(self, offline_okx, monkeypatch):
+        calls = self._record_calls(monkeypatch)
+        orders = run(offline_okx.fetch_open_orders(params={"trigger": True}))
+        assert [c["ordType"] for c in calls] == ["trigger", "conditional"]
+        assert [o["id"] for o in orders] == ["trigger", "conditional"]
+
+    def test_an_explicit_ord_type_is_respected(self, offline_okx, monkeypatch):
+        calls = self._record_calls(monkeypatch)
+        run(offline_okx.fetch_open_orders(params={"trigger": True, "ordType": "oco"}))
+        assert [c["ordType"] for c in calls] == ["oco"]
+
+    def test_regular_listing_is_a_single_untouched_call(self, offline_okx, monkeypatch):
+        calls = self._record_calls(monkeypatch)
+        run(offline_okx.fetch_open_orders("BTC/USDT:USDT"))
+        assert calls == [{}]
+
+
+class TestOrderStatusMapping:
+    """
+    OKX's submit ack is `{ordId, clOrdId, tag, sCode, sMsg}` — no state — so every order
+    logged "Unknown ccxt order status 'None'". ACCEPTED is the right mapping for an ack;
+    it is the warning that was wrong.
+    """
+
+    @staticmethod
+    def _warnings_while(call) -> list[str]:
+        # - caplog does not see loguru records, so the sink has to be loguru's own
+        messages: list[str] = []
+        sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+        try:
+            call()
+        finally:
+            logger.remove(sink_id)
+        return messages
+
+    def test_absent_status_maps_to_accepted_without_warning(self):
+        assert self._warnings_while(lambda: ccxt_status_to_order_status(None)) == []
+        assert ccxt_status_to_order_status(None) is OrderStatus.ACCEPTED
+
+    def test_an_unrecognized_status_still_warns(self):
+        warnings = self._warnings_while(lambda: ccxt_status_to_order_status("teleported"))
+        assert len(warnings) == 1
+        assert "teleported" in warnings[0]
+        assert ccxt_status_to_order_status("teleported") is OrderStatus.ACCEPTED
+
+    def test_known_statuses_are_unchanged(self):
+        assert ccxt_status_to_order_status("closed") is OrderStatus.FILLED
+        assert ccxt_status_to_order_status("canceled") is OrderStatus.CANCELED
+        assert ccxt_status_to_order_status("open", {"status": "partially_filled"}) is OrderStatus.PARTIALLY_FILLED
+
+
+class TestAlgoOrderStream:
+    """
+    OKX pushes trigger/conditional orders on channel "orders-algo"; plain `watch_orders` covers
+    "orders" only. Without the extra stream a stop's terminal state never arrives over the
+    socket — a cancelled stop sat in PENDING_CANCEL for 43s on a live close, until the next
+    order-bearing snapshot resolved it.
+    """
+
+    @staticmethod
+    def _connector() -> "OkxCcxtConnector":
+        exchange_manager = Mock()
+        exchange_manager.exchange = Mock()
+        return OkxCcxtConnector(
+            exchange_name="OKX.F",
+            channel=Mock(spec=CtrlChannel),
+            time_provider=Mock(),
+            exchange_manager=exchange_manager,
+            data_provider=Mock(),
+        )
+
+    def _recorded_streams(self, monkeypatch) -> list[dict]:
+        calls = []
+        monkeypatch.setattr(OkxCcxtConnector, "_run_ws_loop", lambda self, **kwargs: calls.append(kwargs))
+        self._connector()._account_streams()
+        return calls
+
+    def test_three_streams_are_started(self, monkeypatch):
+        assert [c["stream"] for c in self._recorded_streams(monkeypatch)] == [
+            "orders",
+            "my_trades",
+            "orders_algo",
+        ]
+
+    def test_the_algo_stream_asks_for_trigger_orders(self, monkeypatch):
+        algo = self._recorded_streams(monkeypatch)[-1]
+        assert algo["watch"].keywords == {"params": {"trigger": True}}
+
+    def test_only_the_plain_order_stream_owns_liveness(self, monkeypatch):
+        streams = self._recorded_streams(monkeypatch)
+        assert [c["mark_ready"] for c in streams] == [True, False, False]
+
+    def test_algo_orders_go_through_the_same_handler(self, monkeypatch):
+        streams = self._recorded_streams(monkeypatch)
+        assert streams[-1]["handle"].__func__ is streams[0]["handle"].__func__

--- a/tests/qubx/connectors/ccxt/test_okx_exchange.py
+++ b/tests/qubx/connectors/ccxt/test_okx_exchange.py
@@ -13,7 +13,7 @@ from qubx.connectors.ccxt.exchanges import EXCHANGE_ALIASES, OkxFutures
 from qubx.connectors.ccxt.exchanges.okx.connector import OkxCcxtConnector
 from qubx.connectors.ccxt.utils import ccxt_status_to_order_status
 from qubx.core.basics import OrderStatus
-from qubx.core.basics import CtrlChannel
+from qubx.core.basics import CtrlChannel, Instrument, MarketType
 
 
 def run(coro):
@@ -367,3 +367,76 @@ class TestOrderBookChecksumFailure:
         offline_okx.handle_order_book(client, good)
         assert client.rejected == []
         assert "BTC/USDT:USDT" in offline_okx.orderbooks
+
+
+class TestLeverageReads:
+    """
+    ccxt's okx has no `fetchLeverages` and no `fetchLeverageTiers` — the two whole-universe
+    calls the base connector's poller uses — so the venue cap was always None and a flat
+    instrument reported no configured leverage. Both exist per symbol.
+    """
+
+    @staticmethod
+    def _connector(exchange: Mock) -> OkxCcxtConnector:
+        exchange_manager = Mock()
+        exchange_manager.exchange = exchange
+        connector = OkxCcxtConnector(
+            exchange_name="OKX.F",
+            channel=Mock(spec=CtrlChannel),
+            time_provider=Mock(),
+            exchange_manager=exchange_manager,
+            data_provider=Mock(),
+        )
+        connector._run_sync = lambda coro, timeout=None: coro
+        return connector
+
+    @staticmethod
+    def _instrument() -> Instrument:
+        return Instrument(
+            symbol="BTCUSDT",
+            market_type=MarketType.SWAP,
+            exchange="OKX.F",
+            base="BTC",
+            quote="USDT",
+            settle="USDT",
+            exchange_symbol="BTC-USDT-SWAP",
+            tick_size=0.1,
+            lot_size=0.01,
+            min_size=0.01,
+            contract_size=0.01,
+        )
+
+    def test_venue_cap_read_per_symbol(self):
+        exchange = Mock()
+        exchange.has = {}
+        exchange.fetch_market_leverage_tiers = Mock(
+            return_value=[{"maxLeverage": 125}, {"maxLeverage": 50}, {"maxLeverage": 10}]
+        )
+        connector = self._connector(exchange)
+        assert connector.get_max_instrument_leverage(self._instrument()) == 125.0
+        exchange.fetch_market_leverage_tiers.assert_called_once_with("BTC/USDT:USDT")
+
+    def test_venue_cap_is_cached_after_the_first_read(self):
+        exchange = Mock()
+        exchange.has = {}
+        exchange.fetch_market_leverage_tiers = Mock(return_value=[{"maxLeverage": 125}])
+        connector = self._connector(exchange)
+        instrument = self._instrument()
+        connector.get_max_instrument_leverage(instrument)
+        connector.get_max_instrument_leverage(instrument)
+        assert exchange.fetch_market_leverage_tiers.call_count == 1
+
+    def test_venue_cap_survives_a_failing_read(self):
+        exchange = Mock()
+        exchange.has = {}
+        exchange.fetch_market_leverage_tiers = Mock(side_effect=ccxt.NotSupported("nope"))
+        assert self._connector(exchange).get_max_instrument_leverage(self._instrument()) is None
+
+    def test_configured_leverage_falls_back_to_fetch_leverage(self):
+        exchange = Mock()
+        exchange.has = {}
+        exchange.fetch_positions = Mock(return_value=[])
+        exchange.fetch_leverage = Mock(return_value={"longLeverage": 5, "shortLeverage": 5})
+        connector = self._connector(exchange)
+        assert connector.get_instrument_leverage(self._instrument()) == 5.0
+        exchange.fetch_leverage.assert_called_once_with("BTC/USDT:USDT")


### PR DESCRIPTION
Eight OKX defects, all found on a live account or on the prod `reversals` config, each fixed with the measurement that produced it.

## The one that matters most: a book checksum ended the market data stream

OKX sends `checksum: 0` on every `books` message. Read straight off `wss://ws.okx.com:8443/ws/v5/public`, six consecutive messages, both symbols, snapshot and updates alike:

```
BTC-USDT-SWAP  action=snapshot  checksum=0  seqId=335226848531  prevSeqId=-1
ETH-USDT-SWAP  action=update    checksum=0  seqId=332842418754  prevSeqId=332842417855
```

A crc32 is never 0, so ccxt's check fails on the first update after the snapshot, always. The book is not corrupt — building the payload from the venue's own raw strings gives `846098866`, and from ccxt's rendering of it the same `846098866`. There is nothing to compare against.

Below ccxt 4.5.55 that failure ends the stream for good: the error reaches the connection manager, whose retry sleeps a second and re-awaits the same watch, and that await never returns. Reproduced twice on `xrelease/prod/okx/package2/reversals.yaml` in paper mode (14 symbols, `orderbook(0, 1)`, ccxt 4.5.52): dead **1.4 s** after subscribing, no data and no further log line, quotes still frozen six minutes later. This is what took a prod bot down on 2026-08-04 — that traceback's line numbers match ccxt 4.5.50 exactly.

ccxt deleted the check in 4.5.55. `OkxFutures` now sets `watchOrderBook.checksum` False, which carries that to older builds and is a no-op on newer ones. Same config with it off: 17 minutes clean, quotes advancing, the strategy trading. `seqId`/`prevSeqId` continuity still runs and is the real guard on this stream.

## Protective stops were being refused

`AtrRiskTracker` on the broker side sent a take and a stop; the take landed, the stop came back `51205 Reduce Only is not available.`, and the position ran with take-profit only. Four variants on a live position, trigger 20% away, each cancelled immediately:

| params | ordType | result |
|---|---|---|
| `triggerPrice` + `reduceOnly` | trigger | **51205 refused** |
| `triggerPrice`, no `reduceOnly` | trigger | accepted |
| `stopLossPrice` + `reduceOnly` | conditional | **accepted** |
| `stopLossPrice` + `closeFraction=1` | conditional | accepted |

So the discriminator is the algo type, not the account mode. A reduce-only stop now goes out as `stopLossPrice`, which ccxt sends as a conditional algo order (`slTriggerPx` + `slOrdPx=-1`); a plain stop still uses `trigger`.

Two consequences of living on the algo book, both fixed here:

- **`parse_order`** maps algo orders back to `stop_market`/`stop_limit` and fills `triggerPrice`. ccxt returns the raw `ordType` as the order type, so an algo order read as `"trigger"`/`"conditional"` — neither is an `OrderType`, and `cancel_order` picks the venue book by order type, so the cancel missed the algo book entirely. This was already broken for every OKX algo order; it stayed invisible only because the stop was never accepted.
- **`fetch_open_orders`** asks for both algo types. ccxt sets `ordType='trigger'` when the caller passes `{"trigger": True}` and nothing else, and OKX's pending-algo endpoint takes one type, so a conditional stop was absent from every snapshot.
- **A third account stream** watches `orders-algo`. Without it a cancelled stop sat in `PENDING_CANCEL` for **43 s** until the next order-bearing snapshot resolved it; `watch_orders` covers the `orders` channel only.

## Cancels of an order the venue had already removed

OKX cancels reduce-only orders itself when a position goes flat — measured: the take's websocket CANCELED arrived **387 ms before** its REST cancel was answered. The tracker cannot know that, so it always cancels what the venue has already done, and the answer is `51400 "Order cancellation failed as the order has been filled, canceled or does not exist."`

`_classify_cancel_error` triaged by message text — Binance's wording — so 51400 matched nothing, fell through to `retry`, burned 2/4/8/16 s of backoff and then reported `CANCEL_REJECTED`, "order is STILL ALIVE at the venue", about an order that was not. ccxt already maps 51400/51401/51402/51603 to `OrderNotFound`; the fix reads the type before the wording. Venue-agnostic.

## Leverage reads cost a round trip each

ccxt's okx has neither `fetchLeverages` nor `fetchLeverageTiers` — the two whole-universe calls the leverage poller uses — so its cache stayed empty, `get_max_instrument_leverage` was always None and every request went to the venue unclamped. Measured in-process, three calls each:

| | `get_instrument_leverage` | `get_max_instrument_leverage` |
|---|---|---|
| Binance | 0.000048 s | 0.000036 s |
| OKX before | **2.78 s** | 0.000027 s |

Both reads exist per symbol. They now fill the same cache the base getters already check first, and the poller refreshes the symbols the cache holds rather than sweeping a universe OKX will not serve. Setting leverage already worked and is unchanged.

## Smaller

- **`orderbook_checksum_message`** could not be built at all on a snapshot: ccxt's snapshot branch passes no market and the per-item payload carries no `instId`, so the symbol resolved to None and `None + ' : '` raised `TypeError` — before the subscription cleanup and the reject, and inside an event-loop callback, so nothing reached the connection manager. Both guards stay for anyone who turns checksums back on and for venues that still run them.
- **`Unknown ccxt order status 'None'`** fired on every OKX order, because OKX's submit ack is `{ordId, clOrdId, tag, sCode, sMsg}` with no state. ACCEPTED is right for an ack; an absent status now logs at debug, an unrecognized one still warns.

## Tests

40 new tests in `tests/qubx/connectors/ccxt/test_okx_exchange.py`, 4 in `test_ccxt_connector_writes.py`. Several assert the *base* behaviour too — that `cxp.okx()` still raises `TypeError` on the same message, that the OKX 51400 wording still matches none of the string fallbacks — so a fix cannot quietly stop mattering. 635 ccxt tests pass.

## Verified live

Order path, algo orders, cancels, leverage set/get and `move_order` (a resting BUY 0.03 repriced 53,858.7 → 54,321.0 **in place**, same venue id) on a live OKX account; the checksum fix on the prod `reversals` config in paper mode.

## Not fixed here

- The tracker still ignores a REJECTED stop: it keeps the `stop_order_id` from the submit call, so a position can run with no stop while the tracker believes it has one. A venue rejection reaches neither the tracker nor the gatherer — `OrderCreationError` is defined in `core/errors.py` and constructed nowhere. Tracked in #386.
- `set_leverage` goes out as cross whichever mode the instrument is in, because ccxt defaults `mgnMode='cross'` and no OKX call reports the mode without a position. Read and write agree, so cross accounts are consistent.
