### PR TITLE
fix(emitters): CSVMetricEmitter.ensure_table accepts max_ttl

### DIFF
--- a/src/qubx/emitters/csv.py
+++ b/src/qubx/emitters/csv.py
@@ -199,9 +199,16 @@ class CSVMetricEmitter(BaseMetricEmitter):
         symbol_columns: Sequence[str] = (),
         dedup_keys: Sequence[str] | None = None,
         partition_by: str = "DAY",
+        max_ttl: str | None = None,
     ) -> None:
         """
         Declare a strategy-owned table as one CSV file beside the metrics file.
+
+        `max_ttl` is accepted and ignored: a CSV file has no retention to set. It is in the
+        signature so a caller can declare a table without knowing which emitter it holds —
+        without it, a caller that passes `max_ttl` gets a TypeError here and has to either skip
+        declaring the table (losing the schema, so the first row's columns become the schema and
+        every later column is dropped) or drop `max_ttl` from the call for everyone.
         """
         try:
             if isinstance(symbol_columns, str):

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -263,6 +263,25 @@ class TestCSVRecords:
         # a column the row does not carry stays blank rather than shifting the line
         assert rows[1]["price"] == ""
 
+    def test_ensure_table_accepts_max_ttl_and_ignores_it(self, tmp_path):
+        # a caller that declares a table without knowing which emitter it holds passes max_ttl;
+        # a TypeError here would make it skip declaring, and the first row's columns would then
+        # become the schema for every later row
+        em = self._emitter(tmp_path)
+        em.ensure_table("loe.execution", {"price": "DOUBLE"}, symbol_columns=("kind",), max_ttl="90 days")
+
+        header = (tmp_path / "loe.execution.csv").read_text().splitlines()[0].split(",")
+        assert {"kind", "price"} <= set(header)
+
+    def test_a_declared_table_keeps_columns_absent_from_the_first_row(self, tmp_path):
+        em = self._emitter(tmp_path)
+        em.ensure_table("loe.execution", {"price": "DOUBLE", "filled_qty": "DOUBLE"}, max_ttl=None)
+        em.emit_record("loe.execution", {"price": 0.1})          # first row lacks filled_qty
+        em.emit_record("loe.execution", {"filled_qty": 100.0})
+
+        rows = list(csv_mod.DictReader((tmp_path / "loe.execution.csv").read_text().splitlines()))
+        assert rows[1]["filled_qty"] == "100.0"
+
     def test_emit_record_without_ensure_table_still_writes(self, tmp_path):
         em = self._emitter(tmp_path)
         em.emit_record("adhoc.table", {"a": 1.0})


### PR DESCRIPTION
## What

`CSVMetricEmitter.ensure_table` accepts `max_ttl` and ignores it.

`max_ttl` was added to `QuestDBMetricEmitter.ensure_table` only. It is not on
`IMetricEmitter`, so a caller that declares a table without knowing which emitter it holds gets a
`TypeError` from `CSVMetricEmitter`. That caller then has to either skip declaring the table or
drop `max_ttl` from the call for every emitter.

## Why skipping is expensive

`emit_record` falls back to taking the schema from the first row it sees, and every column a
later row adds is dropped with a single warning.

Measured with quantkit's `ExecutionRecorder` writing to CSV. The START row of an execution
episode arrives before the END row, so the schema became the START columns:

```
[CSVMetricEmitter] 'exec.executions': dropping undeclared columns
  ['avg_price', 'dropped_rows', 'duration_sec', 'end_reason', 'fees_quote',
   'filled_qty', 'first_fill_sec', 'maker_fraction', 'n_fills', 'n_orders',
   'n_reprices', 'slip_mid_bps', 'slip_signal_bps', 'slip_touch_bps']
```

Every slippage figure, fill count, maker fraction, fee total and duration — 14 columns, the whole
point of the table. With this change the same run declares all four tables and writes every
column.

## The change

```python
max_ttl: str | None = None,
```

A CSV file has no retention to set, so the value is accepted and ignored; the docstring says so
and says why the parameter is there.

## Tests

Two added to `TestCSVRecords`, both failing without the change:

- `ensure_table` accepts `max_ttl` and still writes the header
- a declared table keeps a column that the first row did not carry

117 emitter tests pass.

## Not in this PR

`CompositeMetricEmitter.ensure_table` still lacks `max_ttl` and still forwards without it, so a
wrapped QuestDB emitter falls back to its own 52-week default. A caller that cares (quantkit's
recorder does) currently detects the missing parameter and skips declaring rather than risk
stamping a TTL it did not ask for. Fixing that properly means putting `max_ttl` on
`IMetricEmitter` and forwarding it from the composite — a wider change than this one.
