### PR TITLE
fix(deps): cap statsmodels<0.15 (release pipeline: image build + cibuildwheel test-install)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ dependencies = [
     "jinja2>=3.1.0,<4",
     "rich>=13.9.4,<14",
     "click>=8.1.7,<9",
-    "statsmodels>=0.14.6,<1",
+    # 0.15.0 (2026-08-27) ships no cp312 manylinux wheels — fresh resolutions (Docker image
+    # pip install, cibuildwheel test-install, downstream consumers) fall back to a meson sdist
+    # build that needs a compiler. Drop the <0.15 cap when 0.15.x publishes cp312 linux wheels.
+    "statsmodels>=0.14.6,<0.15",
 
     # - - - Database backends - - - 
     "pymongo>=4.6.1,<5",

--- a/uv.lock
+++ b/uv.lock
@@ -3789,7 +3789,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.12.0,<2" },
     { name = "sortedcontainers", specifier = ">=2.4.0,<3" },
     { name = "stackprinter", specifier = ">=0.2.10,<1" },
-    { name = "statsmodels", specifier = ">=0.14.6,<1" },
+    { name = "statsmodels", specifier = ">=0.14.6,<0.15" },
     { name = "tabulate", specifier = ">=0.9.0,<1" },
     { name = "textual", extras = ["syntax"], specifier = ">=6.0.0,<7" },
     { name = "textual-autocomplete", specifier = ">=4.0.0,<5" },


### PR DESCRIPTION
The #399 release run failed in two jobs that resolve qubx's dependencies FRESH: the Docker image build (`pip install qubx.whl[connectors]` on compiler-less slim) and cibuildwheel's wheel test-install — both picked statsmodels 0.15.0 (2026-08-27, still no cp312 manylinux wheels as of now) and died on the meson sdist build. Same landmine as quantkit#147 / factors#13, capped at the source this time; the cap also protects every downstream consumer of qubx>=3.6.1 metadata. Drop when 0.15.x ships cp312 linux wheels.

https://claude.ai/code/session_01YP94CXQ2V9LVA38pVoQ75j