### PR TITLE
feat(emitters): QuestDB retention ownership — max_ttl is a cap, reserved tables get a TTL only at creation

### DIFF
--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -2738,7 +2738,7 @@ class IStrategy(metaclass=Mixable):
         return None
 
 
-# - retention a strategy-owned table gets unless the caller says otherwise; None leaves it untouched
+# - default retention cap for a strategy-owned table unless the caller says otherwise; None leaves it untouched
 DEFAULT_TABLE_TTL = "52 weeks"
 
 
@@ -2871,9 +2871,10 @@ class IMetricEmitter:
             symbol_columns: Column names to create as indexed SYMBOL columns
             dedup_keys: Optional designated-timestamp-first dedup key columns
             partition_by: Partitioning unit (default DAY)
-            max_ttl: Retention to apply whether the table is new or already exists
-                (QuestDB TTL shorthand, e.g. "30 days"). None leaves retention untouched.
-                Backends without retention accept and ignore it.
+            max_ttl: Retention cap for the table. Implementations apply it when the table has
+                no retention or a longer one and keep a shorter one, so an operator can tighten
+                retention per environment without a restart undoing it; raising retention is a
+                deliberate manual step. None leaves retention untouched. Default DEFAULT_TABLE_TTL.
         """
         pass
 

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -2871,10 +2871,12 @@ class IMetricEmitter:
             symbol_columns: Column names to create as indexed SYMBOL columns
             dedup_keys: Optional designated-timestamp-first dedup key columns
             partition_by: Partitioning unit (default DAY)
-            max_ttl: Retention cap for the table. Implementations apply it when the table has
-                no retention or a longer one and keep a shorter one, so an operator can tighten
-                retention per environment without a restart undoing it; raising retention is a
-                deliberate manual step. None leaves retention untouched. Default DEFAULT_TABLE_TTL.
+            max_ttl: Retention cap for the table (QuestDB TTL shorthand: "<n> hours|days|weeks|
+                months|years", or "30d"/"4h"/"2w"/"6M"/"1y"). Implementations apply it when the
+                table has no retention or a longer one and keep a shorter one, so an operator can
+                tighten retention per environment without a restart undoing it; raising retention
+                is a deliberate manual step. None leaves retention untouched. Backends without
+                retention accept and ignore it. Default DEFAULT_TABLE_TTL.
         """
         pass
 

--- a/src/qubx/emitters/composite.py
+++ b/src/qubx/emitters/composite.py
@@ -136,7 +136,7 @@ class CompositeMetricEmitter(BaseMetricEmitter):
             symbol_columns: Column names to create as indexed SYMBOL columns
             dedup_keys: Optional designated-timestamp-first dedup key columns
             partition_by: Partitioning unit (default DAY)
-            max_ttl: Retention forwarded as-is; None means "leave retention untouched"
+            max_ttl: Retention cap forwarded as-is; None means "leave retention untouched"
         """
         for emitter in self._emitters:
             try:

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -6,6 +6,7 @@ This module provides an implementation of IMetricEmitter that exports metrics to
 
 import datetime
 import json
+import re
 from collections.abc import Sequence
 from typing import Any, cast
 
@@ -37,6 +38,34 @@ DEALS_TTL = "14 weeks"
 HEALTH_TTL = "30 days"
 RATE_LIMITS_TTL = "30 days"
 DEFAULT_USER_TTL = DEFAULT_TABLE_TTL
+
+_TTL_UNIT_HOURS = {"HOUR": 1.0, "DAY": 24.0, "WEEK": 168.0, "MONTH": 720.0, "YEAR": 8760.0}
+_TTL_SHORT_UNITS = {
+    "h": "HOUR",
+    "d": "DAY",
+    "w": "WEEK",
+    "M": "MONTH",
+    "y": "YEAR",
+}  # QuestDB shorthand, case-sensitive
+_TTL_SPEC = re.compile(r"^\s*(\d+)\s*([A-Za-z]+)\s*$")
+
+
+def ttl_hours(spec: str) -> float:
+    """Hours in a QuestDB TTL spec ('30 days', '52 WEEKS', '4h', '6M'). Minutes are not a TTL unit."""
+    match = _TTL_SPEC.match(spec or "")
+    if match is None:
+        raise ValueError(f"unparseable TTL spec {spec!r}")
+    value, unit = int(match.group(1)), match.group(2)
+    if value <= 0:
+        raise ValueError(f"TTL must be positive: {spec!r}")
+    if len(unit) == 1:
+        canonical = _TTL_SHORT_UNITS.get(unit)
+    else:
+        canonical = unit.upper().rstrip("S")
+        canonical = canonical if canonical in _TTL_UNIT_HOURS else None
+    if canonical is None:
+        raise ValueError(f"unknown TTL unit in {spec!r}")
+    return value * _TTL_UNIT_HOURS[canonical]
 
 
 def _json_scalar(value: Any) -> Any:
@@ -382,6 +411,54 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         except Exception as e:
             logger.warning(f"[QuestDBMetricEmitter] '{table}': TTL {max_ttl!r} not applied: {e}")
 
+    def _current_ttl_hours(self, client: QuestDBClient, table: str) -> float | None:
+        """
+        Retention QuestDB reports for `table` in hours; 0.0 when it has none, None when unreadable.
+
+        `tables()` is the only place QuestDB exposes TTL (`ttlValue`, `ttlUnit`); `ttlValue = 0`
+        means no retention. Any failure is reported as None so the caller can fail open.
+        """
+        try:
+            frame = client.query(
+                "SELECT ttlValue, ttlUnit FROM tables() WHERE table_name = %(table)s", {"table": table}
+            )
+            if not isinstance(frame, pd.DataFrame) or frame.empty:
+                return None
+            value = int(frame.iloc[0]["ttlValue"])
+            if value <= 0:
+                return 0.0
+            return value * _TTL_UNIT_HOURS[str(frame.iloc[0]["ttlUnit"]).upper()]
+        except Exception as e:
+            logger.warning(f"[QuestDBMetricEmitter] '{table}': could not read current TTL ({e})")
+            return None
+
+    def _apply_retention(self, client: QuestDBClient, table: str, max_ttl: str, *, cap: bool) -> None:
+        """
+        cap=True: `max_ttl` is an upper bound — set it when the table has no retention or a longer
+        one, keep a shorter one (the platform may tighten per environment). cap=False: set it only
+        when the table has no retention at all (a bootstrap default the platform owns afterwards).
+        An unreadable current value applies `max_ttl` unconditionally: fail open toward the bound.
+        """
+        current = self._current_ttl_hours(client, table)
+        if current is None:
+            self._set_retention(client, table, max_ttl)
+            return
+        if current == 0.0:
+            self._set_retention(client, table, max_ttl)
+            return
+        if not cap:
+            logger.debug(f"[QuestDBMetricEmitter] '{table}': retention {current:g}h left to the platform")
+            return
+        try:
+            bound = ttl_hours(max_ttl)
+        except ValueError:
+            self._set_retention(client, table, max_ttl)  # QuestDB owns the syntax rule
+            return
+        if current > bound:
+            self._set_retention(client, table, max_ttl)
+        else:
+            logger.debug(f"[QuestDBMetricEmitter] '{table}': retention {current:g}h within the {bound:g}h cap")
+
     def _refuse_reserved(self, table: str) -> None:
         """
         Reject a strategy table that targets one of the emitter's own tables.
@@ -464,8 +541,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         """
         Create a strategy-owned table with explicit types (spec: strategy-tables §2.0).
 
-        `max_ttl` is applied whether the table was just created or already existed. Pass None
-        to leave retention alone.
+        `max_ttl` is a cap: applied when the table has no retention or a longer one, never
+        raising a shorter one. Pass None to leave retention alone.
         """
         try:
             self._refuse_reserved(table)
@@ -495,7 +572,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
             client = QuestDBClient(host=self._host, port=8812)
             client.execute(ddl)
             if max_ttl:
-                self._set_retention(client, table, max_ttl)
+                self._apply_retention(client, table, max_ttl, cap=True)
             self._declared_columns[table] = set(decl)
             self._declared_symbols[table] = {n for n, t in decl.items() if t == "SYMBOL"}
             logger.info(f"[QuestDBMetricEmitter] Ensured table '{table}' exists")

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -29,9 +29,9 @@ DEALS_TABLE = "qubx.deals"
 HEALTH_TABLE = "qubx.health"
 RATE_LIMITS_TABLE = "qubx.rate_limits"
 
-# - retention per reserved table. metrics/signals/deals match what production already carries, so
-#   deploying does not change retention there; health and rate_limits are new and would otherwise
-#   grow without bound.
+# - bootstrap retention per reserved table, applied once (creation, or found with no TTL); a
+#   changed constant does not touch an existing table. metrics/signals/deals are then owned by the
+#   platform's reconciler; health/rate_limits have no reconciler rule yet and just keep this value.
 METRICS_TTL = "30 days"
 SIGNALS_TTL = "14 weeks"
 DEALS_TTL = "14 weeks"
@@ -412,12 +412,15 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         except Exception as e:
             logger.warning(f"[QuestDBMetricEmitter] '{table}': TTL {max_ttl!r} not applied: {e}")
 
-    def _current_ttl_hours(self, client: QuestDBClient, table: str) -> float | None:
+    def _current_ttl_hours(self, client: QuestDBClient, table: str, max_ttl: str) -> float | None:
         """
         Retention QuestDB reports for `table` in hours; 0.0 when it has none, None when unreadable.
 
         `tables()` is the only place QuestDB exposes TTL (`ttlValue`, `ttlUnit`); `ttlValue = 0`
-        means no retention. Any failure is reported as None so the caller can fail open.
+        means no retention. Any failure is reported as None so the caller can fail open. QuestDB
+        releases before 8.2 do not expose `ttlValue`/`ttlUnit` in `tables()` at all, so every read
+        fails there and this path — applying `max_ttl` unconditionally — is taken on every boot,
+        matching the old (pre-cap) behaviour.
         """
         try:
             frame = client.query(
@@ -430,7 +433,10 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
                 return 0.0
             return value * _TTL_UNIT_HOURS[str(frame.iloc[0]["ttlUnit"]).upper()]
         except Exception as e:
-            logger.warning(f"[QuestDBMetricEmitter] '{table}': could not read current TTL ({e})")
+            logger.warning(
+                f"[QuestDBMetricEmitter] '{table}': could not read current TTL ({e}) "
+                f"— applying {max_ttl} unconditionally"
+            )
             return None
 
     def _apply_retention(self, client: QuestDBClient, table: str, max_ttl: str, *, cap: bool) -> None:
@@ -440,7 +446,7 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         when the table has no retention at all (a bootstrap default the platform owns afterwards).
         An unreadable current value applies `max_ttl` unconditionally: fail open toward the bound.
         """
-        current = self._current_ttl_hours(client, table)
+        current = self._current_ttl_hours(client, table, max_ttl)
         if current is None:
             self._set_retention(client, table, max_ttl)
             return

--- a/src/qubx/emitters/questdb.py
+++ b/src/qubx/emitters/questdb.py
@@ -381,7 +381,8 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
 
     def _declare_table(self, table: str, columns: dict[str, str], partition_by: str, max_ttl: str) -> None:
         """
-        Create a reserved table, record its schema, and set its retention.
+        Create a reserved table, record its schema, and give it a bootstrap retention only when
+        it has none — the platform's retention reconciler owns it afterwards.
 
         The recorded schema is what `_split_tags` filters against, so a table whose DDL could
         not be applied still filters against the declaration rather than accepting everything.
@@ -393,14 +394,14 @@ class QuestDBMetricEmitter(BaseMetricEmitter):
         try:
             client = QuestDBClient(host=self._host, port=8812)
             client.execute(ddl)
-            self._set_retention(client, table, max_ttl)
+            self._apply_retention(client, table, max_ttl, cap=False)
             logger.info(f"[QuestDBMetricEmitter] Ensured table '{table}' exists")
         except Exception as e:
             logger.error(f"[QuestDBMetricEmitter] Failed to create table '{table}': {e}")
 
     def _set_retention(self, client: QuestDBClient, table: str, max_ttl: str) -> None:
         """
-        Set retention on a table, whether it was just created or already existed.
+        Issue ALTER TABLE … SET TTL.
 
         Idempotent and ~2ms, so it runs unconditionally rather than reading the current value
         back first. QuestDB rejects a TTL finer than the partition size and leaves the table

--- a/tests/qubx/emitters/questdb_schema_test.py
+++ b/tests/qubx/emitters/questdb_schema_test.py
@@ -132,7 +132,7 @@ def test_a_strategy_table_is_still_accepted(emitter):
     assert "loe.execution" in emitter._declared_columns
 
 
-def test_retention_is_set_on_the_reserved_tables(emitter):
+def test_reserved_table_ttl_constants(emitter):
     # - health and rate_limits are new tables and would otherwise grow without bound
     from qubx.emitters.questdb import DEALS_TTL, HEALTH_TTL, METRICS_TTL, RATE_LIMITS_TTL, SIGNALS_TTL
 

--- a/tests/qubx/emitters/questdb_schema_test.py
+++ b/tests/qubx/emitters/questdb_schema_test.py
@@ -8,6 +8,7 @@ auto-create, for every bot writing to the same server.
 import datetime
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from qubx.emitters.questdb import QuestDBMetricEmitter
@@ -149,3 +150,38 @@ def test_set_retention_survives_a_ttl_questdb_rejects(emitter):
     emitter._set_retention(client, "some.table", "10 days")  # - must not raise
 
     client.execute.assert_called_once_with('ALTER TABLE "some.table" SET TTL 10 days')
+
+
+def _ttl_frame(value: int, unit: str) -> pd.DataFrame:
+    return pd.DataFrame([{"ttlValue": value, "ttlUnit": unit}])
+
+
+def _ttl_statements(client) -> list[str]:
+    return [c[0][0] for c in client.execute.call_args_list if "SET TTL" in c[0][0].upper()]
+
+
+def test_reserved_tables_get_their_ttl_only_when_they_have_none():
+    # the platform reconciler owns qubx.* retention once a table exists (dev: 10 days); a bot
+    # boot must not re-apply METRICS_TTL on top of it
+    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient") as client_cls:
+        client_cls.return_value.query.return_value = _ttl_frame(10, "DAY")
+        QuestDBMetricEmitter(host="qdb", tags={"strategy": "bot-1", "run_id": "r-1", "environment": "dev"})
+        assert _ttl_statements(client_cls.return_value) == []
+
+
+def test_reserved_tables_without_retention_get_the_bootstrap_ttl():
+    from qubx.emitters.questdb import METRICS_TTL
+
+    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient") as client_cls:
+        client_cls.return_value.query.return_value = _ttl_frame(0, "HOUR")
+        QuestDBMetricEmitter(host="qdb", tags={"strategy": "bot-1", "run_id": "r-1", "environment": "dev"})
+        assert f'ALTER TABLE "qubx.metrics" SET TTL {METRICS_TTL}' in _ttl_statements(client_cls.return_value)
+
+
+def test_reserved_tables_apply_the_bootstrap_ttl_when_the_read_fails():
+    from qubx.emitters.questdb import METRICS_TTL
+
+    with patch("qubx.emitters.questdb.Sender"), patch("qubx.emitters.questdb.QuestDBClient") as client_cls:
+        client_cls.return_value.query.side_effect = RuntimeError("no tables()")
+        QuestDBMetricEmitter(host="qdb", tags={"strategy": "bot-1", "run_id": "r-1", "environment": "dev"})
+        assert f'ALTER TABLE "qubx.metrics" SET TTL {METRICS_TTL}' in _ttl_statements(client_cls.return_value)

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -205,6 +205,30 @@ class TestEnsureTableRetention:
         emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
         assert self._ttl_statements(emitter) == ['ALTER TABLE "frab.pairs" SET TTL 30 days']
 
+    def test_empty_tables_result_applies_the_cap(self, emitter):
+        # QuestDB returns an empty frame (not an exception) for a table tables() doesn't know
+        # about yet — the WAL create/read race — and that must fail open the same as a read error
+        emitter._ddl_client_for_test.query.return_value = pd.DataFrame(columns=["ttlValue", "ttlUnit"])
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == ['ALTER TABLE "frab.pairs" SET TTL 30 days']
+
+    def test_shorter_existing_retention_is_kept_across_units(self, emitter):
+        # 2 weeks (336h) < 30 days (720h) cap: the shorter existing retention must survive
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(2, "WEEK")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == []
+
+    def test_lowercase_ttl_unit_is_tolerated(self, emitter):
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(10, "day")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == []
+
+    def test_shorter_existing_retention_is_kept_months_vs_weeks(self, emitter):
+        # 2 months (1440h) < 52 weeks (8736h) cap
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(2, "MONTH")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="52 weeks")
+        assert self._ttl_statements(emitter) == []
+
     def test_unparseable_cap_is_applied_verbatim(self, emitter):
         # QuestDB is the authority on syntax; an unparseable spec skips the comparison, not the ALTER
         emitter._ddl_client_for_test.query.return_value = _ttl_frame(10, "DAY")

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -5,13 +5,14 @@ import datetime
 from unittest.mock import MagicMock
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import qubx.emitters.questdb as qdb_mod
 from qubx.core.interfaces import DEFAULT_TABLE_TTL, IMetricEmitter
 from qubx.emitters.composite import CompositeMetricEmitter
 from qubx.emitters.csv import CSVMetricEmitter
-from qubx.emitters.questdb import QuestDBMetricEmitter
+from qubx.emitters.questdb import QuestDBMetricEmitter, ttl_hours
 
 
 class TestInterfaceDefaults:
@@ -159,6 +160,10 @@ class TestEnsureTable:
         emitter._ddl_client_for_test.execute.assert_not_called()
 
 
+def _ttl_frame(value: int, unit: str) -> pd.DataFrame:
+    return pd.DataFrame([{"ttlValue": value, "ttlUnit": unit}])
+
+
 class TestEnsureTableRetention:
     @staticmethod
     def _ttl_statements(emitter) -> list[str]:
@@ -168,18 +173,49 @@ class TestEnsureTableRetention:
             if "SET TTL" in call[0][0].upper()
         ]
 
-    def test_default_applies_interface_ttl(self, emitter):
+    def test_default_applies_interface_ttl_to_a_table_without_retention(self, emitter):
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(0, "HOUR")
         emitter.ensure_table("frab.trades", {"net_pnl": "DOUBLE"})
         assert self._ttl_statements(emitter) == [f'ALTER TABLE "frab.trades" SET TTL {DEFAULT_TABLE_TTL}']
 
-    def test_explicit_ttl_is_applied(self, emitter):
+    def test_explicit_ttl_is_applied_to_a_new_table(self, emitter):
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(0, "HOUR")
         emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
         assert self._ttl_statements(emitter) == ['ALTER TABLE "frab.pairs" SET TTL 30 days']
+
+    def test_shorter_existing_retention_is_kept(self, emitter):
+        # the platform tightened dev to 10 days; the strategy's 30-day cap must not undo it
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(10, "DAY")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == []
+
+    def test_equal_existing_retention_is_kept(self, emitter):
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(30, "DAY")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == []
+
+    def test_longer_existing_retention_is_tightened(self, emitter):
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(52, "WEEK")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == ['ALTER TABLE "frab.pairs" SET TTL 30 days']
+
+    def test_unreadable_retention_applies_the_cap(self, emitter):
+        # fail open toward the strategy's bound: a read error must not leave a table unbounded
+        emitter._ddl_client_for_test.query.side_effect = RuntimeError("tables() unavailable")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="30 days")
+        assert self._ttl_statements(emitter) == ['ALTER TABLE "frab.pairs" SET TTL 30 days']
+
+    def test_unparseable_cap_is_applied_verbatim(self, emitter):
+        # QuestDB is the authority on syntax; an unparseable spec skips the comparison, not the ALTER
+        emitter._ddl_client_for_test.query.return_value = _ttl_frame(10, "DAY")
+        emitter.ensure_table("frab.pairs", {"ev": "DOUBLE"}, max_ttl="3 fortnights")
+        assert self._ttl_statements(emitter) == ['ALTER TABLE "frab.pairs" SET TTL 3 fortnights']
 
     def test_none_leaves_retention_alone(self, emitter):
         emitter.ensure_table("exec.fills", {"qty": "DOUBLE"}, max_ttl=None)
         assert _create_sql(emitter)  # table still declared
         assert self._ttl_statements(emitter) == []
+        emitter._ddl_client_for_test.query.assert_not_called()
 
 
 class TestEmitRecord:
@@ -338,3 +374,31 @@ class TestCSVRecords:
         em.ensure_table("loe.execution", {"price": "DOUBLE"})
         em._record_path = lambda table: tmp_path / "no_such_dir" / "x" / "y.csv"
         em.emit_record("loe.execution", {"price": 1.0})  # must not raise
+
+
+class TestTtlHours:
+    @pytest.mark.parametrize(
+        "spec,hours",
+        [
+            ("30 days", 720.0),
+            ("52 weeks", 8736.0),
+            ("4 hours", 4.0),
+            ("1 day", 24.0),
+            ("6 months", 4320.0),
+            ("1 year", 8760.0),
+            ("30d", 720.0),
+            ("4h", 4.0),
+            ("2w", 336.0),
+            ("6M", 4320.0),
+            ("1y", 8760.0),
+            ("30 DAYS", 720.0),
+            ("  30 days ", 720.0),
+        ],
+    )
+    def test_parses_questdb_ttl_specs(self, spec, hours):
+        assert ttl_hours(spec) == hours
+
+    @pytest.mark.parametrize("spec", ["", "days", "30", "30 minutes", "30m", "-1 day", "1.5 days"])
+    def test_rejects_unparseable_specs(self, spec):
+        with pytest.raises(ValueError):
+            ttl_hours(spec)

--- a/tests/qubx/emitters/strategy_tables_test.py
+++ b/tests/qubx/emitters/strategy_tables_test.py
@@ -398,7 +398,7 @@ class TestTtlHours:
     def test_parses_questdb_ttl_specs(self, spec, hours):
         assert ttl_hours(spec) == hours
 
-    @pytest.mark.parametrize("spec", ["", "days", "30", "30 minutes", "30m", "-1 day", "1.5 days"])
+    @pytest.mark.parametrize("spec", ["", "days", "30", "30 minutes", "30m", "-1 day", "1.5 days", "0 days", "0d"])
     def test_rejects_unparseable_specs(self, spec):
         with pytest.raises(ValueError):
             ttl_hours(spec)


### PR DESCRIPTION
## Summary

Stops the QuestDB emitter from fighting the platform's retention reconciler. On the dev cluster `qubx.metrics` flapped between 10 days (platform rule, re-applied hourly) and 30 days (`METRICS_TTL`, re-applied at every bot boot).

- `ensure_table(max_ttl=…)` is now a **cap**: after `CREATE TABLE IF NOT EXISTS` the emitter reads the table's current TTL from `tables()` (`ttlValue`/`ttlUnit`) and issues `ALTER TABLE … SET TTL` only when the table has no retention or a longer one. A shorter retention set by an operator or the platform is kept. Raising retention is a deliberate manual step.
- The five reserved tables (`qubx.metrics`, `qubx.signals`, `qubx.deals`, `qubx.health`, `qubx.rate_limits`) receive their built-in TTL only when they have none (bootstrap); an existing value belongs to the platform afterwards.
- Fail-open: if the TTL cannot be read (pgwire error, QuestDB without `ttlValue` in `tables()`), the TTL is applied unconditionally as before, with a warning. A DDL failure still leaves the emitter constructed and emitting over ILP.
- `ttl_hours()` parses QuestDB TTL specs (`30 days`, `52 WEEKS`, `4h`, `6M`); unparseable caps are applied verbatim (QuestDB owns the syntax rule).
- Docstrings (`IMetricEmitter.ensure_table`, `CompositeMetricEmitter`, emitter internals) describe the cap semantics.

Plan: `docs/superpowers/plans/2026-09-09-ttl-ownership.md`. No signature changes; callers passing `max_ttl` keep working, they just no longer undo a tighter platform setting.

## Verification

`uv run pytest tests/qubx/emitters -q` → 157 passed (baseline 123). The final review additionally exercised the branch against a throwaway QuestDB 8.2.3: named pgwire params valid, `tables()` returns int64 `ttlValue` and upper-case singular `ttlUnit`, unknown table → empty frame, full state matrix behaves as designed (platform tightens to 10d → next boot keeps 10 DAY).

https://claude.ai/code/session_01LRsH9BRNcE5BJeCV7JCrrV