### PR TITLE
fix(backtester): refresh OME BBO from order-book ticks

### DIFF
--- a/src/qubx/backtester/ome.py
+++ b/src/qubx/backtester/ome.py
@@ -156,6 +156,13 @@ class OrdersManagementEngine:
             _bs, _as = _b, _a
             _mkt_state = "OB: " + str(mdata)
 
+            # - a book carries a real top-of-book, so refresh the BBO market orders fill against.
+            #   Without this, a venue whose live feed is books only (no quote stream) never moves
+            #   `bbo` off whatever quote happened to seed the OME, and every market order forever
+            #   fills at that startup price while positions mark at live prices.
+            self.__prev_bbo = self.bbo
+            self.bbo = mdata.to_quote()
+
         else:
             raise SimulationError(f"Invalid market data type: {type(mdata)} for update OME({self.instrument.symbol})")
 

--- a/tests/qubx/backtester/ome_test.py
+++ b/tests/qubx/backtester/ome_test.py
@@ -5,7 +5,7 @@ from qubx.backtester.simulated_data import EmulatedTickSequence
 from qubx.core.basics import ZERO_COSTS, ITimeProvider, OrderStatus
 from qubx.core.exceptions import SimulationError
 from qubx.core.lookups import lookup
-from qubx.core.series import Quote, Trade, TradeArray
+from qubx.core.series import OrderBook, Quote, Trade, TradeArray
 from qubx.core.utils import recognize_time
 from qubx.data import CsvStorage
 
@@ -25,6 +25,18 @@ class _TimeService(ITimeProvider):
 
 def Q(time: str, bid: float, ask: float) -> Quote:
     return Quote(recognize_time(time), bid, ask, 0, 0)
+
+
+def OB(time: str, bid: float, ask: float, tick_size: float = 0.1) -> OrderBook:
+    """Top-of-book snapshot in the shape connectors emit for `orderbook(0, 1)`."""
+    return OrderBook(
+        recognize_time(time),
+        bid,
+        ask,
+        tick_size,
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+    )
 
 
 class TestOrderManagementEngineSimulation:
@@ -378,3 +390,69 @@ class TestOrderManagementEngineSimulation:
             assert False
         except SimulationError:
             pass
+
+    def test_orderbook_updates_bbo_for_market_orders(self):
+        """An OrderBook tick must refresh the BBO that market orders fill against.
+
+        Regression: only the Quote branch of process_market_data used to assign `bbo`, so on a
+        venue whose live feed is order books (e.g. `live_base_subscription: orderbook(0, 1)`)
+        every market order kept filling at whatever quote happened to seed the OME at startup —
+        the book stayed frozen while marks moved, silently corrupting simulated PnL.
+        """
+        instr = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instr
+        ome = OrdersManagementEngine(instr, t := _TimeService(), tcc=ZERO_COSTS)
+
+        # - seed the OME the way warmup does: a single synthetic quote
+        ome.process_market_data(t.g(Q("2020-01-01 10:00", 32000, 32001)))
+
+        # - market moves and is reported as an order book, not a quote
+        ob = OB("2020-01-01 11:00", 40000, 40001)
+        t._time = ob.time  # type: ignore
+        ome.process_market_data(ob)
+
+        assert ome.get_quote().bid == 40000
+        assert ome.get_quote().ask == 40001
+
+        buy = ome.place_order("BUY", "MARKET", 0.1, None, "buy-after-ob")
+        assert buy.exec is not None
+        assert buy.exec.price == 40001, "market BUY must fill at the order book's ask, not a stale quote"
+
+        sell = ome.place_order("SELL", "MARKET", 0.1, None, "sell-after-ob")
+        assert sell.exec is not None
+        assert sell.exec.price == 40000, "market SELL must fill at the order book's bid, not a stale quote"
+
+    def test_market_order_fills_on_orderbook_only_feed(self):
+        """A feed that only ever produces order books must still be tradeable.
+
+        Before the fix `bbo` stayed None on such venues and place_order raised
+        "Simulator is not ready for order management - no quote".
+        """
+        instr = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instr
+        ome = OrdersManagementEngine(instr, t := _TimeService(), tcc=ZERO_COSTS)
+
+        ob = OB("2020-01-01 10:00", 32000, 32001)
+        t._time = ob.time  # type: ignore
+        ome.process_market_data(ob)
+
+        r = ome.place_order("BUY", "MARKET", 0.1, None, "ob-only")
+        assert r.order.status == OrderStatus.FILLED
+        assert r.exec is not None
+        assert r.exec.price == 32001
+
+    def test_orderbook_does_not_rewind_bbo_on_stale_tick(self):
+        """Out-of-order order books are dropped before they can rewind the BBO."""
+        instr = lookup.find_symbol("BINANCE.UM", "BTCUSDT")
+        assert instr
+        ome = OrdersManagementEngine(instr, t := _TimeService(), tcc=ZERO_COSTS)
+
+        fresh = OB("2020-01-01 12:00", 40000, 40001)
+        t._time = fresh.time  # type: ignore
+        ome.process_market_data(fresh)
+
+        stale = OB("2020-01-01 11:00", 32000, 32001)
+        ome.process_market_data(stale)
+
+        assert ome.get_quote().bid == 40000
+        assert ome.get_quote().ask == 40001


### PR DESCRIPTION
## The bug

`OrdersManagementEngine.process_market_data` assigns `self.bbo` in exactly one place — the `Quote` branch:

```python
if isinstance(mdata, Quote):
    ...
    self.__prev_bbo = self.bbo
    self.bbo = mdata
elif isinstance(mdata, TradeArray): ...
elif isinstance(mdata, Trade): ...
elif isinstance(mdata, OrderBook):
    _b, _a = mdata.top_bid, mdata.top_ask   # local only — bbo untouched
```

The `OrderBook` branch computes a local `_b, _a` so resting limit orders still match correctly, but never refreshes the BBO. And market orders fill from the BBO:

```python
_c_ask = self.bbo.ask ; _c_bid = self.bbo.bid
case "MARKET":  _exec_price = _c_ask if _buy_side else _c_bid
```

So on a venue whose live feed is **order books only**, the OME's BBO never moves off whatever quote happened to seed it at startup. Every market order from then on fills at that startup price, while positions mark at live prices.

## How it showed up

A LIGHTER paper bot running `live_base_subscription: orderbook(0, 1)` (that venue publishes no OHLC, so the book is the only live feed). Its fill prices were byte-identical for **every fill, buys and sells alike, for six days** — changing only when the pod restarted:

```
XRPUSDC   08-15…08-18: 1.00146   →   08-18…08-24: 1.00062     (pod restarted 08-18 22:37)
LITUSDC   08-15…08-18: 2.21375   →   08-18…08-24: 2.37565
SKYUSDC   08-15…08-18: 0.05244   →   08-18…08-24: 0.05575
```

Meanwhile XRP moved 1.00 → 1.46 on the reference venue. By the end fills were 16–18% away from mark.

The BBO got seeded once because the connector's warmup path synthesises a `Quote` from the last warmup bar's close and sends it with `is_warmup=False`; that single quote is the only one the OME ever sees. Steady-state the connector sends only `orderbook` events (its book-derived quote is cached locally for marking, never put on the channel). Hence: marks live, fills frozen.

The equity impact of each stale fill is exactly `Δequity = (M − P) × qty` (M = live mark, P = frozen fill price) — so stale buys *manufacture* equity and stale sells *destroy* it. That formula reproduced every daily rebalance step on the affected bot:

| rebalance | predicted | actual |
|---|---|---|
| 08-20 | +846 | +713 |
| 08-21 | +167 | +104 |
| 08-22 | +824 | +612 |
| 08-23 | +953 | +1,030 |
| 08-24 | **−2,837** | **−2,958** |

They had been near-cancelling by luck of the buy/sell mix until one rebalance sold far more appreciated exposure than it bought.

## The fix

An order book carries a genuine top-of-book, so take the BBO straight from the existing `OrderBook.to_quote()`, keeping `__prev_bbo` maintained for the fill-at-signal-price path:

```python
self.__prev_bbo = self.bbo
self.bbo = mdata.to_quote()
```

The stale-tick guard at the top of `process_market_data` (`if mdata.time < self._last_data_update_time_ns: return`) already drops out-of-order data before it can rewind the BBO.

## Scope note

`Trade` and `TradeArray` also leave `bbo` untouched. I left them alone deliberately: their `_b, _a` are *synthesised* as `price ± tick_size` rather than a real BBO, so assigning them would change market-order fill prices in existing trade-driven backtests. The `OrderBook` case is unambiguous — `top_bid`/`top_ask` are a real BBO — so it's the safe and correct one to fix. Happy to extend if you'd rather have all branches consistent.

## Tests

Three regression tests in `tests/qubx/backtester/ome_test.py`, all failing before the change:

- `test_orderbook_updates_bbo_for_market_orders` — seed a quote, feed a book at a different level, assert market buy/sell fill at the **book's** touch. Failed with `assert 32000.0 == 40000`.
- `test_market_order_fills_on_orderbook_only_feed` — an OME that has only ever seen books must be tradeable. Previously raised `SimulationError: Simulator is not ready for order management - no quote`.
- `test_orderbook_does_not_rewind_bbo_on_stale_tick` — guards the stale-tick path.

## Verification

- `tests/qubx/backtester/ome_test.py` — 11 passed
- `tests/qubx/backtester` — 130 passed
- Full unit suite (`-m "not integration and not e2e"`) — **2836 passed, 5 skipped**
- `ruff check` on both changed files reports exactly the same 23 pre-existing findings as `origin/main` (none introduced); `ruff format --check` clean

## Blast radius

Backtests driven by OHLC or quotes are unaffected — the `Quote` branch is untouched, and OHLC reaches the OME as an emulated `Quote` via `connector.py`. Order-book-driven simulations are the only behaviour change, and today those either raise "no quote" or fill at a stale price, so this strictly corrects them.
