### PR TITLE
feat(emitters): max_ttl on IMetricEmitter.ensure_table, forwarded by the composite

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -2698,6 +2698,10 @@ class IStrategy(metaclass=Mixable):
         return None
 
 
+# - retention a strategy-owned table gets unless the caller says otherwise; None leaves it untouched
+DEFAULT_TABLE_TTL = "52 weeks"
+
+
 class IMetricEmitter:
     """Interface for emitting metrics to external monitoring systems."""
 
@@ -2811,6 +2815,7 @@ class IMetricEmitter:
         symbol_columns: Sequence[str] = (),
         dedup_keys: Sequence[str] | None = None,
         partition_by: str = "DAY",
+        max_ttl: str | None = DEFAULT_TABLE_TTL,
     ) -> None:
         """
         Declare a strategy-owned table with an explicit schema.
@@ -2826,6 +2831,9 @@ class IMetricEmitter:
             symbol_columns: Column names to create as indexed SYMBOL columns
             dedup_keys: Optional designated-timestamp-first dedup key columns
             partition_by: Partitioning unit (default DAY)
+            max_ttl: Retention to apply whether the table is new or already exists
+                (QuestDB TTL shorthand, e.g. "30 days"). None leaves retention untouched.
+                Backends without retention accept and ignore it.
         """
         pass
 

--- a/src/qubx/emitters/composite.py
+++ b/src/qubx/emitters/composite.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from qubx import logger
 from qubx.core.basics import Deal, Instrument, Signal, TargetPosition, dt_64
-from qubx.core.interfaces import IAccountViewer, IMetricEmitter, IStrategyContext
+from qubx.core.interfaces import DEFAULT_TABLE_TTL, IAccountViewer, IMetricEmitter, IStrategyContext
 from qubx.emitters.base import BaseMetricEmitter
 
 
@@ -125,6 +125,7 @@ class CompositeMetricEmitter(BaseMetricEmitter):
         symbol_columns: Sequence[str] = (),
         dedup_keys: Sequence[str] | None = None,
         partition_by: str = "DAY",
+        max_ttl: str | None = DEFAULT_TABLE_TTL,
     ) -> None:
         """
         Declare a strategy-owned table on all configured emitters.
@@ -135,11 +136,17 @@ class CompositeMetricEmitter(BaseMetricEmitter):
             symbol_columns: Column names to create as indexed SYMBOL columns
             dedup_keys: Optional designated-timestamp-first dedup key columns
             partition_by: Partitioning unit (default DAY)
+            max_ttl: Retention forwarded as-is; None means "leave retention untouched"
         """
         for emitter in self._emitters:
             try:
                 emitter.ensure_table(
-                    table, columns, symbol_columns=symbol_columns, dedup_keys=dedup_keys, partition_by=partition_by
+                    table,
+                    columns,
+                    symbol_columns=symbol_columns,
+                    dedup_keys=dedup_keys,
+                    partition_by=partition_by,
+                    max_ttl=max_ttl,
                 )
             except Exception as e:
                 logger.error(f"Error ensuring table on {emitter.__class__.__name__}: {e}")

--- a/src/qubx/emitters/csv.py
+++ b/src/qubx/emitters/csv.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from qubx import logger
 from qubx.core.basics import Deal, Instrument, Signal, TargetPosition, dt_64
-from qubx.core.interfaces import IAccountViewer
+from qubx.core.interfaces import DEFAULT_TABLE_TTL, IAccountViewer
 from qubx.emitters.base import BaseMetricEmitter
 from qubx.utils.clock import time_now
 
@@ -199,7 +199,7 @@ class CSVMetricEmitter(BaseMetricEmitter):
         symbol_columns: Sequence[str] = (),
         dedup_keys: Sequence[str] | None = None,
         partition_by: str = "DAY",
-        max_ttl: str | None = None,
+        max_ttl: str | None = DEFAULT_TABLE_TTL,
     ) -> None:
         """
         Declare a strategy-owned table as one CSV file beside the metrics file.

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -15,7 +15,7 @@ from questdb.ingress import Sender
 
 from qubx import logger
 from qubx.core.basics import Deal, Instrument, Signal, TargetPosition, dt_64
-from qubx.core.interfaces import IAccountViewer, IStrategyContext
+from qubx.core.interfaces import DEFAULT_TABLE_TTL, IAccountViewer, IStrategyContext
 from qubx.emitters.base import BaseMetricEmitter
 from qubx.utils.questdb import QuestDBClient
 from qubx.utils.threading import BoundedWorker
@@ -36,7 +36,7 @@ SIGNALS_TTL = "14 weeks"
 DEALS_TTL = "14 weeks"
 HEALTH_TTL = "30 days"
 RATE_LIMITS_TTL = "30 days"
-DEFAULT_USER_TTL = "52 weeks"
+DEFAULT_USER_TTL = DEFAULT_TABLE_TTL
 
 
 def _json_scalar(value: Any) -> Any:

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import qubx.emitters.questdb as qdb_mod
-from qubx.core.interfaces import IMetricEmitter
+from qubx.core.interfaces import DEFAULT_TABLE_TTL, IMetricEmitter
 from qubx.emitters.composite import CompositeMetricEmitter
 from qubx.emitters.csv import CSVMetricEmitter
 from qubx.emitters.questdb import QuestDBMetricEmitter
@@ -20,6 +20,12 @@ class TestInterfaceDefaults:
 
     def test_emit_record_is_noop(self):
         IMetricEmitter().emit_record("t", {"a": 1.0})  # must not raise
+
+    def test_ensure_table_accepts_max_ttl(self):
+        # retention is part of the interface: a caller declaring a table through the abstract
+        # type (or any no-op backend) must be able to pass it without a TypeError
+        IMetricEmitter().ensure_table("t", {"a": "DOUBLE"}, max_ttl="30 days")
+        IMetricEmitter().ensure_table("t", {"a": "DOUBLE"}, max_ttl=None)
 
 
 class TestCompositeForwarding:
@@ -37,10 +43,19 @@ class TestCompositeForwarding:
                 symbol_columns=("pair",),
                 dedup_keys=("timestamp", "trade_id"),
                 partition_by="DAY",
+                max_ttl=DEFAULT_TABLE_TTL,
             )
             child.emit_record.assert_called_once_with(
                 "frab.trades", {"net_pnl": 1.5}, symbol_columns=("pair",), timestamp=None
             )
+
+    @pytest.mark.parametrize("max_ttl", ["30 days", None])
+    def test_forwards_max_ttl(self, max_ttl):
+        # None is a real value ("leave retention alone"), not "unspecified": it must reach the
+        # children as-is instead of being replaced by the default
+        child = MagicMock(spec=IMetricEmitter)
+        CompositeMetricEmitter([child]).ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl=max_ttl)
+        assert child.ensure_table.call_args.kwargs["max_ttl"] == max_ttl
 
     def test_child_error_is_isolated(self):
         bad, good = MagicMock(spec=IMetricEmitter), MagicMock(spec=IMetricEmitter)
@@ -142,6 +157,29 @@ class TestEnsureTable:
         # single-letter SYMBOL columns; must be rejected instead, not silently misinterpreted.
         emitter.ensure_table("t", {}, symbol_columns="pair")  # must not raise (logged), no DDL executed
         emitter._ddl_client_for_test.execute.assert_not_called()
+
+
+class TestEnsureTableRetention:
+    @staticmethod
+    def _ttl_statements(emitter) -> list[str]:
+        return [
+            call[0][0]
+            for call in emitter._ddl_client_for_test.execute.call_args_list
+            if "SET TTL" in call[0][0].upper()
+        ]
+
+    def test_default_applies_interface_ttl(self, emitter):
+        emitter.ensure_table("frab.trades", {"net_pnl": "DOUBLE"})
+        assert self._ttl_statements(emitter) == [f'ALTER TABLE "frab.trades" SET TTL {DEFAULT_TABLE_TTL}']
+
+    def test_explicit_ttl_is_applied(self, emitter):
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == ['ALTER TABLE "frab.pairs" SET TTL 30 days']
+
+    def test_none_leaves_retention_alone(self, emitter):
+        emitter.ensure_table("exec.fills", {"qty": "DOUBLE"}, max_ttl=None)
+        assert _create_sql(emitter)  # table still declared
+        assert self._ttl_statements(emitter) == []
 
 
 class TestEmitRecord:
@@ -276,7 +314,7 @@ class TestCSVRecords:
     def test_a_declared_table_keeps_columns_absent_from_the_first_row(self, tmp_path):
         em = self._emitter(tmp_path)
         em.ensure_table("loe.execution", {"price": "DOUBLE", "filled_qty": "DOUBLE"}, max_ttl=None)
-        em.emit_record("loe.execution", {"price": 0.1})          # first row lacks filled_qty
+        em.emit_record("loe.execution", {"price": 0.1})  # first row lacks filled_qty
         em.emit_record("loe.execution", {"filled_qty": 100.0})
 
         rows = list(csv_mod.DictReader((tmp_path / "loe.execution.csv").read_text().splitlines()))


### PR DESCRIPTION
## Summary

`QuestDBMetricEmitter.ensure_table` has accepted `max_ttl` since v3.4.0, but the abstract `IMetricEmitter.ensure_table` and `CompositeMetricEmitter.ensure_table` did not. A strategy declaring a table with a retention through the interface type, or through a composite of two emitters, got a `TypeError` at the call site — quantkit's execution recorder works around this today by inspecting the method signature and skipping the declaration entirely when `max_ttl` is unsupported.

This promotes `max_ttl` to the interface:

- `DEFAULT_TABLE_TTL = "52 weeks"` lives in `qubx.core.interfaces`; the QuestDB emitter's `DEFAULT_USER_TTL` is now an alias of it, so direct callers see no behaviour change.
- `IMetricEmitter.ensure_table(..., max_ttl: str | None = DEFAULT_TABLE_TTL)`: `None` keeps its existing meaning of "leave retention untouched" (relied on by quantkit for the unbounded `exec.*` tables).
- `CompositeMetricEmitter.ensure_table` forwards `max_ttl` as-is instead of dropping it.
- `CSVMetricEmitter.ensure_table` keeps ignoring it; its default is aligned with the interface.

Motivation: frab is moving its per-tick metrics into strategy-owned tables (`frab.portfolio`, `frab.pairs`, `frab.legs`) that need a 30-day TTL rather than the 52-week default, and the platform retention reconciler cannot own that because the emitter re-applies its default on every boot.

## Tests

- `tests/qubx/emitters/strategy_tables_test.py`: interface no-op accepts `max_ttl`; composite forwards both a value and `None`; QuestDB emitter applies the interface default, an explicit TTL, and no `ALTER` for `None`.

https://claude.ai/code/session_01LRsH9BRNcE5BJeCV7JCrrV
