### PR TITLE
fix(deps): exclude statsmodels 0.15.0 (no cp312 linux wheel)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,11 @@ dependencies = [
     "jinja2>=3.1.0,<4",
     "rich>=13.9.4,<14",
     "click>=8.1.7,<9",
-    "statsmodels>=0.14.6,<1",
+    # 0.15.0 ships no cp310/311/312 manylinux x86_64 wheels (only cp313) despite
+    # declaring requires-python >=3.10, so on our 3.12 runtime it resolves to the sdist
+    # and needs a meson source build. Bot containers have no compiler, so any release
+    # ZIP locked after 2026-08-27T10:34Z fails at startup. Lift once 0.15.0 has wheels.
+    "statsmodels>=0.14.6,!=0.15.0,<1",
 
     # - - - Database backends - - - 
     "pymongo>=4.6.1,<5",

--- a/uv.lock
+++ b/uv.lock
@@ -3789,7 +3789,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.12.0,<2" },
     { name = "sortedcontainers", specifier = ">=2.4.0,<3" },
     { name = "stackprinter", specifier = ">=0.2.10,<1" },
-    { name = "statsmodels", specifier = ">=0.14.6,<1" },
+    { name = "statsmodels", specifier = ">=0.14.6,!=0.15.0,<1" },
     { name = "tabulate", specifier = ">=0.9.0,<1" },
     { name = "textual", extras = ["syntax"], specifier = ">=6.0.0,<7" },
     { name = "textual-autocomplete", specifier = ">=4.0.0,<5" },


### PR DESCRIPTION
## Issue

`statsmodels 0.15.0` (published 2026-08-27T10:34Z) ships **no cp312 manylinux x86_64 wheel** — only cp313 gets one on Linux — despite declaring `requires-python >=3.10`.

Our constraint was `statsmodels>=0.14.6,<1`, so 0.15.0 was eligible. On the 3.12 runtime it resolves to the sdist and needs a meson source build. **Bot containers have no C compiler**, so any release ZIP locked after that timestamp dies at startup:

```
ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang'], ...]
hint: `statsmodels` (v0.15.0) was included because ... `qubx` (v3.6.0) depends on `statsmodels`
```

This hits every strategy release built from now on, not one bot.

## Fix

`statsmodels>=0.14.6,!=0.15.0,<1` — excludes the one bad release, allows 0.15.1+ automatically.

Resolved version is unchanged (0.14.6, already what `uv.lock` had), so the dependency set is byte-identical and only the specifier metadata moves. Verified `uv pip compile --no-cache` now resolves 0.14.6.

Lift the exclusion once 0.15.0 has cp312 wheels.
