### PR TITLE
feat(configs): accept release.platform.strategy_kind

### DIFF
--- a/src/qubx/utils/runner/configs.py
+++ b/src/qubx/utils/runner/configs.py
@@ -347,6 +347,10 @@ class ReleasePlatformConfig(StrictBaseModel):
     tags: list[str] = Field(default_factory=list)
     """Descriptive tags for the release."""
 
+    strategy_kind: str | None = None
+    """Platform strategy kind (e.g. 'aggregator', 'funding_arbitrage'); selects the
+    portal's strategy-specific view. Metadata only — never read by the build or runtime."""
+
 
 class ReleaseConfig(StrictBaseModel):
     """Configuration for automated release packaging and platform deployment."""

--- a/tests/qubx/utils/configs_test.py
+++ b/tests/qubx/utils/configs_test.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
 from qubx.core.account_manager import AccountManagerConfig as CoreAMConfig
 from qubx.utils.runner.configs import (
     EmissionConfig,
@@ -188,3 +191,38 @@ def test_validate_no_exchanges_config():
 
     # Should be valid but may have warnings
     assert result.valid is True
+
+
+def _release_yaml(platform_extra: str = "") -> str:
+    return f"""
+strategy: pkg.Strategy
+release:
+  source:
+    repo: xLydianSoftware/quantkit
+    ref: v1.0.0
+  platform:
+    name: lighter.aggregator
+    exchanges: [lighter]
+    image_tag: "3.9.0"
+    tags: [aggregator]
+{platform_extra}
+"""
+
+
+def test_release_platform_strategy_kind(tmp_path: Path):
+    cfg_file = tmp_path / "release.yaml"
+
+    cfg_file.write_text(_release_yaml("    strategy_kind: aggregator"))
+    config = load_strategy_config_from_yaml(cfg_file)
+    assert config.release is not None and config.release.platform is not None
+    assert config.release.platform.strategy_kind == "aggregator"
+
+    cfg_file.write_text(_release_yaml())
+    config = load_strategy_config_from_yaml(cfg_file)
+    assert config.release is not None and config.release.platform is not None
+    assert config.release.platform.strategy_kind is None
+
+    # platform block stays strict: a typo'd key is still rejected
+    cfg_file.write_text(_release_yaml("    strategy_kinds: aggregator"))
+    with pytest.raises(ValidationError, match="strategy_kinds"):
+        load_strategy_config_from_yaml(cfg_file)


### PR DESCRIPTION
## What

Adds an optional `strategy_kind: str | None` to `ReleasePlatformConfig` (the `release.platform` block of a strategy config).

## Why

The xlydian platform keeps a `strategy_kind` per release (`aggregator`, `funding_arbitrage`) that selects the admin portal's strategy-specific tab. The portal's release page says the value is "set via release manifest", but the xrelease manifests could not carry it: `ReleasePlatformConfig` is `extra="forbid"`, so today a config with

```yaml
release:
  platform:
    strategy_kind: aggregator
```

fails `qubx validate` and `qubx release --from-sources` with `release.platform.strategy_kind: Extra inputs are not permitted [extra_forbidden]` (verified against 3.6.1 and current main). This PR is the schema half; the xrelease workflow that passes the value through to `xl release create/update` is xLydianSoftware/xrelease#57 (draft until this ships); the portal half is xLydianSoftware/xlydian-platform#469.

## Safety

- Metadata only: nothing in the build reads it, and `_save_strategy_config` strips the whole `release:` block from the packaged `config.yml`, so no runtime image (old or new) ever sees the key.
- `release.platform` stays strict — the test asserts a typo'd key is still rejected.
- Default `None`; every existing config parses unchanged.

## Release note

`main` is exactly `v3.9.0` right now, so merging this `feat` commit cuts **v3.10.0**. xrelease pins `qubx[connectors]==3.6.1` for its validator and will need to move to that version before its manifests can carry the key.

## Tests

- `uv run pytest tests/qubx/utils/configs_test.py` — 10 passed (new `test_release_platform_strategy_kind`)
- `ruff check` / `ruff format --check` clean

https://claude.ai/code/session_014kQpkju2hECX2xsxdbddPm