### PR TITLE
feat(core): reconcile the instrument lookup against what a venue lists

### DIFF
--- a/src/qubx/core/instrument_service.py
+++ b/src/qubx/core/instrument_service.py
@@ -1,7 +1,9 @@
-"""Instrument blacklist service: pluggable HTTP-backed blacklist with Null default."""
+"""What we are allowed to trade: the operator blacklist, and what the venue actually lists."""
 
 import os
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
+from typing import Any
 
 import httpx
 
@@ -167,3 +169,95 @@ def create_instrument_service(exchanges: list[str]) -> IInstrumentService:
     if not base_url:
         return NullInstrumentService()
     return HttpInstrumentService(base_url=base_url, exchanges=exchanges)
+
+
+@dataclass
+class VenueInstruments:
+    """The result of reconciling the lookup against a venue's market list."""
+
+    # - venue key -> the one instrument both sides agree on. Safe to resolve inbound events with.
+    by_key: dict[Any, Instrument] = field(default_factory=dict)
+    # - (instrument, why) for every candidate the venue did not confirm
+    dropped: list[tuple[Instrument, str]] = field(default_factory=list)
+    # - venue keys with no instrument in the lookup at all: tradeable at the venue, invisible to us
+    unmatched_venue_keys: list[Any] = field(default_factory=list)
+
+    @property
+    def instruments(self) -> list[Instrument]:
+        return list(self.by_key.values())
+
+
+def reconcile_instruments(
+    exchange: str,
+    venue_markets: Mapping[Any, str],
+    candidates: Iterable[Instrument],
+    key_of: Callable[[Instrument], Any],
+    name_of: Callable[[Instrument], str] = lambda i: i.base,
+) -> VenueInstruments:
+    """
+    Keep the instruments the venue confirms, drop the rest, and say why.
+
+    The lookup is our database: it can hold delisted markets, and two entries can claim the same
+    venue id after a rename — market 12 on Lighter was GRAM and TON at once for weeks. That is
+    tolerable in the database and not tolerable in a live connector, which resolves inbound events
+    by venue id: whichever entry a dict happened to keep won, so fills for one instrument were
+    booked against another.
+
+    Venues key their markets differently — ccxt by symbol string, Lighter by integer market id,
+    Hyperliquid by coin — so the caller supplies the key. Identity is compared on
+    ``Instrument.base`` by default, which is what all three name a market by.
+
+    Args:
+        exchange: for the log lines only.
+        venue_markets: the venue's own list, venue key -> the venue's name for it.
+        candidates: what the lookup offers for this exchange.
+        key_of: the venue key an instrument claims. Return None when it claims none.
+        name_of: the instrument's name in the venue's terms. Defaults to ``base``.
+    """
+    result = VenueInstruments()
+    claimed: dict[Any, list[Instrument]] = {}
+
+    def drop(instrument: Instrument, why: str) -> None:
+        result.dropped.append((instrument, why))
+        logger.error(f"[{exchange}] {instrument.symbol} dropped from trading: {why}")
+
+    for instrument in candidates:
+        try:
+            key = key_of(instrument)
+        except Exception as exc:  # noqa: BLE001 — a malformed entry must not stop the rest
+            drop(instrument, f"venue key unreadable: {exc}")
+            continue
+        if key is None:
+            drop(instrument, "carries no venue key")
+        elif key not in venue_markets:
+            drop(instrument, f"venue does not list {key}")
+        else:
+            claimed.setdefault(key, []).append(instrument)
+
+    for key, instruments in claimed.items():
+        venue_name = venue_markets[key]
+        agreed = [i for i in instruments if name_of(i) == venue_name]
+        if len(agreed) == 1:
+            result.by_key[key] = agreed[0]
+        for i in instruments:
+            if len(agreed) == 1 and i is agreed[0]:
+                continue
+            if len(agreed) > 1 and i in agreed:
+                # - same key AND same name twice: nothing tells them apart, so neither can be
+                #   trusted to resolve an inbound event
+                drop(i, f"{len(agreed)} lookup entries claim {key} as {venue_name!r}")
+            else:
+                drop(i, f"{key} is {venue_name!r} at the venue, not {name_of(i)!r}")
+
+    result.unmatched_venue_keys = [k for k in venue_markets if k not in result.by_key]
+    logger.info(
+        f"[{exchange}] instruments: {len(result.by_key)} confirmed against {len(venue_markets)} venue markets, "
+        f"{len(result.dropped)} dropped, {len(result.unmatched_venue_keys)} venue markets unmatched"
+    )
+    if result.unmatched_venue_keys:
+        logger.warning(
+            f"[{exchange}] no lookup entry for venue markets: "
+            f"{', '.join(f'{k}={venue_markets[k]}' for k in result.unmatched_venue_keys[:20])}"
+            + (" …" if len(result.unmatched_venue_keys) > 20 else "")
+        )
+    return result

--- a/tests/qubx/core/reconcile_instruments_test.py
+++ b/tests/qubx/core/reconcile_instruments_test.py
@@ -1,0 +1,85 @@
+"""What the lookup and the venue disagree about must not reach the venue."""
+
+import pytest
+
+from qubx.core.basics import Instrument, MarketType
+from qubx.core.instrument_service import reconcile_instruments
+
+
+def _instr(symbol: str, base: str, market_id: str) -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange="TESTEX",
+        base=base,
+        quote="USDC",
+        settle="USDC",
+        exchange_symbol=market_id,
+        tick_size=0.01,
+        lot_size=0.1,
+        min_size=0.1,
+    )
+
+
+def _reconcile(venue, candidates):
+    return reconcile_instruments("TESTEX", venue, candidates, key_of=lambda i: int(i.exchange_symbol))
+
+
+def test_a_market_the_venue_lists_resolves():
+    btc = _instr("BTCUSDC", "BTC", "1")
+    res = _reconcile({1: "BTC"}, [btc])
+    assert res.by_key == {1: btc}
+    assert res.dropped == []
+
+
+def test_a_market_the_venue_does_not_list_is_dropped():
+    # the lookup keeps delisted markets; a live connector must not resolve them
+    gone = _instr("OLDUSDC", "OLD", "2048")
+    res = _reconcile({1: "BTC"}, [gone])
+    assert res.by_key == {}
+    assert [i for i, _ in res.dropped] == [gone]
+    assert "does not list 2048" in res.dropped[0][1]
+
+
+def test_the_venue_decides_which_of_two_claimants_owns_a_market():
+    # market 34 held DATAUSDC and IPUSDC after a rename; the dict kept whichever came last, so
+    # fills for one were booked against the other
+    data = _instr("DATAUSDC", "DATA", "34")
+    ip = _instr("IPUSDC", "IP", "34")
+    res = _reconcile({34: "DATA"}, [ip, data])
+    assert res.by_key == {34: data}
+    assert [i for i, _ in res.dropped] == [ip]
+    assert "34 is 'DATA' at the venue, not 'IP'" in res.dropped[0][1]
+
+
+def test_neither_is_trusted_when_two_claimants_agree_on_the_key_and_the_name():
+    # nothing tells them apart, so resolving an inbound event would be a coin flip
+    a, b = _instr("XUSDC", "X", "7"), _instr("X2USDC", "X", "7")
+    res = _reconcile({7: "X"}, [a, b])
+    assert res.by_key == {}
+    assert len(res.dropped) == 2
+
+
+def test_an_instrument_with_no_venue_key_is_dropped():
+    res = reconcile_instruments("TESTEX", {1: "BTC"}, [_instr("BTCUSDC", "BTC", "1")], key_of=lambda i: None)
+    assert res.by_key == {}
+    assert res.dropped[0][1] == "carries no venue key"
+
+
+def test_an_unreadable_venue_key_drops_that_one_and_keeps_the_rest():
+    btc, bad = _instr("BTCUSDC", "BTC", "1"), _instr("BADUSDC", "BAD", "not-a-number")
+    res = _reconcile({1: "BTC", 2: "BAD"}, [btc, bad])
+    assert res.by_key == {1: btc}
+    assert "venue key unreadable" in res.dropped[0][1]
+
+
+def test_venue_markets_with_no_lookup_entry_are_reported_not_invented():
+    res = _reconcile({1: "BTC", 2: "ETH"}, [_instr("BTCUSDC", "BTC", "1")])
+    assert res.unmatched_venue_keys == [2]
+    assert res.instruments == [_instr("BTCUSDC", "BTC", "1")]
+
+
+@pytest.mark.parametrize("venue", [{}, {1: "BTC"}])
+def test_no_candidates_resolves_nothing(venue):
+    res = _reconcile(venue, [])
+    assert res.by_key == {} and res.dropped == []


### PR DESCRIPTION
## Why

The lookup is our database. It can hold delisted markets, and after a rename two entries can claim
the same venue id. On Lighter, market 12 was **GRAM and TON at once for weeks**, and market 34 is
**DATA and IP right now**.

That is tolerable in a database. It is not tolerable in a live connector, which resolves inbound
events by venue id:

```python
self._by_market_id = {int(i.exchange_symbol): i for i in instruments}
```

Whichever entry the dict happened to keep won. Fills for one instrument were booked against
another, the executor never saw the position it was building, and on the production pool that
became a runaway buy loop — 2,468 market orders and a real 1.3M GRAM position on a \$497k account.

## What this adds

`reconcile_instruments` in `instrument_service.py`:

```python
reconcile_instruments(exchange, venue_markets, candidates, key_of, name_of=lambda i: i.base)
    -> VenueInstruments(by_key, dropped, unmatched_venue_keys)
```

An instrument is kept when the venue lists its key **and** names it the same thing. Everything else
is dropped from trading, each with a reason, logged at ERROR:

```
IPUSDC dropped from trading: 34 is 'DATA' at the venue, not 'IP'
ETH/USDCUSDC dropped from trading: venue does not list 2048
```

Venue markets with no lookup entry are reported once at WARNING — tradeable at the venue, invisible
to us, and never invented.

Two claimants agreeing on **both** the key and the name drops both. Nothing tells them apart, so
resolving an inbound event would be a coin flip.

## Why it takes callbacks

Venues key markets differently — ccxt by symbol, Lighter by integer market id, Hyperliquid by coin —
so the caller supplies `key_of`. Identity is compared on `Instrument.base`, which is what all three
name a market by.

Worth being honest about where this matters: the check catches a collision when the venue's key and
its name are **independent**. Lighter's integer id versus `GRAM` is that case. For ccxt the key is
derived from the symbol, so a key collision implies the same symbol and only the "venue does not
list it" branch has value. Hyperliquid builds its instruments *from* the venue meta, so it has
nothing to reconcile. **Today there is one real consumer.** It is in qubx rather than the connector
because the next connector mapping a venue id onto looked-up instruments hits the same trap.

## Why `instrument_service.py`

Both things in that module answer "may we trade this instrument" — one by operator policy
(blacklist), one by venue truth. The module docstring changed accordingly.

## Verified

Against the live Lighter venue and the real lookup: **229 confirmed, 9 dropped**, market 34
resolving to `DATAUSDC` instead of `IPUSDC`.

9 new tests cover each drop reason, the contested-market case, and unmatched venue markets. 952
core tests pass.

## Paired with

xLydianSoftware/exchanges#48, the first consumer. That one cannot build until this lands.
