### PR TITLE
fix(ccxt): don't emit an account snapshot built from a leg that failed to fetch

### DIFF
--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -1637,40 +1637,23 @@ class CcxtConnector(ChannelEmitter):
             logger.debug(f"[{self.exchange_name}] snapshot: no trigger open-orders surface ({e}); regular only")
             return []
 
-    def _merge_open_orders(self, raw_orders, raw_trigger_orders) -> list[Order] | None:
+    def _merge_open_orders(self, raw_orders: list[dict], raw_trigger_orders: list[dict]) -> list[Order]:
         """Merge regular + trigger raw open orders into framework Orders (dedup by venue id).
 
-        Returns None if EITHER order leg failed: a partial list would mark the unseen
-        leg's live orders as missing → false reconcile-away. None makes reconcile skip
-        order diffing this tick (positions/balances still apply).
+        A row on an unrecognized symbol is skipped, loudly: reconcile reads the order list as
+        venue truth, so a skipped row reads as cancelled at the venue.
         """
-        # Venue exception text goes in as positional args (may contain HTML/markup that
-        # loguru's colorizer rejects when it appears in the format string — a raised log
-        # call here would sink the whole snapshot).
-        if isinstance(raw_orders, BaseException):
-            logger.warning(
-                "[{}] snapshot: fetch_open_orders failed: {}: {} [{}]",
-                self.exchange_name,
-                type(raw_orders).__name__,
-                raw_orders,
-                self._loop_tag(),
-            )
-            return None
-        if isinstance(raw_trigger_orders, BaseException):
-            logger.warning(
-                "[{}] snapshot: fetch_open_orders(trigger) failed: {}: {} [{}]; skipping order reconcile this tick",
-                self.exchange_name,
-                type(raw_trigger_orders).__name__,
-                raw_trigger_orders,
-                self._loop_tag(),
-            )
-            return None
         open_orders: list[Order] = []
         seen: set[str] = set()
         for raw in [*raw_orders, *raw_trigger_orders]:
             try:
                 instrument = self._instrument_for_symbol(raw["symbol"])
             except CcxtSymbolNotRecognized:
+                # Venue symbol goes in as a positional arg (may contain markup loguru's
+                # colorizer rejects in the format string).
+                logger.error(
+                    "[{}] snapshot: unrecognized symbol {}; open order skipped", self.exchange_name, raw.get("symbol")
+                )
                 continue
             order = ccxt_convert_order_info(instrument, raw, framework_prefix=self.cid_framework_prefix)
             key = order.venue_order_id or order.client_order_id
@@ -1707,54 +1690,40 @@ class CcxtConnector(ChannelEmitter):
         (open_orders=None -> reconcile leaves order state untouched; orders are tracked via the WS
         stream + the periodic full sweep).
 
-        Network/exchange errors are logged, not raised — AM retries on its next snapshot tick.
-        ``return_exceptions=True`` keeps one failing fetch from sinking the others; a failed (or
-        skipped) leg is left None so reconcile won't wipe state it didn't actually observe.
+        Reconcile applies a snapshot as authoritative, so a leg that failed to fetch skips the
+        emit entirely and the AM asks again on its next tick. A single row that will not convert
+        is skipped instead (loudly) — one unresolvable symbol must not stall reconcile for the
+        whole exchange. Errors are logged, never raised.
         """
         ex = self._em.exchange
         as_of: dt_64 = self._time.time()
-        if include_orders:
-            raw_orders, raw_trigger_orders, raw_positions, raw_balance = await asyncio.gather(
-                ex.fetch_open_orders(),
-                self._fetch_trigger_open_orders(),
-                ex.fetch_positions(),
-                ex.fetch_balance(),
-                return_exceptions=True,
-            )
-            open_orders = self._merge_open_orders(raw_orders, raw_trigger_orders)
-        else:
-            raw_positions, raw_balance = await asyncio.gather(
-                ex.fetch_positions(), ex.fetch_balance(), return_exceptions=True
-            )
-            open_orders = None  # - not observed this tick -> reconcile skips order diffing
-
-        positions: list[Position] | None = None
-        if isinstance(raw_positions, BaseException):
-            logger.warning(
-                "[{}] snapshot: fetch_positions failed: {}: {} [{}]",
-                self.exchange_name,
-                type(raw_positions).__name__,
-                raw_positions,
-                self._loop_tag(),
-            )
-        else:
+        try:
+            if include_orders:
+                raw_orders, raw_trigger_orders, raw_positions, raw_balance = await asyncio.gather(
+                    ex.fetch_open_orders(),
+                    self._fetch_trigger_open_orders(),
+                    ex.fetch_positions(),
+                    ex.fetch_balance(),
+                )
+                open_orders = self._merge_open_orders(raw_orders, raw_trigger_orders)
+            else:
+                raw_positions, raw_balance = await asyncio.gather(ex.fetch_positions(), ex.fetch_balance())
+                open_orders = None  # - not observed this tick -> reconcile skips order diffing
             positions = ccxt_convert_positions(raw_positions, ex.name, ex.markets)
             await self._fill_leverage_settings(positions)
-
-        balances: list[Balance] | None = None
-        equity = available_margin = margin_ratio = withdrawable = None
-        if isinstance(raw_balance, BaseException):
-            logger.warning(
-                "[{}] snapshot: fetch_balance failed: {}: {} [{}]",
-                self.exchange_name,
-                type(raw_balance).__name__,
-                raw_balance,
-                self._loop_tag(),
-            )
-        else:
             balances = self._convert_balances(raw_balance)
             equity, available_margin, margin_ratio, withdrawable = self._extract_venue_figures(raw_balance)
-
+        except Exception as e:  # noqa: BLE001 — AM retries on its next snapshot tick
+            # Venue exception text goes in as a positional arg (may contain HTML/markup that
+            # loguru's colorizer rejects when it appears in the format string).
+            logger.error(
+                "[{}] snapshot: {}: {}; not emitting a partial snapshot [{}]",
+                self.exchange_name,
+                type(e).__name__,
+                e,
+                self._loop_tag(),
+            )
+            return
         self.send(
             AccountSnapshotEvent(
                 instrument=None,

--- a/src/qubx/connectors/ccxt/utils.py
+++ b/src/qubx/connectors/ccxt/utils.py
@@ -265,12 +265,12 @@ def ccxt_convert_trade(trade: dict[str, Any]) -> Trade:
 
 
 def ccxt_convert_position(info: dict, ccxt_exchange_name: str, markets: dict[str, dict[str, Any]]) -> Position | None:
-    """Convert one ccxt unified position dict into a Position; None when the symbol is
-    unknown to the loaded markets. Shared by the REST snapshot path (ccxt_convert_positions)
-    and WS position pushes so both produce the identical mapping."""
+    """Convert one ccxt unified position dict into a Position; None when the symbol is unknown
+    to the loaded markets. Loud, because reconcile reads the positions list as venue truth and
+    so reports a skipped row as flat."""
     symbol = info["symbol"]
     if symbol not in markets:
-        logger.warning(f"Could not find symbol {symbol}, skipping position...")
+        logger.error(f"snapshot: no market for {symbol}; position skipped")
         return None
     instr = ccxt_symbol_to_instrument(
         ccxt_exchange_name,
@@ -328,12 +328,9 @@ def ccxt_convert_position(info: dict, ccxt_exchange_name: str, markets: dict[str
 def ccxt_convert_positions(
     pos_infos: list[dict], ccxt_exchange_name: str, markets: dict[str, dict[str, Any]]
 ) -> list[Position]:
-    positions = []
-    for info in pos_infos:
-        pos = ccxt_convert_position(info, ccxt_exchange_name, markets)
-        if pos is not None:
-            positions.append(pos)
-    return positions
+    """Rows whose symbol is unknown to the loaded markets are skipped (and logged there)."""
+    converted = [ccxt_convert_position(info, ccxt_exchange_name, markets) for info in pos_infos]
+    return [p for p in converted if p is not None]
 
 
 def ccxt_extract_leverage_settings(rows: list[dict] | None) -> dict[str, tuple[float | None, float | None]]:

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -21,7 +21,7 @@ Everything here runs fully offline.
 
 import asyncio
 import io
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from qubx import logger
 from qubx.connectors.ccxt.connector import CcxtConnector
@@ -401,18 +401,24 @@ class TestPmAlgoOrders:
 
 
 class TestVenueErrorLogging:
-    def test_merge_open_orders_survives_html_error_text(self):
+    def test_snapshot_failure_log_survives_html_error_text(self):
         """Venue errors can carry raw HTML (Binance 404 pages). With a colorized sink,
         f-stringing that into loguru's format string raises ValueError inside the
         snapshot task — the positional-args form must survive it."""
         connector = TestBinancePmVenueFigures._connector()
         html_error = Exception("404 Not Found <!DOCTYPE html>\n<html>\n<head></head></html>")
-        sink_id = logger.add(io.StringIO(), colorize=True, level="WARNING")
+        ex = connector._em.exchange
+        ex.fetch_open_orders = AsyncMock(side_effect=html_error)
+        ex.fetch_positions = AsyncMock(return_value=[])
+        ex.fetch_balance = AsyncMock(return_value={"total": {}, "used": {}})
+
+        sink = io.StringIO()
+        sink_id = logger.add(sink, colorize=True, level="WARNING")
         try:
-            assert connector._merge_open_orders(html_error, []) is None
-            assert connector._merge_open_orders([], html_error) is None
+            asyncio.run(connector._snapshot_async())
         finally:
             logger.remove(sink_id)
+        assert "not emitting a partial snapshot" in sink.getvalue()
 
 
 class TestPmAdlLevels:

--- a/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_connector_reads.py
@@ -48,6 +48,7 @@ from qubx.core.events import (
 )
 from qubx.core.series import Quote
 from qubx.rate_limiting import RateLimitGateTimeout
+from tests.qubx.connectors.ccxt.data.ccxt_responses import BINANCE_MARKETS, POSITIONS_BINANCE_UM
 from tests.qubx.core.utils_test import DummyTimeProvider
 
 CCXT_SYMBOL = "BTC/USDT:USDT"
@@ -324,8 +325,9 @@ async def test_request_snapshot_emits_account_snapshot() -> None:
 
 
 @pytest.mark.asyncio
-async def test_request_snapshot_failed_leg_left_none() -> None:
-    # A failing fetch leg must not sink the others: positions left None (not wiped).
+async def test_request_snapshot_failed_leg_emits_nothing() -> None:
+    # A failing fetch leg means the account was not fully observed. Reconcile applies a snapshot
+    # as venue truth, so emit nothing and let the AM ask again on its next tick.
     exchange = Mock()
     exchange.has = {"editOrder": True}
     exchange.fetch_open_orders = AsyncMock(return_value=[])
@@ -337,10 +339,7 @@ async def test_request_snapshot_failed_leg_left_none() -> None:
     conn.request_snapshot()
     await _drive(conn)
 
-    snap = sent[0].snapshot
-    assert snap.open_orders == []
-    assert snap.positions is None  # failed leg omitted, not wiped
-    assert len(snap.balances) == 1
+    assert sent == []
 
 
 @pytest.fixture
@@ -353,8 +352,8 @@ def warnings_logged():
         logger.remove(sink_id)
 
 
-def _positions_leg_warnings(records: list) -> list[str]:
-    return [r["message"] for r in records if "fetch_positions failed" in r["message"]]
+def _snapshot_skip_errors(records: list) -> list[str]:
+    return [r["message"] for r in records if "not emitting a partial snapshot" in r["message"]]
 
 
 def _snapshot_exchange(positions_error: BaseException) -> Mock:
@@ -368,28 +367,25 @@ def _snapshot_exchange(positions_error: BaseException) -> Mock:
 
 
 @pytest.mark.asyncio
-async def test_request_snapshot_positions_gate_timeout_left_none(warnings_logged) -> None:
-    # A rate-limit gate timeout is a leg failure like any other: positions omitted, the other legs
-    # still populated. The WARNING must name the exception type — operators need to tell
-    # "we throttled ourselves" apart from "the venue is down".
+async def test_request_snapshot_positions_gate_timeout_emits_nothing(warnings_logged) -> None:
+    # A rate-limit gate timeout is a leg failure like any other: nothing is emitted. The log must
+    # name the exception type — operators need to tell "we throttled ourselves" apart from
+    # "the venue is down".
     exchange = _snapshot_exchange(RateLimitGateTimeout("gate did not reopen within 30s", pool_name="ccxt_rest"))
     conn, sent, _ = _make_connector(exchange=exchange)
 
     conn.request_snapshot()
     await _drive(conn)
 
-    snap = sent[0].snapshot
-    assert snap.positions is None
-    assert [o.venue_order_id for o in snap.open_orders] == ["V1"]
-    assert len(snap.balances) == 1
+    assert sent == []
 
-    messages = _positions_leg_warnings(warnings_logged)
+    messages = _snapshot_skip_errors(warnings_logged)
     assert len(messages) == 1, messages
     assert "RateLimitGateTimeout" in messages[0]
 
 
 @pytest.mark.asyncio
-async def test_request_snapshot_positions_network_error_warning_is_generic(warnings_logged) -> None:
+async def test_request_snapshot_positions_network_error_log_is_generic(warnings_logged) -> None:
     # negative control for the test above: a venue outage produces the same shape without the
     # rate-limit wording, so the two are distinguishable from the log alone
     exchange = _snapshot_exchange(ccxt.NetworkError("boom"))
@@ -398,15 +394,97 @@ async def test_request_snapshot_positions_network_error_warning_is_generic(warni
     conn.request_snapshot()
     await _drive(conn)
 
-    snap = sent[0].snapshot
-    assert snap.positions is None
-    assert [o.venue_order_id for o in snap.open_orders] == ["V1"]
-    assert len(snap.balances) == 1
+    assert sent == []
 
-    messages = _positions_leg_warnings(warnings_logged)
+    messages = _snapshot_skip_errors(warnings_logged)
     assert len(messages) == 1, messages
     assert "NetworkError" in messages[0]
     assert "RateLimitGateTimeout" not in messages[0]
+
+
+def _errors_logged(records: list) -> list[str]:
+    return [r["message"] for r in records if r["level"].name == "ERROR"]
+
+
+def _positions_snapshot_exchange(raw_positions: list[dict], markets: dict) -> Mock:
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.fetch_open_orders = AsyncMock(return_value=[])
+    exchange.fetch_positions = AsyncMock(return_value=raw_positions)
+    exchange.fetch_balance = AsyncMock(return_value={"total": {"USDT": 9.0}, "used": {"USDT": 0.0}})
+    exchange.markets = markets
+    return exchange
+
+
+@pytest.mark.asyncio
+async def test_request_snapshot_positions_clean_payload_populated() -> None:
+    # control for the two below: a fully convertible payload still yields a list
+    exchange = _positions_snapshot_exchange(POSITIONS_BINANCE_UM, BINANCE_MARKETS)
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.request_snapshot()
+    await _drive(conn)
+
+    snap = sent[0].snapshot
+    assert snap.positions is not None
+    assert len(snap.positions) == len(POSITIONS_BINANCE_UM)
+
+
+@pytest.mark.asyncio
+async def test_request_snapshot_unknown_position_symbol_is_skipped(warnings_logged) -> None:
+    # A symbol we cannot resolve has no local position to settle either, so skipping it costs
+    # nothing — but it must be loud, since reconcile reads the leg as venue truth.
+    exchange = _positions_snapshot_exchange([{"symbol": "XYZ/USDT:USDT"}], {})
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.request_snapshot()
+    await _drive(conn)
+
+    snap = sent[0].snapshot
+    assert snap.positions == []
+    assert len(snap.balances) == 1
+    messages = _errors_logged(warnings_logged)
+    assert len(messages) == 1, messages
+    assert "XYZ/USDT:USDT" in messages[0]
+
+
+@pytest.mark.asyncio
+async def test_request_snapshot_one_unknown_position_keeps_the_known_rows() -> None:
+    # one unresolvable row must not cost the rows that did convert
+    exchange = _positions_snapshot_exchange([*POSITIONS_BINANCE_UM, {"symbol": "XYZ/USDT:USDT"}], BINANCE_MARKETS)
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.request_snapshot()
+    await _drive(conn)
+
+    assert len(sent[0].snapshot.positions) == len(POSITIONS_BINANCE_UM)
+
+
+@pytest.mark.asyncio
+async def test_request_snapshot_unknown_order_symbol_is_skipped(warnings_logged) -> None:
+    # same rule on the order leg: the resolvable order survives, the unknown one is logged
+    exchange = Mock()
+    exchange.has = {"editOrder": True}
+    exchange.market = Mock(side_effect=ccxt.BadSymbol("unknown"))
+    exchange.fetch_open_orders = AsyncMock(
+        return_value=[
+            _ws_order(status="open", cid="qubx_x", venue_id="V1"),
+            dict(_ws_order(status="open", cid="qubx_y", venue_id="V2"), symbol="XYZ/USDT:USDT"),
+        ]
+    )
+    exchange.fetch_positions = AsyncMock(return_value=[])
+    exchange.fetch_balance = AsyncMock(return_value={"total": {"USDT": 9.0}, "used": {"USDT": 0.0}})
+    exchange.markets = {}
+    conn, sent, _ = _make_connector(exchange=exchange)
+
+    conn.request_snapshot()
+    await _drive(conn)
+
+    snap = sent[0].snapshot
+    assert [o.venue_order_id for o in snap.open_orders] == ["V1"]
+    messages = _errors_logged(warnings_logged)
+    assert messages, "expected an ERROR naming the unrecognized order symbol"
+    assert "XYZ/USDT:USDT" in messages[0]
 
 
 @pytest.mark.asyncio
@@ -462,10 +540,10 @@ async def test_request_snapshot_trigger_unsupported_uses_regular_only() -> None:
 
 
 @pytest.mark.asyncio
-async def test_request_snapshot_trigger_network_error_left_none() -> None:
+async def test_request_snapshot_trigger_network_error_emits_nothing() -> None:
     # A TRANSIENT trigger-fetch failure must NOT yield a regular-only list (that would mark
-    # live stops missing). Conservative: omit open_orders this tick (None) so reconcile
-    # skips order diffing rather than orphaning unseen trigger orders.
+    # live stops missing). Conservative: emit nothing this tick rather than orphaning
+    # unseen trigger orders.
     exchange = Mock()
     exchange.has = {"editOrder": True}
     exchange.markets = {}
@@ -483,8 +561,7 @@ async def test_request_snapshot_trigger_network_error_left_none() -> None:
     conn.request_snapshot()
     await _drive(conn)
 
-    snap = sent[0].snapshot
-    assert snap.open_orders is None
+    assert sent == []
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qubx/connectors/ccxt/test_utils.py
+++ b/tests/qubx/connectors/ccxt/test_utils.py
@@ -91,6 +91,17 @@ class TestCcxtOrderbookRelatedStuff:
         positions = ccxt_convert_positions(POSITIONS_BINANCE_UM, "BINANCE.UM", BINANCE_MARKETS)
         assert len(positions) > 0
 
+    def test_ccxt_position_unknown_symbol_is_skipped(self):
+        """An unknown symbol yields no Position rather than blowing up the caller."""
+        assert ccxt_convert_position({"symbol": "XYZ/USDT:USDT"}, "BINANCE.UM", BINANCE_MARKETS) is None
+
+    def test_ccxt_positions_skips_only_the_unknown_row(self):
+        """One unconvertible row must not cost the rows that did convert."""
+        positions = ccxt_convert_positions(
+            [*POSITIONS_BINANCE_UM, {"symbol": "XYZ/USDT:USDT"}], "BINANCE.UM", BINANCE_MARKETS
+        )
+        assert len(positions) == len(POSITIONS_BINANCE_UM)
+
     def test_ccxt_position_takes_venue_margins(self):
         """Both margins must come from the venue, which knows the leverage tier.
 


### PR DESCRIPTION
## Context

Companion to xLydianSoftware/exchanges#55, which applies the same rule to Hyperliquid and Lighter after a production incident: a transient spot-balance fetch error reconciled a Hyperliquid account from 203k USDC to 42k and tripped the cross-exchange rebalancer on a balance that never existed.

Reconcile applies a snapshot as authoritative — `_diff_positions` ([diffs.py:371](src/qubx/core/account_manager/diffs.py#L371)) returns early only when a leg is `None`, and otherwise treats the list as venue truth.

## The change

**A leg that failed to fetch means no snapshot.** `_snapshot_async` gathered with `return_exceptions=True` and emitted whatever survived, leaving a failed leg `None`. It now logs an error and emits nothing; the AM asks again on its next tick.

Adopting that let a lot go rather than adding anything:

- `return_exceptions=True` and both per-leg `isinstance(..., BaseException)` branches — gone
- `_merge_open_orders` loses its two `BaseException` guards and its `| None` return

**Net −57 lines in the connector.** `_snapshot_async` is now one `try`, one log, one `return`, then the emit.

**A row that won't convert is still skipped, not fatal.** One unresolvable symbol must not stall reconcile for the whole exchange — and a symbol we can't resolve has no local position for the reconciler to settle either. `ccxt_convert_position` already returned `None` for a symbol absent from `ex.markets`; it now logs at `error` rather than `warning`, because reconcile reads a skipped row as flat. The open-order merge's bare `continue` on `CcxtSymbolNotRecognized` gets the same log.

`include_orders=False` still sets `open_orders=None` deliberately — a choice, not a failure.

## Behaviour change to note

A failed `fetch_positions` no longer lets balances through on their own; the whole tick is skipped. Previously the snapshot emitted with `positions=None`.

## Deliberately not fixed

The OKX empty-payload path — `_account_data` degrading a malformed `info.data` to `{}` so `_convert_balances` returns `[]` ("observed, zero balances") — is the same contract violation but **latent**, verified end to end: `info_float` returns `None` for every missing key so no venue figure can become `0.0`, and `LocalBalanceMissing` is produced by `diffs.py:419` but has no arm in the reconciler. It causes no damage today, and fixing it means widening `_convert_balances` to `list[Balance] | None` across the base and three subclasses — its own change.

## Verification

```
uv run pytest tests/qubx/connectors/ccxt/ -q   ->  672 passed
ruff check / format --check (changed files)     ->  clean
```

New tests were confirmed to fail with the fix reverted. Pre-existing tests asserting the old per-leg-`None` behaviour were inverted, keeping their scenarios; `test_merge_open_orders_survives_html_error_text` was retargeted at the new single error-log site, since that loguru-colorizer hazard moved with it.

Pre-existing ruff failures in `exchanges/bitfinex/bitfinex.py` and three ccxt test files are untouched and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)