### PR TITLE
fix(ccxt): stop PM WS balance pushes overwriting the account balance

### DIFF
--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -159,6 +159,13 @@ class CcxtConnector(ChannelEmitter):
     # make_client_id actually produces, so producer and classifier can never drift.
     cid_framework_prefix: str = FRAMEWORK_CID_PREFIX
 
+    # Whether the venue's ACCOUNT_UPDATE `a.B[].wb` is the ACCOUNT wallet balance.
+    # True on plain UM/CM, where the futures wallet is the account. False on venues
+    # whose stream reports a SUB-wallet (Binance PM) — there an absolute push would
+    # overwrite the account balance with the sub-wallet figure, so they stay
+    # snapshot-only.
+    _wants_ws_balance_push: bool = True
+
     def __init__(
         self,
         *,
@@ -1076,7 +1083,7 @@ class CcxtConnector(ChannelEmitter):
         # snapshot-only until ported.
         if not isinstance(ex, ccxt.pro.binance) or not self._is_derivatives_venue():
             return streams
-        if ex.has.get("watchBalance"):
+        if ex.has.get("watchBalance") and self._wants_ws_balance_push:
             streams.append(
                 self._run_ws_loop(
                     watch=ex.watch_balance,

--- a/src/qubx/connectors/ccxt/exchanges/binance/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/connector.py
@@ -10,6 +10,9 @@ the configured VENUE name (``binance.pm``) — the canonical name both venues sh
   ``GET /papi/v1/account`` into ``info`` — see ``_extract_venue_figures``. The papi
   figures are USD-denominated (vs USDT on fapi); the difference is treated as
   negligible, same as the base class treats fapi's USDT figures.
+- **WS balance push**: disabled (``_wants_ws_balance_push``). The papi user-data
+  ACCOUNT_UPDATE carries the UM sub-wallet in ``wb``, not the account wallet — see
+  the class attribute. Balance refresh rides the papi snapshot instead.
 - **ADL level**: papi positionRisk carries no adl field; PM exposes it on a dedicated
   bulk ``GET /papi/v1/um/adlQuantile`` endpoint. One account-wide call per snapshot
   stamps ``Position.adl_level`` (so ``ctx.get_adl_level`` — an AccountManager dict
@@ -53,6 +56,14 @@ def _parse_adl_quantiles(rows: Any) -> dict[str, int]:
 
 class BinancePmCcxtConnector(CcxtConnector):
     """BINANCE.PM connector: papi account figures + papi ADL on top of the base."""
+
+    # PM has no usable WS balance push. The papi /pm/ws ACCOUNT_UPDATE reports the UM
+    # SUB-wallet in `a.B[].wb`, not the account: PM collateral sits in the cross-margin
+    # wallet, so wb tracks cumulative UM realized PnL/fees (~0 on a fresh account) and
+    # an absolute push overwrites the real balance until the next snapshot. Same trap
+    # the REST path already sidesteps in BinanceQV.parse_balance_custom, which reads
+    # whole-account totalWalletBalance. Snapshot-only here.
+    _wants_ws_balance_push = False
 
     _adl_levels: dict[str, int]
 

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -97,6 +97,32 @@ class TestBinancePmBalanceParse:
         finally:
             run(ex.close())
 
+    def test_pm_total_is_whole_account_not_a_sub_wallet(self):
+        # PM_BALANCE_ROW above omits crossMarginAsset, so it only catches a swap back to
+        # upstream's cross-wallet field via the derived-total fallback. This row carries
+        # every wallet figure, all distinct, so the assertion pins the whole-account one
+        # directly — the invariant disabling the WS push relies on (with no push, the
+        # papi snapshot is the only balance source on PM).
+        row = {
+            "asset": "USDT",
+            "totalWalletBalance": "10000.0",  # whole account
+            "crossMarginAsset": "9990.0",  # cross sub-wallet (upstream ccxt reads this)
+            "crossMarginFree": "9980.0",
+            "crossMarginLocked": "10.0",
+            "crossMarginBorrowed": "0",
+            "crossMarginInterest": "0",
+            "umWalletBalance": "10.0",  # UM sub-wallet — what /pm/ws pushes as `wb`
+            "umUnrealizedPNL": "3.0",
+            "cmWalletBalance": "0",
+            "cmUnrealizedPNL": "0",
+        }
+        ex = _pm_exchange()
+        try:
+            parsed = ex.parse_balance_custom([row], "linear", None, True)
+            assert parsed["USDT"]["total"] == 10000.0
+        finally:
+            run(ex.close())
+
     def test_non_pm_passthrough(self):
         ex = _pm_exchange()
         try:

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
@@ -20,6 +20,7 @@ import pytest
 from qubx import logger
 from qubx.connectors.ccxt.connector import CcxtConnector
 from qubx.connectors.ccxt.exchanges._two_stream import _TwoStreamCcxtConnector
+from qubx.connectors.ccxt.exchanges.binance.connector import BinancePmCcxtConnector
 from qubx.core.account_manager import SimulatedAccountManager
 from qubx.core.basics import (
     Balance,
@@ -1088,6 +1089,24 @@ async def test_account_streams_derivatives_venue_adds_balance_loop() -> None:
     assert [k["mark_ready"] for k in recorded] == [True, False]
     assert [k.get("iterate", True) for k in recorded] == [True, False]
     assert recorded[1]["handle"] == conn._handle_ws_balances
+
+
+@pytest.mark.asyncio
+async def test_portfolio_margin_venue_omits_balance_push_loop() -> None:
+    # A PM ACCOUNT_UPDATE's `a.B[].wb` is the UM SUB-WALLET balance, not the account:
+    # PM collateral lives in the cross-margin wallet, so wb reads ~0 (cumulative UM
+    # realized PnL/fees) and an absolute push would wipe the real balance. PM stays
+    # snapshot-only — the papi snapshot reads whole-account totalWalletBalance.
+    exchange = _binance_exchange(
+        has={"watchBalance": True},
+        options={"defaultType": "swap", "portfolioMargin": True},
+    )
+    conn, _, _ = _make_connector(exchange=exchange, cls=BinancePmCcxtConnector)
+    recorded = _record_streams(conn)
+
+    await conn._subscribe_executions()
+
+    assert [k["stream"] for k in recorded] == ["executions"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The bug

On a **Binance portfolio-margin** account the internal USDT balance collapses to ~0 within seconds of any fill, then gets restored by the next snapshot — repeatedly.

```
11:58:05 reconcile: balance USDT from snapshot -> total=10000.0        (was —)
11:59:13 fill: sell 338 POLUSDT @ 0.1215
11:59:40 reconcile: balance USDT from snapshot -> total=9999.99589398  (was total=-0.00410602)
```

`-0.00410602` is exactly the maker fee on that one fill (338 × 0.1215 × 0.01%).

**Cause.** `_handle_ws_balances` takes `a.B[].wb` from the Binance `ACCOUNT_UPDATE` stream as the absolute account balance:

```python
total = entry.get("wb")          # "Wallet Balance"
```

On plain UM that is the account. On PM it is the **UM sub-wallet** — collateral sits in the cross-margin wallet, so `wb` only tracks cumulative UM realized PnL and fees, starting at zero. `apply_balance_push` writes it absolutely, so every fill wipes the real balance until the next 30s snapshot reconciles it back.

The REST path already sidesteps this: `BinanceQV.parse_balance_custom` deliberately reads whole-account `totalWalletBalance` instead of upstream ccxt's cross-wallet field. The WS push path never got the same treatment — and `BinancePortfolioMargin`'s `defaultType: "swap"` is what makes the balance loop compose in the first place.

## The fix

Gate the balance push loop on a new `_wants_ws_balance_push` seam (default `True`) and turn it off for `BinancePmCcxtConnector`. PM stays snapshot-only, like every non-Binance venue already does.

There is no field to swap to — the papi user-data message simply does not carry an account total — and no accuracy is lost: the papi snapshot runs every 30s and already reads `totalWalletBalance`.

## Impact

`get_total_capital()` prefers venue equity (papi `accountEquity`) so dashboards looked correct throughout, which is why this went unnoticed. Anything reading `ctx.get_balance(...).total` saw the sub-wallet figure. In production this caused an aggregator's balance-drift checker to compute a scale factor of `-4.1e-07`, sign-flipping and annihilating all 44 stored targets.

## Tests

- `test_portfolio_margin_venue_omits_balance_push_loop` — PM composes only the executions stream (fails without the fix).
- `test_account_streams_derivatives_venue_adds_balance_loop` — unchanged, pins that plain UM still gets its balance loop.
- `test_pm_total_is_whole_account_not_a_sub_wallet` — the existing PM row omits `crossMarginAsset` and only catches a regression via the derived-total fallback; the new row carries every wallet figure, all distinct, so it pins `totalWalletBalance` directly. With the push disabled the snapshot is the only balance source on PM, so this invariant now carries the whole balance path.

`tests/qubx/connectors/` + `tests/qubx/core/` — 1643 passed.

## Verification note

Not exercised against a live venue: **Binance has no portfolio-margin testnet** — ccxt's `test` and `demo` URL blocks carry no `papi` entry, it exists only under `api` (`papi.binance.com`). The evidence above is from two production bots.
