### PR TITLE
feat(core): default instrument leverage, applied on universe add

### DIFF
--- a/src/qubx/core/account_manager/manager.py
+++ b/src/qubx/core/account_manager/manager.py
@@ -6,6 +6,7 @@ Periodic ticks (reconcile, sweep, liveness) call the reconcile.py decision helpe
 fire the connector requests — connector calls stay manager-only, as does PM wiring.
 """
 
+from collections.abc import Iterable
 from typing import Callable, Literal
 
 import numpy as np
@@ -30,6 +31,7 @@ from qubx.core.basics import (
     FundingPayment,
     Instrument,
     ITimeProvider,
+    MarketType,
     Order,
     OrderOrigin,
     OrderStatus,
@@ -55,6 +57,17 @@ def liveness_overdue(unready_since: np.datetime64, now: np.datetime64, threshold
     return (now - unready_since) >= threshold  # type: ignore
 
 
+# - market types that carry leverage.
+_LEVERAGED_MARKET_TYPES = (
+    MarketType.SWAP,
+    MarketType.FUTURE,
+    MarketType.MARGIN,
+    MarketType.FOREX,
+    MarketType.STOCK,
+    MarketType.CFD,
+)
+
+
 class AccountManager(IAccountViewer, IAccountConfigurator):
     account_id: str
 
@@ -71,6 +84,8 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
     _liveness_unready_since: dict[str, np.datetime64]
     _last_eviction_sweep: np.datetime64
     _reconcilers: dict[str, Reconciler]
+    # - None leaves every venue's own leverage alone; seeded from the config via the context
+    _default_instrument_leverage: float | None
 
     def __init__(
         self,
@@ -82,6 +97,7 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
         cfg: AccountManagerConfig | None = None,
         account_id: str = "AccountManager",
         tcc: dict[str, TransactionCostsCalculator] | None = None,
+        default_instrument_leverage: float | None = None,
     ):
         self._pm = pm
         self._init_state(
@@ -91,6 +107,7 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
             cfg=cfg,
             account_id=account_id,
             tcc=tcc,
+            default_instrument_leverage=default_instrument_leverage,
         )
         # Live passes pm=None and registers the ticks later — see set_processing_manager.
         if self._pm is not None:
@@ -116,10 +133,12 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
         cfg: AccountManagerConfig | None,
         account_id: str,
         tcc: dict[str, TransactionCostsCalculator] | None,
+        default_instrument_leverage: float | None,
     ) -> None:
         # Shared field init for both the live and simulation managers, so the
         # subclass can't silently drift from the parent's field set.
         self._connectors = connectors
+        self._default_instrument_leverage = default_instrument_leverage
         self._time = time
         self._cfg = cfg or AccountManagerConfig()
         self.account_id = account_id
@@ -582,6 +601,39 @@ class AccountManager(IAccountViewer, IAccountConfigurator):
             return
         connector.set_instrument_leverage(instrument, leverage)
 
+    def set_default_instrument_leverage(self, leverage: float | None) -> None:
+        """Set the leverage leveraged instruments should run at, and apply it to everything this
+        manager knows about. None leaves each venue's own setting alone from here on.
+        """
+        self._default_instrument_leverage = leverage
+        self.apply_default_instrument_leverage(self.positions)
+
+    def apply_default_instrument_leverage(self, instruments: Iterable[Instrument]) -> None:
+        """Set the current default leverage on these instruments.
+
+        Setting it again on an instrument that already has it costs nothing: connectors
+        either skip it from cache (ccxt, lighter) or send it because reading the current value
+        is dearer than writing (hyperliquid).
+
+        Never raises — the universe calls this when instruments are added, and one venue
+        refusing must not stop an instrument joining.
+        """
+        leverage = self._default_instrument_leverage
+        if leverage is None:
+            return
+        leveraged = [i for i in instruments if i.market_type in _LEVERAGED_MARKET_TYPES]
+        if not leveraged:
+            return
+        for instrument in leveraged:
+            try:
+                self.set_instrument_leverage(instrument, leverage)
+            except Exception as exc:  # noqa: BLE001 — one refusal must not block the rest
+                logger.error(f"leverage {leverage}x for {instrument.symbol} failed: {exc}")
+        logger.info(f"set {leverage}x leverage on {len(leveraged)} instrument(s)")
+
+    def get_default_instrument_leverage(self) -> float | None:
+        return self._default_instrument_leverage
+
     def set_margin_mode(self, instrument: Instrument, mode: str) -> bool:
         connector = self._connectors.get(instrument.exchange)
         if connector is None:
@@ -649,6 +701,7 @@ class SimulatedAccountManager(AccountManager):
         cfg: AccountManagerConfig | None = None,
         account_id: str = "SimulatedAccountManager",
         tcc: dict[str, TransactionCostsCalculator] | None = None,
+        default_instrument_leverage: float | None = None,
     ):
         super().__init__(
             connectors=connectors,
@@ -657,6 +710,7 @@ class SimulatedAccountManager(AccountManager):
             cfg=cfg,
             account_id=account_id,
             tcc=tcc,
+            default_instrument_leverage=default_instrument_leverage,
         )
 
     def set_processing_manager(self, pm: IProcessingManager) -> None:

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -985,6 +985,11 @@ class Transfer:
 
 DEFAULT_MAINTENANCE_MARGIN = 0.05
 
+# - venue leverage applied to every perp on universe add unless the config or the strategy says
+#   otherwise. Not the same as "off": an unset leverage is whatever the venue last had, which is
+#   how an account ends up opening positions at a leverage nobody chose.
+DEFAULT_INSTRUMENT_LEVERAGE = 3.0
+
 
 class Position:
     instrument: Instrument  # instrument for this position

--- a/src/qubx/core/context.py
+++ b/src/qubx/core/context.py
@@ -364,6 +364,11 @@ class StrategyContext(IStrategyContext):
 
         self._trading_manager.set_deny_trading_when_degraded(self.initializer.get_deny_trading_when_degraded())
 
+        # - only when on_init actually set one: the account manager already holds
+        #   live.default_instrument_leverage, passed by the runner at construction
+        if (leverage := self.initializer.get_default_instrument_leverage()) is not None:
+            self._account_manager.set_default_instrument_leverage(leverage)
+
         # Configure stale data detection based on strategy settings
         stale_data_config = self.initializer.get_stale_data_detection_config()
         self._processing_manager.configure_stale_data_detection(*stale_data_config)
@@ -744,6 +749,24 @@ class StrategyContext(IStrategyContext):
             raise ReadOnlyConnector("account configuration is read-only — write rejected")
         self._account_manager.set_instrument_leverage(instrument, leverage)
 
+    def set_default_instrument_leverage(self, leverage: float | None) -> None:
+        """
+        Change the leverage applied to instruments added to the universe, and apply it now to
+        the ones already there. None leaves every venue's own leverage alone from here on.
+        """
+        self._assert_not_fit_thread("set_default_instrument_leverage")
+        if self._read_only:
+            raise ReadOnlyConnector("account configuration is read-only — write rejected")
+        # - refuse rather than clamp: a sub-1 leverage is a typo or a percentage, and silently
+        #   turning it into 1 would trade a size nobody asked for
+        if leverage is not None and leverage < 1:
+            logger.error(
+                f"[StrategyContext] default instrument leverage must be >= 1, got {leverage} — "
+                f"keeping {self._account_manager.get_default_instrument_leverage()}"
+            )
+            return
+        self._account_manager.set_default_instrument_leverage(leverage)
+
     def set_margin_mode(self, instrument: Instrument, mode: str) -> bool:
         self._assert_not_fit_thread("set_margin_mode")
         if self._read_only:
@@ -884,11 +907,23 @@ class StrategyContext(IStrategyContext):
         self, instruments: list[Instrument], skip_callback: bool = False, if_has_position_then: RemovalPolicy = "close"
     ):
         self._assert_not_fit_thread("set_universe")
-        return self._universe_manager.set_universe(instruments, skip_callback, if_has_position_then)
+        result = self._universe_manager.set_universe(instruments, skip_callback, if_has_position_then)
+        self._apply_default_leverage(instruments)
+        return result
 
     def add_instruments(self, instruments: list[Instrument]):
         self._assert_not_fit_thread("add_instruments")
-        return self._universe_manager.add_instruments(instruments)
+        result = self._universe_manager.add_instruments(instruments)
+        self._apply_default_leverage(instruments)
+        return result
+
+    def _apply_default_leverage(self, instruments: list[Instrument]) -> None:
+        # - the initial universe arrives here too (start() calls set_universe with
+        #   skip_callback=True), so this is the only place that sees every instrument the bot
+        #   trades before it trades them. set_universe passes the whole new universe because the
+        #   added ones are only known inside UniverseManager; add_instruments passes just those.
+        if self.is_live and not self._read_only:
+            self._account_manager.apply_default_instrument_leverage(instruments)
 
     def remove_instruments(self, instruments: list[Instrument], if_has_position_then: RemovalPolicy = "close"):
         self._assert_not_fit_thread("remove_instruments")

--- a/src/qubx/core/fit_context.py
+++ b/src/qubx/core/fit_context.py
@@ -357,6 +357,7 @@ class FitContext(ITimeProvider):
     settle_position = _denied("settle_position")
     # venue/account configuration writes
     set_instrument_leverage = _denied("set_instrument_leverage")
+    set_default_instrument_leverage = _denied("set_default_instrument_leverage")
     set_margin_mode = _denied("set_margin_mode")
     transfer_funds = _denied("transfer_funds")
     # subscription/schedule plumbing with no deferred story (on_init-time concerns)

--- a/src/qubx/core/initializer.py
+++ b/src/qubx/core/initializer.py
@@ -9,6 +9,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable
 
+from qubx import logger
 from qubx.core.basics import Instrument, td_64
 from qubx.core.interfaces import IStrategyInitializer, ITransferManager, StartTimeFinderProtocol, StateResolverProtocol
 from qubx.core.utils import recognize_timeframe
@@ -32,6 +33,8 @@ class BasicStrategyInitializer(IStrategyInitializer):
     fit_schedule: str | None = None
     event_schedule: str | None = None
     warmup_period: str | None = None
+    # - None means on_init said nothing, so live.default_instrument_leverage stands
+    default_instrument_leverage: float | None = None
     start_time_finder: StartTimeFinderProtocol | None = None
     mismatch_resolver: StateResolverProtocol | None = None
     auto_subscribe: bool | None = None
@@ -102,6 +105,19 @@ class BasicStrategyInitializer(IStrategyInitializer):
 
     def get_warmup(self) -> td_64 | None:
         return td_64(recognize_timeframe(self.warmup_period), "ns") if self.warmup_period else None
+
+    def set_default_instrument_leverage(self, leverage: float | None) -> None:
+        # - refuse rather than clamp: a sub-1 leverage is a typo or a percentage, and silently
+        #   turning it into 1 would trade a size nobody asked for
+        if leverage is not None and leverage < 1:
+            logger.error(
+                f"default instrument leverage must be >= 1, got {leverage} — keeping {self.default_instrument_leverage}"
+            )
+            return
+        self.default_instrument_leverage = leverage
+
+    def get_default_instrument_leverage(self) -> float | None:
+        return self.default_instrument_leverage
 
     def set_start_time_finder(self, finder: StartTimeFinderProtocol) -> None:
         self.start_time_finder = finder

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -1524,6 +1524,17 @@ class IStrategyContext(
         """Check if the warmup is in progress."""
         return self._strategy_state.is_warmup_in_progress
 
+    def set_default_instrument_leverage(self, leverage: float | None) -> None:
+        """
+        Change the leverage applied to perps added to the universe, and apply it now to the ones
+        already there. None leaves every venue's own leverage alone from here on.
+
+        Seeded from ``live.default_instrument_leverage`` and overridable in ``on_init`` via
+        ``initializer.set_default_instrument_leverage``. Raises on a read-only account; refuses a
+        value below 1 with an error and changes nothing.
+        """
+        ...
+
     @property
     def is_simulation(self) -> bool:
         """Check if the strategy context is running in simulation mode."""
@@ -2245,6 +2256,22 @@ class IStrategyInitializer:
     def get_warmup(self) -> td_64 | None:
         """
         Get the warmup period for the strategy.
+        """
+        ...
+
+    def set_default_instrument_leverage(self, leverage: float | None) -> None:
+        """
+        Set the venue leverage applied to every perp added to the universe.
+
+        Overrides ``live.default_instrument_leverage`` from the config, which seeds this before
+        ``on_init`` runs. ``None`` means leave the venue's own leverage alone; a value below 1 is
+        refused with an error and changes nothing.
+        """
+        ...
+
+    def get_default_instrument_leverage(self) -> float | None:
+        """
+        The venue leverage to apply on universe add, or None to leave the venue alone.
         """
         ...
 

--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -5,6 +5,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from qubx.core.basics import DEFAULT_INSTRUMENT_LEVERAGE
 from qubx.core.fit_executor import FitExecutorMode
 from qubx.core.interfaces import IStrategy
 
@@ -234,6 +235,10 @@ class MarketCacheConfig(StrictBaseModel):
 
 class LiveConfig(StrictBaseModel):
     read_only: bool = False
+    # - venue leverage applied to every perp on universe add. Omit for the 3x default; set null
+    #   to leave the venue's own leverage alone. A strategy can override it in on_init via
+    #   initializer.set_default_instrument_leverage().
+    default_instrument_leverage: float | None = DEFAULT_INSTRUMENT_LEVERAGE
     base_currency: str | None = None
     exchanges: dict[str, ExchangeConfig]
     logging: LoggingConfig

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -623,6 +623,7 @@ def create_strategy_context(
         cfg=AccountManagerConfig(**config.live.account_manager.model_dump()),
         account_id=stg_name,
         tcc=_exchange_to_tcc,
+        default_instrument_leverage=config.live.default_instrument_leverage,
     )
     # Paper seeds the configured initial capital per exchange (no venue to query); live seeds
     # nothing here — balances/positions come from the venue snapshot. Restored state (positions

--- a/tests/qubx/core/mixins/fit_executor_test.py
+++ b/tests/qubx/core/mixins/fit_executor_test.py
@@ -578,6 +578,11 @@ class TestStashedContextTripwires:
         ctx._processing_manager = MagicMock()
         ctx._trading_manager = MagicMock()
         ctx._transfer_manager = MagicMock()
+        # - set_universe/add_instruments also request the default instrument leverage, which
+        #   reads is_live and the read-only flag before it touches the account manager
+        ctx._data_providers = [MagicMock(is_simulation=True)]
+        ctx._account_manager = MagicMock()
+        ctx._read_only = False
         return ctx
 
     def test_stashed_ctx_mutators_raise_from_fit_thread(self):


### PR DESCRIPTION
Closes #393.

## Why

An instrument nobody set leverage on trades at whatever the venue last had. That is how an
account ends up opening positions at a leverage nobody chose — and there was no way to say
"everything runs at 3x" without a strategy doing it by hand.

## The config parameter

```yaml
live:
  default_instrument_leverage: 5     # omit for the 3x default; null leaves each venue alone
```

| yaml | meaning |
|---|---|
| omitted | `DEFAULT_INSTRUMENT_LEVERAGE` = **3.0** |
| a number | that leverage |
| `null` | do not touch the venue's own setting |

`DEFAULT_INSTRUMENT_LEVERAGE` lives in `qubx.core.basics`.

## Public methods

**`IStrategyInitializer.set_default_instrument_leverage(leverage)`** — call it in `on_init` to
override the config from code:

```python
def on_init(self, initializer: IStrategyInitializer) -> None:
    initializer.set_default_instrument_leverage(5)
```

Paired with `get_default_instrument_leverage()`. Its field defaults to `None` meaning "on_init
said nothing", so the config value stands unless a strategy actually calls it. One consequence:
`set_default_instrument_leverage(None)` from `on_init` is a no-op rather than "leave venues
alone" — use `default_instrument_leverage: null` in yaml, or `ctx` at runtime, for that.

**`IStrategyContext.set_default_instrument_leverage(leverage)`** — change it while running. It
stores the new value and applies it immediately to every instrument the account manager knows:

```python
def on_start(self, ctx: IStrategyContext) -> None:
    ctx.set_default_instrument_leverage(5)
```

Raises `ReadOnlyConnector` on a read-only account and asserts it is not on the fit thread, like
the `set_instrument_leverage` next to it. Classified as denied on `FitContext`.

Both refuse a value below 1 with an error and change nothing — a sub-1 leverage is a typo or a
percentage, and turning it into 1 would trade a size nobody asked for.

## Where the work happens

`AccountManager` holds the value and does the applying, beside the other per-instrument venue
settings it already owns (`set_instrument_leverage`, `set_margin_mode`, `get_max_instrument_leverage`).
It takes `default_instrument_leverage` through `__init__` and `_init_state`, defaulting to `None`
so an account manager built standalone writes nothing.

Two methods:

- `set_default_instrument_leverage(leverage)` — store it and apply to everything known
- `apply_default_instrument_leverage(instruments)` — apply the current value to those instruments

`StrategyContext.set_universe` and `add_instruments` call the second with the instruments they
were handed. **The initial universe arrives through `set_universe` with `skip_callback=True`**
(`context.py` `start()`), so that path is the only one that sees every instrument the bot trades
before it trades it — the strategy callback never fires for it.

Skipped when the context is read-only or not live.

## Market types

Applied to `SWAP`, `FUTURE`, `MARGIN`, `FOREX`, `STOCK`. Plain spot, bonds, options, CFDs and
indices have no leverage to set.

## What it does not do

**No skip for instruments already at the value.** That is the connector's decision and they
disagree for good reasons: ccxt and lighter skip from their cache, hyperliquid sends every time
because reading the current value there costs 21x the write.

**Never raises from the universe path.** A venue refusing one instrument must not stop it joining
the universe; a refusal is logged and the rest continue.

## Verified live

Lighter, 41 instruments, checked against `/api/v1/account` rather than our logs:

| config | result |
|---|---|
| `default_instrument_leverage: 5.0` | 41 at 5x, 0 refusals |
| omitted | 41 at 3x, 0 refusals |

Needs xLydianSoftware/exchanges#47 to run clean on Lighter — `L2UpdateLeverage` has a 40/min
budget of its own and 41 writes at once had the venue refuse one until that pool existed.

943 core tests pass.

## Known gaps, not addressed here

- A leverage change on N instruments is paced by the venue: 41 takes about a minute on Lighter, and
  instruments trade at the old value until their write lands.
- Whether the account snapshot arrives before `set_universe` decides if a connector can skip
  already-correct instruments. Two of three cold starts lost that race in testing; it costs venue
  calls, not correctness.
