### PR TITLE
debug(account): trace every order event and every confirm decision

### DIFF
--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -244,8 +244,25 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
             return ApplyResult()
         now = self._time.time()
         result = self._apply_to_state(state, event, now)
+        self._trace_event(state, event, result)
         self._maybe_sweep_evictions(now)
         return result
+
+    def _trace_event(self, state: AccountState, event: AccountMessage, result: ApplyResult) -> None:
+        # - one line per venue event and what it did to the order. Reconstructs an order's whole
+        #   life from the log, which is the only way to tell a message the venue never sent from
+        #   one we received and mishandled. DEBUG on the account_manager area.
+        if not isinstance(event, OrderEvent):
+            return
+        order = result.order
+        age = ""
+        if order is not None and order.submitted_at is not None:
+            age = f" age={(self._time.time() - order.submitted_at) / np.timedelta64(1, 's'):.3f}s"
+        logger.debug(
+            f"[{state.exchange}] event {type(event).__name__} cid={event.client_order_id} "
+            f"vid={event.venue_order_id} -> change={result.order_change} "
+            f"status={order.status if order is not None else None}{age}"
+        )
 
     def _apply_to_state(self, state: AccountState, event: AccountMessage, now: np.datetime64) -> ApplyResult:
         rec = self._reconcilers[state.exchange]

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -231,6 +231,7 @@ class AwaitOrderConfirm(Task):
         self._wait = wait
         self._max_retries = max_retries
         self._retries = 0
+        self._armed_at = now
         self._next_fetch_at = now + wait
         self._done = False
 
@@ -262,6 +263,13 @@ class AwaitOrderConfirm(Task):
         order = state.get_order(self._cid)
 
         if order is None or not order.status.is_inflight:
+            # - the venue answered on its own: log what state ended the wait and after how long,
+            #   so a slow stream is visible as a number rather than an absence
+            _log.debug(
+                f"[{state.exchange}] confirm {self._cid} ended by venue state "
+                f"status={order.status if order is not None else 'gone'} "
+                f"after {(now - self._armed_at) / np.timedelta64(1, 'ms'):.0f}ms, no fetch needed"
+            )
             self._done = True  # - confirmed (ACCEPTED), terminal, or gone
             return []
 
@@ -273,6 +281,11 @@ class AwaitOrderConfirm(Task):
         if self._retries < self._max_retries:
             self._retries += 1
             self._next_fetch_at = now + self._wait
+            _log.debug(
+                f"[{state.exchange}] confirm {self._cid} no venue answer in "
+                f"{(now - self._armed_at) / np.timedelta64(1, 'ms'):.0f}ms — asking the venue "
+                f"(status={order.status}, retry {self._retries}/{self._max_retries})"
+            )
             return [RequestStatus(cid=self._cid, venue_id=self._venue_id, instrument=self._instrument)]
 
         # - budget exhausted → route LOST via the bus (same as ResolveMissingOrder give-up)


### PR DESCRIPTION
## What

Two DEBUG traces in the account manager, added while diagnosing orders that accumulated in
`PENDING_CANCEL` on a Lighter public pool account. Both are behind existing debug areas and emit
nothing at INFO.

**`manager` — one line per venue order event** (`QUBX_DEBUG_AREAS=account_manager`):

```
event OrderAcceptedEvent cid=276925699729420 vid=19984723197131622 -> change=ACCEPTED status=ACCEPTED age=1.380s
event OrderRejectedEvent cid=272945669152601 vid=18577348326798511 -> change=REJECTED status=REJECTED age=25.381s
```

Event class, client and venue ids, the resulting `order_change`, the new status, and the order's
age. The age is what made the pool problem legible: orders were being rejected 25 and 47 seconds
after they were sent, which is what pointed at the snapshot reconcile rather than the venue.

**`reconciler` — why each confirm ended** (`QUBX_DEBUG_AREAS=reconciler`):

```
confirm <cid> ended by venue state status=ACCEPTED after 812ms, no fetch needed
confirm <cid> no venue answer in 5001ms - asking the venue (status=PENDING_CANCEL, retry 1/5)
```

The second prints the local status at the moment we go asking. `PENDING_CANCEL` there means we are
about to ask the venue about an order we ourselves cancelled, which returns `OrderNotFound` and
becomes a rejection.

## Why keep it

The Lighter cause is fixed elsewhere (xLydianSoftware/exchanges#45 — the venue does not report
cancellations on that account's channel, so we subscribe to a different one). These lines are what
made it findable, and neither is venue-specific.

Measured cost at ten concurrent symbols: 1,111 lines over 22 minutes, ~50 lines/min, only with
`account_manager` enabled.

## Still open

An order in `PENDING_CANCEL` that the venue reports as not live is a completed cancel, not a
rejection. The reconciler currently emits `REJECTED`, which downstream treats as a venue refusal.
That is a behaviour change and belongs in its own PR.

## Tests

274 account-manager tests pass. No behaviour change in this PR.
