### PR TITLE
Execution hardening: whole-lot booking, precision-0 rounding, a portable rejection cause, and a pending marker that can end

### DIFF
--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -52,6 +52,7 @@ from qubx.core.basics import (
     OrderStatus,
     OrderType,
     Position,
+    RejectCause,
     dt_64,
     resolve_reduce_only,
 )
@@ -94,6 +95,7 @@ from .utils import (
     instrument_to_ccxt_symbol,
     normalize_margin_mode,
     prepare_ccxt_order_payload,
+    reject_cause_of,
 )
 
 # Venue-verdict exceptions: every one of these is the venue refusing the order,
@@ -380,6 +382,7 @@ class CcxtConnector(ChannelEmitter):
                 client_order_id=client_id,
                 reason=str(error),
                 code=type(error).__name__,
+                cause=reject_cause_of(error),
             )
         )
 
@@ -441,6 +444,7 @@ class CcxtConnector(ChannelEmitter):
         venue_order_id: str | None,
         reason: str | None = None,
         code: str | None = None,
+        cause: RejectCause = RejectCause.UNKNOWN,
     ) -> None:
         # Carry both ids: AM's reject handler resolves the order by cid first, then venue id,
         # so the order can revert out of PENDING_CANCEL regardless of which id the caller had.
@@ -451,6 +455,7 @@ class CcxtConnector(ChannelEmitter):
                 venue_order_id=venue_order_id,
                 reason=reason or f"venue rejected cancel for {venue_order_id or client_order_id}",
                 code=code,
+                cause=cause,
             )
         )
 
@@ -772,6 +777,7 @@ class CcxtConnector(ChannelEmitter):
                 venue_order_id=venue_order_id,
                 reason=str(error),
                 code=type(error).__name__,
+                cause=reject_cause_of(error),
             )
         )
 

--- a/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/exchange.py
@@ -731,7 +731,20 @@ class BinancePortfolioMargin(BinanceQVUSDM):
                     "defaultType": "swap",
                     "portfolioMargin": True,
                     "fetchMarkets": ["spot", "linear", "inverse"],
-                }
+                },
+                # ccxt's handle_errors reads the URL-scoped map BEFORE the global one, and its
+                # portfolioMargin group maps -2019 to OperationFailed — so a papi order refused
+                # for margin never reached BinanceQV's global "-2019": InsufficientFunds. It has
+                # to sit here, in the LAST describe of the chain: binanceusdm's own describe runs
+                # after BinanceQV's and would overwrite the group. Measured on BINANCE.PM: 105
+                # margin refusals arrived as OperationFailed and were logged as unexpected errors.
+                "exceptions": {
+                    "portfolioMargin": {
+                        "exact": {
+                            "-2019": InsufficientFunds,
+                        },
+                    },
+                },
             },
         )
 

--- a/src/qubx/connectors/ccxt/utils.py
+++ b/src/qubx/connectors/ccxt/utils.py
@@ -22,6 +22,7 @@ from qubx.core.basics import (
     OrderSide,
     OrderStatus,
     Position,
+    RejectCause,
     classify_origin,
     dt_64,
 )
@@ -56,6 +57,19 @@ _CCXT_STATUS_MAP: dict[str, OrderStatus] = {
     "cancelled": OrderStatus.CANCELED,
     "expired": OrderStatus.EXPIRED,
     "rejected": OrderStatus.REJECTED,
+}
+
+# - ccxt normalises every venue's error into its own exception classes, so the class name is
+#   already a portable vocabulary; this is the reading of it the framework acts on. Names, not
+#   classes, so a ccxt version that drops one does not break the import.
+_REJECT_CAUSE_BY_CCXT_ERROR: dict[str, RejectCause] = {
+    "InsufficientFunds": RejectCause.INSUFFICIENT_MARGIN,
+    "OrderNotFillable": RejectCause.NOT_FILLABLE,
+    "OrderImmediatelyFillable": RejectCause.NOT_FILLABLE,
+    "RateLimitExceeded": RejectCause.RATE_LIMITED,
+    "DDoSProtection": RejectCause.RATE_LIMITED,
+    "OrderNotFound": RejectCause.NOT_FOUND,
+    "InvalidOrder": RejectCause.TOO_SMALL,
 }
 
 
@@ -693,3 +707,10 @@ def ccxt_convert_timeframe_to_exchange_format(timeframe: str) -> str | None:
         _t = re.match(r"(\d+)(\w+)", timeframe)
         timeframe = f"{_t[1]}{_t[2][0].lower()}" if _t and len(_t.groups()) > 1 else timeframe
     return timeframe
+
+
+def reject_cause_of(error: Exception) -> RejectCause:
+    """
+    Classify a ccxt error for callers that cannot read venue codes. UNKNOWN when unmapped.
+    """
+    return _REJECT_CAUSE_BY_CCXT_ERROR.get(type(error).__name__, RejectCause.UNKNOWN)

--- a/src/qubx/core/account_manager/diffs.py
+++ b/src/qubx/core/account_manager/diffs.py
@@ -28,6 +28,12 @@ RTOL = 1e-9
 # under 1 cent is not a reconcilable difference. Absolute, because "1 cent" is absolute.
 BALANCE_ABS_TOL = 0.01
 
+# Maintenance margin is size x mark x fraction, and the venue's mark is not ours, so it differs on
+# almost every snapshot by an amount that carries no information. Measured over one live run: 175
+# diffs, median $0.000052, only one above a cent — and that one was a real position change.
+# Absolute, for the same reason balances are.
+MARGIN_ABS_TOL = 0.01
+
 
 # - Diff atoms ------------------------------------------------------------------ #
 @dataclass_transform(frozen_default=True, kw_only_default=True)
@@ -377,7 +383,7 @@ class Differ:
             if abs(lp.position_avg_price - sp.position_avg_price) > _peps(sp.instrument):
                 diffs.append(PositionAvgPriceMismatch(local=lp, origin=sp))
 
-            if not _close_rel(lp.maint_margin, sp.maint_margin):
+            if abs(lp.maint_margin - sp.maint_margin) > MARGIN_ABS_TOL:
                 diffs.append(PositionMarginMismatch(local=lp, origin=sp))
 
         for inst, lp in local_pos.items():

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -475,7 +475,7 @@ class Reconciler:
                         self._recover_order(state, snap_order, snap.as_of)
 
                     case OrderFieldMismatch(origin=snap_order):
-                        if (ev := self._reconcile_order(state, snap_order)) is not None:
+                        if (ev := self._reconcile_order(state, snap_order, now)) is not None:
                             actions.append(RouteEvent(ev))
 
                     # - size diff = missed deals
@@ -627,19 +627,37 @@ class Reconciler:
             )
         return state.get_position(instrument)
 
-    def _reconcile_order(self, state: AccountState, snap_order: Order) -> Action | None:
+    def _reconcile_order(self, state: AccountState, snap_order: Order, now: np.datetime64) -> Action | None:
         """Apply a snapshot order's status/filled to local state; return the fill event to route.
 
-        Snapshot is authoritative for the order's own state. Guards: skip if locally terminal or
-        not venue-newer; never wipe an in-flight pending marker (the venue resolves that race).
+        Snapshot is authoritative for the order's own state. Skipped when the order is locally
+        terminal, and while a pending marker is still inside the confirm window — see
+        _pending_expired. For anything else the snapshot has to be venue-newer.
         """
         local = state.get_active_order(snap_order.client_order_id)
-        if local is None or local.status.is_terminal or not self._venue_newer(snap_order, local):
+        if local is None or local.status.is_terminal:
             return None
-        if local.status.is_pending and not snap_order.status.is_terminal:
+        if local.status.is_pending:
+            # - a pending marker carries the local clock while the snapshot carries the venue's, so
+            #   _venue_newer cannot judge it: the confirm window decides instead
+            if not snap_order.status.is_terminal and not self._pending_expired(local, now):
+                return None
+        elif not self._venue_newer(snap_order, local):
             return None
         self._apply_order_snapshot(state, local, snap_order)
         return self._fill_event(local)
+
+    def _pending_expired(self, local: Order, now: np.datetime64) -> bool:
+        """
+        True once a pending marker has outlived the confirm window with the venue still holding the
+        order live — the cancel or update never reached it, so the snapshot has to win.
+
+        Inside the window the marker is defended: a snapshot fetched before the cancel landed shows
+        the order alive, and reverting then would undo a correct PENDING_CANCEL. Measured cancel
+        confirm on LIGHTER is 568 ms median, so the window is ~9x headroom. Both stamps are the
+        local clock — transition_order stamps a locally-driven transition with `now`.
+        """
+        return local.last_update_time is not None and (now - local.last_update_time) >= self._order_confirm_wait  # type: ignore
 
     @staticmethod
     def _venue_newer(snap: Order, local: Order) -> bool:

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -19,6 +19,7 @@ import numpy as np
 from qubx import area_logger
 from qubx.core.account_manager.diffs import (
     BalanceMismatch,
+    Diff,
     Differ,
     LocalOrderMissing,
     LocalPositionMissing,
@@ -433,8 +434,30 @@ class Reconciler:
         state.mark_snapshot_applied(snap.as_of)
         changed = changed_positions if changed_positions is not None else []
         actions: list[Action] = []
-        for difference in self._differ.diff(state, snap):
+        differences = self._differ.diff(state, snap)
+        # - a snapshot requested before a deal was booked cannot contain that deal, so letting it
+        #   write the position rewinds a real fill. The decision is per instrument, not per diff:
+        #   a size change always brings a margin change, and PositionFieldMismatch routes through
+        #   reconcile_position_from_snapshot, which is authoritative for size and avg-price too.
+        #   Measured LIGHTER 2026-08-28 (ENAUSDC 272.6 -> 181.8, 84ms after the deal booked) and
+        #   BINANCE.UM (TRXUSDT 146 -> 127 against a snapshot 1.58s stale); on ALGOUSDT the
+        #   executor sized its next clip off the rewound number and overshot by 16.9%.
+        stale_for = {
+            instr
+            for instr in {self._position_instrument(d) for d in differences}
+            if instr is not None
+            and (booked := state.get_position_deal_booked_at(instr)) is not None
+            and booked > snap.as_of
+        }
+        for instr in stale_for:
+            _log.info(
+                f"[{state.exchange}] reconcile: <y>{instr}</y> snapshot as_of={snap.as_of} predates a deal "
+                f"booked at {state.get_position_deal_booked_at(instr)} — keeping the local position"
+            )
+        for difference in differences:
             _log.debug(difference.describe())
+            if self._position_instrument(difference) in stale_for:
+                continue
             # - each atom is applied in isolation: a handler that raises (e.g. a venue/state
             #   surprise) must not sink the rest of the snapshot reconcile (balances/figures/
             #   other positions). Log and move on; the next snapshot re-derives the diff.
@@ -493,6 +516,18 @@ class Reconciler:
             )
 
         return actions + self._dispatch(SnapshotIn(snap), state, now)
+
+    @staticmethod
+    def _position_instrument(difference: Diff) -> Instrument | None:
+        """
+        The instrument a position diff is about, or None for the order and balance diffs.
+        """
+        match difference:
+            case PositionFieldMismatch(origin=pos):
+                return pos.instrument
+            case OriginalPositionMissing(position=pos) | LocalPositionMissing(position=pos):
+                return pos.instrument
+        return None
 
     @staticmethod
     def _recover_order(state: AccountState, snap_order: Order, as_of: np.datetime64) -> Order:

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -280,6 +280,7 @@ def _handle_rejected(state: AccountState, event: OrderRejectedEvent, now: np.dat
         return ApplyResult()
     order.rejected_reason = event.reason
     order.error_code = event.code
+    order.reject_cause = event.cause
     order = transition(state, order.client_order_id, OrderStatus.REJECTED, now, update_time=event.last_update_time)
     return ApplyResult(order=order, order_change=OrderChange.REJECTED)
 

--- a/src/qubx/core/account_manager/reducer.py
+++ b/src/qubx/core/account_manager/reducer.py
@@ -300,7 +300,7 @@ def _reconciled_past(state: AccountState, instrument: Instrument, deal: Deal) ->
     return watermark is not None and deal.time <= watermark
 
 
-def _book_deal(state: AccountState, instrument: Instrument, deal: Deal) -> Position:
+def _book_deal(state: AccountState, instrument: Instrument, deal: Deal, now: np.datetime64) -> Position:
     """Apply a deal's effect to the position and balances. Caller dedups first.
 
     Futures/swap: credits realized PnL and debits the fee to the settle-currency
@@ -314,6 +314,8 @@ def _book_deal(state: AccountState, instrument: Instrument, deal: Deal) -> Posit
     _before = pos.quantity
     realized_pnl, fee = pos.update_position_by_deal(deal, state.conversion_rate(instrument))
     logger.debug("deal {} amt={} {}->{} tid={}", instrument.symbol, deal.amount, _before, pos.quantity, deal.trade_id)
+    # - a position snapshot requested before this moment cannot contain this deal
+    state.mark_position_deal_booked(instrument, now)
     if instrument.is_futures():
         state.mark_cash_currency(instrument.settle)
         # TODO(account-mgmt): fee is folded into settle here (correct when
@@ -387,11 +389,13 @@ def _handle_fill(state: AccountState, event: OrderFilledEvent, now: np.datetime6
         if event.fill is not None
         else None
     )
-    position = _book_deal(state, order.instrument, deal) if deal is not None and order.instrument is not None else None
+    position = (
+        _book_deal(state, order.instrument, deal, now) if deal is not None and order.instrument is not None else None
+    )
     # Terminal fill-gap: book executions the venue counted but never delivered as deals so
     # position AND realized PnL converge now, not size-only at the next snapshot.
     if (gap := _reconcile_fill_gap(state, order, event, now)) is not None and order.instrument is not None:
-        position = _book_deal(state, order.instrument, gap)
+        position = _book_deal(state, order.instrument, gap, now)
         deal = deal or gap
     order = transition(state, order.client_order_id, OrderStatus.FILLED, now, update_time=event.last_update_time)
     return ApplyResult(order=order, order_change=OrderChange.FILLED, deal=deal, position=position)
@@ -410,7 +414,9 @@ def _handle_partial_fill(state: AccountState, event: OrderPartiallyFilledEvent, 
         if event.fill is not None
         else None
     )
-    position = _book_deal(state, order.instrument, deal) if deal is not None and order.instrument is not None else None
+    position = (
+        _book_deal(state, order.instrument, deal, now) if deal is not None and order.instrument is not None else None
+    )
     # a pending cancel/update is resolved by the venue separately — don't disturb its status
     pending = order.status.is_pending
     if pending:
@@ -460,7 +466,7 @@ def _handle_deal(state: AccountState, event: DealEvent, now: np.datetime64) -> A
         pos = state.ensure_position(order.instrument)
         pos.update_position_by_deal(deal, state.conversion_rate(order.instrument), realize_only=True)
         return ApplyResult(deal=deal, position=pos)
-    return ApplyResult(deal=deal, position=_book_deal(state, order.instrument, deal))
+    return ApplyResult(deal=deal, position=_book_deal(state, order.instrument, deal, now))
 
 
 def _handle_updated(state: AccountState, event: OrderUpdatedEvent, now: np.datetime64) -> ApplyResult:

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -65,6 +65,7 @@ class AccountState:
         "_applied_funding_buckets",
         "_balance_push_as_of",
         "_position_reconcile_as_of",
+        "_position_deal_booked_at",
     )
 
     def __init__(self, exchange: str, base_currency: str, *, terminal_history_size: int = 10_000):
@@ -113,6 +114,11 @@ class AccountState:
         # - watermark: snapshot reconciled the size up to this venue time; a deal at/under it is
         #   already in that size → reducer records but doesn't re-book it
         self._position_reconcile_as_of: dict[Instrument, np.datetime64] = {}
+        # - local clock of the most recent deal booked into the size, per instrument. A position
+        #   snapshot requested before it cannot contain that deal, so it must not overwrite the
+        #   size. Same domain as AccountSnapshot.as_of, which both connectors stamp before the
+        #   fetch (ccxt connector.py:1708, lighter connector.py:487).
+        self._position_deal_booked_at: dict[Instrument, np.datetime64] = {}
 
     def __repr__(self) -> str:
         return (
@@ -174,6 +180,12 @@ class AccountState:
 
     def get_balance_push_as_of(self, currency: str) -> np.datetime64 | None:
         return self._balance_push_as_of.get(currency)
+
+    def get_position_deal_booked_at(self, instrument: Instrument) -> np.datetime64 | None:
+        return self._position_deal_booked_at.get(instrument)
+
+    def mark_position_deal_booked(self, instrument: Instrument, at: np.datetime64) -> None:
+        self._position_deal_booked_at[instrument] = at
 
     def get_transition_counts(self) -> dict[str, int]:
         """Audit counter snapshot: status.value -> number of transitions into it."""
@@ -453,9 +465,7 @@ class AccountState:
                 f"[{self.exchange}] reconcile: position <y>{snapshot.instrument}</y> from snapshot -> "
                 f"size {existing.quantity}->{snapshot.quantity} avg {existing.position_avg_price}->{snapshot.position_avg_price}"
             )
-            existing.reconcile_size(
-                snapshot.quantity, snapshot.position_avg_price, timestamp=snapshot.last_update_time
-            )
+            existing.reconcile_size(snapshot.quantity, snapshot.position_avg_price, timestamp=snapshot.last_update_time)
 
         # external margins first, so the mark refresh below skips recalculating them
         if snapshot._maint_margin_external:

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -10,9 +10,10 @@ from typing import Any, Literal, TypeAlias
 import numpy as np
 import pandas as pd
 
+from qubx import logger
 from qubx.core.exceptions import QueueTimeout
 from qubx.core.series import Bar, OrderBook, Quote, Trade, time_as_nsec
-from qubx.core.utils import prec_ceil, prec_floor, time_delta_to_str, time_to_str
+from qubx.core.utils import add_in_lots, is_lot_multiple, prec_ceil, prec_floor, time_delta_to_str, time_to_str
 from qubx.utils.clock import start_clock_discipline, time_now
 from qubx.utils.misc import Stopwatch
 from qubx.utils.time import to_timedelta
@@ -1212,9 +1213,21 @@ class Position:
         *,
         realize_only: bool = False,
     ) -> tuple[float, float]:
+        # - both operands are lot multiples, so add in whole lots: 28.2 + (-28.1) is 282 + (-281)
+        #   ticks, exactly one tick. Flooring the float sum loses a lot whenever subtraction leaves
+        #   the result a few ulp short of the grid, which is how a position reached 0.0 locally
+        #   while the venue still held one lot.
+        lot = self.instrument.lot_size
+        if not is_lot_multiple(self.quantity, lot) or not is_lot_multiple(amount, lot):
+            # - stale instrument metadata or a connector fault. Reported, then booked to the
+            #   nearest lot: dropping the deal is the worse error.
+            logger.error(
+                f"[{self.instrument.symbol}] booking {self.quantity} + {amount} is not on the "
+                f"lot grid (lot_size {lot}) — rounding to the nearest lot"
+            )
         return self.update_position(
             timestamp,
-            self.instrument.round_size_down(self.quantity + amount),
+            add_in_lots(self.quantity, amount, lot),
             exec_price,
             fee_amount,
             conversion_rate=conversion_rate,

--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -790,6 +790,25 @@ def resolve_reduce_only(options: dict[str, Any]) -> bool | None:
     return None
 
 
+class RejectCause(StrEnum):
+    """
+    Why a venue refused an order, cancel or update, in terms a caller can act on.
+
+    ``OrderRejectedEvent.code`` keeps the venue's own value — a ccxt exception class, a Lighter
+    numeric code — which is what a log reader wants. This is the portable reading of it, so a
+    strategy can say "give up on repeated INSUFFICIENT_MARGIN, keep retrying NOT_FILLABLE"
+    without a per-venue lookup table. Anything a connector does not map stays UNKNOWN.
+    """
+
+    INSUFFICIENT_MARGIN = "INSUFFICIENT_MARGIN"
+    NOT_FILLABLE = "NOT_FILLABLE"  # - post-only that would have crossed
+    RATE_LIMITED = "RATE_LIMITED"
+    TOO_SMALL = "TOO_SMALL"  # - below min size / min notional
+    NOT_FOUND = "NOT_FOUND"  # - cancel/update of an order the venue does not have
+    SEQUENCE = "SEQUENCE"  # - venue-ordering refusal; the connector rewrites it
+    UNKNOWN = "UNKNOWN"
+
+
 class OrderChange(StrEnum):
     """What happened to an order, paired with it on ApplyResult. Covers the cases
     order.status can't express on its own: UPDATED (status unchanged), CANCEL_REJECTED/
@@ -871,6 +890,8 @@ class Order:
     # venue/connector error code accompanying a reject (e.g. the ccxt error class name);
     # None when the reject path carries no code (synthetic reconcile rejects).
     error_code: str | None = None
+    # the portable reading of that code; UNKNOWN when the connector does not map it
+    reject_cause: RejectCause = RejectCause.UNKNOWN
     reduce_only: bool = False
     post_only: bool = False
     # Defaults to FRAMEWORK (the common case); the snapshot/external materialization

--- a/src/qubx/core/events.py
+++ b/src/qubx/core/events.py
@@ -15,6 +15,7 @@ from qubx.core.basics import (
     OrderBook,
     Position,
     Quote,
+    RejectCause,
     Trade,
 )
 
@@ -71,6 +72,7 @@ class OrderAcceptedEvent(OrderEvent):
 class OrderRejectedEvent(OrderEvent):
     reason: str
     code: str | None = None
+    cause: RejectCause = RejectCause.UNKNOWN
 
 
 @msg
@@ -137,12 +139,14 @@ class OrderUpdatedEvent(OrderEvent):
 class OrderCancelRejectedEvent(OrderEvent):
     reason: str
     code: str | None = None
+    cause: RejectCause = RejectCause.UNKNOWN
 
 
 @msg
 class OrderUpdateRejectedEvent(OrderEvent):
     reason: str
     code: str | None = None
+    cause: RejectCause = RejectCause.UNKNOWN
 
 
 @msg

--- a/src/qubx/core/utils.pyx
+++ b/src/qubx/core/utils.pyx
@@ -112,3 +112,18 @@ cpdef double prec_floor(double a, int precision):
     cdef double scale = pow(10.0, precision)
     cdef double ticks = _snap_tick_noise(fabs(a) * scale)
     return copysign(floor(ticks) / scale, a)
+
+
+cpdef double add_in_lots(double quantity, double amount, double lot_size) noexcept:
+    """
+    Sum two lot multiples in whole lots, so a subtraction cannot land a few ulp off the grid.
+    """
+    return (round(quantity / lot_size) + round(amount / lot_size)) * lot_size
+
+
+cpdef bint is_lot_multiple(double quantity, double lot_size) noexcept:
+    """
+    True when quantity sits on the lot grid, within the float noise of one division.
+    """
+    cdef double raw = quantity / lot_size
+    return fabs(raw - round(raw)) <= 16.0 * DBL_EPSILON * fmax(1.0, fabs(raw))

--- a/src/qubx/core/utils.pyx
+++ b/src/qubx/core/utils.pyx
@@ -3,6 +3,8 @@ import numpy as np
 cimport numpy as np
 import pandas as pd
 import datetime
+from libc.float cimport DBL_EPSILON
+from libc.math cimport ceil, copysign, fabs, floor, fmax, pow, round
 
 NS = 1_000_000_000 
 
@@ -82,9 +84,31 @@ cpdef recognize_timeframe(timeframe):
     return tf
 
 
+cdef inline double _snap_tick_noise(double x) noexcept:
+    """
+    Snap x to the nearest integer when it is already within float noise of one. 0.29 * 100 is
+    28.999999999999996, which would otherwise floor to 28. The tolerance is relative because
+    float error scales with magnitude: 3.6e-15 at x=29, 3.7e-9 at x=2.9e7.
+    """
+    cdef double nearest = round(x)
+    cdef double tolerance = 16.0 * DBL_EPSILON * fmax(1.0, fabs(x))
+    if fabs(x - nearest) <= tolerance:
+        return nearest
+    return x
+
+
+# - previous implementation rounded the SCALED value to `precision` decimals before the floor.
+#   At precision 0 that window is half a lot, so prec_floor(3.7, 0) gave 4.0 and
+#   prec_ceil(3.4, 0) gave 3.0 — neither was a floor or a ceil any more.
+#   return np.sign(a) * np.true_divide(np.ceil(round(abs(a) * 10**precision, precision)), 10**precision)
+#   return np.sign(a) * np.true_divide(np.floor(round(abs(a) * 10**precision, precision)), 10**precision)
 cpdef double prec_ceil(double a, int precision):
-    return np.sign(a) * np.true_divide(np.ceil(round(abs(a) * 10**precision, precision)), 10**precision)
+    cdef double scale = pow(10.0, precision)
+    cdef double ticks = _snap_tick_noise(fabs(a) * scale)
+    return copysign(ceil(ticks) / scale, a)
 
 
 cpdef double prec_floor(double a, int precision):
-    return np.sign(a) * np.true_divide(np.floor(round(abs(a) * 10**precision, precision)), 10**precision)
+    cdef double scale = pow(10.0, precision)
+    cdef double ticks = _snap_tick_noise(fabs(a) * scale)
+    return copysign(floor(ticks) / scale, a)

--- a/src/qubx/utils/runner/textual/app.py
+++ b/src/qubx/utils/runner/textual/app.py
@@ -287,12 +287,14 @@ class TextualStrategyApp(App[None]):
                 with Vertical(id="tables-container", classes="tables-column"):
                     # Positions panel
                     self.positions_panel = Vertical(id="positions-panel", classes="side-panel")
+                    self.positions_panel.border_title = "Positions"
                     with self.positions_panel:
                         self.positions_table = PositionsTable(id="positions-table")
                         self.positions_table.setup_columns()
                         yield self.positions_table
                     # Orders panel
                     self.orders_panel = Vertical(id="orders-panel", classes="side-panel")
+                    self.orders_panel.border_title = "Orders"
                     with self.orders_panel:
                         self.orders_table = OrdersTable(id="orders-table")
                         self.orders_table.setup_columns()

--- a/src/qubx/utils/runner/textual/widgets/orders_table.py
+++ b/src/qubx/utils/runner/textual/widgets/orders_table.py
@@ -109,6 +109,14 @@ class OrdersTable(DataTable):
             except Exception as e:
                 logger.warning(f"Failed to add order row {order_id}: {e}")
 
+        self._retitle(len(new_orders))
+
+    def _retitle(self, active_orders: int) -> None:
+        # - the border lives on the containing panel, so the count goes there
+        panel = self.parent
+        if panel is not None:
+            panel.border_title = f"Orders ({active_orders})"
+
     def _get_price_precision(self, row: dict) -> int:
         """Get price precision for formatting (default to 2 decimals)."""
         # Could be enhanced to use instrument precision if available

--- a/src/qubx/utils/runner/textual/widgets/positions_table.py
+++ b/src/qubx/utils/runner/textual/widgets/positions_table.py
@@ -142,6 +142,13 @@ class PositionsTable(DataTable):
                 logger.warning(f"Failed to add position row {pos_key}: {e}")
 
         self._sort()
+        self._retitle(sum(1 for r in sanitized_rows if r.get("qty")))
+
+    def _retitle(self, open_positions: int) -> None:
+        # - the border lives on the containing panel, so the count goes there
+        panel = self.parent
+        if panel is not None:
+            panel.border_title = f"Positions ({open_positions})"
 
     def _get_side(self, r: dict) -> str:
         leverage = r.get("leverage", 0.0)

--- a/tests/qubx/core/account_manager/reconciler_test.py
+++ b/tests/qubx/core/account_manager/reconciler_test.py
@@ -374,13 +374,69 @@ def test_snapshot_still_adopts_a_genuinely_higher_filled():
     assert o.filled_quantity == 0.6  # type: ignore
 
 
-def test_snapshot_does_not_wipe_pending_cancel_marker():
+def test_snapshot_does_not_wipe_a_fresh_pending_cancel_marker():
     D_ON()
-    # our cancel is in flight (PENDING_CANCEL). A snapshot poll still showing the order live
-    # (non-terminal) must NOT wipe the pending marker — the venue resolves the race itself.
-    rec = _reconciler()
-    st = _local(_order("order1", status=OrderStatus.PENDING_CANCEL))
+    # our cancel is in flight (PENDING_CANCEL) and was armed a moment ago. A snapshot poll still
+    # showing the order live was fetched before the cancel landed, so it must NOT wipe the marker.
+    rec = _reconciler()  # order_confirm_wait = 2s
+    st = _local(_order("order1", status=OrderStatus.PENDING_CANCEL, last_update_time=_passed_seconds(T0, 4)))
     a = rec.on_snapshot(
+        st,
+        _origin(
+            as_of=_passed_seconds(T0, 5),
+            open_orders=[_order("order1", status=OrderStatus.ACCEPTED, last_update_time=_passed_seconds(T0, 5))],
+        ),
+        _passed_seconds(T0, 5),  # marker is 1s old — inside the window
+    )
+    assert a == []  # nothing reconciled / routed
+    assert st.get_order("order1").status == OrderStatus.PENDING_CANCEL  # type: ignore # marker preserved
+    D_OFF()
+
+
+def test_a_pending_cancel_past_the_confirm_window_yields_to_the_venue():
+    D_ON()
+    # the cancel never reached the venue (measured on LIGHTER: both writes refused for nonce, the
+    # sender gave up). The order sat PENDING_CANCEL locally and ACCEPTED at the venue for minutes,
+    # every snapshot logging the mismatch and doing nothing. Past the window the venue wins, which
+    # is what a delivered cancel-reject would have done — and OrderManager.sync then re-cancels.
+    rec = _reconciler()  # order_confirm_wait = 2s
+    st = _local(_order("order1", status=OrderStatus.PENDING_CANCEL))  # marker stamped at SETTLED
+    rec.on_snapshot(
+        st,
+        _origin(
+            as_of=_passed_seconds(T0, 5),
+            open_orders=[_order("order1", status=OrderStatus.ACCEPTED, last_update_time=_passed_seconds(T0, 4))],
+        ),
+        _passed_seconds(T0, 5),  # marker is 35s old — past the window
+    )
+    assert st.get_order("order1").status == OrderStatus.ACCEPTED  # type: ignore
+    D_OFF()
+
+
+def test_a_pending_marker_stamped_after_the_venue_still_yields_past_the_window():
+    D_ON()
+    # measured on LIGHTER: the cancel was armed at 14:25:25 on the local clock, while the order's
+    # venue updated_at was still the 14:25:10 amend. Comparing the two made the snapshot look older
+    # than the marker, so the order never left PENDING_CANCEL and LOE stalled on it for minutes.
+    rec = _reconciler()  # order_confirm_wait = 2s
+    st = _local(_order("order1", status=OrderStatus.PENDING_CANCEL, last_update_time=_passed_seconds(T0, 4)))
+    rec.on_snapshot(
+        st,
+        _origin(
+            as_of=_passed_seconds(T0, 40),
+            open_orders=[_order("order1", status=OrderStatus.ACCEPTED, last_update_time=SETTLED)],
+        ),
+        _passed_seconds(T0, 40),  # marker is 36s old — past the window
+    )
+    assert st.get_order("order1").status == OrderStatus.ACCEPTED  # type: ignore
+    D_OFF()
+
+
+def test_a_pending_update_past_the_window_yields_the_same_way():
+    D_ON()
+    rec = _reconciler()
+    st = _local(_order("order1", status=OrderStatus.PENDING_UPDATE))  # stamped at SETTLED
+    rec.on_snapshot(
         st,
         _origin(
             as_of=_passed_seconds(T0, 5),
@@ -388,8 +444,23 @@ def test_snapshot_does_not_wipe_pending_cancel_marker():
         ),
         _passed_seconds(T0, 5),
     )
-    assert a == []  # nothing reconciled / routed
-    assert st.get_order("order1").status == OrderStatus.PENDING_CANCEL  # type: ignore # marker preserved
+    assert st.get_order("order1").status == OrderStatus.ACCEPTED  # type: ignore
+    D_OFF()
+
+
+def test_a_locally_terminal_order_is_never_reopened_by_a_snapshot():
+    D_ON()
+    rec = _reconciler()
+    st = _local(_order("order1", status=OrderStatus.CANCELED))
+    rec.on_snapshot(
+        st,
+        _origin(
+            as_of=_passed_seconds(T0, 5),
+            open_orders=[_order("order1", status=OrderStatus.ACCEPTED, last_update_time=_passed_seconds(T0, 4))],
+        ),
+        _passed_seconds(T0, 5),
+    )
+    assert st.get_order("order1").status == OrderStatus.CANCELED  # type: ignore
     D_OFF()
 
 

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -43,6 +43,8 @@ from qubx.core.events import (
 )
 from qubx.core.lookups import lookup
 
+_BOOKED_AT = np.datetime64("2026-08-28T00:00:00", "ns")
+
 T0 = np.datetime64("2026-05-28T00:00:00", "ns")
 T1 = np.datetime64("2026-05-28T00:01:00", "ns")
 
@@ -814,8 +816,8 @@ USDC_PERP = Instrument(
 def test_futures_deal_marks_settle_currency_as_cash():
     # Round trip on a USDC-settled perp inside a USDT-based state: buy 1 @ 100, sell 1 @ 110.
     state = AccountState("hyperliquid", "USDT")
-    reducer._book_deal(state, USDC_PERP, _fill(amount=1.0, price=100.0))
-    reducer._book_deal(state, USDC_PERP, _fill(trade_id="t2", amount=-1.0, price=110.0))
+    reducer._book_deal(state, USDC_PERP, _fill(amount=1.0, price=100.0), _BOOKED_AT)
+    reducer._book_deal(state, USDC_PERP, _fill(trade_id="t2", amount=-1.0, price=110.0), _BOOKED_AT)
 
     assert state.conversion_rate_to_base("USDC") == 1.0
     assert state.get_balance("USDC").total == pytest.approx(10.0)
@@ -840,8 +842,8 @@ BTC_PERP = Instrument(
 def test_btc_settled_deal_does_not_become_cash():
     # BINANCE.UM:ETHBTC is BTC-settled; 0.01 BTC of realized PnL is not 0.01 of capital.
     state = AccountState("binance.um", "USDT")
-    reducer._book_deal(state, BTC_PERP, _fill(amount=1.0, price=0.05))
-    reducer._book_deal(state, BTC_PERP, _fill(trade_id="t2", amount=-1.0, price=0.06))
+    reducer._book_deal(state, BTC_PERP, _fill(amount=1.0, price=0.05), _BOOKED_AT)
+    reducer._book_deal(state, BTC_PERP, _fill(trade_id="t2", amount=-1.0, price=0.06), _BOOKED_AT)
 
     assert state.conversion_rate_to_base("BTC") is None
     assert state.get_balance("BTC").total == pytest.approx(0.01)

--- a/tests/qubx/core/test_account_manager_position.py
+++ b/tests/qubx/core/test_account_manager_position.py
@@ -12,6 +12,8 @@ from qubx.core.basics import (
 )
 from qubx.core.events import FundingPaymentEvent
 
+_BOOKED_AT = np.datetime64("2026-08-28T00:00:00", "ns")
+
 
 class _T:
     def __init__(self, t="2026-05-28T00:00:00"):
@@ -131,13 +133,13 @@ def test_futures_realized_pnl_folds_into_total_capital():
     state.update_balance("USDT", Balance(exchange="binance", currency="USDT", total=100_000.0, free=100_000.0))
 
     # open long 1.0 @ 50k
-    reducer._book_deal(state, inst, _fill(trade_id="t1", amount=1.0, price=50_000.0))
+    reducer._book_deal(state, inst, _fill(trade_id="t1", amount=1.0, price=50_000.0), _BOOKED_AT)
     # opening a futures position does not touch cash
     assert state.get_balance("USDT").total == 100_000.0
     assert am.get_total_capital("binance") == 100_000.0
 
     # close 1.0 @ 60k -> realized +10k
-    reducer._book_deal(state, inst, _fill(trade_id="t2", amount=-1.0, price=60_000.0))
+    reducer._book_deal(state, inst, _fill(trade_id="t2", amount=-1.0, price=60_000.0), _BOOKED_AT)
     bal = state.get_balance("USDT")
     assert abs(bal.total - 110_000.0) < 1e-6
     assert abs(bal.free - 110_000.0) < 1e-6
@@ -153,7 +155,7 @@ def test_spot_fill_credits_base_and_debits_quote():
     state.update_balance("USDT", Balance(exchange="binance", currency="USDT", total=100_000.0, free=100_000.0))
 
     deal = _fill(trade_id="t1", amount=0.5, price=100_000.0)
-    reducer._book_deal(state, inst, deal)
+    reducer._book_deal(state, inst, deal, _BOOKED_AT)
     # mark the position so its market value contributes to total capital
     state.get_position(inst).update_market_price(am._time.time(), 100_000.0, 1.0)
 

--- a/tests/qubx/core/test_account_manager_snapshot.py
+++ b/tests/qubx/core/test_account_manager_snapshot.py
@@ -367,11 +367,8 @@ def test_snapshot_terminalization_runs_full_transition_machinery():
     assert state.get_order("cid-1") is not None  # findable in the terminal-history ring
 
 
-def test_snapshot_does_not_wipe_pending_marker_with_live_status():
-    # The snapshot is a poll of venue state; an outstanding cancel may still be in flight.
-    # A live venue status (ACCEPTED) must NOT clear PENDING_CANCEL — the venue resolves
-    # the race itself (canceled, or cancel-rejected which reverts via pre_pending).
-    am = _am()
+def _pending_marker_case(am):
+    """Arm a cancel on cid-1, then poll a snapshot an hour later that still shows it live."""
     state = am._states["binance"]
     inst = _instrument()
     state.add_order(_order("cid-1", OrderStatus.ACCEPTED, "2026-05-28T00:00:00", vid="V1", instrument=inst))
@@ -380,11 +377,33 @@ def test_snapshot_does_not_wipe_pending_marker_with_live_status():
     snap_order.filled_quantity = 0.3
     am._time.t = np.datetime64("2026-05-28T01:00:00")
     am.apply(_snap_event(as_of="2026-05-28T01:00:00", open_orders=[snap_order]))
+    return state
+
+
+def test_snapshot_does_not_wipe_pending_marker_with_live_status():
+    # The snapshot is a poll of venue state; an outstanding cancel may still be in flight.
+    # A live venue status (ACCEPTED) must NOT clear PENDING_CANCEL — the venue resolves
+    # the race itself (canceled, or cancel-rejected which reverts via pre_pending).
+    # The confirm wait is widened past the hour the clock moves, so this stays inside it.
+    state = _pending_marker_case(_am(cfg=AccountManagerConfig(snapshot_grace_ms=5_000, order_confirm_wait_ms=7_200_000)))
 
     order = state.get_order("cid-1")
     assert order.status is OrderStatus.PENDING_CANCEL
     assert state.get_pre_pending("cid-1") is OrderStatus.ACCEPTED  # revert target intact
     assert len(state.get_inflight_orders()) == 1  # sweep keeps polling the cancel
+
+
+def test_snapshot_past_the_confirm_window_wipes_a_pending_marker_the_venue_never_took():
+    # Measured on LIGHTER: the cancel never reached the venue, the order sat PENDING_CANCEL
+    # locally and ACCEPTED at the venue for 5m20s, and the executor parked on it. Past the
+    # confirm wait the marker stops being defended and the venue's view wins.
+    state = _pending_marker_case(_am())  # default order_confirm_wait_ms = 5s
+
+    order = state.get_order("cid-1")
+    assert order.status is OrderStatus.ACCEPTED
+    assert order.filled_quantity == 0.3
+    assert state.get_pre_pending("cid-1") is None  # no longer pending, nothing to revert to
+    assert state.get_inflight_orders() == []
 
 
 def test_snapshot_terminal_status_resolves_pending_marker():

--- a/tests/qubx/core/test_position_lot_arithmetic.py
+++ b/tests/qubx/core/test_position_lot_arithmetic.py
@@ -1,0 +1,57 @@
+"""A booked deal moves the position by whole lots, so a float subtraction cannot lose one."""
+
+import pandas as pd
+import pytest
+
+from qubx.core.basics import Position
+from qubx.core.lookups import lookup
+
+TIME = lambda x: pd.Timestamp(x, unit="ns").asm8
+T0 = TIME("2026-08-28 00:00:00")
+
+
+def _pos(exchange: str, symbol: str, quantity: float, price: float) -> Position:
+    instr = lookup.find_symbol(exchange, symbol)
+    assert instr is not None
+    p = Position(instr)
+    p.update_position(T0, position=quantity, exec_price=price)
+    return p
+
+
+def test_a_subtraction_that_lands_a_few_ulp_short_still_books_a_whole_lot():
+    # 26.0 - 25.6 is 0.3999999999999986; flooring the float sum returned 0.3 and lost a lot
+    p = _pos("LIGHTER", "ETHFIUSDC", 26.0, 0.58)
+    p.change_position_by(T0, -25.6, 0.58)
+    assert p.quantity == pytest.approx(0.4, abs=1e-12)
+
+
+def test_the_last_lot_is_not_swallowed():
+    # 28.2 - 28.1 is 0.09999999999999787; the position read 0.0 while the venue still held 0.1
+    p = _pos("LIGHTER", "AEROUSDC", 28.2, 0.53)
+    p.change_position_by(T0, -28.1, 0.53)
+    assert p.quantity == pytest.approx(0.1, abs=1e-12)
+
+
+def test_a_short_position_books_the_same_way():
+    p = _pos("LIGHTER", "AEROUSDC", -28.2, 0.53)
+    p.change_position_by(T0, 28.1, 0.53)
+    assert p.quantity == pytest.approx(-0.1, abs=1e-12)
+
+
+def test_a_close_reaches_exactly_flat():
+    p = _pos("LIGHTER", "ETHFIUSDC", 51.6, 0.58)
+    for amount in (-25.6, -25.6, -0.2, -0.2):
+        p.change_position_by(T0, amount, 0.58)
+    assert p.quantity == pytest.approx(0.0, abs=1e-12)
+
+
+def test_a_booked_amount_off_the_lot_grid_is_reported_and_still_booked():
+    """Stale instrument metadata or a connector fault — but dropping the deal is worse."""
+    p = _pos("LIGHTER", "AEROUSDC", 28.2, 0.53)
+    # - 0.05 is half a lot; C rounds half away from zero, so it books as one
+    p.change_position_by(T0, -0.05, 0.53)
+    assert p.quantity == pytest.approx(28.1, abs=1e-12)
+
+    # - 0.16 is 1.6 lots -> 2
+    p.change_position_by(T0, -0.16, 0.53)
+    assert p.quantity == pytest.approx(27.9, abs=1e-12)

--- a/tests/qubx/core/test_position_lot_arithmetic.py
+++ b/tests/qubx/core/test_position_lot_arithmetic.py
@@ -3,17 +3,35 @@
 import pandas as pd
 import pytest
 
-from qubx.core.basics import Position
-from qubx.core.lookups import lookup
+from qubx.core.basics import Instrument, MarketType, Position
 
 TIME = lambda x: pd.Timestamp(x, unit="ns").asm8
 T0 = TIME("2026-08-28 00:00:00")
 
+# - built here rather than looked up: the arithmetic only depends on lot_size, and reading it from
+#   the instrument store makes the test need one. LIGHTER's ETHFIUSDC and AEROUSDC both carry 0.1,
+#   which is where the live numbers below come from.
+LOT = 0.1
+
+
+def _instrument(symbol: str, lot_size: float = LOT) -> Instrument:
+    return Instrument(
+        symbol=symbol,
+        market_type=MarketType.SWAP,
+        exchange="LIGHTER",
+        base=symbol.replace("USDC", ""),
+        quote="USDC",
+        settle="USDC",
+        exchange_symbol=symbol,
+        tick_size=1e-05,
+        lot_size=lot_size,
+        min_size=lot_size,
+        contract_size=1.0,
+    )
+
 
 def _pos(exchange: str, symbol: str, quantity: float, price: float) -> Position:
-    instr = lookup.find_symbol(exchange, symbol)
-    assert instr is not None
-    p = Position(instr)
+    p = Position(_instrument(symbol))
     p.update_position(T0, position=quantity, exec_price=price)
     return p
 

--- a/tests/qubx/core/utils_test.py
+++ b/tests/qubx/core/utils_test.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from qubx.core.basics import Balance, Deal, Instrument, ITimeProvider, Position, dt_64
-from qubx.core.utils import prec_ceil, prec_floor
+from qubx.core.utils import add_in_lots, is_lot_multiple, prec_ceil, prec_floor
 
 
 def test_prec_floor():
@@ -18,6 +18,39 @@ def test_prec_ceil():
     precision = 2
     assert prec_ceil(a, precision) == 608.82
     assert prec_ceil(prec_ceil(a, precision), precision) == prec_ceil(a, precision)
+
+
+def test_precision_zero_is_a_true_floor_and_ceil():
+    """Rounding the SCALED value to `precision` decimals made this a round-to-nearest."""
+    assert prec_floor(3.7, 0) == 3.0
+    assert prec_floor(200.6, 0) == 200.0
+    assert prec_floor(0.6, 0) == 0.0
+    assert prec_floor(-3.7, 0) == -3.0
+    assert prec_ceil(3.4, 0) == 4.0
+    assert prec_ceil(200.4, 0) == 201.0
+    assert prec_ceil(-3.4, 0) == -4.0
+
+
+def test_a_boundary_value_is_not_snapped_away():
+    assert prec_floor(1.2349999, 3) == 1.234
+    assert prec_ceil(2.0000000005, 0) == 3.0
+    assert prec_ceil(0.0000000001, 0) == 1.0
+
+
+def test_binary_noise_still_lands_on_the_tick():
+    assert prec_floor(0.29, 2) == 0.29
+    assert prec_floor(0.07, 2) == 0.07
+    assert prec_floor(0.1 + 0.2, 1) == 0.3
+    assert prec_floor(1.1 * 3, 1) == 3.3
+    # the tolerance is relative: 0.29 * 1e8 sits 3.7e-9 from the tick
+    assert prec_floor(0.29, 8) == 0.29
+    assert prec_ceil(0.29, 8) == 0.29
+
+
+def test_a_notional_derived_minimum_ceils_to_a_tradeable_size():
+    """_adjust_size falls back to round_size_up(min_size); min_notional/price is fractional."""
+    assert prec_ceil(23.196474135931336, 0) == 24.0
+    assert prec_ceil(113.37868480725623, 0) == 114.0
 
 
 class DummyTimeProvider(ITimeProvider):
@@ -71,3 +104,22 @@ class StubAccount:
     def get_total_capital(self, exchange: str | None = None) -> float:
         cash = self._balances[self.base_currency].total if self.base_currency in self._balances else 0.0
         return cash + sum(p.market_value_funds for p in self._positions.values())
+
+
+def test_add_in_lots_survives_a_cancelling_subtraction():
+    """28.2 - 28.1 is 0.09999999999999787 as floats; in lots it is 282 - 281."""
+    assert add_in_lots(26.0, -25.6, 0.1) == 0.4
+    assert add_in_lots(28.2, -28.1, 0.1) == 0.1
+    assert add_in_lots(21.4, -21.0, 0.1) == 0.4
+    assert add_in_lots(51.6, -25.6, 0.1) == 26.0
+    assert add_in_lots(-28.2, 28.1, 0.1) == -0.1
+    assert add_in_lots(0.1, -0.1, 0.1) == 0.0
+
+
+def test_is_lot_multiple_admits_the_grid_and_refuses_a_half_lot():
+    assert is_lot_multiple(28.2, 0.1)
+    assert is_lot_multiple(-28.2, 0.1)
+    assert is_lot_multiple(0.0, 0.1)
+    assert is_lot_multiple(0.00054, 0.00001)
+    assert not is_lot_multiple(-0.05, 0.1)
+    assert not is_lot_multiple(23.196474135931336, 1.0)


### PR DESCRIPTION
Six fixes found by running the LOE test harness live on Lighter, Binance Portfolio Margin, OKX and Hyperliquid. Every one carries the measurement that produced it.

## `prec_floor` / `prec_ceil` round to the nearest lot at precision 0 — `d10e77ea`

The old form rounded the SCALED value to `precision` decimals, which is a half-lot window at precision 0. `round(x, 9)` is not a safe substitute either: `prec_floor(0.29, 8)` gives `0.28999999`, and BINANCE.UM has `price_precision 8`. The new form snaps to the nearest integer only within `16 * DBL_EPSILON` relative, then floors or ceils.

## Positions book in whole lots — `3840fe17`

A position was losing a lot to float subtraction: `0.6 - 0.4 -> 0.19999999999999998`. `change_position_by` now adds in lot units (`add_in_lots`), and an amount off the lot grid is logged and rounded rather than raised — `reducer.apply` is unwrapped, so raising would drop the deal. Measured: 7,849 instruments checked for `lot_size > 0`, 1,087 fills, 206ns vs 289ns for the Cython form. Zero dust across two full universe closes.

Also here: a snapshot older than a booked deal no longer rewinds the position. The first attempt only skipped `PositionSizeMismatch` while `PositionMarginMismatch` routed through `reconcile_position_from_snapshot`, which rewrites size too — measured 6 size-mismatch batches, 0 with the size mismatch alone. It is now a per-instrument decision taken before the diff loop.

## A portable rejection cause — `fc7dce75`

Rejection events carried the venue's own vocabulary and nothing a caller could act on, so "give up on insufficient margin" could not be written portably (see #403). `RejectCause` is a StrEnum on `OrderRejectedEvent` and `Order`. The ccxt side maps by exception class; the `-2019` override had to move to `BinancePortfolioMargin.describe()` because `describe()` merges outermost-last and `cxp.binanceusdm.describe()` runs after `BinanceQV`'s.

Live on BINANCE.PM at 1x: 21 symbols ended once each, 0 unexpected errors against 105 before.

## A pending marker the venue never took can now end — `9769791b`, `29aca96d`

A cancel that never reaches the venue left the order `PENDING_CANCEL` locally and `ACCEPTED` at the venue, and nothing moved it back: `_reconcile_order` compared the snapshot's venue-clock `last_update_time` against the marker's, which `transition_order` stamps with the local clock, so the snapshot always read older. The diff was logged on every poll and never applied. Measured on LIGHTER: an order held that way for 5m20s with the executor parked on `waiting on PENDING_CANCEL to terminalize`.

The marker is now judged by the confirm window instead. Live: 5 markers released after 5s and re-cancelled 3s later, 0 holds, 0 forced transitions.

## Margin-diff noise and TUI counts — `3840fe17`, `61d1c0fc`

`MARGIN_ABS_TOL = 0.01` stops a sub-cent maintenance-margin change logging a diff on every snapshot. The TUI panels now carry the active order and open position counts in their titles.

## Verification

`2917 passed, 5 skipped` on this machine and on the OKX host. Live across four venues and six entry/exit cycles.

Related: xLydianSoftware/exchanges#49 (the Lighter and Hyperliquid halves), xLydianSoftware/quantkit#144 (the executor side).