### PR TITLE
feat: runtime info blob — versions + exported streams in state:{bot_id}:info

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -196,6 +196,17 @@ class ITradeDataExport:
         """
         pass
 
+    def get_export_info(self) -> dict[str, list[str]]:
+        """
+        Describe what this exporter publishes: export kind -> destination identifiers.
+
+        Kinds are "signals", "targets", "position_changes"; destinations are e.g.
+        Redis stream names. Read once at startup for the runtime-info blob, so the
+        platform can join exported streams to their consumers. Exporters that
+        publish nothing (or have nothing enabled) return an empty dict.
+        """
+        return {}
+
     def stop(self) -> None:
         """Stop the exporter and release resources.
 

--- a/src/qubx/core/mixins/processing.py
+++ b/src/qubx/core/mixins/processing.py
@@ -62,6 +62,7 @@ from qubx.core.loggers import StrategyLogging
 from qubx.core.series import Bar, OrderBook, Quote, Trade
 from qubx.restarts.state_resolvers import StateResolver
 from qubx.state.dummy import DummyStatePersistence
+from qubx.state.runtime_info import RUNTIME_INFO_KEY, build_runtime_info
 from qubx.trackers.riskctrl import _InitializationStageTracker
 from qubx.utils.throttler import InstrumentThrottler
 from qubx.utils.time import interval_to_cron
@@ -133,6 +134,7 @@ class ProcessingManager(IProcessingManager):
     _scheduler: BasicScheduler
     _universe_manager: IUniverseManager
     _exporter: ITradeDataExport | None = None
+    _runtime_info_saved: bool = False
     _health_monitor: IHealthMonitor
     _stale_data_detector: StaleDataDetector
     _delisting_detector: DelistingDetector
@@ -414,6 +416,23 @@ class ProcessingManager(IProcessingManager):
                 cron_schedule = interval_to_cron(interval)
                 self._scheduler.schedule_event(cron_schedule, "state_snapshot")
                 logger.info(f"State snapshot enabled with interval: {interval}")
+                self._save_runtime_info()
+
+    def _save_runtime_info(self) -> None:
+        """
+        Persist the static runtime-info blob (package versions, exported streams)
+        once per process, under the same live+real-persistence gate as the
+        snapshot. Failure is a warning: versions are observability, never worth
+        blocking startup over.
+        """
+        if self._runtime_info_saved:
+            return
+        try:
+            info = build_runtime_info(self._strategy, self._exporter, str(self._time_provider.time()))
+            self._context.persistence.save(RUNTIME_INFO_KEY, info)
+            self._runtime_info_saved = True
+        except Exception as e:
+            logger.warning(f"Failed to save runtime info: {e}")
 
     def configure_rate_limit_metrics(self, interval: str | None) -> None:
         """

--- a/src/qubx/exporters/composite.py
+++ b/src/qubx/exporters/composite.py
@@ -93,3 +93,10 @@ class CompositeExporter(ITradeDataExport):
                 from qubx import logger
 
                 logger.error(f"[CompositeExporter] Error stopping {exporter.__class__.__name__}: {e}")
+
+    def get_export_info(self) -> dict[str, list[str]]:
+        info: dict[str, list[str]] = {}
+        for exporter in self._exporters:
+            for kind, destinations in exporter.get_export_info().items():
+                info.setdefault(kind, []).extend(destinations)
+        return info

--- a/src/qubx/exporters/redis_streams.py
+++ b/src/qubx/exporters/redis_streams.py
@@ -126,6 +126,16 @@ class RedisStreamsExporter(ITradeDataExport):
         except Exception as e:
             self._log_warning(f"Failed to close Redis connection: {e}")
 
+    def get_export_info(self) -> dict[str, list[str]]:
+        info: dict[str, list[str]] = {}
+        if self._export_signals:
+            info["signals"] = [self._signals_stream]
+        if self._export_targets:
+            info["targets"] = [self._targets_stream]
+        if self._export_position_changes:
+            info["position_changes"] = [self._position_changes_stream]
+        return info
+
     def _prepare_for_redis(self, data: Dict[str, Any]) -> Dict[FieldT, EncodableT]:
         """
         Prepare data for Redis by ensuring all values are strings.

--- a/src/qubx/state/runtime_info.py
+++ b/src/qubx/state/runtime_info.py
@@ -41,6 +41,15 @@ def _strategy_identity(strategy_class: type, packages: dict[str, str]) -> dict:
                 break
     except Exception:  # packages_distributions can choke on broken metadata
         pass
+    if version is None and top_module.lower() in packages:
+        # metadata.packages_distributions() reads top_level.txt / RECORD entries
+        # that uv editable installs (root project run from source, e.g. `qubx`
+        # itself or a strategy repo installed with `-e .`) don't always populate,
+        # so the loop above finds nothing even though the module name IS the
+        # distribution name. Fall back to a direct name match against the
+        # already-collected distributions before giving up on a version.
+        package = top_module.lower()
+        version = packages[top_module.lower()]
     return {
         "package": package,
         "version": version,

--- a/src/qubx/state/runtime_info.py
+++ b/src/qubx/state/runtime_info.py
@@ -1,0 +1,67 @@
+"""
+Static runtime facts written once at startup to ``state:{bot_id}:info``.
+
+The blob is the platform's only runtime source for package versions and
+exported streams (see xlydian-platform
+docs/superpowers/specs/2026-09-01-bot-versions-and-dependency-graph-design.md).
+It is computed once — importlib.metadata.distributions() is too slow for the
+5s snapshot cadence — and everything in it is plain JSON types.
+"""
+
+import sys
+from importlib import metadata
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qubx.core.interfaces import ITradeDataExport
+
+RUNTIME_INFO_KEY = "info"
+RUNTIME_INFO_SCHEMA_VERSION = 1
+
+
+def _distribution_versions() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for dist in metadata.distributions():
+        name = (dist.metadata["Name"] or "").strip() if dist.metadata else ""
+        if name:
+            out[name.lower()] = dist.version
+    return out
+
+
+def _strategy_identity(strategy_class: type, packages: dict[str, str]) -> dict:
+    """Resolve the strategy's distribution name + version from its top module."""
+    top_module = strategy_class.__module__.split(".")[0]
+    package: str = top_module
+    version: str | None = None
+    try:
+        for dist_name in metadata.packages_distributions().get(top_module) or []:
+            if dist_name.lower() in packages:
+                package = dist_name.lower()
+                version = packages[dist_name.lower()]
+                break
+    except Exception:  # packages_distributions can choke on broken metadata
+        pass
+    return {
+        "package": package,
+        "version": version,
+        "class": f"{strategy_class.__module__}.{strategy_class.__name__}",
+    }
+
+
+def build_runtime_info(strategy: object, exporter: "ITradeDataExport | None", timestamp: str) -> dict:
+    packages = _distribution_versions()
+    exports: dict[str, list[str]] = {}
+    if exporter is not None:
+        try:
+            exports = exporter.get_export_info()
+        except Exception:
+            exports = {}
+    return {
+        "schema_version": RUNTIME_INFO_SCHEMA_VERSION,
+        "started_at": timestamp,
+        "python": ".".join(str(v) for v in sys.version_info[:3]),
+        "qubx": packages.get("qubx", "Dev"),
+        "strategy": _strategy_identity(type(strategy), packages),
+        "packages": packages,
+        "exports": exports,
+    }

--- a/tests/qubx/core/test_runtime_info_hook.py
+++ b/tests/qubx/core/test_runtime_info_hook.py
@@ -1,0 +1,55 @@
+"""The runtime-info blob is written exactly once, under the same gate as the snapshot."""
+
+from unittest.mock import Mock
+
+from qubx.core.mixins.processing import ProcessingManager
+from qubx.state import DummyStatePersistence
+
+
+def _manager(persistence) -> ProcessingManager:
+    # ProcessingManager.__init__ wires the whole trading context; the hook only
+    # touches these attributes, so build a bare instance for a focused test.
+    m = object.__new__(ProcessingManager)
+    m._scheduler = Mock()
+    m._is_simulation = False
+    m._context = Mock()
+    m._context.persistence = persistence
+    m._exporter = None
+    m._strategy = Mock()
+    m._time_provider = Mock()
+    m._time_provider.time = Mock(return_value="2026-09-01T09:00:00")
+    m._runtime_info_saved = False
+    return m
+
+
+def test_writes_info_once_when_snapshot_enabled():
+    persistence = Mock()
+    m = _manager(persistence)
+
+    m.configure_state_snapshot("5s")
+    m.configure_state_snapshot("5s")  # reconfigure must not rewrite
+
+    info_calls = [c for c in persistence.save.call_args_list if c.args[0] == "info"]
+    assert len(info_calls) == 1
+    blob = info_calls[0].args[1]
+    assert blob["schema_version"] == 1
+    assert "qubx" in blob
+
+
+def test_skips_in_simulation_and_with_dummy_persistence():
+    m = _manager(Mock())
+    m._is_simulation = True
+    m.configure_state_snapshot("5s")
+    m._context.persistence.save.assert_not_called()
+
+    m2 = _manager(DummyStatePersistence())
+    m2.configure_state_snapshot("5s")
+    assert m2._runtime_info_saved is False
+
+
+def test_failed_write_does_not_raise_and_allows_retry():
+    persistence = Mock()
+    persistence.save.side_effect = RuntimeError("redis down")
+    m = _manager(persistence)
+    m.configure_state_snapshot("5s")  # must not raise
+    assert m._runtime_info_saved is False

--- a/tests/qubx/exporters/test_export_info.py
+++ b/tests/qubx/exporters/test_export_info.py
@@ -1,0 +1,64 @@
+"""get_export_info() — the exporter's self-description consumed by the runtime-info blob."""
+
+from qubx.core.interfaces import ITradeDataExport
+from qubx.exporters.composite import CompositeExporter
+from qubx.exporters.redis_streams import RedisStreamsExporter
+
+# redis.from_url is lazy (no connection until a command runs), so constructing
+# the exporter against a dead URL is fine — same approach as the bounded-worker tests.
+DEAD_REDIS = "redis://localhost:6399/0"
+
+
+def test_default_is_empty():
+    assert ITradeDataExport().get_export_info() == {}
+
+
+def test_redis_exporter_reports_only_enabled_streams():
+    exporter = RedisStreamsExporter(
+        redis_url=DEAD_REDIS,
+        strategy_name="binance.factors-buf",
+        export_position_changes=True,
+        position_changes_stream="strategy:binance.factors-buf:position_changes",
+    )
+    try:
+        assert exporter.get_export_info() == {
+            "position_changes": ["strategy:binance.factors-buf:position_changes"]
+        }
+    finally:
+        exporter.stop()
+
+
+def test_redis_exporter_defaults_streams_from_strategy_name():
+    exporter = RedisStreamsExporter(
+        redis_url=DEAD_REDIS,
+        strategy_name="mybot",
+        export_signals=True,
+        export_targets=True,
+    )
+    try:
+        assert exporter.get_export_info() == {
+            "signals": ["strategy:mybot:signals"],
+            "targets": ["strategy:mybot:targets"],
+        }
+    finally:
+        exporter.stop()
+
+
+def test_composite_concatenates_children():
+    a = RedisStreamsExporter(
+        redis_url=DEAD_REDIS, strategy_name="a", export_position_changes=True
+    )
+    b = RedisStreamsExporter(
+        redis_url=DEAD_REDIS, strategy_name="b", export_position_changes=True, export_signals=True
+    )
+    composite = CompositeExporter([a, b])
+    try:
+        assert composite.get_export_info() == {
+            "position_changes": [
+                "strategy:a:position_changes",
+                "strategy:b:position_changes",
+            ],
+            "signals": ["strategy:b:signals"],
+        }
+    finally:
+        composite.stop()

--- a/tests/qubx/state/test_runtime_info.py
+++ b/tests/qubx/state/test_runtime_info.py
@@ -1,0 +1,57 @@
+"""build_runtime_info — the static blob written once to state:{bot_id}:info."""
+
+import json
+import sys
+
+from qubx.core.interfaces import ITradeDataExport
+from qubx.state.runtime_info import (
+    RUNTIME_INFO_KEY,
+    RUNTIME_INFO_SCHEMA_VERSION,
+    build_runtime_info,
+)
+
+
+class _FakeStrategy:
+    pass
+
+
+class _FakeExporter(ITradeDataExport):
+    def get_export_info(self) -> dict[str, list[str]]:
+        return {"position_changes": ["strategy:x:position_changes"]}
+
+
+class _BrokenExporter(ITradeDataExport):
+    def get_export_info(self) -> dict[str, list[str]]:
+        raise RuntimeError("boom")
+
+
+def test_blob_shape_and_versions():
+    info = build_runtime_info(_FakeStrategy(), _FakeExporter(), "2026-09-01T09:00:00")
+
+    assert info["schema_version"] == RUNTIME_INFO_SCHEMA_VERSION
+    assert info["started_at"] == "2026-09-01T09:00:00"
+    assert info["python"] == ".".join(str(v) for v in sys.version_info[:3])
+    # qubx is installed in the test env, so both the top-level field and the
+    # packages dict must carry a real version string.
+    assert info["qubx"] == info["packages"]["qubx"]
+    assert info["qubx"][0].isdigit() or info["qubx"] == "Dev"
+    assert info["exports"] == {"position_changes": ["strategy:x:position_changes"]}
+    # The strategy class is recorded fully qualified; the test strategy lives in
+    # this test module, which belongs to no installed distribution -> version None.
+    assert info["strategy"]["class"].endswith("._FakeStrategy")
+    assert info["strategy"]["version"] is None
+
+
+def test_blob_is_json_serializable():
+    # SafeStatePersistence.save does an eager json.dumps; a non-serializable
+    # value would silently lose the blob at runtime.
+    json.dumps(build_runtime_info(_FakeStrategy(), _FakeExporter(), "t"))
+
+
+def test_no_exporter_and_broken_exporter_degrade_to_empty_exports():
+    assert build_runtime_info(_FakeStrategy(), None, "t")["exports"] == {}
+    assert build_runtime_info(_FakeStrategy(), _BrokenExporter(), "t")["exports"] == {}
+
+
+def test_key_constant():
+    assert RUNTIME_INFO_KEY == "info"

--- a/tests/qubx/state/test_runtime_info.py
+++ b/tests/qubx/state/test_runtime_info.py
@@ -15,6 +15,16 @@ class _FakeStrategy:
     pass
 
 
+class _EditableInstallStrategy:
+    """Simulates a strategy whose top module IS an installed distribution name
+    (e.g. `qubx` itself run from source via `uv run` in an editable checkout),
+    where importlib.metadata.packages_distributions() fails to map the module
+    to its distribution but the module/distribution names match directly."""
+
+
+_EditableInstallStrategy.__module__ = "qubx.fake_editable_module"
+
+
 class _FakeExporter(ITradeDataExport):
     def get_export_info(self) -> dict[str, list[str]]:
         return {"position_changes": ["strategy:x:position_changes"]}
@@ -55,3 +65,14 @@ def test_no_exporter_and_broken_exporter_degrade_to_empty_exports():
 
 def test_key_constant():
     assert RUNTIME_INFO_KEY == "info"
+
+
+def test_strategy_identity_matches_editable_install_by_top_module():
+    # qubx is always installed in the test env (it's the package under test), so
+    # a strategy class whose top module is "qubx" must resolve a real version —
+    # this is the from-source/editable-install path that packages_distributions()
+    # alone misses.
+    info = build_runtime_info(_EditableInstallStrategy(), None, "t")
+    assert info["strategy"]["package"] == "qubx"
+    assert info["strategy"]["version"] is not None
+    assert info["strategy"]["version"] == info["packages"]["qubx"]


### PR DESCRIPTION
Producer side of the xlydian-platform bot-versions + dependency-graph feature (spec lives in `xlydian-platform/docs/superpowers/specs/2026-09-01-bot-versions-and-dependency-graph-design.md`).

## What this adds

- **`ITradeDataExport.get_export_info() -> dict[str, list[str]]`** — exporters self-describe what they publish (kind → destinations). `RedisStreamsExporter` reports only enabled streams; `CompositeExporter` concatenates children. Default `{}`, purely additive, no behavior change to any export path.
- **`qubx.state.runtime_info.build_runtime_info()`** — a static blob of runtime facts: `schema_version`, `started_at`, `python`, `qubx`, `strategy{package, version, class}`, full `packages` dict (via `importlib.metadata`, computed once), and `exports` from the live exporter objects. Strategy version resolves via `packages_distributions()` with a direct top-module lookup for editable installs (uv `package=false` roots return nothing from `packages_distributions()`).
- **Startup hook** — `configure_state_snapshot` writes the blob once per process to `state:{bot_id}:info` via `ctx.persistence`, under the same gate as the snapshot (live mode + real persistence). A failed write logs a warning, never blocks startup, and leaves the guard unset so a reconfigure retries. The key rides the platform's existing `state:{uuid}:*` lifecycle (reconciler wipe, reset-state).

The platform's `GET /bots/graph` (xlydian-platform PR) joins these blobs into the fleet dependency graph; `xl bot info <id>` shows the blob directly.

## Testing

`uv run pytest tests/qubx` — 2988 passed, 5 skipped; the only errors are the pre-existing `test_postgres_e2e.py` environment gap (no local `qubx_test_e2e` DB), unrelated to this change. New coverage: exporter self-description (incl. composite), blob shape/serializability/degradation, write-once + gating + failure paths of the hook.

Note: merging to `main` triggers the stable release pipeline — the platform PR is reader-side null-tolerant, so any order is safe.

https://claude.ai/code/session_01CJruz4HdmJuwozny8U8v7s
