### PR TITLE
feat(core): first-class boot phase — unconditional state resolution, set_fit_on_start, strict sync gate, boot-fit failure handling

### DIFF
--- a/docs/specs/2026-08-27-boot-phase-design.md
+++ b/docs/specs/2026-08-27-boot-phase-design.md
@@ -1,0 +1,361 @@
+# Boot Phase Design
+
+**Date:** 2026-08-27
+**Status:** Approved design, pending implementation plan
+**Issues:** closes [#363](https://github.com/xLydianSoftware/Qubx/issues/363); documents [#388](https://github.com/xLydianSoftware/Qubx/issues/388)
+
+## Background
+
+Enabling a buffered tracker (quantkit `BufferedPositionsTracker`) in a live strategy broke
+restarts: the warmup simulation always starts flat — only balances are seeded
+(`src/qubx/backtester/runner.py:620`), never positions — and buffering makes targets
+path-dependent, so from a flat start every target within the buffer band of zero collapses
+to an explicit size-0 target. The warmup sim's end book is therefore a flat-start
+*artifact*, not a prescription. `StateResolver.SYNC_STATE` (and the default `REDUCE_ONLY`)
+then drove real live positions to that artifact — closing them at boot.
+
+Investigating the incident surfaced four framework-level weaknesses in the boot path,
+all in the same pipeline block (`src/qubx/core/mixins/processing.py:499-527`):
+
+1. **No way to guarantee a live boot fit.** `is_on_fit_called` lives on the shared
+   `StrategyState`; a warmup-sim fit sets it, so after warmup the live pipeline never
+   forces a fit. Strategies that reconcile through their tracker on fit (the correct
+   pattern for buffered strategies) had to hand-roll `ctx.trigger_fit()` in
+   `on_warmup_finished` — and on venues where the warmup sim ran no fit (LIGHTER: no sim
+   data), that hand-rolled fit double-fires with the `processing.py:521` fallback.
+2. **State resolution is silently skipped when warmup is off** (#363). The resolver call
+   is gated on `get_warmup_positions() or get_warmup_orders()` (`processing.py:510`), so
+   disabling warmup — a plain config change — silently disables position-based state
+   seeding (frab's pair-book resolver). The gate also *accidentally* protects
+   `SYNC_STATE`/`REDUCE_ONLY` from flattening the live book on empty sim state.
+3. **Boot failures are invisible.** `__invoke_on_fit` and `__invoke_on_warmup_finished`
+   (`processing.py:746-771`) swallow strategy exceptions and latch their done-flags in
+   `finally`. A failed boot fit means the bot silently trades (or holds) having never
+   successfully fitted, until the next scheduled fit — possibly never.
+4. **The account-sync gate leaks at boot.** `_is_ready()` (`processing.py:918-945`)
+   falls through after `ACCOUNT_SYNC_TIMEOUT` with only a warning, so boot resolution and
+   the boot fit can run against phantom-zero positions — the live-edge cousin of the
+   buffering bug; it can double-open positions.
+
+This design makes boot a first-class phase that fixes all four together.
+
+## Terminology
+
+Two unrelated things are both called "warmup"; this document always qualifies them:
+
+- **Warmup simulation** (`live.warmup` config → `_run_warmup`,
+  `src/qubx/utils/runner/runner.py:994`): an in-process backtest of *the same strategy
+  object* over the trailing period, run before the live context starts. It warms the
+  strategy's internal state (fitted models, indicators held on `self`, tracker state) and
+  produces the "intended book" consumed by state resolution.
+- **Subscription warmup** (`ISubscriptionManager.set_warmup({DataType.OHLC["1h"]: "30d"})`,
+  usually called from `on_init`): historical OHLC backfill into the **live** data cache
+  when instruments are subscribed, fetched from the exchange by the connector's warmup
+  handlers (`src/qubx/connectors/ccxt/warmup_service.py`). The warmup sim does **not**
+  populate the live cache — the sim context has its own; only the strategy object's state
+  survives into live.
+
+## Goals and invariants
+
+The boot phase provides three guarantees:
+
+1. **No boot action sees an unsynced account.** State resolution, tracker/gatherer
+   restore, `on_warmup_finished`, and the boot fit run only after the initial venue
+   account snapshot has applied (`is_synced()`), with no timeout fall-through. Live
+   non-paper only; simulation and paper are unaffected.
+2. **State resolution always runs at live boot** — warmup sim or not (#363). Empty warmup
+   output means "hold + loud warning", never "flatten".
+3. **`on_event` is never delivered before a *successful* fit** — and with
+   `set_fit_on_start(True)`, that fit is guaranteed to have run in the live context
+   against live positions.
+
+Non-goals: changing simulation behavior (the sim pipeline must behave identically);
+making resolvers tracker/buffer-aware (see Out of scope).
+
+## Design
+
+### 1. Boot state machine
+
+A small `BootStateMachine` helper owned by the `ProcessingManager`, driven from
+`_run_strategy_pipeline` on each pass until terminal. It replaces the flag-combination
+checks at `processing.py:502-527` with one question ("is boot done?").
+
+```
+WAIT_READY → ON_START → RESOLVE → RESTORE → WARMUP_FINISHED → BOOT_FIT → TRADING
+                                                                  ↓ (retries exhausted)
+                                                               BLOCKED(reason)
+```
+
+- The existing `StrategyState` flags (`is_on_start_called`, `is_on_fit_called`,
+  `is_on_warmup_finished_called`, `is_warmup_in_progress`) **stay** — the warmup-sim
+  runner shares them — the machine wraps them as transition inputs; it does not replace
+  them.
+- `WAIT_READY` = data ready **and** strict account sync (section 2).
+- `ON_START`, `RESOLVE`, `RESTORE`, `WARMUP_FINISHED` invoke the existing handlers
+  (`_handle_start`, `_handle_state_resolution`, `_restore_tracker_and_gatherer_state`,
+  `_handle_warmup_finished`) in the current order. Steps whose flag is already set (e.g.
+  `on_start` already fired inside the warmup-sim context) are passed through.
+- `BOOT_FIT` covers **every** first live fit: the `set_fit_on_start` reset, the
+  no-warmup boot, and the warmup-sim-ran-no-fit fallback — one code path, which is where
+  retry and health handling attach (section 5).
+- `BLOCKED` is sticky for trading (no `on_event` delivery), carries a reason, emits a
+  health gauge and periodic error logs, and can self-heal (section 5).
+- In simulation the machine degenerates to today's behavior: readiness has no account
+  requirement, `RESOLVE` is skipped (resolution is a live-boot concept), and hooks fire
+  as they do now.
+
+### 2. Strict account-sync gate
+
+`_is_ready()` splits into two concerns:
+
+- **Data readiness** keeps its current two-phase timeout with partial-data fall-through.
+- **Account sync**: the timeout fall-through (`processing.py:937-944`) is **removed**.
+  Its only consumers were boot actions, so nothing else changes behavior.
+  `ACCOUNT_SYNC_TIMEOUT` is repurposed as the *alert* threshold: on crossing it, the
+  machine emits `boot.account_sync_blocked = 1` and a warning, then keeps waiting.
+  The moment the snapshot applies, boot proceeds and the gauge clears — self-healing, no
+  restart required. The bot simply never trades blind.
+
+### 3. Unconditional state resolution (#363)
+
+- The `processing.py:510` gate is removed; `RESOLVE` always runs at live boot.
+- The default resolver install (`REDUCE_ONLY`) moves out of `_run_warmup`
+  (`src/qubx/utils/runner/runner.py:1019` — currently unreachable when warmup is off)
+  into unconditional context setup.
+- **Resolver protocol unchanged:** `(ctx, sim_positions, sim_orders, sim_active_targets)`.
+  When no warmup sim ran, all three sim args are empty dicts. This is unambiguous: a
+  warmup sim that ran always captures a `Position` for every sim instrument, flat ones
+  included (`runner.py` capture filters on `quantity is not None`), so "all empty" ⇔
+  "no warmup output". Existing custom resolvers (frab, factors) work unchanged.
+- **Stock resolver guards:** `REDUCE_ONLY` and `SYNC_STATE` start with: all sim args
+  empty → log a loud warning ("state resolver has no warmup output — holding live book")
+  and return. `CLOSE_ALL` keeps its semantics (an explicit instruction independent of sim
+  state). `NONE` is trivially unaffected.
+- **New stock resolver `StateResolver.HOLD`:** cancels all open live orders, keeps all
+  positions, emits no signals. This is the recommended partner of
+  `set_fit_on_start(True)` for buffered/tracker-reconciling strategies (the factors
+  recipe, generalized). `NONE` remains pure do-nothing.
+- Cleanup riders: drop the dead `use_limit_order` computation in `SYNC_STATE` (the flag
+  is read nowhere); document that `sim_orders` is unused by all stock resolvers (kept in
+  the signature for custom resolvers).
+
+### 4. Opt-in boot fit: `set_fit_on_start`
+
+New `IStrategyInitializer` methods `set_fit_on_start(enabled: bool)` /
+`get_fit_on_start() -> bool`, called from `IStrategy.on_init(initializer)`.
+
+- **Semantics:** "the warmup-sim fit does not count — my first `on_fit` must run in the
+  live context." Identical behavior on first start and restart (the framework does not
+  distinguish them; a restart differs only in restored state existing).
+- **Mechanism:** after `WARMUP_FINISHED` completes, if the flag is set and a warmup-sim
+  fit had latched `is_on_fit_called`, the machine resets the flag; the existing
+  first-fit path then fires exactly one live fit (through `_handle_fit`, threaded or
+  inline per the executor mode).
+- **No-warmup case:** a no-op — nothing ever set the flag, so the boot fit fires anyway
+  (today's behavior, unchanged, for every strategy).
+- **Contract:** opting in *replaces* the `ctx.trigger_fit()`-in-`on_warmup_finished`
+  boilerplate. Calling both produces a double fit (documented, not defended against).
+- Explicitly **opt-in**: strategies that must fit only at deliberately scheduled times
+  are untouched.
+
+### 5. Boot failure handling
+
+- **Latch only on success (live only).** Inline path: `__invoke_on_fit` sets
+  `is_on_fit_called` only when `on_fit` returned without raising. Threaded path:
+  `FitCommitData` gains an `error` field set on the fit thread; `_handle_fit_commit`
+  (`processing.py:1288-1318`) latches only when `error is None`. Scheduled (non-boot)
+  fits see no behavior change — the flag is already `True` by then. **Simulation keeps
+  the latch-in-`finally`** (the retry machinery is live-only; without the latch a raising
+  sim fit would retry on every tick and change backtest behavior).
+- **Boot fit retry:** on failure, the machine schedules a retry — **3 attempts total
+  (initial + 2 retries), 60s apart**, deadline-driven from the pipeline (a stored
+  next-retry timestamp checked on each pass; no scheduler dependency). Each attempt
+  increments `boot.fit_attempts`.
+- **Exhausted → `BLOCKED("boot fit failed")`:** `on_event` is never delivered, gauge
+  `boot.fit_failed = 1`, periodic error logs. Rationale: for a scheduled fit,
+  latch-and-continue is defensible (trading continues on the previous fit's state); for
+  the boot fit there is no previous state — continuing means running a
+  never-successfully-fitted strategy.
+- **Self-heal:** any later *successful* fit (the recurring schedule, or a manual
+  `trigger_fit`) releases `BLOCKED(fit)` and clears the gauge — consistent with the
+  sync-gate philosophy: block, alert, recover without a restart.
+- **`on_warmup_finished` failure:** latch as today (the hook is not guaranteed
+  idempotent — no auto-retry), plus gauge `boot.warmup_finished_failed = 1` and an error
+  log. Boot continues to `BOOT_FIT`.
+
+### 6. Observability surface
+
+Emitted via the existing `IHealthMonitor.record_gauge`:
+
+| Gauge | Meaning |
+|---|---|
+| `boot.state` | current phase as a number (WAIT_READY=0 … TRADING=6, BLOCKED=-1) |
+| `boot.account_sync_blocked` | 1 while boot is held waiting for the account snapshot past the alert threshold |
+| `boot.fit_attempts` | boot-fit attempt counter |
+| `boot.fit_failed` | 1 when boot-fit retries are exhausted (cleared on self-heal) |
+| `boot.warmup_finished_failed` | 1 when `on_warmup_finished` raised |
+
+Ops alerting hangs off these; the exporters already ship gauges.
+
+## Boot sequencing (reference)
+
+### Without warmup sim
+
+```
+runner main thread                        ProcessorThread (boot state machine)
+──────────────────                        ────────────────────────────────────
+read RestoredState (--restore:
+  positions/signals/targets from the
+  previous run's logs)
+create ctx (restored positions
+  seeded into account manager)
+ctx.start()
+ ├ connect live connectors
+ └ initial subscribe commit
+    └ WarmupThread: OHLC backfill
+       then swap → live streams on ──►  first live tick per instrument
+                                        ┌ WAIT_READY   data ready + account synced (strict)
+                                        ├ ON_START     on_start fires (live ctx)
+                                        ├ RESOLVE      resolver runs, sim args EMPTY
+                                        │              → stock: hold + loud warning
+                                        │              → custom: e.g. seed from ctx.get_positions()
+                                        ├ RESTORE      tracker/gatherer from RestoredState
+                                        ├ WARMUP_FIN   on_warmup_finished fires
+                                        ├ BOOT_FIT     on_fit fires — ALWAYS (flag never set)
+                                        └ TRADING      on_event starts flowing
+```
+
+### With warmup sim
+
+```
+runner main thread                        ProcessorThread (boot state machine)
+──────────────────
+read RestoredState
+create ctx (restored pos → account)
+_run_warmup (blocking, in-process):
+ ├ start = start_time_finder(restored) − warmup period
+ ├ seed REAL capital from venue snapshot
+ ├ backtest same strategy object on sim ctx:
+ │   on_start, on_fit(s), on_event(s) fire HERE
+ │   (sim book starts FLAT — only balances seeded)
+ └ capture sim end state →
+     ctx.set_warmup_positions/orders/active_targets
+ctx.start()
+ └ initial subscribe → WarmupThread backfill
+    → swap → live ticks            ──►  ┌ WAIT_READY   data ready + account synced (strict)
+                                        ├ ON_START     SKIPPED — already fired in sim ctx (#388)
+                                        ├ RESOLVE      resolver vs sim end state (non-empty:
+                                        │              sim captures a Position per instrument)
+                                        ├ RESTORE      tracker/gatherer from RestoredState
+                                        ├ WARMUP_FIN   on_warmup_finished fires (live ctx)
+                                        ├ BOOT_FIT     fires IFF fit_on_start OR sim ran no fit;
+                                        │              otherwise skipped
+                                        └ TRADING
+```
+
+### When `on_fit` runs — all cases
+
+| Scenario | Fit during warmup sim | Live boot fit | First `on_event` sees a live-fitted strategy? |
+|---|---|---|---|
+| No warmup sim | — | always (flag never set) | yes |
+| Warmup sim, knob off, sim fit ran | yes, in sim ctx | no — waits for the next scheduled fit | no — fit state came from the sim |
+| Warmup sim, knob off, sim ran no fit (e.g. LIGHTER) | no | yes (existing fallback, now the BOOT_FIT path) | yes |
+| Warmup sim + `set_fit_on_start(True)` | yes, in sim ctx | exactly one, after `on_warmup_finished` | yes |
+
+### Subscription warmup — when, and who waits
+
+| When | Trigger | Where the fetch runs | Who waits on it |
+|---|---|---|---|
+| Live boot (warmup sim on or off — identical) | initial subscribe commit inside `ctx.start()` | WarmupThread (`src/qubx/core/mixins/subscription.py:114-152`); ccxt handlers fetch with bounded concurrency + timeout (`warmup_service.py:117-142`) | Nobody blocks directly; the ordering is transitive: swap applies only after history lands → live streams start only after the swap → data-ready needs one live tick per instrument → the machine sits in `WAIT_READY`. |
+| Universe change from a fit | subscription commit during FitCommit replay | WarmupThread (deferred) | Only the added instruments — they go live after their backfill; trading on the existing universe continues. |
+| During the warmup sim | n/a | the sim reads history synchronously from the warmup storage (`live.warmup.data`) | the sim itself. |
+
+**Guarantee:** `on_start`, `RESOLVE`, and the boot fit always run after the initial
+subscription warmup has completed *or degraded by timeout* — never before it. Degraded
+paths: (a) backfill timeout cancels the fetch and applies the swap with partial history
+(`warmup_service.py:135-142`); (b) data-ready's own two-phase timeout can fall through
+with the subset of instruments that ticked; (c) with no subscription warmup configured
+the swap is synchronous and the boot sequence proceeds off the first natural ticks with
+an empty OHLC cache.
+
+### RESOLVE vs RESTORE
+
+- **RESOLVE** acts on the **venue** and may trade: the resolver compares the live book
+  (`ctx.get_positions()` / `get_orders()`) against the strategy's intended book (warmup
+  sim end state, or nothing) and emits `InitializingSignal`s → real orders.
+- **RESTORE** re-seeds **in-memory bookkeeping** and never trades: the tracker receives
+  the previous run's persisted signals, the gatherer the latest persisted targets (from
+  `RestoredState`), and targets are re-persisted so the restore chain survives the next
+  restart.
+
+## Out of scope
+
+- **Resolver ↔ tracker integration.** Resolver signals route through the internal
+  `_InitializationStageTracker` (`src/qubx/trackers/riskctrl.py:988`), bypassing the
+  strategy's tracker — resolvers structurally cannot be band/buffer-aware. The supported
+  answer for buffered strategies is `HOLD` + `set_fit_on_start(True)`: let the first live
+  fit reconcile *through* the tracker. Deeper integration is a separate design if ever
+  needed.
+- **Warmup sim position seeding.** Seeding the warmup sim with restored/live positions
+  (instead of a flat start) would remove the artifact at its source but changes
+  backtester semantics; not attempted here.
+- **#388's breaker note** (a per-instrument exception counts toward the global
+  ten-failure breaker) — separate issue.
+
+## Documentation deliverable (#388)
+
+A "Strategy boot lifecycle" docs page covering: the phase order and diagrams above; the
+`on_start`-fires-in-warmup-context asymmetry and its consequence (per-instrument state
+must be built lazily or in `on_warmup_finished`, never only in `on_start`); the resolver
+contract (empty sim args ⇔ no warmup output); `set_fit_on_start` usage; and a
+recommended-patterns table:
+
+| Strategy style | Resolver | `set_fit_on_start` |
+|---|---|---|
+| Buffered / tracker-reconciling | `HOLD` | `True` |
+| Target-state (sim targets are prescriptive) | `SYNC_STATE` | optional |
+| Conservative default | `REDUCE_ONLY` | optional |
+| Fully custom boot seeding | custom resolver | as needed |
+
+This closes #388's documentation ask.
+
+## Testing
+
+Unit tests (`tests/qubx/core/`), fake time throughout:
+
+- State-machine transitions, including `BLOCKED` entry and both self-heal paths
+  (late account snapshot; later successful fit).
+- Resolution runs with warmup off; stock-resolver empty guards (hold + warn, no orders);
+  `CLOSE_ALL` unaffected by empty args; `HOLD` cancels orders and keeps positions.
+- Default resolver installed without warmup config.
+- `set_fit_on_start`: exactly one live fit with warmup; no double fit in the
+  sim-ran-no-fit case; no-op without warmup; untouched when not opted in.
+- Strict sync gate: boot holds past `ACCOUNT_SYNC_TIMEOUT`, gauge emitted, proceeds on
+  late snapshot.
+- Boot-fit failure: latch-only-on-success in both executor modes (inline and threaded via
+  `FitCommitData.error`); 3×60s retry cadence; `BLOCKED` after exhaustion; no `on_event`
+  while blocked; release on later successful fit.
+- `on_warmup_finished` failure: latches, gauge emitted, boot continues.
+- Simulation parity: sim pipeline behavior unchanged (regression suite).
+
+## Rollout
+
+One Qubx release, no feature flags — the removed behaviors are the bug. The changelog
+must call out three behavior changes for existing bots:
+
+1. **No-warmup bots now run boot resolution.** Default (`REDUCE_ONLY` + empty guard) →
+   hold + warning, no trading action. Bots with a registered custom resolver: it now
+   actually fires at boot — this is the #363 fix.
+2. **A failed boot fit now blocks trading** (retry → `BLOCKED` + health event) instead of
+   silently trading unfitted.
+3. **An unsynced account now blocks boot** (+ health event) instead of proceeding after
+   the timeout with phantom-zero positions.
+
+Downstream: factors and frab can later simplify to stock `HOLD` + `set_fit_on_start(True)`.
+
+## Follow-ups after this spec
+
+- Post the design (or a summary) as the "Solution" comment on #363.
+- Open issues for: opt-in boot fit (`set_fit_on_start`), boot failure handling +
+  observability, strict account-sync gate — linking back to this spec.
+- Implementation plan via the standard planning flow.

--- a/docs/specs/2026-08-27-boot-phase-impl.md
+++ b/docs/specs/2026-08-27-boot-phase-impl.md
@@ -1,0 +1,1305 @@
+# Boot Phase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make live-strategy boot a first-class phase: strict account-sync gate, unconditional state resolution, an opt-in live boot fit (`set_fit_on_start`), and boot-failure retry/observability.
+
+**Architecture:** A new pure `BootStateMachine` (`src/qubx/core/boot.py`) holds phase, retry bookkeeping, and health-gauge emission. `ProcessingManager._run_strategy_pipeline` drives it via a new `_advance_boot()` that replaces the flag-soup block at `processing.py:502-527`, calling the existing handlers in the same order. Stock resolvers gain empty-output guards plus a new `HOLD` resolver.
+
+**Tech Stack:** Python 3.12, pytest (`uv run pytest`), MagicMock-based unit harnesses (see `tests/qubx/core/mixins/fit_executor_test.py`), ruff (120 cols).
+
+**Spec:** `docs/specs/2026-08-27-boot-phase-design.md` — read it first; it contains the sequencing diagrams, the four-case `on_fit` table, and the rationale each task implements.
+
+## Global Constraints
+
+- Work in the worktree `/home/yuriy/devs/Qubx/.worktrees/boot-phase-spec`. Before Task 1: `git checkout -b feat/boot-phase` (branches off `docs/boot-phase-design-spec`, which contains the spec).
+- Run all Python through `uv run` (e.g. `uv run pytest ...`). Full suite: `just test` from the worktree root.
+- Modern types only: `list`, `dict`, `| None`, `tuple`. Never `from __future__ import annotations`.
+- Logging: `from qubx import logger`.
+- Comments terse, only non-obvious constraints. NO banner/section-divider comments. Do not comment what a change fixes.
+- Conventional commits (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`). No co-authored-by lines.
+- Simulation behavior must not change (regression-checked in Task 8). The warmup-sim context runs the same pipeline with `is_warmup_in_progress=True` — every task touching the pipeline must preserve that path's behavior as documented in the spec diagrams.
+- Line references (`processing.py:510` etc.) are as of branch point `57397d47`; re-locate by content if drifted.
+
+---
+
+### Task 1: Resolver empty-output guards, `StateResolver.HOLD`, dead-flag cleanup
+
+**Files:**
+- Modify: `src/qubx/restarts/state_resolvers.py`
+- Test: `tests/qubx/restarts/test_state_resolvers.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `StateResolver.HOLD(ctx, sim_positions, sim_orders, sim_active_targets) -> None`; module-level `_no_warmup_output(sim_positions, sim_orders, sim_active_targets) -> bool`. `REDUCE_ONLY`/`SYNC_STATE` now return early (no venue reads, no signals) when all three sim args are empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/qubx/restarts/test_state_resolvers.py` (follow the file's existing `TestStateResolverBase` pattern — MagicMock ctx, `self._find_instrument("BINANCE.UM", "BTCUSDT")`):
+
+```python
+class TestStateResolverEmptyGuards(TestStateResolverBase):
+    """All-empty sim args mean 'no warmup output' -> hold the live book, touch nothing."""
+
+    def test_reduce_only_all_empty_holds(self):
+        StateResolver.REDUCE_ONLY(self.ctx, {}, {}, {})
+        self.ctx.get_positions.assert_not_called()
+        self.ctx.emit_signal.assert_not_called()
+
+    def test_sync_state_all_empty_holds(self):
+        StateResolver.SYNC_STATE(self.ctx, {}, {}, {})
+        self.ctx.get_positions.assert_not_called()
+        self.ctx.emit_signal.assert_not_called()
+        self.ctx.cancel_orders.assert_not_called()
+
+    def test_close_all_ignores_empty_sim_args(self):
+        instr = self._find_instrument("BINANCE.UM", "BTCUSDT")
+        pos = MagicMock()
+        pos.quantity = 1.0
+        self.ctx.get_orders.return_value = {}
+        self.ctx.get_positions.return_value = {instr: pos}
+        StateResolver.CLOSE_ALL(self.ctx, {}, {}, {})
+        self.ctx.emit_signal.assert_called_once()
+
+
+class TestStateResolverHold(TestStateResolverBase):
+    def test_hold_cancels_orders_keeps_positions(self):
+        order = MagicMock()
+        order.venue_order_id = "v-1"
+        order.client_order_id = "c-1"
+        self.ctx.get_orders.return_value = {"v-1": order}
+        StateResolver.HOLD(self.ctx, {}, {}, {})
+        self.ctx.cancel_order.assert_called_once_with(order_id="v-1")
+        self.ctx.emit_signal.assert_not_called()
+
+    def test_hold_no_orders_does_nothing(self):
+        self.ctx.get_orders.return_value = {}
+        StateResolver.HOLD(self.ctx, {}, {}, {})
+        self.ctx.cancel_order.assert_not_called()
+        self.ctx.emit_signal.assert_not_called()
+```
+
+Also UPDATE the existing `test_reduce_only_with_empty_positions` in `TestStateResolverReduceOnly`: it currently asserts `self.ctx.get_positions.assert_called_once()` with all-empty sim args — under the guard the resolver returns before reading positions. Change those assertions to:
+
+```python
+        self.ctx.get_positions.assert_not_called()
+        self.ctx.emit_signal.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `uv run pytest tests/qubx/restarts/test_state_resolvers.py -v -x`
+Expected: `TestStateResolverHold` fails with `AttributeError: ... has no attribute 'HOLD'`; guard tests fail on `get_positions.assert_not_called()`.
+
+- [ ] **Step 3: Implement guards, HOLD, and cleanup**
+
+In `src/qubx/restarts/state_resolvers.py`:
+
+Add a module-level helper above the class:
+
+```python
+def _no_warmup_output(
+    sim_positions: dict[Instrument, Position],
+    sim_orders: dict[Instrument, list[Order]],
+    sim_active_targets: dict[Instrument, TargetPosition],
+) -> bool:
+    """All-empty sim args ⇔ no warmup sim ran (a sim that ran captures a Position per
+    instrument, flat included). Resolvers that steer toward sim state must hold then."""
+    if sim_positions or sim_orders or sim_active_targets:
+        return False
+    logger.warning(
+        "<yellow>State resolver received no warmup output — holding the live book as-is. "
+        "Register a custom resolver (or StateResolver.HOLD) to silence this.</yellow>"
+    )
+    return True
+```
+
+At the top of `REDUCE_ONLY` (before `live_positions = ctx.get_positions()`):
+
+```python
+        if _no_warmup_output(sim_positions, sim_orders, sim_active_targets):
+            return
+```
+
+Same two lines at the top of `SYNC_STATE`. Do NOT add the guard to `CLOSE_ALL` or `NONE`.
+
+In `SYNC_STATE`, delete the dead `use_limit_order` computation and its kwarg (the field is read nowhere):
+
+```python
+        for instrument, a_tgt in sim_active_targets.items():
+            s = InitializingSignal(
+                time=ctx.time(),
+                instrument=instrument,
+                signal=a_tgt.target_position_size,
+                price=a_tgt.price,
+                stop=a_tgt.stop,
+                take=a_tgt.take,
+            )
+            ctx.emit_signal(s)
+```
+
+(also remove the now-stale comment block about limit orders above it, and the commented-out legacy code at the bottom of `SYNC_STATE`).
+
+Add `HOLD` after `NONE`:
+
+```python
+    @staticmethod
+    def HOLD(
+        ctx: IStrategyContext,
+        sim_positions: dict[Instrument, Position],
+        sim_orders: dict[Instrument, list[Order]],
+        sim_active_targets: dict[Instrument, TargetPosition],
+    ) -> None:
+        """
+        Cancel all open live orders, keep all live positions untouched, emit nothing.
+        The recommended partner of initializer.set_fit_on_start(True): let the first
+        live fit reconcile positions through the strategy's own tracker.
+        """
+        orders = ctx.get_orders()
+        if not orders:
+            return
+        logger.info(f"HOLD resolver: cancelling {len(orders)} live orders, keeping positions")
+        for order in orders.values():
+            oid = order.venue_order_id or order.client_order_id
+            try:
+                ctx.cancel_order(order_id=oid)
+            except OrderNotFound:
+                logger.debug(f"Order {oid} already cancelled or doesn't exist")
+```
+
+Also document in `sim_orders`'s docstring mention (one line in the class docstring): `sim_orders is unused by all stock resolvers; it remains in the signature for custom resolvers.`
+
+- [ ] **Step 4: Run the file's full test suite**
+
+Run: `uv run pytest tests/qubx/restarts/test_state_resolvers.py -v`
+Expected: all PASS (including pre-existing REDUCE_ONLY/SYNC_STATE/CLOSE_ALL tests — if any pre-existing SYNC_STATE test asserts `use_limit_order`, update it to not expect the kwarg).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/restarts/state_resolvers.py tests/qubx/restarts/test_state_resolvers.py
+git commit -m "feat(restarts): empty-warmup guards for stock resolvers, StateResolver.HOLD, drop dead use_limit_order"
+```
+
+---
+
+### Task 2: `set_fit_on_start` initializer API
+
+**Files:**
+- Modify: `src/qubx/core/interfaces.py` (in `IStrategyInitializer`, next to `set_state_resolver`/`get_state_resolver` ~:2263-2286)
+- Modify: `src/qubx/core/initializer.py` (in `BasicStrategyInitializer`, next to `set_state_resolver` ~:112-118)
+- Test: `tests/qubx/core/initializer_test.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `IStrategyInitializer.set_fit_on_start(enabled: bool = True) -> None` and `IStrategyInitializer.get_fit_on_start() -> bool` (default `False`). Task 6 reads `ctx.initializer.get_fit_on_start()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/qubx/core/initializer_test.py` (match its existing construction of `BasicStrategyInitializer` — copy the fixture/instantiation pattern already used there):
+
+```python
+def test_fit_on_start_defaults_false_and_toggles():
+    init = BasicStrategyInitializer()
+    assert init.get_fit_on_start() is False
+    init.set_fit_on_start(True)
+    assert init.get_fit_on_start() is True
+    init.set_fit_on_start(False)
+    assert init.get_fit_on_start() is False
+```
+
+If `BasicStrategyInitializer()` requires constructor args in this repo, reuse whatever the existing tests in the file pass.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/qubx/core/initializer_test.py -v -k fit_on_start`
+Expected: FAIL with `AttributeError: ... 'get_fit_on_start'`.
+
+- [ ] **Step 3: Implement**
+
+`src/qubx/core/interfaces.py`, inside `IStrategyInitializer`, following the exact style of the neighboring `set_state_resolver`/`get_state_resolver` (same body convention those use — `...` or `raise NotImplementedError`, copy it):
+
+```python
+    def set_fit_on_start(self, enabled: bool = True) -> None:
+        """
+        Force the first on_fit to run in the live context even when a warmup-sim fit ran.
+
+        The warmup simulation fits against sim state; strategies that reconcile positions
+        through their tracker on fit (e.g. buffered trackers) need the first fit to run
+        live, against live positions. Opting in guarantees exactly one live fit after
+        on_warmup_finished and replaces calling ctx.trigger_fit() there (doing both
+        double-fits). No-op when no warmup sim runs — the first fit is live anyway.
+        """
+        ...
+
+    def get_fit_on_start(self) -> bool:
+        """Whether the first on_fit is forced to run in the live context (default False)."""
+        ...
+```
+
+`src/qubx/core/initializer.py`, inside `BasicStrategyInitializer`: add a backing field where the class initializes its other fields (e.g. next to the state-resolver field — match how `_state_resolver` is stored):
+
+```python
+    def set_fit_on_start(self, enabled: bool = True) -> None:
+        self._fit_on_start = enabled
+
+    def get_fit_on_start(self) -> bool:
+        return getattr(self, "_fit_on_start", False)
+```
+
+(The `getattr` default makes the field optional in `__init__`; if the class body declares fields as annotations, add `_fit_on_start: bool = False` there instead and drop the `getattr`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/qubx/core/initializer_test.py tests/qubx/core/strategy_initializer_test.py -v`
+Expected: PASS (both files, no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/interfaces.py src/qubx/core/initializer.py tests/qubx/core/initializer_test.py
+git commit -m "feat(core): IStrategyInitializer.set_fit_on_start opt-in live boot fit knob"
+```
+
+---
+
+### Task 3: `BootPhase` + `BootStateMachine`
+
+**Files:**
+- Create: `src/qubx/core/boot.py`
+- Test: `tests/qubx/core/boot_test.py`
+
+**Interfaces:**
+- Consumes: `IHealthMonitor.record_gauge(name: str, value: float, tags: dict[str, str] | None = None)`; `dt_64`, `td_64` from `qubx.core.basics`.
+- Produces (used verbatim by Tasks 4-7):
+
+```python
+class BootPhase(IntEnum):
+    BLOCKED = -1
+    WAIT_READY = 0
+    ON_START = 1
+    RESOLVE = 2
+    RESTORE = 3
+    WARMUP_FINISHED = 4
+    BOOT_FIT = 5
+    TRADING = 6
+
+class BootStateMachine:
+    def __init__(self, health_monitor, *, fit_max_attempts: int = 3, fit_retry_delay: td_64 = ...) -> None
+    phase: BootPhase
+    blocked_reason: str | None
+    fit_attempts: int
+    @property is_trading: bool
+    @property is_blocked: bool
+    def advance(self, phase: BootPhase) -> None
+    def account_sync_alert(self) -> None
+    def account_synced(self) -> None
+    def fit_attempt_allowed(self, now: dt_64) -> bool
+    def record_fit_attempt(self) -> None
+    def record_fit_failure(self, now: dt_64) -> None
+    def record_fit_success(self) -> None
+    def record_warmup_finished_failure(self) -> None
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/qubx/core/boot_test.py`:
+
+```python
+from unittest.mock import MagicMock, call
+
+import numpy as np
+
+from qubx.core.basics import td_64
+from qubx.core.boot import BootPhase, BootStateMachine
+
+T0 = np.datetime64("2025-01-01T00:00:00", "ns")
+SEC = td_64(1, "s")
+
+
+def make_machine(**kw) -> tuple[BootStateMachine, MagicMock]:
+    health = MagicMock()
+    return BootStateMachine(health, **kw), health
+
+
+def test_initial_phase_and_advance_emits_state_gauge():
+    m, health = make_machine()
+    assert m.phase == BootPhase.WAIT_READY
+    assert not m.is_trading and not m.is_blocked
+    m.advance(BootPhase.ON_START)
+    assert m.phase == BootPhase.ON_START
+    health.record_gauge.assert_called_with("boot.state", float(BootPhase.ON_START))
+
+
+def test_account_sync_alert_emits_once_and_clears():
+    m, health = make_machine()
+    m.account_sync_alert()
+    m.account_sync_alert()
+    assert health.record_gauge.call_args_list.count(call("boot.account_sync_blocked", 1.0)) == 1
+    m.account_synced()
+    health.record_gauge.assert_called_with("boot.account_sync_blocked", 0.0)
+    health.record_gauge.reset_mock()
+    m.account_synced()  # no alert pending -> no gauge
+    health.record_gauge.assert_not_called()
+
+
+def test_fit_retry_cadence_and_blocked_after_exhaustion():
+    m, health = make_machine(fit_max_attempts=3, fit_retry_delay=td_64(60, "s"))
+    m.advance(BootPhase.BOOT_FIT)
+
+    assert m.fit_attempt_allowed(T0)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0)
+    assert m.phase == BootPhase.BOOT_FIT
+    assert not m.fit_attempt_allowed(T0 + 59 * SEC)
+    assert m.fit_attempt_allowed(T0 + 60 * SEC)
+
+    m.record_fit_attempt()
+    m.record_fit_failure(T0 + 60 * SEC)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0 + 120 * SEC)
+
+    assert m.is_blocked
+    assert m.blocked_reason == "boot fit failed"
+    assert m.fit_attempts == 3
+    health.record_gauge.assert_any_call("boot.fit_failed", 1.0)
+    assert not m.fit_attempt_allowed(T0 + 300 * SEC)
+
+
+def test_fit_success_reaches_trading():
+    m, health = make_machine()
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    m.record_fit_success()
+    assert m.is_trading
+    health.record_gauge.assert_called_with("boot.state", float(BootPhase.TRADING))
+
+
+def test_blocked_self_heals_on_later_fit_success():
+    m, health = make_machine(fit_max_attempts=1)
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0)
+    assert m.is_blocked
+    m.record_fit_success()
+    assert m.is_trading
+    health.record_gauge.assert_any_call("boot.fit_failed", 0.0)
+
+
+def test_fit_failure_while_blocked_is_noop():
+    m, _ = make_machine(fit_max_attempts=1)
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0)
+    m.record_fit_failure(T0 + SEC)
+    assert m.is_blocked and m.fit_attempts == 1
+
+
+def test_warmup_finished_failure_gauge():
+    m, health = make_machine()
+    m.record_warmup_finished_failure()
+    health.record_gauge.assert_called_with("boot.warmup_finished_failed", 1.0)
+
+
+def test_fit_attempts_gauge_emitted():
+    m, health = make_machine()
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    health.record_gauge.assert_any_call("boot.fit_attempts", 1.0)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/boot_test.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'qubx.core.boot'`.
+
+- [ ] **Step 3: Implement `src/qubx/core/boot.py`**
+
+```python
+from enum import IntEnum
+
+from qubx import logger
+from qubx.core.basics import dt_64, td_64
+
+
+class BootPhase(IntEnum):
+    BLOCKED = -1
+    WAIT_READY = 0
+    ON_START = 1
+    RESOLVE = 2
+    RESTORE = 3
+    WARMUP_FINISHED = 4
+    BOOT_FIT = 5
+    TRADING = 6
+
+
+class BootStateMachine:
+    """Live-boot phase bookkeeping: current phase, boot-fit retry policy, health gauges.
+
+    Pure state — the ProcessingManager drives transitions and executes side effects
+    (see _advance_boot). BLOCKED is sticky for trading; a later successful fit releases
+    it (record_fit_success), a late account snapshot releases WAIT_READY (caller-side).
+    """
+
+    def __init__(self, health_monitor, *, fit_max_attempts: int = 3, fit_retry_delay: td_64 = td_64(60, "s")) -> None:
+        self.phase = BootPhase.WAIT_READY
+        self.blocked_reason: str | None = None
+        self.fit_attempts = 0
+        self._health = health_monitor
+        self._fit_max_attempts = fit_max_attempts
+        self._fit_retry_delay = fit_retry_delay
+        self._next_fit_attempt: dt_64 | None = None
+        self._sync_alerted = False
+
+    @property
+    def is_trading(self) -> bool:
+        return self.phase == BootPhase.TRADING
+
+    @property
+    def is_blocked(self) -> bool:
+        return self.phase == BootPhase.BLOCKED
+
+    def advance(self, phase: BootPhase) -> None:
+        if phase == self.phase:
+            return
+        self.phase = phase
+        self._gauge("boot.state", float(phase))
+
+    def account_sync_alert(self) -> None:
+        if self._sync_alerted:
+            return
+        self._sync_alerted = True
+        self._gauge("boot.account_sync_blocked", 1.0)
+        logger.warning("<yellow>Boot blocked: initial account snapshot not applied — holding until synced</yellow>")
+
+    def account_synced(self) -> None:
+        if not self._sync_alerted:
+            return
+        self._sync_alerted = False
+        self._gauge("boot.account_sync_blocked", 0.0)
+
+    def fit_attempt_allowed(self, now: dt_64) -> bool:
+        if self.phase != BootPhase.BOOT_FIT:
+            return False
+        return self._next_fit_attempt is None or now >= self._next_fit_attempt
+
+    def record_fit_attempt(self) -> None:
+        self.fit_attempts += 1
+        self._gauge("boot.fit_attempts", float(self.fit_attempts))
+
+    def record_fit_failure(self, now: dt_64) -> None:
+        if self.is_blocked:
+            return
+        if self.fit_attempts >= self._fit_max_attempts:
+            self.blocked_reason = "boot fit failed"
+            self.advance(BootPhase.BLOCKED)
+            self._gauge("boot.fit_failed", 1.0)
+            logger.error(
+                f"<red>Boot fit failed after {self.fit_attempts} attempts — trading blocked, "
+                "book unreconciled; a later successful fit will unblock</red>"
+            )
+        else:
+            self._next_fit_attempt = now + self._fit_retry_delay
+            logger.warning(f"<yellow>Boot fit failed (attempt {self.fit_attempts}/{self._fit_max_attempts}) — retrying</yellow>")
+
+    def record_fit_success(self) -> None:
+        if self.is_blocked:
+            self._gauge("boot.fit_failed", 0.0)
+            self.blocked_reason = None
+        self.advance(BootPhase.TRADING)
+
+    def record_warmup_finished_failure(self) -> None:
+        self._gauge("boot.warmup_finished_failed", 1.0)
+
+    def _gauge(self, name: str, value: float) -> None:
+        try:
+            self._health.record_gauge(name, value)
+        except Exception:
+            logger.exception(f"failed to record {name} gauge")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/boot_test.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/boot.py tests/qubx/core/boot_test.py
+git commit -m "feat(core): BootStateMachine — boot phase, fit retry policy, health gauges"
+```
+
+---
+
+### Task 4: Wire the machine into the pipeline (unconditional resolution, parity)
+
+**Files:**
+- Modify: `src/qubx/core/mixins/processing.py` (block `:502-527` inside `_run_strategy_pipeline`; `_handle_state_resolution:1096`; `_handle_start:1090`; init section near `:242`)
+- Modify: `src/qubx/utils/runner/runner.py:1019-1020` (remove the warmup-only default-resolver install)
+- Test: `tests/qubx/core/mixins/boot_pipeline_test.py` (new)
+
+**Interfaces:**
+- Consumes: `BootPhase`, `BootStateMachine` (Task 3, exact API above).
+- Produces: `ProcessingManager._boot: BootStateMachine`; `ProcessingManager._advance_boot() -> bool` (True ⇔ trading may proceed this pass). `_handle_state_resolution` now falls back to `StateResolver.REDUCE_ONLY` when no resolver is registered, and no longer checks `_is_ready` itself (the machine already did). Tasks 5-7 build on `_boot` and `_advance_boot`.
+
+**Behavioral contract (from the spec — the test list below encodes it):**
+1. Live, no warmup output: RESOLVE runs anyway; default resolver = `REDUCE_ONLY` (whose Task-1 guard makes it hold + warn).
+2. Live, warmup output present: resolver called with the warmup dicts (as today).
+3. Warmup-sim context (`is_simulation=True, is_warmup_in_progress=True`): on_start + fit fire; resolution, restore, and `on_warmup_finished` do NOT (pass-through).
+4. Plain simulation: on_start, `on_warmup_finished`, fit fire; resolution and restore do NOT.
+5. The pass that fires the boot fit returns `False` (no event processing on the fit pass — parity with old `:526-527`).
+6. Warmup fit already latched `is_on_fit_called` (knob off): BOOT_FIT passes through without firing a fit; `on_event` flows.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/qubx/core/mixins/boot_pipeline_test.py`. Build the harness by adapting `make_thread_pm` from `tests/qubx/core/mixins/fit_executor_test.py` (copy its collaborator mocks verbatim; differences noted inline):
+
+```python
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from qubx.core.basics import CtrlChannel
+from qubx.core.boot import BootPhase
+from qubx.core.interfaces import StrategyState
+from qubx.core.mixins.processing import ProcessingManager
+
+T0 = np.datetime64("2025-01-01T00:00:00", "ns")
+
+
+def make_pm(
+    *,
+    is_simulation: bool = False,
+    is_warmup_in_progress: bool = False,
+    is_on_fit_called: bool = False,
+    warmup_positions: dict | None = None,
+    restored_state=None,
+    resolver=None,
+    fit_on_start: bool = False,
+):
+    channel = CtrlChannel("test-databus")
+    context = MagicMock()
+    context.is_simulation = is_simulation
+    context.is_paper_trading = False
+    context.instruments = []
+    context._strategy_state = StrategyState(
+        is_on_init_called=True,
+        is_on_start_called=False,
+        is_on_warmup_finished_called=False,
+        is_on_fit_called=is_on_fit_called,
+        is_warmup_in_progress=is_warmup_in_progress,
+    )
+    context._data_providers = [MagicMock(channel=channel)]
+    context.emitter = None
+    context._market_data_provider = MagicMock()
+    context.get_warmup_positions.return_value = warmup_positions or {}
+    context.get_warmup_orders.return_value = {}
+    context.get_warmup_active_targets.return_value = {}
+    context.get_restored_state.return_value = restored_state
+    context.initializer.get_state_resolver.return_value = resolver
+    context.initializer.get_fit_on_start.return_value = fit_on_start
+
+    strategy = MagicMock()
+    strategy.__class__.__name__ = "TestStrategy"
+    strategy.on_fit.return_value = None
+    strategy.on_event.return_value = []
+    strategy.on_market_data.return_value = []
+
+    cache = MagicMock()
+    cache.default_timeframe = "1h"
+    market_data = MagicMock()
+    market_data.get_market_data_cache.return_value = cache
+
+    subscription_manager = MagicMock()
+    subscription_manager.get_base_subscription.return_value = "quote"
+    time_provider = MagicMock()
+    time_provider.time.return_value = T0
+    position_tracker = MagicMock()
+    position_tracker.process_signals.return_value = []
+    position_tracker.update.return_value = []
+    universe_manager = MagicMock()
+    universe_manager.is_trading_allowed.return_value = True
+    health_monitor = MagicMock()
+    health_monitor.return_value.__enter__ = MagicMock(return_value=None)
+    health_monitor.return_value.__exit__ = MagicMock(return_value=False)
+    account_manager = MagicMock()
+    account_manager.is_synced.return_value = True
+    account_manager.get_positions.return_value = {}
+    account_manager.get_orders.return_value = {}  # _log_state_mismatch iterates these
+
+    pm = ProcessingManager(
+        context=context,
+        strategy=strategy,
+        logging=MagicMock(),
+        market_data=market_data,
+        subscription_manager=subscription_manager,
+        time_provider=time_provider,
+        account_manager=account_manager,
+        connectors={},
+        position_tracker=position_tracker,
+        position_gathering=MagicMock(),
+        universe_manager=universe_manager,
+        scheduler=MagicMock(),
+        is_simulation=is_simulation,
+        health_monitor=health_monitor,
+        delisting_detector=MagicMock(),
+        fit_executor="inline",
+    )
+    pm._is_data_ready = lambda: True  # type: ignore[method-assign]
+    pm._init_stage_position_tracker = MagicMock()
+    pm._init_stage_position_tracker.process_signals.return_value = []
+    pm._init_stage_position_tracker.update.return_value = []
+    context._processing_manager = pm
+    return pm, context, strategy
+
+
+def drive(pm, passes: int = 1):
+    for _ in range(passes):
+        pm._run_strategy_pipeline(None)
+
+
+class TestLiveBoot:
+    def test_resolution_runs_without_warmup_output(self):
+        resolver = MagicMock()
+        resolver.__name__ = "custom"
+        pm, ctx, _ = make_pm(resolver=resolver)
+        drive(pm)
+        resolver.assert_called_once_with(ctx, {}, {}, {})
+
+    def test_default_resolver_installed_when_none_registered(self):
+        pm, ctx, _ = make_pm(resolver=None)
+        drive(pm)  # REDUCE_ONLY with empty args -> guard: must not read live positions
+        ctx.get_positions.assert_not_called()
+        assert pm._boot.phase in (BootPhase.BOOT_FIT, BootPhase.TRADING)
+
+    def test_resolution_receives_warmup_output(self):
+        resolver = MagicMock()
+        resolver.__name__ = "custom"
+        instr = MagicMock()
+        instr.symbol = "BTCUSDT"
+        pos = MagicMock()
+        pos.quantity = 1.0  # real float: _log_state_mismatch formats it with :.6f
+        wp = {instr: pos}
+        pm, ctx, _ = make_pm(resolver=resolver, warmup_positions=wp)
+        drive(pm)
+        resolver.assert_called_once_with(ctx, wp, {}, {})
+
+    def test_boot_sequence_reaches_trading_and_fit_pass_returns_false(self):
+        pm, ctx, strategy = make_pm()
+        assert pm._run_strategy_pipeline(None) is False  # boot pass fires on_start..fit
+        strategy.on_start.assert_called_once()
+        strategy.on_warmup_finished.assert_called_once()
+        strategy.on_fit.assert_called_once()
+        assert ctx._strategy_state.is_on_fit_called
+        assert pm._boot.is_trading
+
+    def test_warmup_fit_satisfies_boot_fit_when_knob_off(self):
+        pm, ctx, strategy = make_pm(is_on_fit_called=True)
+        drive(pm)
+        strategy.on_fit.assert_not_called()
+        assert pm._boot.is_trading
+
+    def test_restore_called_with_restored_state(self):
+        restored = MagicMock()
+        restored.instrument_to_signal_positions = {}
+        restored.instrument_to_target_positions = {}
+        pm, ctx, _ = make_pm(restored_state=restored)
+        drive(pm)
+        assert pm._boot.is_trading
+
+
+class TestSimulationParity:
+    def test_plain_simulation_boots_without_resolution(self):
+        resolver = MagicMock()
+        pm, ctx, strategy = make_pm(is_simulation=True, resolver=resolver)
+        drive(pm)
+        resolver.assert_not_called()
+        strategy.on_start.assert_called_once()
+        strategy.on_warmup_finished.assert_called_once()
+        strategy.on_fit.assert_called_once()
+        assert pm._boot.is_trading
+
+    def test_warmup_sim_context_skips_warmup_finished_and_restore(self):
+        restored = MagicMock()
+        pm, ctx, strategy = make_pm(
+            is_simulation=True, is_warmup_in_progress=True, restored_state=restored
+        )
+        drive(pm)
+        strategy.on_start.assert_called_once()
+        strategy.on_warmup_finished.assert_not_called()
+        strategy.on_fit.assert_called_once()
+        ctx.get_restored_state.assert_not_called()
+        assert pm._boot.is_trading
+        assert not ctx._strategy_state.is_on_warmup_finished_called
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/mixins/boot_pipeline_test.py -v`
+Expected: FAIL — `ProcessingManager` has no `_boot` attribute; the old gate skips resolution with empty warmup output.
+
+- [ ] **Step 3: Implement**
+
+In `src/qubx/core/mixins/processing.py`:
+
+**(a)** Import and construct the machine. Add `from qubx.core.boot import BootPhase, BootStateMachine` to imports. Where the manager initializes instance state (the section around `:242`, next to `self._account_sync_deadline = None`), add:
+
+```python
+        self._boot = BootStateMachine(self._health_monitor)
+```
+
+**(b)** Replace the boot block in `_run_strategy_pipeline` (`:502-527`, the code from `if not self._context._strategy_state.is_on_start_called:` through the `_handle_fit(...)` / `return False` block) with:
+
+```python
+        if not self._advance_boot():
+            return False
+```
+
+Then DELETE the now-redundant later checks that `_advance_boot` subsumes: the block at `:533-535` (`if not self._context._strategy_state.is_on_fit_called or (not self._is_simulation and not ...is_on_warmup_finished_called): return False`) and the `:539-540` `_warmup_finished_is_running` check. KEEP the `_fit_is_running`/executor-mode check (`:546-547`) — a scheduled threaded fit runs concurrently with trading.
+
+**(c)** Add `_advance_boot` next to `_handle_state_resolution`:
+
+```python
+    def _advance_boot(self) -> bool:
+        """Drive the boot machine one pipeline pass. True ⇔ the strategy may trade.
+
+        Linearizes the old flag checks: WAIT_READY → ON_START → RESOLVE → RESTORE →
+        WARMUP_FINISHED → BOOT_FIT → TRADING. RESOLVE/RESTORE/WARMUP_FINISHED are
+        live-boot steps: skipped in simulation (RESOLVE) and while the warmup sim is
+        running this pipeline (is_warmup_in_progress). The boot-fit pass returns False
+        so no event is processed on it (old :526-527 behavior).
+        """
+        boot = self._boot
+        if boot.is_trading:
+            return True
+        if boot.is_blocked:
+            return False
+        state = self._context._strategy_state
+
+        if boot.phase == BootPhase.WAIT_READY:
+            if not self._is_ready():
+                return False
+            boot.advance(BootPhase.ON_START)
+
+        if boot.phase == BootPhase.ON_START:
+            if not state.is_on_start_called:
+                self._strategy.on_start(self._context)
+                state.is_on_start_called = True
+            boot.advance(BootPhase.RESOLVE)
+
+        if boot.phase == BootPhase.RESOLVE:
+            if not self._is_simulation and not state.is_on_warmup_finished_called:
+                self._handle_state_resolution()
+            boot.advance(BootPhase.RESTORE)
+
+        if boot.phase == BootPhase.RESTORE:
+            if not state.is_warmup_in_progress and not state.is_on_warmup_finished_called:
+                restored_state = self._context.get_restored_state()
+                if restored_state is not None:
+                    self._restore_tracker_and_gatherer_state(restored_state)
+            boot.advance(BootPhase.WARMUP_FINISHED)
+
+        if boot.phase == BootPhase.WARMUP_FINISHED:
+            if state.is_warmup_in_progress:
+                boot.advance(BootPhase.BOOT_FIT)  # warmup-sim ctx: the hook belongs to the live boot
+            else:
+                if not state.is_on_warmup_finished_called and not self._warmup_finished_is_running:
+                    self._handle_warmup_finished()
+                if not state.is_on_warmup_finished_called:
+                    return False
+                if not self._is_simulation and state.is_on_fit_called and self._context.initializer.get_fit_on_start():
+                    state.is_on_fit_called = False  # warmup fit doesn't count: force one live fit
+                boot.advance(BootPhase.BOOT_FIT)
+
+        if boot.phase == BootPhase.BOOT_FIT:
+            if state.is_on_fit_called:
+                boot.record_fit_success()
+                return True
+            if self._fit_is_running or self._warmup_finished_is_running:
+                return False
+            if boot.fit_attempt_allowed(self._time_provider.time()):
+                boot.record_fit_attempt()
+                self._handle_fit(None, "fit", (None, self._time_provider.time()))
+                if state.is_on_fit_called:
+                    boot.record_fit_success()
+            return False
+
+        return boot.is_trading
+```
+
+Notes on BOOT_FIT: the `state.is_on_fit_called → record_fit_success → return True` head covers the warmup-fit-satisfied case — trading proceeds on that same pass (old behavior, no lost pass). The `if state.is_on_fit_called` check after `_handle_fit(...)` covers the inline mode, which latches synchronously (threaded mode leaves the flag unset here; its outcome arrives via the FitCommit in Task 7). The fit-firing pass always returns `False` — parity with old `:526-527`. Task 7 moves outcome reporting into `_handle_fit` itself and deletes the two post-`_handle_fit` lines.
+
+**(d)** `_handle_start` (`:1090-1094`) is no longer called (its body moved into ON_START). Delete the method. `_handle_state_resolution` (`:1096`): remove its `if not self._is_ready(): return` (the machine gates), and replace the resolver-missing warning with a default:
+
+```python
+        resolver = _ctx.initializer.get_state_resolver()
+        if resolver is None:
+            resolver = StateResolver.REDUCE_ONLY
+```
+
+Add `from qubx.restarts.state_resolvers import StateResolver` to the module imports (check for import cycles: `restarts` imports only `qubx.core.*`, so importing it from a mixin is safe; if a cycle does appear, import inside the method). Also remove the `if not self._is_ready(): return` from `_restore_tracker_and_gatherer_state` and `_handle_warmup_finished` (same reason). KEEP the `_is_ready` check in `_handle_fit` — scheduled fits arrive outside `_advance_boot`.
+
+**(e)** `src/qubx/utils/runner/runner.py:1019-1020`: delete the two lines
+
+```python
+    if initializer.get_state_resolver() is None:
+        initializer.set_state_resolver(StateResolver.REDUCE_ONLY)
+```
+
+(the `_handle_state_resolution` fallback replaces them; drop the now-unused `StateResolver` import if nothing else in the file uses it).
+
+- [ ] **Step 4: Run the new tests plus the neighboring pipeline suites**
+
+Run: `uv run pytest tests/qubx/core/mixins/ tests/qubx/core/boot_test.py -v`
+Expected: all PASS — including `fit_executor_test.py`, `processing_fit_refresh_test.py`, `processing_pending_signals_test.py`, `test_processing_dispatch.py`. These construct `ProcessingManager` with `is_on_warmup_finished_called=True`-style states; two known hazards when fixing them:
+
+1. If one drives `_run_strategy_pipeline` and stalls in WAIT_READY, patch that test's pm with `pm._is_data_ready = lambda: True` (not by weakening `_advance_boot`).
+2. **MagicMock contexts make `context.initializer.get_fit_on_start()` return a truthy MagicMock**, accidentally enabling the knob and resetting `is_on_fit_called`. In any pre-existing harness whose tests reach the pipeline, add `context.initializer.get_fit_on_start.return_value = False` (mirror how `make_pm` does it).
+
+- [ ] **Step 5: Run the broader core + backtester suites (simulation parity)**
+
+Run: `uv run pytest tests/qubx/core/ tests/qubx/backtester/ -x -q --disable-warnings -n 2`
+Expected: PASS. Any failure here is a parity break — fix `_advance_boot`, do not adjust simulation expectations.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/qubx/core/mixins/processing.py src/qubx/utils/runner/runner.py tests/qubx/core/mixins/boot_pipeline_test.py
+git commit -m "feat(core): boot state machine drives the live boot; state resolution runs unconditionally (#363)"
+```
+
+---
+
+### Task 5: Strict account-sync gate
+
+**Files:**
+- Modify: `src/qubx/core/mixins/processing.py` (`_is_ready`, `:918-945`)
+- Test: `tests/qubx/core/mixins/boot_pipeline_test.py` (extend)
+
+**Interfaces:**
+- Consumes: `_boot.account_sync_alert()` / `_boot.account_synced()` (Task 3).
+- Produces: `_is_ready()` never returns True in live non-paper while `account_manager.is_synced()` is False. `ACCOUNT_SYNC_TIMEOUT` (15s, unchanged) is now the alert threshold, not a fall-through.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/qubx/core/mixins/boot_pipeline_test.py`:
+
+```python
+class TestStrictAccountSyncGate:
+    def test_boot_holds_until_synced_and_alerts_after_timeout(self):
+        pm, ctx, strategy = make_pm()
+        pm._account_manager.is_synced.return_value = False
+        tp = pm._time_provider
+
+        drive(pm)  # arms the deadline
+        assert pm._boot.phase == BootPhase.WAIT_READY
+        strategy.on_start.assert_not_called()
+
+        tp.time.return_value = T0 + np.timedelta64(20, "s")  # past ACCOUNT_SYNC_TIMEOUT (15s)
+        drive(pm)
+        assert pm._boot.phase == BootPhase.WAIT_READY
+        strategy.on_start.assert_not_called()
+        pm._health_monitor.record_gauge.assert_any_call("boot.account_sync_blocked", 1.0)
+
+    def test_boot_proceeds_when_snapshot_lands_late(self):
+        pm, ctx, strategy = make_pm()
+        pm._account_manager.is_synced.return_value = False
+        tp = pm._time_provider
+        drive(pm)
+        tp.time.return_value = T0 + np.timedelta64(30, "s")
+        drive(pm)
+        pm._account_manager.is_synced.return_value = True
+        drive(pm)
+        strategy.on_start.assert_called_once()
+        pm._health_monitor.record_gauge.assert_any_call("boot.account_sync_blocked", 0.0)
+```
+
+If `pm._account_manager` / `pm._time_provider` / `pm._health_monitor` are not the attribute names on the manager, find the actual private names in `ProcessingManager`'s field list and use those (they are the constructor kwargs with a leading underscore).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/mixins/boot_pipeline_test.py -v -k StrictAccountSync`
+Expected: FAIL — old fall-through lets `on_start` fire after the timeout.
+
+- [ ] **Step 3: Implement**
+
+Replace `_is_ready`'s account section (`:929-945`) with:
+
+```python
+        if self._context.is_simulation or self._context.is_paper_trading:
+            return True
+        if self._account_manager.is_synced():
+            self._boot.account_synced()
+            return True
+        # - data ready but the initial venue snapshot hasn't applied: hold the boot.
+        #   ACCOUNT_SYNC_TIMEOUT is the alert threshold, not a fall-through — trading
+        #   against phantom-zero positions can double-open the book.
+        now = self._time_provider.time()
+        if self._account_sync_deadline is None:
+            self._account_sync_deadline = now + self.ACCOUNT_SYNC_TIMEOUT
+        elif now >= self._account_sync_deadline:
+            self._boot.account_sync_alert()
+        return False
+```
+
+Update the method docstring accordingly (remove the "falls through" paragraph). Delete the now-unused `_account_sync_timeout_logged` field and its reset.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/mixins/boot_pipeline_test.py tests/qubx/core/mixins/ -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qubx/core/mixins/processing.py tests/qubx/core/mixins/boot_pipeline_test.py
+git commit -m "feat(core): strict account-sync gate for the boot phase — alert and hold, no fall-through"
+```
+
+---
+
+### Task 6: `set_fit_on_start` end-to-end behavior
+
+**Files:**
+- Test: `tests/qubx/core/mixins/boot_pipeline_test.py` (extend; the production hook was wired in Task 4's WARMUP_FINISHED step)
+
+**Interfaces:**
+- Consumes: `context.initializer.get_fit_on_start()` (Task 2), `_advance_boot` (Task 4).
+- Produces: verified four-case behavior table from the spec.
+
+- [ ] **Step 1: Write the tests (some may already pass — that's expected; they pin the contract)**
+
+```python
+class TestFitOnStart:
+    def test_knob_forces_exactly_one_live_fit_after_warmup(self):
+        pm, ctx, strategy = make_pm(is_on_fit_called=True, fit_on_start=True)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_called_once()
+        assert pm._boot.is_trading
+
+    def test_knob_off_no_live_fit_when_warmup_fit_ran(self):
+        pm, ctx, strategy = make_pm(is_on_fit_called=True, fit_on_start=False)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_not_called()
+        assert pm._boot.is_trading
+
+    def test_no_double_fit_when_warmup_ran_no_fit(self):
+        # LIGHTER case: flag unset after warmup; knob on must still yield exactly one fit
+        pm, ctx, strategy = make_pm(is_on_fit_called=False, fit_on_start=True)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_called_once()
+        assert pm._boot.is_trading
+
+    def test_knob_ignored_in_simulation(self):
+        pm, ctx, strategy = make_pm(is_simulation=True, is_on_fit_called=True, fit_on_start=True)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_not_called()
+        assert pm._boot.is_trading
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/qubx/core/mixins/boot_pipeline_test.py -v -k FitOnStart`
+Expected: PASS if Task 4's reset line is correct; any FAIL means the reset fires in the wrong phase or mode — fix in `_advance_boot`'s WARMUP_FINISHED step (the reset must be: live only, once, only when the flag was set by a warmup fit).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/qubx/core/mixins/boot_pipeline_test.py
+git commit -m "test(core): pin set_fit_on_start four-case boot-fit contract"
+```
+
+---
+
+### Task 7: Boot-fit failure handling (latch-on-success, retry, BLOCKED, self-heal)
+
+**Files:**
+- Modify: `src/qubx/core/mixins/processing.py` (`__invoke_on_fit:733-752`, `_handle_fit:1174-1196`, `_run_fit_off_thread:1226-1280`, `_handle_fit_commit:1288-1318`, `_handle_warmup_finished:1161` + `__invoke_on_warmup_finished:754-771`)
+- Modify: `src/qubx/core/fit_executor.py` (`FitCommitData`)
+- Test: `tests/qubx/core/mixins/boot_pipeline_test.py` (extend) and `tests/qubx/core/mixins/fit_executor_test.py` (extend)
+
+**Interfaces:**
+- Consumes: `_boot.record_fit_failure(now)`, `_boot.record_fit_success()`, `_boot.record_warmup_finished_failure()`, `_boot.is_trading` (Task 3).
+- Produces: `FitCommitData.error: BaseException | None = None`; `__invoke_on_fit() -> bool` (success); `__invoke_on_warmup_finished() -> bool` (success). Live latch rule: `is_on_fit_called` set only on success; simulation keeps latch-always.
+
+- [ ] **Step 1: Write the failing tests (inline mode + hook failure)**
+
+Append to `tests/qubx/core/mixins/boot_pipeline_test.py`:
+
+```python
+class TestBootFitFailure:
+    def test_failed_boot_fit_retries_then_blocks(self):
+        pm, ctx, strategy = make_pm()
+        strategy.on_fit.side_effect = RuntimeError("boom")
+        tp = pm._time_provider
+
+        drive(pm)  # attempt 1
+        assert not ctx._strategy_state.is_on_fit_called
+        assert pm._boot.phase == BootPhase.BOOT_FIT
+
+        drive(pm)  # before the retry deadline: no new attempt
+        assert strategy.on_fit.call_count == 1
+
+        tp.time.return_value = T0 + np.timedelta64(61, "s")
+        drive(pm)  # attempt 2
+        tp.time.return_value = T0 + np.timedelta64(122, "s")
+        drive(pm)  # attempt 3 -> exhausted
+        assert strategy.on_fit.call_count == 3
+        assert pm._boot.is_blocked
+        pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 1.0)
+
+        drive(pm)  # blocked: no on_event, no more attempts
+        assert strategy.on_fit.call_count == 3
+        strategy.on_event.assert_not_called()
+
+    def test_blocked_self_heals_on_later_successful_fit(self):
+        pm, ctx, strategy = make_pm()
+        strategy.on_fit.side_effect = RuntimeError("boom")
+        tp = pm._time_provider
+        drive(pm)
+        tp.time.return_value = T0 + np.timedelta64(61, "s")
+        drive(pm)
+        tp.time.return_value = T0 + np.timedelta64(122, "s")
+        drive(pm)
+        assert pm._boot.is_blocked
+
+        strategy.on_fit.side_effect = None  # a scheduled fit arrives via _handle_fit
+        pm._handle_fit(None, "fit", (None, tp.time.return_value))
+        assert ctx._strategy_state.is_on_fit_called
+        assert pm._boot.is_trading
+        pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 0.0)
+
+    def test_warmup_finished_failure_latches_and_gauges(self):
+        pm, ctx, strategy = make_pm()
+        strategy.on_warmup_finished.side_effect = RuntimeError("hook boom")
+        drive(pm, passes=2)
+        assert ctx._strategy_state.is_on_warmup_finished_called  # latched as before
+        pm._health_monitor.record_gauge.assert_any_call("boot.warmup_finished_failed", 1.0)
+        assert pm._boot.is_trading  # boot continued to the fit
+
+    def test_simulation_keeps_latch_on_failure(self):
+        pm, ctx, strategy = make_pm(is_simulation=True)
+        strategy.on_fit.side_effect = RuntimeError("boom")
+        drive(pm, passes=2)
+        assert ctx._strategy_state.is_on_fit_called  # sim: latch-in-finally preserved
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/qubx/core/mixins/boot_pipeline_test.py -v -k "BootFitFailure"`
+Expected: FAIL — the old `finally` latches `is_on_fit_called` even on error, so no retry happens.
+
+- [ ] **Step 3: Implement inline-path + hook changes**
+
+**(a)** `__invoke_on_fit` — return success, latch only on success in live (`:733-752`):
+
+```python
+    def __invoke_on_fit(self) -> bool:
+        with self._health_monitor("ctx.on_fit"):
+            try:
+                self._context._instrument_service_manager.enforce_at_fit()
+                logger.debug(f"[<y>{self.__class__.__name__}</y>] :: Invoking <g>{self._strategy_name}</g> on_fit")
+                self._strategy.on_fit(self._context)
+                self._subscription_manager.commit()  # apply pending operations
+                logger.debug(f"[<y>{self.__class__.__name__}</y>] :: <g>{self._strategy_name}</g> is fitted")
+                self._context._strategy_state.is_on_fit_called = True
+                return True
+            except Exception as strat_error:
+                logger.error(
+                    f"[{self.__class__.__name__}] :: Strategy {self._strategy_name} on_fit raised an exception: {strat_error}"
+                )
+                logger.opt(colors=False).error(traceback.format_exc())
+                # - simulation keeps the latch: no retry machinery there, and a raising
+                #   fit must not re-fire every tick (would change backtest behavior)
+                if self._is_simulation:
+                    self._context._strategy_state.is_on_fit_called = True
+                return False
+```
+
+(preserve the existing comment above `enforce_at_fit` verbatim.)
+
+**(b)** `_handle_fit` inline branch (`:1188-1196`) — report to the machine when boot is not done:
+
+```python
+        self._fit_is_running = True
+        try:
+            current_time = data[1]
+            self._cache.finalize_ohlc_for_instruments(current_time, self._context.instruments)
+            ok = self.__invoke_on_fit()
+        finally:
+            self._fit_is_running = False
+        if not self._is_simulation and not self._boot.is_trading:
+            if ok:
+                self._boot.record_fit_success()
+            else:
+                self._boot.record_fit_failure(self._time_provider.time())
+```
+
+Then in Task 4's `_advance_boot` BOOT_FIT step, DELETE the post-`_handle_fit` `if state.is_on_fit_called: boot.record_fit_success()` correction lines — `_handle_fit` now reports both outcomes itself.
+
+**(c)** `_handle_warmup_finished` / `__invoke_on_warmup_finished` (`:754-771`, `:1161-1172`): make the invoker return success (True on no exception; keep the latch in `finally` exactly as-is), and in `_handle_warmup_finished` after the call:
+
+```python
+            if not self.__invoke_on_warmup_finished():
+                self._boot.record_warmup_finished_failure()
+```
+
+(adjust: the current code calls `self.__invoke_on_warmup_finished()` inside the try — capture its return there.)
+
+- [ ] **Step 4: Run inline tests to verify they pass**
+
+Run: `uv run pytest tests/qubx/core/mixins/boot_pipeline_test.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Write the failing threaded-path test**
+
+Append to `tests/qubx/core/mixins/fit_executor_test.py` (reuse its `make_thread_pm` + `drain_until_committed` helpers):
+
+```python
+def test_threaded_fit_failure_does_not_latch_and_reports_boot_failure():
+    pm, context, channel = make_thread_pm()
+    pm._strategy.on_fit.side_effect = RuntimeError("thread boom")
+    pm._boot.advance(BootPhase.BOOT_FIT)
+    pm._boot.record_fit_attempt()
+
+    pm._handle_fit(None, "fit", (None, T0))
+    drain_until_committed(pm, channel)
+
+    assert not context._strategy_state.is_on_fit_called
+    assert pm._boot.phase == BootPhase.BOOT_FIT  # retry pending, not blocked (attempt 1/3)
+
+
+def test_threaded_fit_success_latches_and_reaches_trading():
+    pm, context, channel = make_thread_pm()
+    pm._strategy.on_fit.side_effect = None
+    pm._boot.advance(BootPhase.BOOT_FIT)
+    pm._boot.record_fit_attempt()
+
+    pm._handle_fit(None, "fit", (None, T0))
+    drain_until_committed(pm, channel)
+
+    assert context._strategy_state.is_on_fit_called
+    assert pm._boot.is_trading
+```
+
+Add `from qubx.core.boot import BootPhase` to that file's imports. If `make_thread_pm`'s context state has `is_on_warmup_finished_called=True` and the machine starts in WAIT_READY, that is fine — these tests drive the machine explicitly.
+
+- [ ] **Step 6: Run to verify the failure test fails**
+
+Run: `uv run pytest tests/qubx/core/mixins/fit_executor_test.py -v -k threaded_fit_failure`
+Expected: FAIL — `_handle_fit_commit` latches unconditionally today.
+
+- [ ] **Step 7: Implement the threaded path**
+
+`src/qubx/core/fit_executor.py`, `FitCommitData`:
+
+```python
+    ops: tuple[Callable[[], None], ...] = ()
+    signals: tuple[Signal, ...] = ()
+    duration_s: float = 0.0
+    error: BaseException | None = None
+```
+
+`_run_fit_off_thread` (`:1226-1280`): capture the strategy error — in the `except Exception as strat_error:` branch add `_fit_error = strat_error` (initialize `_fit_error: BaseException | None = None` before the try), and pass it in the finally's send:
+
+```python
+            channel.send(
+                (None, FIT_COMMIT_EVENT, FitCommitData(ops=_ops, signals=_signals, duration_s=_duration_s, error=_fit_error), False)
+            )
+```
+
+`_handle_fit_commit` finally block (`:1314-1318`):
+
+```python
+        finally:
+            if commit.signals:
+                self._emitted_signals.extend(commit.signals)
+            if commit.error is None:
+                self._context._strategy_state.is_on_fit_called = True
+            self._fit_is_running = False
+            if not self._boot.is_trading:
+                if commit.error is None:
+                    self._boot.record_fit_success()
+                else:
+                    self._boot.record_fit_failure(self._time_provider.time())
+```
+
+- [ ] **Step 8: Run the full mixin suite**
+
+Run: `uv run pytest tests/qubx/core/mixins/ tests/qubx/core/boot_test.py -v`
+Expected: all PASS (existing fit_executor tests included — none of them raise in `on_fit`, so the latch behavior they see is unchanged).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/qubx/core/mixins/processing.py src/qubx/core/fit_executor.py tests/qubx/core/mixins/boot_pipeline_test.py tests/qubx/core/mixins/fit_executor_test.py
+git commit -m "feat(core): boot-fit failure handling — latch on success only, bounded retry, BLOCKED with self-heal"
+```
+
+---
+
+### Task 8: Full-suite verification and style
+
+**Files:** none new.
+
+- [ ] **Step 1: Style check**
+
+Run: `just style-check`
+Expected: clean. Fix any ruff findings in files this branch touched.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `just test`
+Expected: PASS. Simulation-behavior failures (backtester suites) are parity breaks — fix in `_advance_boot`/`__invoke_on_fit`, never by changing simulation test expectations. Live-runner suites (`tests/qubx/utils/runner/` if present) may assert the old default-resolver install in `_run_warmup` — update those to the new contract (fallback lives in `_handle_state_resolution`).
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(core): full-suite fixes for boot phase wiring"
+```
+
+(skip if nothing changed)
+
+---
+
+### Task 9: Boot lifecycle documentation (#388)
+
+**Files:**
+- Create: `docs/trading/boot-lifecycle.md`
+- Modify: `mkdocs.yml` (nav — add the page next to the other `trading/` entries; if `docs/trading/` pages are not in nav, mirror however its siblings are registered)
+
+**Interfaces:** none — documentation only.
+
+- [ ] **Step 1: Write the page**
+
+Create `docs/trading/boot-lifecycle.md` with these sections, sourcing content from `docs/specs/2026-08-27-boot-phase-design.md` (adapt, don't copy verbatim — the audience is strategy authors, not framework reviewers):
+
+1. **Two warmups** — warmup simulation vs subscription warmup (spec "Terminology", one paragraph each).
+2. **Boot sequence** — both ASCII diagrams from the spec ("Boot sequencing (reference)"), unchanged.
+3. **When `on_fit` runs** — the four-case table from the spec, plus the invariant sentence ("`on_event` is never delivered before a successful fit").
+4. **`on_start` fires in the warmup context** — the #388 asymmetry: with warmup, `on_start` ran in the sim against the sim universe; per-instrument state must be built lazily on first use or rebuilt in `on_warmup_finished`, never only in `on_start`; `ctx.instruments` at live start can contain held instruments the strategy never selected.
+5. **State resolvers** — the contract (runs at every live boot; all-empty sim args ⇔ no warmup output; stock resolvers hold + warn then), and the recommended-patterns table from the spec ("Documentation deliverable" section: HOLD+`set_fit_on_start` / SYNC_STATE / REDUCE_ONLY / custom).
+6. **`set_fit_on_start`** — what it guarantees, that it replaces `trigger_fit()` in `on_warmup_finished`, no-op without warmup.
+7. **Boot health** — the five `boot.*` gauges table from the spec and what BLOCKED means operationally (self-heals on a later successful fit or account snapshot).
+
+- [ ] **Step 2: Verify docs build (if mkdocs is wired locally)**
+
+Run: `uv run mkdocs build --strict 2>&1 | tail -5` (skip without failing the task if mkdocs isn't in the dev deps — check `just update-docs` in the justfile as the alternative).
+Expected: no errors/warnings about the new page.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/trading/boot-lifecycle.md mkdocs.yml
+git commit -m "docs: strategy boot lifecycle — phases, resolvers, set_fit_on_start, boot health (#388)"
+```
+
+---
+
+## Self-Review Notes (already applied)
+
+- Spec coverage: §1 machine → Tasks 3-4; §2 strict gate → Task 5; §3 unconditional resolution + guards + HOLD + default move + cleanup → Tasks 1, 4; §4 knob → Tasks 2, 4, 6; §5 failure handling incl. threaded path and sim latch carve-out → Task 7; §6 gauges → Tasks 3, 5, 7; docs deliverable → Task 9; testing §each → per-task tests + Task 8 parity run; rollout/changelog → release notes ride the conventional-commit messages (Qubx changelog is generated).
+- The old `:521` fallback, the `:533-535` and `:539-540` gates are subsumed by `_advance_boot`; the `:546-547` threaded-fit re-entrancy guard stays (documented in Task 4b).
+- Type consistency: `BootPhase`/`BootStateMachine` names and signatures are identical in Tasks 3 (definition), 4-7 (use). `FitCommitData.error: BaseException | None` defined in Task 7 and used only there.

--- a/docs/trading/boot-lifecycle.md
+++ b/docs/trading/boot-lifecycle.md
@@ -1,0 +1,265 @@
+# Strategy Boot Lifecycle
+
+Every live boot — first start or restart — runs through a fixed sequence before the
+strategy is allowed to trade: the account has to sync, `on_start` has to fire, the live
+book has to be reconciled against whatever the strategy intended, and the strategy has to
+fit at least once. This page describes that sequence, what a strategy author needs to do
+to cooperate with it, and how to read its health signals.
+
+It does not apply to backtesting: simulation has no account to sync and no venue book to
+reconcile, so most of what follows is live-only (called out where it matters).
+
+## Two Kinds of Warmup
+
+Qubx uses the word "warmup" for two unrelated mechanisms. This page always qualifies
+which one it means.
+
+**Warmup simulation** (`initializer.set_warmup("14d")` in `on_init`, or the `live.warmup`
+config key): before the live context starts, an in-process backtest runs *the same
+strategy object* over the trailing period. It warms the strategy's own state — fitted
+models, indicators held on `self`, tracker state — and its final book (positions, open
+orders, active targets) becomes the "intended state" that the boot state resolver later
+compares the live account against. The warmup sim always starts from a flat, balance-only
+book (`src/qubx/backtester/runner.py`); it does not touch the live data cache — only the
+strategy object's in-memory state survives into the live context.
+
+**Subscription warmup** (`ISubscriptionManager.set_warmup({DataType.OHLC["1h"]: "30d"})`,
+usually called from `on_init`): a historical OHLC backfill into the *live* data cache,
+fetched by the connector when instruments are subscribed. It is unrelated to the warmup
+simulation and runs on every live boot — warmup sim on or off. It gates when live
+streaming starts: the swap from history to live ticks only applies once the backfill
+lands (or times out), and boot's `WAIT_READY` phase in turn waits for a live tick before
+proceeding — so a slow backfill delays boot, it never skips it.
+
+## Boot Sequence
+
+Boot is driven by a state machine with one question per pass: "is boot done?" Its phases
+run in order, live or in the warmup sim:
+
+```
+WAIT_READY → ON_START → RESOLVE → RESTORE → WARMUP_FINISHED → BOOT_FIT → TRADING
+                                                                  ↓ (retries exhausted)
+                                                               BLOCKED(reason)
+```
+
+`WAIT_READY` requires market data readiness *and*, live only, a synced account. `BLOCKED`
+is a sticky failure state — no `on_event` is delivered while blocked — reached only if the
+boot fit exhausts its retries (see [Boot Health](#boot-health)). In simulation the account
+requirement drops out, `RESOLVE` is skipped entirely (state resolution is a live-boot
+concept — there is no venue book to reconcile against), and the rest fires as it always
+has.
+
+The concrete sequence differs depending on whether a warmup simulation ran, because the
+warmup sim fires `on_start` (and possibly `on_fit`) itself, before the live context even
+exists.
+
+### Without warmup sim
+
+```
+runner main thread                        ProcessorThread (boot state machine)
+──────────────────                        ────────────────────────────────────
+read RestoredState (--restore:
+  positions/signals/targets from the
+  previous run's logs)
+create ctx (restored positions
+  seeded into account manager)
+ctx.start()
+ ├ connect live connectors
+ └ initial subscribe commit
+    └ WarmupThread: OHLC backfill
+       then swap → live streams on ──►  first live tick per instrument
+                                        ┌ WAIT_READY   data ready + account synced (strict)
+                                        ├ ON_START     on_start fires (live ctx)
+                                        ├ RESOLVE      resolver runs, sim args EMPTY
+                                        │              → stock: hold + loud warning
+                                        │              → custom: e.g. seed from ctx.get_positions()
+                                        ├ RESTORE      tracker/gatherer from RestoredState
+                                        ├ WARMUP_FIN   on_warmup_finished fires
+                                        ├ BOOT_FIT     on_fit fires — ALWAYS (flag never set)
+                                        └ TRADING      on_event starts flowing
+```
+
+### With warmup sim
+
+```
+runner main thread                        ProcessorThread (boot state machine)
+──────────────────
+read RestoredState
+create ctx (restored pos → account)
+_run_warmup (blocking, in-process):
+ ├ start = start_time_finder(restored) − warmup period
+ ├ seed REAL capital from venue snapshot
+ ├ backtest same strategy object on sim ctx:
+ │   on_start, on_fit(s), on_event(s) fire HERE
+ │   (sim book starts FLAT — only balances seeded)
+ └ capture sim end state →
+     ctx.set_warmup_positions/orders/active_targets
+ctx.start()
+ └ initial subscribe → WarmupThread backfill
+    → swap → live ticks            ──►  ┌ WAIT_READY   data ready + account synced (strict)
+                                        ├ ON_START     SKIPPED — already fired in sim ctx (#388)
+                                        ├ RESOLVE      resolver vs sim end state (non-empty:
+                                        │              sim captures a Position per instrument)
+                                        ├ RESTORE      tracker/gatherer from RestoredState
+                                        ├ WARMUP_FIN   on_warmup_finished fires (live ctx)
+                                        ├ BOOT_FIT     fires IFF fit_on_start OR sim ran no fit;
+                                        │              otherwise skipped
+                                        └ TRADING
+```
+
+Two phases are worth calling out explicitly since the diagrams compress them:
+
+- **RESOLVE** acts on the venue and may trade: the resolver compares the live book
+  (`ctx.get_positions()` / `ctx.get_orders()`) against the strategy's intended book and
+  can emit signals that become real orders.
+- **RESTORE** only re-seeds in-memory bookkeeping and never trades: the tracker replays
+  the previous run's persisted signals, the gatherer replays the latest persisted target,
+  and that target is re-persisted so a subsequent `--restore` still finds something to
+  restore from.
+
+## When `on_fit` Runs
+
+Whether the boot fit (the `BOOT_FIT` phase) actually invokes `on_fit` depends on whether a
+warmup sim ran, whether it fitted, and whether the strategy opted into
+[`set_fit_on_start`](#set_fit_on_start):
+
+| Scenario | Fit during warmup sim | Live boot fit | First `on_event` sees a live-fitted strategy? |
+|---|---|---|---|
+| No warmup sim | — | always (flag never set) | yes |
+| Warmup sim, knob off, sim fit ran | yes, in sim ctx | no — waits for the next scheduled fit | no — fit state came from the sim |
+| Warmup sim, knob off, sim ran no fit (e.g. no warmup data for the venue) | no | yes (fallback) | yes |
+| Warmup sim + `set_fit_on_start(True)` | yes, in sim ctx | exactly one, after `on_warmup_finished` | yes |
+
+This table is a consequence of one invariant, and it always holds: **`on_event` is never
+delivered before a successful fit.** Boot sits in `BOOT_FIT` — no events, no trading — until
+`on_fit` returns without raising for the first time in the live context (or, in row 2,
+until the machine recognizes the sim's fit as already having satisfied that requirement).
+
+## `on_start` Fires in the Warmup Context
+
+When a warmup sim runs, `on_start` is **not** re-invoked live — the `ON_START` phase is
+skipped because the flag is already set from the sim (see the "With warmup sim" diagram
+above). That means the `on_start` a strategy actually observes ran inside the sim, against
+the sim's universe, before the live context — and its real venue positions — existed at
+all.
+
+This has two concrete consequences for strategy code:
+
+- **Any per-instrument state a strategy initializes in `on_start` will not exist for
+  instruments that only become relevant later** (a restored position, an instrument the
+  live universe includes that the sim window didn't). Build such state lazily on first
+  use, or (re)build it in `on_warmup_finished`, which always fires in the live context
+  before `BOOT_FIT`. Never rely on `on_start` alone to have initialized it.
+- **`ctx.instruments` at live start can already contain instruments the strategy never
+  explicitly selected** — held positions from a previous run flow into the context ahead
+  of any strategy universe call. Code that assumes `ctx.instruments` is exactly what
+  `on_start` selected can be surprised by extra members.
+
+The safe pattern: treat `on_start` as "runs once, maybe in a sim, maybe before real state
+exists" and push anything that must reflect the live account into `on_warmup_finished` or
+lazy per-instrument initialization.
+
+## State Resolvers
+
+The state resolver is the mechanism that reconciles the live account with the strategy's
+intended book at boot. Its contract:
+
+- **It runs at every live boot** — warmup sim or not. This is unconditional; there is no
+  config flag that silently disables it. If no custom resolver is registered, the default
+  is `StateResolver.REDUCE_ONLY`.
+- **All-empty resolver arguments mean "no warmup output."** The resolver signature is
+  `(ctx, sim_positions, sim_orders, sim_active_targets)`. When a warmup sim ran, it always
+  captures a `Position` per sim instrument — flat ones included — so all three arguments
+  being empty is unambiguous: no warmup sim ran (or it produced nothing to compare
+  against). Custom resolvers can rely on this to distinguish "nothing to seed from" from
+  "sim ended flat."
+- **The stock resolvers that steer toward sim state guard the empty case.**
+  `REDUCE_ONLY` and `SYNC_STATE` check for all-empty arguments first; if empty, they log a
+  loud warning ("State resolver received no warmup output — holding the live book
+  as-is.") and return without touching the account. This is what makes it safe to run
+  with warmup disabled: nothing gets silently flattened. `CLOSE_ALL` is unaffected —
+  closing everything is an explicit instruction independent of sim state. `NONE` does
+  nothing, always.
+- **`StateResolver.HOLD`** cancels every open live order, leaves all live positions
+  untouched, and emits no signals. It is the recommended partner for strategies whose
+  tracker (e.g. a buffered/banded position tracker) reconciles state itself — instead of
+  letting the resolver drive positions toward a flat-start sim artifact, `HOLD` leaves the
+  book alone and lets the first live fit reconcile through the tracker.
+
+Custom resolvers (frab's pair-book resolver, factors' resolver) receive the same
+arguments and are unaffected by any of this — they always ran and always will.
+
+### Recommended patterns
+
+| Strategy style | Resolver | `set_fit_on_start` |
+|---|---|---|
+| Buffered / tracker-reconciling | `HOLD` | `True` |
+| Target-state (sim targets are prescriptive) | `SYNC_STATE` | optional |
+| Conservative default | `REDUCE_ONLY` | optional |
+| Fully custom boot seeding | custom resolver | as needed |
+
+Register a resolver from `on_init`:
+
+```python
+def on_init(self, initializer: IStrategyInitializer) -> None:
+    initializer.set_state_resolver(StateResolver.HOLD)
+    initializer.set_fit_on_start(True)
+```
+
+## `set_fit_on_start`
+
+`initializer.set_fit_on_start(True)`, called from `on_init`, tells boot: "the warmup-sim
+fit doesn't count — my first `on_fit` must run in the live context, against live
+positions."
+
+- **What it guarantees:** when a warmup sim ran and fitted, boot forces exactly one
+  additional live fit after `on_warmup_finished` completes, before `TRADING`. Without the
+  flag, that fit is skipped (row 2 of the [`on_fit` table](#when-on_fit-runs) above) and
+  the strategy trades on state the sim computed against a flat, balance-only book.
+- **It replaces `ctx.trigger_fit()` boilerplate.** Strategies that needed a guaranteed
+  live fit used to hand-roll a call to `ctx.trigger_fit()` in `on_warmup_finished`.
+  Opting into `set_fit_on_start(True)` is the supported way to get the same guarantee;
+  calling both produces a double fit — this is documented, not defended against, so pick
+  one.
+- **No-op without a warmup sim.** If no warmup sim runs, nothing ever sets the fit flag,
+  so the boot fit fires unconditionally regardless of this setting (row 1 of the table) —
+  today's behavior, unchanged.
+- **Opt-in only.** Strategies that must fit exclusively on a deliberate schedule are
+  untouched if they never call this.
+
+## Boot Health
+
+Boot emits gauges through the existing health-monitor pipeline (same exporters as other
+`stg.*` metrics):
+
+| Gauge | Meaning |
+|---|---|
+| `boot.state` | current phase as a number: `WAIT_READY`=0, `ON_START`=1, `RESOLVE`=2, `RESTORE`=3, `WARMUP_FINISHED`=4, `BOOT_FIT`=5, `TRADING`=6, `BLOCKED`=-1 |
+| `boot.account_sync_blocked` | 1 while boot is held in `WAIT_READY`, past the alert threshold, waiting for the initial account snapshot |
+| `boot.fit_attempts` | boot-fit attempt counter, incremented on every attempt |
+| `boot.fit_failed` | 1 when boot-fit retries are exhausted (cleared on self-heal) |
+| `boot.warmup_finished_failed` | 1 when `on_warmup_finished` raised |
+
+Two failure paths hold boot rather than let it proceed blind, and both recover without a
+restart — but they are independent mechanisms, not the same one:
+
+- **Unsynced account.** `WAIT_READY` never falls through on a timeout: if the initial
+  venue account snapshot hasn't applied, boot simply waits. `ACCOUNT_SYNC_TIMEOUT` (15s)
+  is only an *alert* threshold — crossing it emits `boot.account_sync_blocked = 1` and a
+  warning, but boot keeps waiting. The moment the snapshot applies, boot proceeds and the
+  gauge clears on its own.
+- **Boot fit failure → `BLOCKED`.** If `on_fit` raises during `BOOT_FIT`, boot retries: 3
+  attempts total (the initial attempt plus 2 retries), 60 seconds apart, each incrementing
+  `boot.fit_attempts`. If all 3 fail, boot enters `BLOCKED("boot fit failed")`:
+  `boot.fit_failed = 1`, periodic error logs, and no `on_event` is delivered — the
+  strategy holds an unreconciled book rather than trade having never successfully fitted.
+  `BLOCKED` self-heals: **any** later successful fit — the normal recurring schedule, or a
+  manual `ctx.trigger_fit()` — clears it and releases boot into `TRADING`. This works
+  because fit outcomes only reach the boot machine while it is still in `BOOT_FIT` or
+  `BLOCKED`; once boot reaches `TRADING` normally, ordinary scheduled-fit failures follow
+  their usual latch-and-continue behavior and do not re-enter the boot machine at all.
+
+`on_warmup_finished` failure is handled separately and does not block: the hook is not
+guaranteed idempotent, so it is latched as called either way (no auto-retry), but a raise
+emits `boot.warmup_finished_failed = 1` and an error log, and boot continues on to
+`BOOT_FIT`.

--- a/docs/trading/boot-lifecycle.md
+++ b/docs/trading/boot-lifecycle.md
@@ -187,7 +187,10 @@ intended book at boot. Its contract:
   book alone and lets the first live fit reconcile through the tracker.
 
 Custom resolvers (frab's pair-book resolver, factors' resolver) receive the same
-arguments and are unaffected by any of this — they always ran and always will.
+arguments and are unaffected by any of this — they now run at every live boot with no
+empty-guard applied. Before this release, a registered custom resolver was silently
+skipped at boot whenever warmup was disabled (#363); that gap is what this release
+closes.
 
 ### Recommended patterns
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
   - Trading:
       - Paper Trading: trading/paper-trading.md
       - Live Trading: trading/live-trading.md
+      - Boot Lifecycle: trading/boot-lifecycle.md
       - Bot Control Protocol: trading/control-protocol.md
       - Risk Management: trading/risk-management.md
   - Analysis and Reporting:

--- a/src/qubx/core/account_manager/diffs.py
+++ b/src/qubx/core/account_manager/diffs.py
@@ -28,6 +28,11 @@ RTOL = 1e-9
 # under 1 cent is not a reconcilable difference. Absolute, because "1 cent" is absolute.
 BALANCE_ABS_TOL = 0.01
 
+# Maintenance margin re-marks with every snapshot's mark price, so RTOL-tight comparison
+# emits a diff per position per poll. Only a material move (leverage/size change) is worth
+# re-syncing; sub-0.5% (and sub-cent) drift is mark noise.
+MARGIN_RTOL = 5e-3
+
 
 # - Diff atoms ------------------------------------------------------------------ #
 @dataclass_transform(frozen_default=True, kw_only_default=True)
@@ -67,6 +72,10 @@ def _close_rel(a: float, b: float) -> bool:
 def _close_bal(a: float, b: float) -> bool:
     # balance legs: absolute 1-cent tolerance (ignore sub-cent margin/PnL float drift)
     return abs(a - b) <= BALANCE_ABS_TOL
+
+
+def _close_margin(a: float, b: float) -> bool:
+    return abs(a - b) <= max(BALANCE_ABS_TOL, MARGIN_RTOL * max(abs(a), abs(b)))
 
 
 def _material_pos(position: Position) -> bool:
@@ -377,7 +386,7 @@ class Differ:
             if abs(lp.position_avg_price - sp.position_avg_price) > _peps(sp.instrument):
                 diffs.append(PositionAvgPriceMismatch(local=lp, origin=sp))
 
-            if not _close_rel(lp.maint_margin, sp.maint_margin):
+            if not _close_margin(lp.maint_margin, sp.maint_margin):
                 diffs.append(PositionMarginMismatch(local=lp, origin=sp))
 
         for inst, lp in local_pos.items():

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -26,6 +26,10 @@ from qubx.core.basics import STABLE_CURRENCIES, Balance, Deal, Instrument, Order
 # sessions. A re-delivered funding event only needs RECENT buckets to dedup against.
 _FUNDING_BUCKET_CAP: int = 4096
 
+# Snapshot balance-apply log level: a total move above this is real money (fill/funding/
+# transfer) and logs INFO; below it (incl. pure free/locked reshuffles) logs DEBUG.
+_BALANCE_LOG_ABS_TOL: float = 0.01
+
 
 @dataclass
 class VenueAccountFigures:
@@ -527,7 +531,11 @@ class AccountState:
         )
         if changed:
             old = "—" if existing is None else f"total={existing.total} free={existing.free} locked={existing.locked}"
-            logger.info(
+            # - free/locked reshuffle with total unchanged is margin mark-to-market noise
+            #   (every poll on a leveraged book); only a real total move is INFO-worthy
+            material = existing is None or abs(balance.total - existing.total) > _BALANCE_LOG_ABS_TOL
+            log = logger.info if material else logger.debug
+            log(
                 f"[{self.exchange}] reconcile: balance <y>{balance.currency}</y> from snapshot -> "
                 f"total=<g>{balance.total}</g> free={balance.free} locked={balance.locked} (was {old})"
             )

--- a/src/qubx/core/boot.py
+++ b/src/qubx/core/boot.py
@@ -44,6 +44,7 @@ class BootStateMachine:
     def advance(self, phase: BootPhase) -> None:
         if phase == self.phase:
             return
+        logger.info(f"<yellow>boot</yellow> :: {self.phase.name} -> <green>{phase.name}</green>")
         self.phase = phase
         self._gauge("boot.state", float(phase))
 

--- a/src/qubx/core/boot.py
+++ b/src/qubx/core/boot.py
@@ -1,0 +1,102 @@
+from enum import IntEnum
+
+from qubx import logger
+from qubx.core.basics import dt_64, td_64
+
+
+class BootPhase(IntEnum):
+    BLOCKED = -1
+    WAIT_READY = 0
+    ON_START = 1
+    RESOLVE = 2
+    RESTORE = 3
+    WARMUP_FINISHED = 4
+    BOOT_FIT = 5
+    TRADING = 6
+
+
+class BootStateMachine:
+    """Live-boot phase bookkeeping: current phase, boot-fit retry policy, health gauges.
+
+    Pure state — the ProcessingManager drives transitions and executes side effects
+    (see _advance_boot). BLOCKED is sticky for trading; a later successful fit releases
+    it (record_fit_success), a late account snapshot releases WAIT_READY (caller-side).
+    """
+
+    def __init__(self, health_monitor, *, fit_max_attempts: int = 3, fit_retry_delay: td_64 = td_64(60, "s")) -> None:
+        self.phase = BootPhase.WAIT_READY
+        self.blocked_reason: str | None = None
+        self.fit_attempts = 0
+        self._health = health_monitor
+        self._fit_max_attempts = fit_max_attempts
+        self._fit_retry_delay = fit_retry_delay
+        self._next_fit_attempt: dt_64 | None = None
+        self._sync_alerted = False
+
+    @property
+    def is_trading(self) -> bool:
+        return self.phase == BootPhase.TRADING
+
+    @property
+    def is_blocked(self) -> bool:
+        return self.phase == BootPhase.BLOCKED
+
+    def advance(self, phase: BootPhase) -> None:
+        if phase == self.phase:
+            return
+        self.phase = phase
+        self._gauge("boot.state", float(phase))
+
+    def account_sync_alert(self) -> None:
+        if self._sync_alerted:
+            return
+        self._sync_alerted = True
+        self._gauge("boot.account_sync_blocked", 1.0)
+        logger.warning("<yellow>Boot blocked: initial account snapshot not applied — holding until synced</yellow>")
+
+    def account_synced(self) -> None:
+        if not self._sync_alerted:
+            return
+        self._sync_alerted = False
+        self._gauge("boot.account_sync_blocked", 0.0)
+
+    def fit_attempt_allowed(self, now: dt_64) -> bool:
+        if self.phase != BootPhase.BOOT_FIT:
+            return False
+        return self._next_fit_attempt is None or now >= self._next_fit_attempt
+
+    def record_fit_attempt(self) -> None:
+        self.fit_attempts += 1
+        self._gauge("boot.fit_attempts", float(self.fit_attempts))
+
+    def record_fit_failure(self, now: dt_64) -> None:
+        if self.is_blocked:
+            return
+        if self.fit_attempts >= self._fit_max_attempts:
+            self.blocked_reason = "boot fit failed"
+            self.advance(BootPhase.BLOCKED)
+            self._gauge("boot.fit_failed", 1.0)
+            logger.error(
+                f"<red>Boot fit failed after {self.fit_attempts} attempts — trading blocked, "
+                "book unreconciled; a later successful fit will unblock</red>"
+            )
+        else:
+            self._next_fit_attempt = now + self._fit_retry_delay
+            logger.warning(
+                f"<yellow>Boot fit failed (attempt {self.fit_attempts}/{self._fit_max_attempts}) — retrying</yellow>"
+            )
+
+    def record_fit_success(self) -> None:
+        if self.is_blocked:
+            self._gauge("boot.fit_failed", 0.0)
+            self.blocked_reason = None
+        self.advance(BootPhase.TRADING)
+
+    def record_warmup_finished_failure(self) -> None:
+        self._gauge("boot.warmup_finished_failed", 1.0)
+
+    def _gauge(self, name: str, value: float) -> None:
+        try:
+            self._health.record_gauge(name, value)
+        except Exception:
+            logger.exception(f"failed to record {name} gauge")

--- a/src/qubx/core/fit_executor.py
+++ b/src/qubx/core/fit_executor.py
@@ -47,11 +47,14 @@ class FitCommitData:
     order (they run on the ProcessorThread, where the fit-thread interception no
     longer triggers, so each takes today's normal path). ``signals`` are the
     fit-emitted signals, drained into the normal pipeline in emission order.
+    ``error`` carries whatever made the fit fail (strategy raise or framework raise):
+    the ProcessorThread latches ``is_on_fit_called`` only when it is None.
     """
 
     ops: tuple[Callable[[], None], ...] = ()
     signals: tuple[Signal, ...] = ()
     duration_s: float = 0.0
+    error: BaseException | None = None
 
 
 class FitCycleState:

--- a/src/qubx/core/initializer.py
+++ b/src/qubx/core/initializer.py
@@ -34,6 +34,7 @@ class BasicStrategyInitializer(IStrategyInitializer):
     warmup_period: str | None = None
     start_time_finder: StartTimeFinderProtocol | None = None
     mismatch_resolver: StateResolverProtocol | None = None
+    _fit_on_start: bool = False
     auto_subscribe: bool | None = None
     simulation: bool | None = None
     subscription_warmup: dict[Any, str] | None = None
@@ -114,6 +115,12 @@ class BasicStrategyInitializer(IStrategyInitializer):
 
     def set_state_resolver(self, resolver: StateResolverProtocol) -> None:
         self.mismatch_resolver = resolver
+
+    def set_fit_on_start(self, enabled: bool = True) -> None:
+        self._fit_on_start = enabled
+
+    def get_fit_on_start(self) -> bool:
+        return self._fit_on_start
 
     def set_config(self, key: str, value: Any) -> None:
         self.config[key] = value

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -2284,6 +2284,22 @@ class IStrategyInitializer:
         """
         ...
 
+    def set_fit_on_start(self, enabled: bool = True) -> None:
+        """
+        Force the first on_fit to run in the live context even when a warmup-sim fit ran.
+
+        The warmup simulation fits against sim state; strategies that reconcile positions
+        through their tracker on fit (e.g. buffered trackers) need the first fit to run
+        live, against live positions. Opting in guarantees exactly one live fit after
+        on_warmup_finished and replaces calling ctx.trigger_fit() there (doing both
+        double-fits). No-op when no warmup sim runs — the first fit is live anyway.
+        """
+        ...
+
+    def get_fit_on_start(self) -> bool:
+        """Whether the first on_fit is forced to run in the live context (default False)."""
+        ...
+
     def set_config(self, key: str, value: Any) -> None:
         """
         Set an additional configuration value.

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -28,6 +28,7 @@ from qubx.core.basics import (
     dt_64,
     td_64,
 )
+from qubx.core.boot import BootPhase, BootStateMachine
 from qubx.core.connector import IConnector, IMarketDataSink
 from qubx.core.detectors import DelistingDetector, StaleDataDetector
 from qubx.core.errors import BaseErrorEvent
@@ -59,6 +60,7 @@ from qubx.core.interfaces import (
 )
 from qubx.core.loggers import StrategyLogging
 from qubx.core.series import Bar, OrderBook, Quote, Trade
+from qubx.restarts.state_resolvers import StateResolver
 from qubx.state.dummy import DummyStatePersistence
 from qubx.trackers.riskctrl import _InitializationStageTracker
 from qubx.utils.throttler import InstrumentThrottler
@@ -166,6 +168,7 @@ class ProcessingManager(IProcessingManager):
     _all_instruments_ready_logged: bool = False
     _account_sync_deadline: dt_64 | None = None  # - startup: bound the wait for the initial snapshot
     _account_sync_timeout_logged: bool = False
+    _boot: BootStateMachine
     _emitted_signals: list[Signal] = []  # signals that were emitted
     _active_targets: dict[Instrument, TargetPosition] = {}
     _pending_no_quote_signals: dict[Instrument, Signal] = {}  # signals waiting for quote to arrive
@@ -242,6 +245,7 @@ class ProcessingManager(IProcessingManager):
         self._account_sync_deadline = None
         self._account_sync_timeout_logged = False
         self._emitted_signals = []
+        self._boot = BootStateMachine(self._health_monitor)
 
         # - special tracker for post-warmup initialization signals
         self._init_stage_position_tracker = _InitializationStageTracker()
@@ -497,46 +501,12 @@ class ProcessingManager(IProcessingManager):
         return self._run_strategy_pipeline(event)
 
     def _run_strategy_pipeline(self, event: Any) -> bool:
-        """Warmup/fit checks, strategy callback firing and signal processing — the
+        """Boot advance, strategy callback firing and signal processing — the
         shared tail of the tuple data path (__process_data)."""
-        if not self._context._strategy_state.is_on_start_called:
-            self._handle_start()
-
-        if (
-            not self._context._strategy_state.is_on_warmup_finished_called
-            and not self._context._strategy_state.is_warmup_in_progress
-            and not self._warmup_finished_is_running
-        ):
-            if self._context.get_warmup_positions() or self._context.get_warmup_orders():
-                self._handle_state_resolution()
-
-            # Restore tracker and gatherer state if available
-            restored_state = self._context.get_restored_state()
-            if restored_state is not None:
-                self._restore_tracker_and_gatherer_state(restored_state)
-
-            self._handle_warmup_finished()
-
-        # - check if it still didn't call on_fit() for first time
-        if (
-            not self._context._strategy_state.is_on_fit_called
-            and not self._fit_is_running
-            and not self._warmup_finished_is_running
-        ):
-            self._handle_fit(None, "fit", (None, self._time_provider.time()))
+        if not self._advance_boot():
             return False
 
         if not event and not self._emitted_signals:
-            return False
-
-        # - if fit was not called - skip on_event call
-        if not self._context._strategy_state.is_on_fit_called or (
-            not self._is_simulation and not self._context._strategy_state.is_on_warmup_finished_called
-        ):
-            return False
-
-        # - warmup-finished still running (inline): skip on_event call
-        if self._warmup_finished_is_running:
             return False
 
         # - strategy still fitting: inline mode (and simulation) skips the strategy
@@ -1087,21 +1057,77 @@ class ProcessingManager(IProcessingManager):
         """It is used by simulation as a dummy to trigger actual time events."""
         pass
 
-    def _handle_start(self) -> None:
-        if not self._is_ready():
-            return
-        self._strategy.on_start(self._context)
-        self._context._strategy_state.is_on_start_called = True
+    def _advance_boot(self) -> bool:
+        """Drive the boot machine one pipeline pass. True ⇔ the strategy may trade.
+
+        Linearizes the old flag checks: WAIT_READY → ON_START → RESOLVE → RESTORE →
+        WARMUP_FINISHED → BOOT_FIT → TRADING. RESOLVE/RESTORE/WARMUP_FINISHED are
+        live-boot steps: skipped in simulation (RESOLVE) and while the warmup sim is
+        running this pipeline (is_warmup_in_progress). The boot-fit pass returns False
+        so no event is processed on it.
+        """
+        boot = self._boot
+        if boot.is_trading:
+            return True
+        if boot.is_blocked:
+            return False
+        state = self._context._strategy_state
+
+        if boot.phase == BootPhase.WAIT_READY:
+            if not self._is_ready():
+                return False
+            boot.advance(BootPhase.ON_START)
+
+        if boot.phase == BootPhase.ON_START:
+            if not state.is_on_start_called:
+                self._strategy.on_start(self._context)
+                state.is_on_start_called = True
+            boot.advance(BootPhase.RESOLVE)
+
+        if boot.phase == BootPhase.RESOLVE:
+            if not self._is_simulation and not state.is_on_warmup_finished_called:
+                self._handle_state_resolution()
+            boot.advance(BootPhase.RESTORE)
+
+        if boot.phase == BootPhase.RESTORE:
+            if not state.is_warmup_in_progress and not state.is_on_warmup_finished_called:
+                restored_state = self._context.get_restored_state()
+                if restored_state is not None:
+                    self._restore_tracker_and_gatherer_state(restored_state)
+            boot.advance(BootPhase.WARMUP_FINISHED)
+
+        if boot.phase == BootPhase.WARMUP_FINISHED:
+            if state.is_warmup_in_progress:
+                boot.advance(BootPhase.BOOT_FIT)  # warmup-sim ctx: the hook belongs to the live boot
+            else:
+                if not state.is_on_warmup_finished_called and not self._warmup_finished_is_running:
+                    self._handle_warmup_finished()
+                if not state.is_on_warmup_finished_called:
+                    return False
+                if not self._is_simulation and state.is_on_fit_called and self._context.initializer.get_fit_on_start():
+                    state.is_on_fit_called = False  # warmup fit doesn't count: force one live fit
+                boot.advance(BootPhase.BOOT_FIT)
+
+        if boot.phase == BootPhase.BOOT_FIT:
+            if state.is_on_fit_called:
+                boot.record_fit_success()
+                return True
+            if self._fit_is_running or self._warmup_finished_is_running:
+                return False
+            if boot.fit_attempt_allowed(self._time_provider.time()):
+                boot.record_fit_attempt()
+                self._handle_fit(None, "fit", (None, self._time_provider.time()))
+                if state.is_on_fit_called:
+                    boot.record_fit_success()
+            return False
+
+        return boot.is_trading
 
     def _handle_state_resolution(self) -> None:
-        if not self._is_ready():
-            return
-
         _ctx = self._context
         resolver = _ctx.initializer.get_state_resolver()
         if resolver is None:
-            logger.warning("No state resolver found, skipping state resolution")
-            return
+            resolver = StateResolver.REDUCE_ONLY
 
         self._log_state_mismatch()
 
@@ -1122,9 +1148,6 @@ class ProcessingManager(IProcessingManager):
         Args:
             restored_state: The restored state containing signals and target positions
         """
-        if not self._is_ready():
-            return
-
         # Restore tracker state from signals.
         # NB: unlike targets below, signals are NOT re-persisted on restart, so a run that
         # hasn't re-emitted yet restores no signals (state restore is run-scoped). Harmless
@@ -1159,8 +1182,6 @@ class ProcessingManager(IProcessingManager):
             self._logging.save_targets(latest_targets)
 
     def _handle_warmup_finished(self) -> None:
-        if not self._is_ready():
-            return
         # The flag reset lives in an outer finally so no raise (health monitor included)
         # can strand it True — a stranded flag silently disables the strategy forever.
         self._warmup_finished_is_running = True

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -1136,8 +1136,6 @@ class ProcessingManager(IProcessingManager):
                     raise
             return False
 
-        return boot.is_trading
-
     def _report_boot_fit(self, ok: bool) -> None:
         """Hand a fit outcome to the boot machine — only while it still owns the fit
         (BOOT_FIT) or waits for a self-heal (BLOCKED). A fit triggered mid-boot (handlers

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -698,7 +698,8 @@ class ProcessingManager(IProcessingManager):
                 self._time_provider.time(), signals, self._account_manager, _targets_from_trackers
             )
 
-    def __invoke_on_fit(self) -> None:
+    def __invoke_on_fit(self) -> bool:
+        """Run on_fit inline. True ⇔ it completed without raising."""
         with self._health_monitor("ctx.on_fit"):
             try:
                 # - enforce the blacklist before fitting: refresh the cache AND force-close
@@ -711,15 +712,21 @@ class ProcessingManager(IProcessingManager):
                 self._strategy.on_fit(self._context)
                 self._subscription_manager.commit()  # apply pending operations
                 logger.debug(f"[<y>{self.__class__.__name__}</y>] :: <g>{self._strategy_name}</g> is fitted")
+                self._context._strategy_state.is_on_fit_called = True
+                return True
             except Exception as strat_error:
                 logger.error(
                     f"[{self.__class__.__name__}] :: Strategy {self._strategy_name} on_fit raised an exception: {strat_error}"
                 )
                 logger.opt(colors=False).error(traceback.format_exc())
-            finally:
-                self._context._strategy_state.is_on_fit_called = True
+                # - simulation keeps the latch: no retry machinery there, and a raising fit
+                #   must not re-fire on every tick
+                if self._is_simulation:
+                    self._context._strategy_state.is_on_fit_called = True
+                return False
 
-    def __invoke_on_warmup_finished(self) -> None:
+    def __invoke_on_warmup_finished(self) -> bool:
+        """Run on_warmup_finished inline. True ⇔ it completed without raising."""
         with self._health_monitor("ctx.on_warmup_finished"):
             try:
                 logger.debug(
@@ -730,12 +737,15 @@ class ProcessingManager(IProcessingManager):
                 logger.debug(
                     f"[<y>{self.__class__.__name__}</y>] :: <g>{self._strategy_name}</g> warmup finished completed"
                 )
+                return True
             except Exception as strat_error:
                 logger.error(
                     f"[{self.__class__.__name__}] :: Strategy {self._strategy_name} on_warmup_finished raised an exception: {strat_error}"
                 )
                 logger.opt(colors=False).error(traceback.format_exc())
+                return False
             finally:
+                # - the hook is not guaranteed idempotent: latch it either way, no auto-retry
                 self._context._strategy_state.is_on_warmup_finished_called = True
 
     def __preprocess_and_log_target_positions(self, target_positions: list[TargetPosition]) -> list[TargetPosition]:
@@ -1111,13 +1121,29 @@ class ProcessingManager(IProcessingManager):
             if self._fit_is_running or self._warmup_finished_is_running:
                 return False
             if boot.fit_attempt_allowed(self._time_provider.time()):
+                # - _handle_fit no-ops when readiness lapsed (account desync): such a pass
+                #   must not consume an attempt, or three of them would block an unrun fit
+                if not self._is_ready():
+                    return False
                 boot.record_fit_attempt()
                 self._handle_fit(None, "fit", (None, self._time_provider.time()))
-                if state.is_on_fit_called:
-                    boot.record_fit_success()
             return False
 
         return boot.is_trading
+
+    def _report_boot_fit(self, ok: bool) -> None:
+        """Hand a fit outcome to the boot machine — only while it still owns the fit
+        (BOOT_FIT) or waits for a self-heal (BLOCKED). A fit triggered mid-boot (handlers
+        run ahead of the pipeline) would otherwise jump the machine straight to TRADING.
+        Failures are live-only: simulation latches instead of retrying.
+        """
+        boot = self._boot
+        if boot.phase != BootPhase.BOOT_FIT and not boot.is_blocked:
+            return
+        if ok:
+            boot.record_fit_success()
+        elif not self._is_simulation:
+            boot.record_fit_failure(self._time_provider.time())
 
     def _handle_state_resolution(self) -> None:
         _ctx = self._context
@@ -1184,7 +1210,8 @@ class ProcessingManager(IProcessingManager):
         try:
             # Runs inline on the processing thread (single-mutator invariant): account events
             # queue in the channel until the callback returns.
-            self.__invoke_on_warmup_finished()
+            if not self.__invoke_on_warmup_finished():
+                self._boot.record_warmup_finished_failure()
         finally:
             self._warmup_finished_is_running = False
 
@@ -1208,9 +1235,10 @@ class ProcessingManager(IProcessingManager):
             self._cache.finalize_ohlc_for_instruments(current_time, self._context.instruments)
             # Runs inline on the processing thread (single-mutator invariant): a long fit
             # blocks event processing until it returns.
-            self.__invoke_on_fit()
+            ok = self.__invoke_on_fit()
         finally:
             self._fit_is_running = False
+        self._report_boot_fit(ok)
 
     def _submit_threaded_fit(self, data: tuple[dt_64 | None, dt_64]) -> None:
         """Thread-mode fit (live only): submit the fit body to the single-thread
@@ -1253,6 +1281,7 @@ class ProcessingManager(IProcessingManager):
         _t_start = time.monotonic()
         _deadline_timer: threading.Timer | None = None
         fit_ctx: FitContext | None = None
+        _fit_error: BaseException | None = None
         try:
             # Everything from here — including proxy construction and the timer start
             # (Timer.start can raise "can't start new thread" under resource pressure) —
@@ -1274,10 +1303,16 @@ class ProcessingManager(IProcessingManager):
                     self._strategy.on_fit(fit_ctx)  # type: ignore[arg-type]
                     logger.debug(f"[<y>{self.__class__.__name__}</y>] :: <g>{self._strategy_name}</g> is fitted")
                 except Exception as strat_error:
+                    _fit_error = strat_error
                     logger.error(
                         f"[{self.__class__.__name__}] :: Strategy {self._strategy_name} on_fit raised an exception: {strat_error}"
                     )
                     logger.opt(colors=False).error(traceback.format_exc())
+        except BaseException as framework_error:
+            # - the body never ran (proxy/timer/health-monitor raise): report it as a
+            #   failed fit too, so nothing latches as fitted
+            _fit_error = framework_error
+            raise
         finally:
             if _deadline_timer is not None:
                 _deadline_timer.cancel()
@@ -1294,7 +1329,14 @@ class ProcessingManager(IProcessingManager):
             except Exception:
                 logger.exception("failed to record fit_duration_s gauge")
             _ops, _signals = self._fit_state.end()
-            channel.send((None, FIT_COMMIT_EVENT, FitCommitData(ops=_ops, signals=_signals, duration_s=_duration_s), False))
+            channel.send(
+                (
+                    None,
+                    FIT_COMMIT_EVENT,
+                    FitCommitData(ops=_ops, signals=_signals, duration_s=_duration_s, error=_fit_error),
+                    False,
+                )
+            )
 
     def _warn_fit_soft_deadline(self) -> None:
         logger.warning(
@@ -1312,8 +1354,9 @@ class ProcessingManager(IProcessingManager):
         by the subscription commit to its background worker, so the replay stays fast and
         the added instruments go live only after their history landed), commit any
         remaining deferred subscriptions, then — in a finally so no replay failure can
-        strand the flag — drain fit-emitted signals into the normal pipeline, set
-        is_on_fit_called and clear _fit_is_running. Returning None hands control to
+        strand the flag — drain fit-emitted signals into the normal pipeline, latch
+        is_on_fit_called (only when the fit itself did not fail) and clear
+        _fit_is_running. Returning None hands control to
         _run_strategy_pipeline, which processes the drained signals immediately.
         """
         try:
@@ -1331,8 +1374,10 @@ class ProcessingManager(IProcessingManager):
         finally:
             if commit.signals:
                 self._emitted_signals.extend(commit.signals)
-            self._context._strategy_state.is_on_fit_called = True
+            if commit.error is None:
+                self._context._strategy_state.is_on_fit_called = True
             self._fit_is_running = False
+            self._report_boot_fit(commit.error is None)
 
     def _handle_subscription_swap(self, instrument: Instrument | None, event_type: str, apply_swap: Callable) -> None:
         """Apply a deferred subscription commit's swap on the ProcessorThread. Posted by

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -1126,7 +1126,14 @@ class ProcessingManager(IProcessingManager):
                 if not self._is_ready():
                     return False
                 boot.record_fit_attempt()
-                self._handle_fit(None, "fit", (None, self._time_provider.time()))
+                try:
+                    self._handle_fit(None, "fit", (None, self._time_provider.time()))
+                except Exception:
+                    # - framework raise (cache finalize, health monitor, executor submit):
+                    #   stays loud, but the attempt must arm the retry deadline like any
+                    #   other failure instead of hot-looping on an unaccounted budget
+                    self._report_boot_fit(False)
+                    raise
             return False
 
         return boot.is_trading

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -167,7 +167,6 @@ class ProcessingManager(IProcessingManager):
     _last_data_ready_log_time: dt_64 | None = None
     _all_instruments_ready_logged: bool = False
     _account_sync_deadline: dt_64 | None = None  # - startup: bound the wait for the initial snapshot
-    _account_sync_timeout_logged: bool = False
     _boot: BootStateMachine
     _emitted_signals: list[Signal] = []  # signals that were emitted
     _active_targets: dict[Instrument, TargetPosition] = {}
@@ -243,7 +242,6 @@ class ProcessingManager(IProcessingManager):
         self._last_data_ready_log_time = None
         self._all_instruments_ready_logged = False
         self._account_sync_deadline = None
-        self._account_sync_timeout_logged = False
         self._emitted_signals = []
         self._boot = BootStateMachine(self._health_monitor)
 
@@ -891,27 +889,25 @@ class ProcessingManager(IProcessingManager):
         Gates on_start / on_fit / state-resolution / restore so those callbacks see REAL capital +
         venue positions instead of the pre-sync zero state (which would produce 0-capital sizing and
         transiently-flat restored positions). No account requirement in simulation (no venue snapshot).
-        Falls through after ACCOUNT_SYNC_TIMEOUT so a missing/failed snapshot never hangs the strategy
-        — mirrors the data-ready two-phase timeout; the reconciler heals state on the next snapshot.
+        Never falls through: trading against phantom-zero positions can double-open the book.
+        ACCOUNT_SYNC_TIMEOUT only arms an alert (once), the boot keeps holding until synced.
         """
         if not self._is_data_ready():
             return False
         # - simulation & paper have a locally-seeded account (no venue snapshot to wait for)
-        if self._context.is_simulation or self._context.is_paper_trading or self._account_manager.is_synced():
+        if self._context.is_simulation or self._context.is_paper_trading:
             return True
-        # - data ready but the initial venue snapshot hasn't applied yet: wait, bounded.
+        if self._account_manager.is_synced():
+            self._boot.account_synced()
+            return True
+        # - data ready but the initial venue snapshot hasn't applied: hold the boot.
+        #   ACCOUNT_SYNC_TIMEOUT is the alert threshold, not a fall-through — trading
+        #   against phantom-zero positions can double-open the book.
         now = self._time_provider.time()
         if self._account_sync_deadline is None:
             self._account_sync_deadline = now + self.ACCOUNT_SYNC_TIMEOUT
-            return False
-        if now >= self._account_sync_deadline:
-            if not self._account_sync_timeout_logged:
-                logger.warning(
-                    "Initial account snapshot not applied within timeout — starting without it; "
-                    "capital/positions may be incomplete until the next reconcile"
-                )
-                self._account_sync_timeout_logged = True
-            return True
+        elif now >= self._account_sync_deadline:
+            self._boot.account_sync_alert()
         return False
 
     def __update_base_data(

--- a/src/qubx/restarts/state_resolvers.py
+++ b/src/qubx/restarts/state_resolvers.py
@@ -20,6 +20,22 @@ def _no_warmup_output(
     return True
 
 
+def _cancel_all_orders(ctx: IStrategyContext) -> None:
+    orders = ctx.get_orders()
+    if not orders:
+        return
+    logger.info(f"Cancelling {len(orders)} live orders ...")
+    for order in orders.values():
+        try:
+            # - route by the id we actually hold: venue id when acked, else the client id
+            if order.venue_order_id:
+                ctx.cancel_order(order_id=order.venue_order_id)
+            else:
+                ctx.cancel_order(client_order_id=order.client_order_id)
+        except OrderNotFound:
+            logger.debug(f"Order {order.venue_order_id or order.client_order_id} already cancelled or doesn't exist")
+
+
 class StateResolver:
     """
     Collection of static methods for resolving position mismatches between
@@ -53,16 +69,7 @@ class StateResolver:
         The recommended partner of initializer.set_fit_on_start(True): let the first
         live fit reconcile positions through the strategy's own tracker.
         """
-        orders = ctx.get_orders()
-        if not orders:
-            return
-        logger.info(f"HOLD resolver: cancelling {len(orders)} live orders, keeping positions")
-        for order in orders.values():
-            oid = order.venue_order_id or order.client_order_id
-            try:
-                ctx.cancel_order(order_id=oid)
-            except OrderNotFound:
-                logger.debug(f"Order {oid} already cancelled or doesn't exist")
+        _cancel_all_orders(ctx)
 
     @staticmethod
     def REDUCE_ONLY(
@@ -136,15 +143,7 @@ class StateResolver:
             sim_active_targets (dict[Instrument, list[TargetPosition]]): Active targets from the simulation
         """
         # TODO: optimize with batch requests
-        orders = ctx.get_orders()
-        if orders:
-            logger.info(f"Cancelling {len(orders)} live orders ...")
-            for order in orders.values():
-                oid = order.venue_order_id or order.client_order_id
-                try:
-                    ctx.cancel_order(order_id=oid)
-                except OrderNotFound:
-                    logger.debug(f"Order {oid} already cancelled or doesn't exist")
+        _cancel_all_orders(ctx)
 
         # Get current live positions
         live_positions = ctx.get_positions()

--- a/src/qubx/restarts/state_resolvers.py
+++ b/src/qubx/restarts/state_resolvers.py
@@ -4,11 +4,29 @@ from qubx.core.exceptions import OrderNotFound
 from qubx.core.interfaces import IStrategyContext
 
 
+def _no_warmup_output(
+    sim_positions: dict[Instrument, Position],
+    sim_orders: dict[Instrument, list[Order]],
+    sim_active_targets: dict[Instrument, TargetPosition],
+) -> bool:
+    """All-empty sim args ⇔ no warmup sim ran (a sim that ran captures a Position per
+    instrument, flat included). Resolvers that steer toward sim state must hold then."""
+    if sim_positions or sim_orders or sim_active_targets:
+        return False
+    logger.warning(
+        "<yellow>State resolver received no warmup output — holding the live book as-is. "
+        "Register a custom resolver (or StateResolver.HOLD) to silence this.</yellow>"
+    )
+    return True
+
+
 class StateResolver:
     """
     Collection of static methods for resolving position mismatches between
     warmup simulation and live trading.
     These methods can be used with IStrategyInitializer.set_state_resolver().
+
+    sim_orders is unused by all stock resolvers; it remains in the signature for custom resolvers.
     """
 
     @staticmethod
@@ -22,6 +40,29 @@ class StateResolver:
         Do nothing.
         """
         pass
+
+    @staticmethod
+    def HOLD(
+        ctx: IStrategyContext,
+        sim_positions: dict[Instrument, Position],
+        sim_orders: dict[Instrument, list[Order]],
+        sim_active_targets: dict[Instrument, TargetPosition],
+    ) -> None:
+        """
+        Cancel all open live orders, keep all live positions untouched, emit nothing.
+        The recommended partner of initializer.set_fit_on_start(True): let the first
+        live fit reconcile positions through the strategy's own tracker.
+        """
+        orders = ctx.get_orders()
+        if not orders:
+            return
+        logger.info(f"HOLD resolver: cancelling {len(orders)} live orders, keeping positions")
+        for order in orders.values():
+            oid = order.venue_order_id or order.client_order_id
+            try:
+                ctx.cancel_order(order_id=oid)
+            except OrderNotFound:
+                logger.debug(f"Order {oid} already cancelled or doesn't exist")
 
     @staticmethod
     def REDUCE_ONLY(
@@ -38,6 +79,9 @@ class StateResolver:
             sim_positions (dict[Instrument, Position]): Positions from the simulation
             sim_orders (dict[Instrument, list[Order]]): Orders from the simulation
         """
+        if _no_warmup_output(sim_positions, sim_orders, sim_active_targets):
+            return
+
         # Get current live positions
         live_positions = ctx.get_positions()
 
@@ -127,16 +171,14 @@ class StateResolver:
             sim_orders (dict[Instrument, list[Order]]): Orders from the simulation
             sim_active_targets (dict[Instrument, list[TargetPosition]]): Active targets from the simulation
         """
+        if _no_warmup_output(sim_positions, sim_orders, sim_active_targets):
+            return
+
         # Get current live positions
         live_positions = ctx.get_positions()
 
         # - process last active targets from simulation and send them as initializing signals
         for instrument, a_tgt in sim_active_targets.items():
-            # - if there is no position in simulation,
-            #   but there is a target it means that position is still not open
-            #   so we need use limit order
-            use_limit_order = instrument in sim_positions and not sim_positions[instrument].is_open()
-
             s = InitializingSignal(
                 time=ctx.time(),
                 instrument=instrument,
@@ -144,7 +186,6 @@ class StateResolver:
                 price=a_tgt.price,
                 stop=a_tgt.stop,
                 take=a_tgt.take,
-                use_limit_order=use_limit_order,
             )
             ctx.emit_signal(s)
 
@@ -154,24 +195,3 @@ class StateResolver:
             if live_pos.is_open() and instrument not in sim_active_targets:
                 # - just close the position
                 ctx.emit_signal(InitializingSignal(time=ctx.time(), instrument=instrument, signal=0.0))
-
-        # for instrument, sim_pos in sim_positions.items():
-        #     live_qty = 0
-        #     if instrument in live_positions:
-        #         live_qty = live_positions[instrument].quantity
-
-        #     # Calculate the difference needed to match simulation position
-        #     qty_diff = sim_pos.quantity - live_qty
-
-        #     # Only trade if there's a difference
-        #     if abs(qty_diff) > instrument.lot_size:
-        #         logger.info(
-        #             f"Syncing position for {instrument.symbol}: {live_qty} -> {sim_pos.quantity} (diff: {qty_diff:.4f})"
-        #         )
-        #         ctx.trade(instrument, qty_diff)
-
-        # # Close positions that exist in live but not in simulation
-        # for instrument, live_pos in live_positions.items():
-        #     if instrument not in sim_positions and abs(live_pos.quantity) > instrument.lot_size:
-        #         logger.info(f"Closing position for {instrument.symbol} not in simulation: {live_pos.quantity} -> 0")
-        #         ctx.trade(instrument, -live_pos.quantity)

--- a/src/qubx/utils/runner/runner.py
+++ b/src/qubx/utils/runner/runner.py
@@ -53,7 +53,6 @@ from qubx.data.storages.stub import NoConfiguredStorage
 from qubx.health import BaseHealthMonitor
 from qubx.loggers import create_logs_writer
 from qubx.rate_limiting.manager import RateLimitManager
-from qubx.restarts.state_resolvers import StateResolver
 from qubx.restarts.time_finders import TimeFinder
 from qubx.restorers import create_state_restorer
 from qubx.utils.misc import class_import, green, install_uvloop, makedirs, red
@@ -1015,9 +1014,6 @@ def _run_warmup(
     # - find start time for warmup
     if (start_time_finder := initializer.get_start_time_finder()) is None:
         initializer.set_start_time_finder(start_time_finder := TimeFinder.LAST_SIGNAL)
-
-    if initializer.get_state_resolver() is None:
-        initializer.set_state_resolver(StateResolver.REDUCE_ONLY)
 
     current_time = ctx.time()
     warmup_start_time = current_time

--- a/tests/qubx/core/account_manager/state_diffs_test.py
+++ b/tests/qubx/core/account_manager/state_diffs_test.py
@@ -313,6 +313,19 @@ def test_position_margin_drift_emits_margin_mismatch():
     assert [type(d) for d in _differ().diff(local, origin)] == [PositionMarginMismatch]
 
 
+def test_position_margin_mark_noise_yields_no_diff():
+    # sub-0.5% mark-to-market drift re-marks maint margin every snapshot — not a diff
+    local = _state(positions=[_pos(maint_margin=100.0)])
+    origin = _snap(positions=[_pos(maint_margin=100.4)])
+    assert _differ().diff(local, origin) == []
+
+
+def test_position_margin_subcent_near_zero_yields_no_diff():
+    local = _state(positions=[_pos(maint_margin=0.002)])
+    origin = _snap(positions=[_pos(maint_margin=0.009)])
+    assert _differ().diff(local, origin) == []
+
+
 def test_position_multi_field_emits_one_atom_per_field():
     local = _state(positions=[_pos(quantity=1.5, maint_margin=100.0)])
     origin = _snap(positions=[_pos(quantity=1.2, maint_margin=120.0)])

--- a/tests/qubx/core/account_manager/state_test.py
+++ b/tests/qubx/core/account_manager/state_test.py
@@ -482,6 +482,31 @@ def test_snapshot_does_not_clobber_push_balance_ts():
     assert state.get_balance("USDT").last_update_time == T1  # push E preserved, not T2
 
 
+def test_snapshot_balance_free_locked_reshuffle_logs_debug_not_info():
+    # margin mark-to-market reshuffles free/locked every poll with total unchanged — that
+    # must not land at INFO; a real total move must
+    from qubx import logger
+
+    state = AccountState("binance", "USDT")
+    state.apply_balance_snapshot(Balance(exchange="binance", currency="USDT", total=100.0, free=100.0), T1)
+
+    records: list = []
+    sink_id = logger.add(lambda msg: records.append(msg.record), level="DEBUG")
+    try:
+        # reshuffle: total identical, free/locked move
+        state.apply_balance_snapshot(
+            Balance(exchange="binance", currency="USDT", total=100.0, free=80.0, locked=20.0), T2
+        )
+        # real move: total changes by more than a cent
+        state.apply_balance_snapshot(
+            Balance(exchange="binance", currency="USDT", total=105.0, free=85.0, locked=20.0), T2
+        )
+    finally:
+        logger.remove(sink_id)
+    levels = [r["level"].name for r in records if "reconcile: balance" in r["message"]]
+    assert levels == ["DEBUG", "INFO"]
+
+
 def test_snapshot_balance_no_push_uses_as_of_without_ratchet():
     state = AccountState("binance", "USDT")
     state.apply_balance_snapshot(Balance(exchange="binance", currency="USDT", total=50.0, free=50.0), T1)

--- a/tests/qubx/core/boot_test.py
+++ b/tests/qubx/core/boot_test.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, call
+
+import numpy as np
+
+from qubx.core.basics import td_64
+from qubx.core.boot import BootPhase, BootStateMachine
+
+T0 = np.datetime64("2025-01-01T00:00:00", "ns")
+SEC = td_64(1, "s")
+
+
+def make_machine(**kw) -> tuple[BootStateMachine, MagicMock]:
+    health = MagicMock()
+    return BootStateMachine(health, **kw), health
+
+
+def test_initial_phase_and_advance_emits_state_gauge():
+    m, health = make_machine()
+    assert m.phase == BootPhase.WAIT_READY
+    assert not m.is_trading and not m.is_blocked
+    m.advance(BootPhase.ON_START)
+    assert m.phase == BootPhase.ON_START
+    health.record_gauge.assert_called_with("boot.state", float(BootPhase.ON_START))
+
+
+def test_account_sync_alert_emits_once_and_clears():
+    m, health = make_machine()
+    m.account_sync_alert()
+    m.account_sync_alert()
+    assert health.record_gauge.call_args_list.count(call("boot.account_sync_blocked", 1.0)) == 1
+    m.account_synced()
+    health.record_gauge.assert_called_with("boot.account_sync_blocked", 0.0)
+    health.record_gauge.reset_mock()
+    m.account_synced()  # no alert pending -> no gauge
+    health.record_gauge.assert_not_called()
+
+
+def test_fit_retry_cadence_and_blocked_after_exhaustion():
+    m, health = make_machine(fit_max_attempts=3, fit_retry_delay=td_64(60, "s"))
+    m.advance(BootPhase.BOOT_FIT)
+
+    assert m.fit_attempt_allowed(T0)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0)
+    assert m.phase == BootPhase.BOOT_FIT
+    assert not m.fit_attempt_allowed(T0 + 59 * SEC)
+    assert m.fit_attempt_allowed(T0 + 60 * SEC)
+
+    m.record_fit_attempt()
+    m.record_fit_failure(T0 + 60 * SEC)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0 + 120 * SEC)
+
+    assert m.is_blocked
+    assert m.blocked_reason == "boot fit failed"
+    assert m.fit_attempts == 3
+    health.record_gauge.assert_any_call("boot.fit_failed", 1.0)
+    assert not m.fit_attempt_allowed(T0 + 300 * SEC)
+
+
+def test_fit_success_reaches_trading():
+    m, health = make_machine()
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    m.record_fit_success()
+    assert m.is_trading
+    health.record_gauge.assert_called_with("boot.state", float(BootPhase.TRADING))
+
+
+def test_blocked_self_heals_on_later_fit_success():
+    m, health = make_machine(fit_max_attempts=1)
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0)
+    assert m.is_blocked
+    m.record_fit_success()
+    assert m.is_trading
+    health.record_gauge.assert_any_call("boot.fit_failed", 0.0)
+
+
+def test_fit_failure_while_blocked_is_noop():
+    m, _ = make_machine(fit_max_attempts=1)
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    m.record_fit_failure(T0)
+    m.record_fit_failure(T0 + SEC)
+    assert m.is_blocked and m.fit_attempts == 1
+
+
+def test_warmup_finished_failure_gauge():
+    m, health = make_machine()
+    m.record_warmup_finished_failure()
+    health.record_gauge.assert_called_with("boot.warmup_finished_failed", 1.0)
+
+
+def test_fit_attempts_gauge_emitted():
+    m, health = make_machine()
+    m.advance(BootPhase.BOOT_FIT)
+    m.record_fit_attempt()
+    health.record_gauge.assert_any_call("boot.fit_attempts", 1.0)

--- a/tests/qubx/core/boot_test.py
+++ b/tests/qubx/core/boot_test.py
@@ -23,6 +23,24 @@ def test_initial_phase_and_advance_emits_state_gauge():
     health.record_gauge.assert_called_with("boot.state", float(BootPhase.ON_START))
 
 
+def test_advance_logs_each_transition_once():
+    from qubx import logger
+
+    lines: list[str] = []
+    sink_id = logger.add(lambda msg: lines.append(str(msg)), level="INFO")
+    try:
+        m, _ = make_machine()
+        m.advance(BootPhase.ON_START)
+        m.advance(BootPhase.ON_START)  # same phase: no log
+        m.advance(BootPhase.RESOLVE)
+    finally:
+        logger.remove(sink_id)
+    transitions = [ln for ln in lines if "boot" in ln and "->" in ln]
+    assert len(transitions) == 2
+    assert "WAIT_READY -> " in transitions[0] and "ON_START" in transitions[0]
+    assert "ON_START -> " in transitions[1] and "RESOLVE" in transitions[1]
+
+
 def test_account_sync_alert_emits_once_and_clears():
     m, health = make_machine()
     m.account_sync_alert()

--- a/tests/qubx/core/conftest.py
+++ b/tests/qubx/core/conftest.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+from qubx.core.boot import BootStateMachine
 from qubx.core.mixins.processing import ProcessingManager
 
 
@@ -15,6 +16,8 @@ def make_pm(**overrides) -> ProcessingManager:
     pm._account_manager = MagicMock()
     pm._context = MagicMock()
     pm._context.emitter = None
+    pm._context.initializer.get_fit_on_start.return_value = False  # a MagicMock would read as the knob being on
+    pm._boot = BootStateMachine(MagicMock())  # __new__ skips __init__, which builds it
     pm._position_gathering = MagicMock()
     pm._exporter = None
     pm._universe_manager = MagicMock()

--- a/tests/qubx/core/initializer_test.py
+++ b/tests/qubx/core/initializer_test.py
@@ -168,3 +168,13 @@ class TestBasicStrategyInitializer:
 
         # Get a non-existent config value without default
         assert initializer.get_config("non_existent") is None
+
+    def test_fit_on_start_defaults_false_and_toggles(self):
+        """Test the fit_on_start default and toggling."""
+        initializer = BasicStrategyInitializer()
+
+        assert initializer.get_fit_on_start() is False
+        initializer.set_fit_on_start(True)
+        assert initializer.get_fit_on_start() is True
+        initializer.set_fit_on_start(False)
+        assert initializer.get_fit_on_start() is False

--- a/tests/qubx/core/mixins/boot_pipeline_test.py
+++ b/tests/qubx/core/mixins/boot_pipeline_test.py
@@ -1,0 +1,185 @@
+"""Boot state machine driving the strategy pipeline: live boot ordering and simulation parity."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from qubx.core.basics import CtrlChannel, TriggerEvent
+from qubx.core.boot import BootPhase
+from qubx.core.interfaces import StrategyState
+from qubx.core.mixins.processing import ProcessingManager
+
+T0 = np.datetime64("2025-01-01T00:00:00", "ns")
+
+
+def make_pm(
+    *,
+    is_simulation: bool = False,
+    is_warmup_in_progress: bool = False,
+    is_on_fit_called: bool = False,
+    warmup_positions: dict | None = None,
+    restored_state=None,
+    resolver=None,
+    fit_on_start: bool = False,
+):
+    channel = CtrlChannel("test-databus")
+    context = MagicMock()
+    context.is_simulation = is_simulation
+    context.is_paper_trading = False
+    context.instruments = []
+    context._strategy_state = StrategyState(
+        is_on_init_called=True,
+        is_on_start_called=False,
+        is_on_warmup_finished_called=False,
+        is_on_fit_called=is_on_fit_called,
+        is_warmup_in_progress=is_warmup_in_progress,
+    )
+    context._data_providers = [MagicMock(channel=channel)]
+    context.emitter = None
+    context._market_data_provider = MagicMock()
+    context.get_warmup_positions.return_value = warmup_positions or {}
+    context.get_warmup_orders.return_value = {}
+    context.get_warmup_active_targets.return_value = {}
+    context.get_restored_state.return_value = restored_state
+    context.initializer.get_state_resolver.return_value = resolver
+    context.initializer.get_fit_on_start.return_value = fit_on_start
+
+    strategy = MagicMock()
+    strategy.__class__.__name__ = "TestStrategy"
+    strategy.on_fit.return_value = None
+    strategy.on_event.return_value = []
+    strategy.on_market_data.return_value = []
+
+    cache = MagicMock()
+    cache.default_timeframe = "1h"
+    market_data = MagicMock()
+    market_data.get_market_data_cache.return_value = cache
+
+    subscription_manager = MagicMock()
+    subscription_manager.get_base_subscription.return_value = "quote"
+    time_provider = MagicMock()
+    time_provider.time.return_value = T0
+    position_tracker = MagicMock()
+    position_tracker.process_signals.return_value = []
+    position_tracker.update.return_value = []
+    universe_manager = MagicMock()
+    universe_manager.is_trading_allowed.return_value = True
+    health_monitor = MagicMock()
+    health_monitor.return_value.__enter__ = MagicMock(return_value=None)
+    health_monitor.return_value.__exit__ = MagicMock(return_value=False)
+    account_manager = MagicMock()
+    account_manager.is_synced.return_value = True
+    account_manager.get_positions.return_value = {}
+    account_manager.get_orders.return_value = {}  # _log_state_mismatch iterates these
+
+    pm = ProcessingManager(
+        context=context,
+        strategy=strategy,
+        logging=MagicMock(),
+        market_data=market_data,
+        subscription_manager=subscription_manager,
+        time_provider=time_provider,
+        account_manager=account_manager,
+        connectors={},
+        position_tracker=position_tracker,
+        position_gathering=MagicMock(),
+        universe_manager=universe_manager,
+        scheduler=MagicMock(),
+        is_simulation=is_simulation,
+        health_monitor=health_monitor,
+        delisting_detector=MagicMock(),
+        fit_executor="inline",
+    )
+    pm._is_data_ready = lambda: True  # type: ignore[method-assign]
+    pm._init_stage_position_tracker = MagicMock()
+    pm._init_stage_position_tracker.process_signals.return_value = []
+    pm._init_stage_position_tracker.update.return_value = []
+    context._processing_manager = pm
+    return pm, context, strategy
+
+
+def drive(pm, passes: int = 1):
+    for _ in range(passes):
+        pm._run_strategy_pipeline(None)
+
+
+class TestLiveBoot:
+    def test_resolution_runs_without_warmup_output(self):
+        resolver = MagicMock()
+        resolver.__name__ = "custom"
+        pm, ctx, _ = make_pm(resolver=resolver)
+        drive(pm)
+        resolver.assert_called_once_with(ctx, {}, {}, {})
+
+    def test_default_resolver_installed_when_none_registered(self):
+        pm, ctx, _ = make_pm(resolver=None)
+        drive(pm)  # REDUCE_ONLY with empty args -> guard: must not read live positions
+        ctx.get_positions.assert_not_called()
+        assert pm._boot.phase in (BootPhase.BOOT_FIT, BootPhase.TRADING)
+
+    def test_resolution_receives_warmup_output(self):
+        resolver = MagicMock()
+        resolver.__name__ = "custom"
+        instr = MagicMock()
+        instr.symbol = "BTCUSDT"
+        pos = MagicMock()
+        pos.quantity = 1.0  # real float: _log_state_mismatch formats it with :.6f
+        wp = {instr: pos}
+        pm, ctx, _ = make_pm(resolver=resolver, warmup_positions=wp)
+        drive(pm)
+        resolver.assert_called_once_with(ctx, wp, {}, {})
+
+    def test_boot_sequence_reaches_trading_and_fit_pass_returns_false(self):
+        pm, ctx, strategy = make_pm()
+        assert pm._run_strategy_pipeline(None) is False  # boot pass fires on_start..fit
+        strategy.on_start.assert_called_once()
+        strategy.on_warmup_finished.assert_called_once()
+        strategy.on_fit.assert_called_once()
+        assert ctx._strategy_state.is_on_fit_called
+        assert pm._boot.is_trading
+
+    def test_no_event_is_processed_on_the_boot_fit_pass(self):
+        pm, _, strategy = make_pm()
+        event = TriggerEvent(time=T0, type="time", instrument=None, data=None)
+        pm._run_strategy_pipeline(event)
+        strategy.on_fit.assert_called_once()
+        strategy.on_event.assert_not_called()
+        pm._run_strategy_pipeline(event)
+        strategy.on_event.assert_called_once()
+
+    def test_warmup_fit_satisfies_boot_fit_when_knob_off(self):
+        pm, ctx, strategy = make_pm(is_on_fit_called=True)
+        drive(pm)
+        strategy.on_fit.assert_not_called()
+        assert pm._boot.is_trading
+
+    def test_restore_called_with_restored_state(self):
+        restored = MagicMock()
+        restored.instrument_to_signal_positions = {}
+        restored.instrument_to_target_positions = {}
+        pm, ctx, _ = make_pm(restored_state=restored)
+        drive(pm)
+        assert pm._boot.is_trading
+
+
+class TestSimulationParity:
+    def test_plain_simulation_boots_without_resolution(self):
+        resolver = MagicMock()
+        pm, ctx, strategy = make_pm(is_simulation=True, resolver=resolver)
+        drive(pm)
+        resolver.assert_not_called()
+        strategy.on_start.assert_called_once()
+        strategy.on_warmup_finished.assert_called_once()
+        strategy.on_fit.assert_called_once()
+        assert pm._boot.is_trading
+
+    def test_warmup_sim_context_skips_warmup_finished_and_restore(self):
+        restored = MagicMock()
+        pm, ctx, strategy = make_pm(is_simulation=True, is_warmup_in_progress=True, restored_state=restored)
+        drive(pm)
+        strategy.on_start.assert_called_once()
+        strategy.on_warmup_finished.assert_not_called()
+        strategy.on_fit.assert_called_once()
+        ctx.get_restored_state.assert_not_called()
+        assert pm._boot.is_trading
+        assert not ctx._strategy_state.is_on_warmup_finished_called

--- a/tests/qubx/core/mixins/boot_pipeline_test.py
+++ b/tests/qubx/core/mixins/boot_pipeline_test.py
@@ -154,11 +154,16 @@ class TestLiveBoot:
         assert pm._boot.is_trading
 
     def test_restore_called_with_restored_state(self):
+        instr, signal, target = MagicMock(), MagicMock(), MagicMock()
+        target.time = 1
         restored = MagicMock()
-        restored.instrument_to_signal_positions = {}
-        restored.instrument_to_target_positions = {}
+        restored.instrument_to_signal_positions = {instr: [signal]}
+        restored.instrument_to_target_positions = {instr: [target]}
         pm, ctx, _ = make_pm(restored_state=restored)
         drive(pm)
+        ctx.get_restored_state.assert_called()
+        pm._position_tracker.restore_position_from_signals.assert_called_once_with(ctx, [signal])
+        pm._position_gathering.restore_from_target_positions.assert_called_once_with(ctx, [target])
         assert pm._boot.is_trading
 
 

--- a/tests/qubx/core/mixins/boot_pipeline_test.py
+++ b/tests/qubx/core/mixins/boot_pipeline_test.py
@@ -244,3 +244,97 @@ class TestFitOnStart:
         drive(pm, passes=3)
         strategy.on_fit.assert_not_called()
         assert pm._boot.is_trading
+
+
+class TestBootFitFailure:
+    def test_failed_boot_fit_retries_then_blocks(self):
+        pm, ctx, strategy = make_pm()
+        strategy.on_fit.side_effect = RuntimeError("boom")
+        tp = pm._time_provider
+
+        drive(pm)  # attempt 1
+        assert not ctx._strategy_state.is_on_fit_called
+        assert pm._boot.phase == BootPhase.BOOT_FIT
+
+        drive(pm)  # before the retry deadline: no new attempt
+        assert strategy.on_fit.call_count == 1
+
+        tp.time.return_value = T0 + np.timedelta64(61, "s")
+        drive(pm)  # attempt 2
+        tp.time.return_value = T0 + np.timedelta64(122, "s")
+        drive(pm)  # attempt 3 -> exhausted
+        assert strategy.on_fit.call_count == 3
+        assert pm._boot.is_blocked
+        pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 1.0)
+
+        drive(pm)  # blocked: no on_event, no more attempts
+        assert strategy.on_fit.call_count == 3
+        strategy.on_event.assert_not_called()
+
+    def test_blocked_self_heals_on_later_successful_fit(self):
+        pm, ctx, strategy = make_pm()
+        strategy.on_fit.side_effect = RuntimeError("boom")
+        tp = pm._time_provider
+        drive(pm)
+        tp.time.return_value = T0 + np.timedelta64(61, "s")
+        drive(pm)
+        tp.time.return_value = T0 + np.timedelta64(122, "s")
+        drive(pm)
+        assert pm._boot.is_blocked
+
+        strategy.on_fit.side_effect = None  # a scheduled fit arrives via _handle_fit
+        pm._handle_fit(None, "fit", (None, tp.time.return_value))
+        assert ctx._strategy_state.is_on_fit_called
+        assert pm._boot.is_trading
+        pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 0.0)
+
+    def test_warmup_finished_failure_latches_and_gauges(self):
+        pm, ctx, strategy = make_pm()
+        strategy.on_warmup_finished.side_effect = RuntimeError("hook boom")
+        drive(pm, passes=2)
+        assert ctx._strategy_state.is_on_warmup_finished_called  # latched as before
+        pm._health_monitor.record_gauge.assert_any_call("boot.warmup_finished_failed", 1.0)
+        assert pm._boot.is_trading  # boot continued to the fit
+
+    def test_simulation_keeps_latch_on_failure(self):
+        pm, ctx, strategy = make_pm(is_simulation=True)
+        strategy.on_fit.side_effect = RuntimeError("boom")
+        drive(pm, passes=2)
+        assert ctx._strategy_state.is_on_fit_called  # sim: latch-in-finally preserved
+
+    def test_not_ready_boot_fit_pass_consumes_no_attempt(self):
+        # a pass that cannot fit (account went out of sync after the first attempt) must
+        # not burn attempts — otherwise three such no-ops would block a never-run fit
+        pm, ctx, strategy = make_pm()
+        strategy.on_fit.side_effect = RuntimeError("boom")
+        tp = pm._time_provider
+        drive(pm)
+        assert pm._boot.phase == BootPhase.BOOT_FIT
+        assert pm._boot.fit_attempts == 1
+
+        pm._account_manager.is_synced.return_value = False
+        for n in range(1, 5):
+            tp.time.return_value = T0 + np.timedelta64(61 * n, "s")
+            drive(pm)
+        assert strategy.on_fit.call_count == 1
+        assert pm._boot.fit_attempts == 1
+        assert not pm._boot.is_blocked
+
+        pm._account_manager.is_synced.return_value = True
+        strategy.on_fit.side_effect = None
+        drive(pm)
+        assert pm._boot.is_trading
+        assert strategy.on_fit.call_count == 2
+
+    def test_mid_boot_scheduled_fit_does_not_skip_the_boot_steps(self):
+        # a fit trigger dispatched before the machine owns the fit (handlers run ahead of
+        # the pipeline) must not report an outcome and jump the machine to TRADING
+        pm, ctx, strategy = make_pm()
+        pm._handle_fit(None, "fit", (None, T0))
+        assert pm._boot.phase == BootPhase.WAIT_READY
+        assert not pm._boot.is_trading
+
+        drive(pm)
+        strategy.on_start.assert_called_once()
+        strategy.on_warmup_finished.assert_called_once()
+        assert pm._boot.is_trading

--- a/tests/qubx/core/mixins/boot_pipeline_test.py
+++ b/tests/qubx/core/mixins/boot_pipeline_test.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 from qubx.core.basics import CtrlChannel, TriggerEvent
 from qubx.core.boot import BootPhase
@@ -267,7 +268,9 @@ class TestBootFitFailure:
         assert pm._boot.is_blocked
         pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 1.0)
 
-        drive(pm)  # blocked: no on_event, no more attempts
+        # blocked: a real event is dropped — no on_event, no more attempts
+        event = TriggerEvent(time=tp.time.return_value, type="time", instrument=None, data=None)
+        assert pm._run_strategy_pipeline(event) is False
         assert strategy.on_fit.call_count == 3
         strategy.on_event.assert_not_called()
 
@@ -282,11 +285,18 @@ class TestBootFitFailure:
         drive(pm)
         assert pm._boot.is_blocked
 
+        event = TriggerEvent(time=tp.time.return_value, type="time", instrument=None, data=None)
+        pm._run_strategy_pipeline(event)
+        strategy.on_event.assert_not_called()  # blocked: the event never reaches the strategy
+
         strategy.on_fit.side_effect = None  # a scheduled fit arrives via _handle_fit
         pm._handle_fit(None, "fit", (None, tp.time.return_value))
         assert ctx._strategy_state.is_on_fit_called
         assert pm._boot.is_trading
         pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 0.0)
+
+        pm._run_strategy_pipeline(event)  # released: the same event now flows through
+        strategy.on_event.assert_called_once()
 
     def test_warmup_finished_failure_latches_and_gauges(self):
         pm, ctx, strategy = make_pm()
@@ -325,6 +335,29 @@ class TestBootFitFailure:
         drive(pm)
         assert pm._boot.is_trading
         assert strategy.on_fit.call_count == 2
+
+    def test_framework_raise_on_the_boot_fit_pass_arms_the_retry_deadline(self):
+        # a raise before on_fit (cache finalize here) stays loud, but must still count as a
+        # failed attempt: otherwise the pass retries hot and poisons the retry budget
+        pm, ctx, strategy = make_pm()
+        tp = pm._time_provider
+        pm._cache.finalize_ohlc_for_instruments.side_effect = RuntimeError("cache boom")
+
+        with pytest.raises(RuntimeError, match="cache boom"):
+            drive(pm)
+        strategy.on_fit.assert_not_called()
+        assert pm._boot.fit_attempts == 1
+
+        drive(pm)  # deadline armed: no immediate re-attempt
+        assert pm._boot.fit_attempts == 1
+        strategy.on_fit.assert_not_called()
+
+        pm._cache.finalize_ohlc_for_instruments.side_effect = None
+        tp.time.return_value = T0 + np.timedelta64(61, "s")
+        drive(pm)
+        strategy.on_fit.assert_called_once()
+        assert pm._boot.fit_attempts == 2
+        assert pm._boot.is_trading
 
     def test_mid_boot_scheduled_fit_does_not_skip_the_boot_steps(self):
         # a fit trigger dispatched before the machine owns the fit (handlers run ahead of

--- a/tests/qubx/core/mixins/boot_pipeline_test.py
+++ b/tests/qubx/core/mixins/boot_pipeline_test.py
@@ -188,3 +188,32 @@ class TestSimulationParity:
         ctx.get_restored_state.assert_not_called()
         assert pm._boot.is_trading
         assert not ctx._strategy_state.is_on_warmup_finished_called
+
+
+class TestStrictAccountSyncGate:
+    def test_boot_holds_until_synced_and_alerts_after_timeout(self):
+        pm, ctx, strategy = make_pm()
+        pm._account_manager.is_synced.return_value = False
+        tp = pm._time_provider
+
+        drive(pm)  # arms the deadline
+        assert pm._boot.phase == BootPhase.WAIT_READY
+        strategy.on_start.assert_not_called()
+
+        tp.time.return_value = T0 + np.timedelta64(20, "s")  # past ACCOUNT_SYNC_TIMEOUT (15s)
+        drive(pm)
+        assert pm._boot.phase == BootPhase.WAIT_READY
+        strategy.on_start.assert_not_called()
+        pm._health_monitor.record_gauge.assert_any_call("boot.account_sync_blocked", 1.0)
+
+    def test_boot_proceeds_when_snapshot_lands_late(self):
+        pm, ctx, strategy = make_pm()
+        pm._account_manager.is_synced.return_value = False
+        tp = pm._time_provider
+        drive(pm)
+        tp.time.return_value = T0 + np.timedelta64(30, "s")
+        drive(pm)
+        pm._account_manager.is_synced.return_value = True
+        drive(pm)
+        strategy.on_start.assert_called_once()
+        pm._health_monitor.record_gauge.assert_any_call("boot.account_sync_blocked", 0.0)

--- a/tests/qubx/core/mixins/boot_pipeline_test.py
+++ b/tests/qubx/core/mixins/boot_pipeline_test.py
@@ -217,3 +217,30 @@ class TestStrictAccountSyncGate:
         drive(pm)
         strategy.on_start.assert_called_once()
         pm._health_monitor.record_gauge.assert_any_call("boot.account_sync_blocked", 0.0)
+
+
+class TestFitOnStart:
+    def test_knob_forces_exactly_one_live_fit_after_warmup(self):
+        pm, ctx, strategy = make_pm(is_on_fit_called=True, fit_on_start=True)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_called_once()
+        assert pm._boot.is_trading
+
+    def test_knob_off_no_live_fit_when_warmup_fit_ran(self):
+        pm, ctx, strategy = make_pm(is_on_fit_called=True, fit_on_start=False)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_not_called()
+        assert pm._boot.is_trading
+
+    def test_no_double_fit_when_warmup_ran_no_fit(self):
+        # LIGHTER case: flag unset after warmup; knob on must still yield exactly one fit
+        pm, ctx, strategy = make_pm(is_on_fit_called=False, fit_on_start=True)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_called_once()
+        assert pm._boot.is_trading
+
+    def test_knob_ignored_in_simulation(self):
+        pm, ctx, strategy = make_pm(is_simulation=True, is_on_fit_called=True, fit_on_start=True)
+        drive(pm, passes=3)
+        strategy.on_fit.assert_not_called()
+        assert pm._boot.is_trading

--- a/tests/qubx/core/mixins/fit_executor_test.py
+++ b/tests/qubx/core/mixins/fit_executor_test.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 from qubx.core.basics import CtrlChannel, DataType, FundingPayment, Instrument, ITimeProvider, Signal
+from qubx.core.boot import BootPhase
 from qubx.core.context import StrategyContext
 from qubx.core.exceptions import QueueTimeout
 from qubx.core.fit_context import FitContext, UnclassifiedFitContextAccess
@@ -264,6 +265,7 @@ class TestThreadedFitExecution:
 
     def test_exception_in_fit_still_posts_commit_and_clears_flags(self):
         pm, context, channel = make_thread_pm()
+        pm._boot.advance(BootPhase.TRADING)  # a scheduled re-fit, boot long done
         applied: list[str] = []
 
         def failing_fit(ctx):
@@ -274,7 +276,8 @@ class TestThreadedFitExecution:
         pm._handle_fit(None, "fit", (None, T0))
         drain_until_committed(pm, channel)
 
-        assert context._strategy_state.is_on_fit_called is True
+        # - live never latches a failed fit: the strategy stays unfitted, the next fit retries
+        assert context._strategy_state.is_on_fit_called is False
         assert pm._fit_is_running is False
         # - ops recorded before the raise are applied, mirroring inline semantics
         #   (mutations before an inline raise stay applied)
@@ -295,6 +298,72 @@ class TestThreadedFitExecution:
         drain_until_committed(pm, channel)
         time.sleep(0.05)  # give a mis-armed timer a chance to fire
         pm._warn_fit_soft_deadline.assert_not_called()
+
+
+class TestThreadedBootFitOutcome:
+    """The boot machine sees the threaded fit's outcome through the FitCommit."""
+
+    def test_threaded_fit_failure_does_not_latch_and_reports_boot_failure(self):
+        pm, context, channel = make_thread_pm()
+        pm._strategy.on_fit.side_effect = RuntimeError("thread boom")
+        pm._boot.advance(BootPhase.BOOT_FIT)
+        pm._boot.record_fit_attempt()
+
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+
+        assert not context._strategy_state.is_on_fit_called
+        assert pm._boot.phase == BootPhase.BOOT_FIT  # retry pending, not blocked (attempt 1/3)
+
+    def test_threaded_fit_success_latches_and_reaches_trading(self):
+        pm, context, channel = make_thread_pm()
+        pm._strategy.on_fit.side_effect = None
+        pm._boot.advance(BootPhase.BOOT_FIT)
+        pm._boot.record_fit_attempt()
+
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+
+        assert context._strategy_state.is_on_fit_called
+        assert pm._boot.is_trading
+
+    def test_threaded_boot_fit_blocks_when_attempts_exhausted(self):
+        pm, context, channel = make_thread_pm()
+        pm._strategy.on_fit.side_effect = RuntimeError("thread boom")
+        pm._boot.advance(BootPhase.BOOT_FIT)
+
+        for attempt in range(3):
+            pm._time_provider.time.return_value = T0 + np.timedelta64(61 * attempt, "s")
+            pm._boot.record_fit_attempt()
+            pm._handle_fit(None, "fit", (None, T0))
+            drain_until_committed(pm, channel)
+
+        assert pm._boot.is_blocked
+        assert not context._strategy_state.is_on_fit_called
+        pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 1.0)
+
+        # - self-heal: a later successful fit releases the block
+        pm._strategy.on_fit.side_effect = None
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+        assert pm._boot.is_trading
+        pm._health_monitor.record_gauge.assert_any_call("boot.fit_failed", 0.0)
+
+    def test_framework_failure_before_the_fit_body_does_not_latch(self, monkeypatch):
+        pm, context, channel = make_thread_pm()
+        monkeypatch.setattr(
+            "qubx.core.mixins.processing.FitContext",
+            MagicMock(side_effect=RuntimeError("boom at proxy construction")),
+        )
+        pm._boot.advance(BootPhase.BOOT_FIT)
+        pm._boot.record_fit_attempt()
+
+        pm._handle_fit(None, "fit", (None, T0))
+        drain_until_committed(pm, channel)
+
+        # - on_fit never ran: the strategy is not fitted and the boot fit is not done
+        assert not context._strategy_state.is_on_fit_called
+        assert pm._boot.phase == BootPhase.BOOT_FIT
 
 
 class TestDeferredMutationsAndSignals:

--- a/tests/qubx/core/mixins/fit_executor_test.py
+++ b/tests/qubx/core/mixins/fit_executor_test.py
@@ -65,6 +65,7 @@ def make_thread_pm(fit_executor: str = "thread", is_simulation: bool = False, **
     context._data_providers = [MagicMock(channel=channel)]
     context.emitter = None
     context._market_data_provider = MagicMock()  # FitContext snapshot reads
+    context.initializer.get_fit_on_start.return_value = False  # a MagicMock would read as the knob being on
 
     strategy = MagicMock()
     strategy.__class__.__name__ = "TestStrategy"

--- a/tests/qubx/restarts/test_state_resolvers.py
+++ b/tests/qubx/restarts/test_state_resolvers.py
@@ -467,9 +467,9 @@ class TestStateResolverCloseAll(TestStateResolverBase):
             assert signal.signal == 0.0  # All positions should be closed
 
     def test_close_all_with_unacked_order_reaches_connector_cancel(self):
-        """An order without a venue id (fire-and-forget, not acked yet) makes CLOSE_ALL pass
-        its cid as order_id; the TradingManager venue->cid fallback must still resolve it and
-        deliver the cancel to the connector."""
+        """An order without a venue id (fire-and-forget, not acked yet) makes CLOSE_ALL cancel
+        by client_order_id; the TradingManager must resolve it and deliver the cancel to the
+        connector."""
         btc = self._find_instrument("BINANCE.UM", "BTCUSDT")
         unacked = Order(
             client_order_id="qubx_BTCUSDT_1",
@@ -573,6 +573,15 @@ class TestStateResolverHold(TestStateResolverBase):
         self.ctx.get_orders.return_value = {"v-1": order}
         StateResolver.HOLD(self.ctx, {}, {}, {})
         self.ctx.cancel_order.assert_called_once_with(order_id="v-1")
+        self.ctx.emit_signal.assert_not_called()
+
+    def test_hold_unacked_order_cancelled_by_client_id(self):
+        order = MagicMock()
+        order.venue_order_id = None
+        order.client_order_id = "c-1"
+        self.ctx.get_orders.return_value = {"c-1": order}
+        StateResolver.HOLD(self.ctx, {}, {}, {})
+        self.ctx.cancel_order.assert_called_once_with(client_order_id="c-1")
         self.ctx.emit_signal.assert_not_called()
 
     def test_hold_no_orders_does_nothing(self):

--- a/tests/qubx/restarts/test_state_resolvers.py
+++ b/tests/qubx/restarts/test_state_resolvers.py
@@ -51,7 +51,7 @@ class TestStateResolverReduceOnly(TestStateResolverBase):
         StateResolver.REDUCE_ONLY(self.ctx, sim_positions, sim_orders, {})
 
         # Verify
-        self.ctx.get_positions.assert_called_once()
+        self.ctx.get_positions.assert_not_called()
         self.ctx.emit_signal.assert_not_called()
 
     def test_reduce_only_with_matching_positions(self):
@@ -228,8 +228,8 @@ class TestStateResolverSyncState(TestStateResolverBase):
         # Execute
         StateResolver.SYNC_STATE(self.ctx, sim_positions, sim_orders, {})
 
-        # Verify
-        self.ctx.get_positions.assert_called_once()
+        # Verify: all-empty sim args -> empty-warmup guard holds, no venue reads
+        self.ctx.get_positions.assert_not_called()
         self.ctx.emit_signal.assert_not_called()
 
     def test_sync_state_with_matching_positions(self):
@@ -539,3 +539,44 @@ class TestStateResolverCloseAll(TestStateResolverBase):
         assert isinstance(signal_call, InitializingSignal)
         assert signal_call.signal == 0.0  # Close position
         assert signal_call.instrument == eth_instrument
+
+
+class TestStateResolverEmptyGuards(TestStateResolverBase):
+    """All-empty sim args mean 'no warmup output' -> hold the live book, touch nothing."""
+
+    def test_reduce_only_all_empty_holds(self):
+        StateResolver.REDUCE_ONLY(self.ctx, {}, {}, {})
+        self.ctx.get_positions.assert_not_called()
+        self.ctx.emit_signal.assert_not_called()
+
+    def test_sync_state_all_empty_holds(self):
+        StateResolver.SYNC_STATE(self.ctx, {}, {}, {})
+        self.ctx.get_positions.assert_not_called()
+        self.ctx.emit_signal.assert_not_called()
+        self.ctx.cancel_orders.assert_not_called()
+
+    def test_close_all_ignores_empty_sim_args(self):
+        instr = self._find_instrument("BINANCE.UM", "BTCUSDT")
+        pos = MagicMock()
+        pos.quantity = 1.0
+        self.ctx.get_orders.return_value = {}
+        self.ctx.get_positions.return_value = {instr: pos}
+        StateResolver.CLOSE_ALL(self.ctx, {}, {}, {})
+        self.ctx.emit_signal.assert_called_once()
+
+
+class TestStateResolverHold(TestStateResolverBase):
+    def test_hold_cancels_orders_keeps_positions(self):
+        order = MagicMock()
+        order.venue_order_id = "v-1"
+        order.client_order_id = "c-1"
+        self.ctx.get_orders.return_value = {"v-1": order}
+        StateResolver.HOLD(self.ctx, {}, {}, {})
+        self.ctx.cancel_order.assert_called_once_with(order_id="v-1")
+        self.ctx.emit_signal.assert_not_called()
+
+    def test_hold_no_orders_does_nothing(self):
+        self.ctx.get_orders.return_value = {}
+        StateResolver.HOLD(self.ctx, {}, {}, {})
+        self.ctx.cancel_order.assert_not_called()
+        self.ctx.emit_signal.assert_not_called()


### PR DESCRIPTION
Makes live-strategy boot a first-class phase with explicit guarantees, replacing the flag-check block in `_run_strategy_pipeline` with a `BootStateMachine`-driven sequence:

```
WAIT_READY → ON_START → RESOLVE → RESTORE → WARMUP_FINISHED → BOOT_FIT → TRADING
                                                                  ↓ (retries exhausted)
                                                               BLOCKED (self-heals on a later successful fit)
```

Design spec: `docs/specs/2026-08-27-boot-phase-design.md` (in this PR) — includes the sequencing diagrams, the four-case `on_fit` table, and rationale. Implementation plan: `docs/specs/2026-08-27-boot-phase-impl.md`. Strategy-author docs: `docs/trading/boot-lifecycle.md`.

Closes #363. Documents the #388 asymmetry (`on_start` fires in the warmup context).

## What changed

- **State resolution runs at every live boot** (#363) — the `get_warmup_positions() or get_warmup_orders()` gate is gone. `REDUCE_ONLY`/`SYNC_STATE` gain an empty-output guard: all-empty sim args ⇔ no warmup output → hold the live book + loud warning, never flatten. Default resolver (`REDUCE_ONLY`) install moved from `_run_warmup` into `_handle_state_resolution` (works with warmup off). New `StateResolver.HOLD`: cancel stale orders, keep positions, emit nothing — the partner of `set_fit_on_start` for buffered/tracker-reconciling strategies. Dead `use_limit_order` computation dropped from `SYNC_STATE`.
- **`initializer.set_fit_on_start(True)`** — opt-in guarantee that the first `on_fit` runs in the live context against live positions (the warmup-sim fit no longer counts). Replaces the `ctx.trigger_fit()`-in-`on_warmup_finished` boilerplate and kills the double-fit on venues where the warmup sim runs no fit. No-op without warmup. Identical on first start and restart.
- **Strict account-sync gate** — boot actions never run against phantom-zero positions. The `ACCOUNT_SYNC_TIMEOUT` fall-through is removed; 15s is now the alert threshold (`boot.account_sync_blocked` gauge + warning), and boot holds until the snapshot applies, self-healing when it lands. Simulation/paper unchanged.
- **Boot-fit failure handling** — live fits latch `is_on_fit_called` only on success (simulation keeps latch-in-finally, backtest behavior unchanged). Boot fit failure → 3 attempts, 60s apart → `BLOCKED` (`boot.fit_failed` gauge, no `on_event` delivery) → self-heals on any later successful fit (scheduled or `trigger_fit`). Works in both fit executor modes (`FitCommitData` gains an `error` field for the threaded path). `on_warmup_finished` failure latches as before + `boot.warmup_finished_failed` gauge. Framework raises on the boot-fit pass count as failed attempts (deadline armed, no hot loop) and stay loud.
- **Boot health gauges** — `boot.state`, `boot.account_sync_blocked`, `boot.fit_attempts`, `boot.fit_failed`, `boot.warmup_finished_failed`.

## ⚠️ Behavior changes for existing bots (operator-facing)

1. **No-warmup bots now run boot resolution.** Default → hold + warning, no trading action. Bots with a registered custom resolver: it now actually fires at boot (previously silently skipped — this is the #363 fix; frab's profile).
2. **A failed boot fit now blocks trading** (bounded retry → `BLOCKED` + health event) instead of silently trading unfitted.
3. **An unsynced account now blocks boot** (+ health event) instead of proceeding after the 15s timeout with phantom-zero positions.

Nothing else changes for existing bots: scheduled (post-boot) fits, simulation, and paper behavior are unchanged (parity pinned by tests).

## Noteworthy implementation decisions (deviations from the spec's literal pseudocode, reviewed and accepted)

- Fit-outcome reporting to the boot machine is **phase-gated** (`BOOT_FIT`/`BLOCKED`), not `not is_trading` — the literal spec code would have let a mid-boot `trigger_fit`/scheduled fit jump the machine to TRADING and skip `on_start`/resolution/restore. Regression-pinned by `test_mid_boot_scheduled_fit_does_not_skip_the_boot_steps`.
- The threaded fit path records **framework** raises (not just strategy raises) into `FitCommitData.error`, so a fit whose body never ran can't latch as fitted; propagation unchanged.

## Testing

- Full unit suite: **2919 passed, 5 skipped, 0 failed**; zero simulation-parity breaks (backtester suites untouched and green).
- New: `tests/qubx/core/boot_test.py` (machine), `tests/qubx/core/mixins/boot_pipeline_test.py` (boot sequence, resolution wiring, sync gate, four-case `set_fit_on_start` contract, failure/BLOCKED/self-heal), threaded-path tests in `fit_executor_test.py`.
- `uv run mkdocs build --strict` clean; ruff clean on all touched files.

## Follow-ups (not in this PR)

- BLOCKED-release hygiene: the compound-improbable latched-flag-at-exhaustion corner, and a log line for resolver signals that queue through a block and execute at self-heal.
- Repo chores: `just test` hardcodes `-n auto` (OOM footgun on arc runners); `just style-check` is red on main baseline.

https://claude.ai/code/session_0165zZzjTJTURiqEPksotMni
