### PR TITLE
fix(account): keep the client id the venue reported for external orders

### DIFF
--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -31,7 +31,14 @@ from qubx.core.account_manager.diffs import (
 )
 from qubx.core.account_manager.state import AccountState, VenueAccountFigures
 from qubx.core.account_manager.state_machine import can_transition
-from qubx.core.basics import EXTERNAL_CID_PREFIX, Instrument, Order, OrderOrigin, OrderStatus, Position
+from qubx.core.basics import (
+    Instrument,
+    Order,
+    OrderOrigin,
+    OrderStatus,
+    Position,
+    external_client_id,
+)
 from qubx.core.events import (
     AccountSnapshot,
     DealEvent,
@@ -495,9 +502,10 @@ class Reconciler:
         #   any replayed fills (situation II).
         if snap_order.origin is OrderOrigin.EXTERNAL:
             origin = OrderOrigin.EXTERNAL
-            cid = snap_order.client_order_id
-            if not cid.startswith(EXTERNAL_CID_PREFIX):
-                cid = f"{EXTERNAL_CID_PREFIX}{snap_order.venue_order_id}"
+            # - keep the client id the venue reported (external_client_id); it is what a cancel
+            #   addresses on venues that take one. A cid already held locally never reaches here:
+            #   the differ counts such a snapshot order as matched (diffs.py:331).
+            cid = external_client_id(snap_order.client_order_id, snap_order.venue_order_id)
         else:
             origin = OrderOrigin.RECOVERED
             cid = snap_order.client_order_id

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -18,7 +18,6 @@ from qubx import area_logger
 from qubx.core.account_manager.state import AccountState
 from qubx.core.account_manager.state_machine import can_transition, validate_transition
 from qubx.core.basics import (
-    EXTERNAL_CID_PREFIX,
     Balance,
     Deal,
     Instrument,
@@ -29,6 +28,7 @@ from qubx.core.basics import (
     OrderStatus,
     OrderType,
     Position,
+    external_client_id,
 )
 from qubx.core.events import (
     AccountMessage,
@@ -139,14 +139,16 @@ def _materialize_external(
     status: OrderStatus = OrderStatus.ACCEPTED,
 ) -> Order:
     # Unknown to us => external order (manual UI / another bot / pre-existing, or a recovered
-    # historical trade). A venue lifecycle event always carries the id the venue assigned; fall
-    # back to the cid for a stable identity only in the (malformed) case where it doesn't.
+    # historical trade). The client id the event carries is kept when there is one — see
+    # external_client_id; ext:<venue id> is the fallback, not the default.
     # status defaults to ACCEPTED (a live external order exists at the venue); a recovered
     # historical deal passes FILLED so the order is terminal (audit record, never chased as
     # a missing open order). Terminal orders require last_update_time for eviction.
     venue_id = event.venue_order_id
+    # - no cid collision to guard here: _resolve matches an existing order by cid first, so
+    #   materialization only runs for a cid the state does not hold
     order = Order(
-        client_order_id=f"{EXTERNAL_CID_PREFIX}{venue_id or event.client_order_id}",
+        client_order_id=external_client_id(event.client_order_id, venue_id),
         venue_order_id=venue_id,
         origin=OrderOrigin.EXTERNAL,
         type=OrderType.LIMIT,

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -13,8 +13,8 @@ import pandas as pd
 from qubx.core.exceptions import QueueTimeout
 from qubx.core.series import Bar, OrderBook, Quote, Trade, time_as_nsec
 from qubx.core.utils import prec_ceil, prec_floor, time_delta_to_str, time_to_str
-from qubx.utils.misc import Stopwatch
 from qubx.utils.clock import start_clock_discipline, time_now
+from qubx.utils.misc import Stopwatch
 from qubx.utils.time import to_timedelta
 
 dt_64 = np.datetime64
@@ -734,6 +734,23 @@ _PENDING_ORDER_STATUSES = frozenset(
 # framework discovered at the venue but never placed.
 FRAMEWORK_CID_PREFIX = "qubx_"
 EXTERNAL_CID_PREFIX = "ext:"
+
+
+def external_client_id(client_order_id: str | None, venue_order_id: str | None) -> str:
+    """
+    The identity to track a venue order the framework did not place under.
+
+    A client id the venue reported is kept as-is. On venues that address cancel and modify by
+    client id — Lighter takes nothing else — it is the only handle the order has, and replacing
+    it leaves the order unmanageable for the life of the process. Classifying an order as
+    EXTERNAL is a judgement about who placed it; the client id is a fact about how to reach it,
+    and the judgement must not overwrite the fact.
+
+    Only when the venue reports no client id is a stable ``ext:<venue_order_id>`` synthesised.
+    """
+    if client_order_id:
+        return str(client_order_id)
+    return f"{EXTERNAL_CID_PREFIX}{venue_order_id}"
 
 
 class OrderOrigin(StrEnum):

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -758,7 +758,7 @@ def test_external_fill_materializes_books_and_fires_all():
     )
     assert r.order is not None
     assert r.order.origin is OrderOrigin.EXTERNAL
-    assert r.order.client_order_id == "ext:EXT1"
+    assert r.order.client_order_id == "x"
     assert r.order.status is OrderStatus.FILLED
     assert r.deal is not None
     assert r.position is not None and r.position.quantity == 0.5
@@ -775,7 +775,7 @@ def test_external_order_resolves_same_on_second_event():
     apply(state, DealEvent(instrument=BTC, client_order_id="x", venue_order_id="EXT1", deal=_fill("t1", 0.3)), T1)
     apply(state, DealEvent(instrument=BTC, client_order_id="x", venue_order_id="EXT1", deal=_fill("t2", 0.2)), T1)
     order = state.get_order_by_venue_id("EXT1")
-    assert order is not None and order.client_order_id == "ext:EXT1"
+    assert order is not None and order.client_order_id == "x"
     assert _present(state.get_position(BTC)).quantity == 0.5  # accumulated on one external order
 
 

--- a/tests/qubx/core/test_account_manager_apply.py
+++ b/tests/qubx/core/test_account_manager_apply.py
@@ -391,7 +391,8 @@ def test_deal_event_on_unknown_order_materializes_external():
     assert r.position is not None and r.position.quantity == 0.3
     o = am.get_state("binance").get_order_by_venue_id("VX")
     assert o is not None
-    assert o.client_order_id == "ext:VX"
+    # - the venue reported a client id: it is the handle a cancel addresses, so it is kept
+    assert o.client_order_id == "alien"
     assert o.origin is OrderOrigin.EXTERNAL
     assert o.status is OrderStatus.ACCEPTED
     assert o.filled_quantity == 0.3
@@ -694,7 +695,7 @@ def test_materialize_external_for_unknown_cid_and_venue():
     o = state.get_order_by_venue_id("VX")
     assert o is not None
     assert o.origin is OrderOrigin.EXTERNAL
-    assert o.client_order_id == "ext:VX"
+    assert o.client_order_id == "alien"
     assert o.filled_quantity == 0.5
 
 

--- a/tests/qubx/core/test_account_manager_snapshot.py
+++ b/tests/qubx/core/test_account_manager_snapshot.py
@@ -161,7 +161,8 @@ def test_out_of_order_snapshot_skipped():
 
 
 def test_external_order_materialized_from_snapshot():
-    # Producer-classified EXTERNAL (AccountSnapshot contract) -> synthesized ext:<vid> cid.
+    # Producer-classified EXTERNAL (AccountSnapshot contract) keeps the client id the venue
+    # reported — on venues that cancel by client id it is the only handle.
     am = _am()
     state = am._states["binance"]
     inst = _instrument()
@@ -178,7 +179,7 @@ def test_external_order_materialized_from_snapshot():
     materialized = state.get_order_by_venue_id("VX")
     assert materialized is not None
     assert materialized.origin is OrderOrigin.EXTERNAL
-    assert materialized.client_order_id == "ext:VX"
+    assert materialized.client_order_id == "manual-123"
 
 
 def test_recovered_order_materialized_from_snapshot():
@@ -719,3 +720,21 @@ def test_sim_capital_getters_derive_consistently():
     assert am.get_total_capital("binance") == 1000.0
     assert am.get_available_margin("binance") == 900.0
     assert am.get_withdrawable_balance("binance") == am.get_available_margin("binance") == 900.0
+
+
+def test_external_order_with_no_client_id_gets_synthesized_cid():
+    # The venue reported no client id: fall back to the stable ext:<vid> convention.
+    am = _am()
+    state = am._states["binance"]
+    inst = _instrument()
+    snap_order = _order(
+        "ext:VY",
+        OrderStatus.ACCEPTED,
+        "2026-05-28T00:00:00",
+        vid="VY",
+        origin=OrderOrigin.EXTERNAL,
+        instrument=inst,
+    )
+    am._time.t = np.datetime64("2026-05-28T01:00:00")
+    am.apply(_snap_event(as_of="2026-05-28T01:00:00", open_orders=[snap_order]))
+    assert state.get_order_by_venue_id("VY").client_order_id == "ext:VY"


### PR DESCRIPTION
## What

An order classified `EXTERNAL` had its client id replaced with `ext:<venue_order_id>` — in both the snapshot-recovery path (`reconciler.py:497-500`) and the websocket materialization path (`reducer.py:149`).

On a venue that addresses cancel and modify **by client id**, that rewrite is fatal. `int("ext:…")` raises, the connector refuses the cancel locally, and it never reaches the venue. The order rests forever and the executor retries it every tick.

Classifying an order as EXTERNAL is a judgement about who placed it. The client id is a fact about how to reach it. The judgement must not overwrite the fact.

## Found live

A connector version change on a Lighter pool left resting orders whose client ids the new connector does not mint (different id scheme). 22 were classified EXTERNAL, lost their ids, and became permanently un-cancellable — **261 refused cancels in 55 seconds**, cleared only by rolling the connector back.

## Change

- `basics.py` — `external_client_id(client_order_id, venue_order_id)`: keep a reported client id, synthesise `ext:<venue_order_id>` only when there is none
- `reducer.py:149`, `reconciler.py:497-500` — call it instead of rewriting unconditionally

`origin` is unchanged: an external order still reads EXTERNAL.

No collision guard, deliberately: a cid the state already holds never reaches either site. The differ counts such a snapshot order as matched (`diffs.py:331`) and `_resolve` matches by cid before materializing, so the guard would be dead code.

## Other connectors

Both already do the right thing at their own layer and only synthesise when the venue gave nothing — `ccxt/utils.py:188` (`clientOrderId or ext:<id>`), `hyperliquid/translate.py:82,254` (`cloid or ext:<oid>`). This stops qubx from discarding what they produced. Neither is affected functionally: ccxt cancels by both ids, Hyperliquid by `oid`. Lighter is the only venue where the client id is the sole handle.

## Tests

933 core + 670 connector, all green. Three tests asserted the old rule and now assert the new one; one new test pins the no-client-id fallback.

## Live verification

11 resting orders planted on a live Lighter account — 10 carrying old-scheme client ids, 1 carrying an id the new scheme accepts (the control). Identical in market, price, size, side and id length; only the leading digits differ.

| | before | after |
|---|---:|---:|
| adoption | `'EXTERNAL' order ext:11540473910500379` | `'EXTERNAL' order 484410420` |
| refused cancels | 3,176 | **0** |
| cleared | 1 of 11 (the control only) | **11 of 11** |

Reproduction script: `test-strategies` `loe_tests/scripts/plant_old_style_orders.py` (`--place` / `--status` / `--cancel`).