### PR TITLE
fix(core): drop venue-reported margins when a position goes flat

### DIFF
--- a/src/qubx/core/basics.py
+++ b/src/qubx/core/basics.py
@@ -1160,7 +1160,9 @@ class Position:
         self.market_value = 0.0
         self.market_value_funds = 0.0
         self.initial_margin = 0.0
+        self._initial_margin_external = False
         self.maint_margin = 0.0
+        self._maint_margin_external = False
         self.pnl = self.r_pnl  # unrealized PnL is zero at zero quantity
         self.__pos_incr_qty = 0
 
@@ -1541,6 +1543,14 @@ class Position:
         self._initial_margin_external = True
 
     def _update_maint_margin(self) -> None:
+        # A flat position reserves nothing. Venues report margins for OPEN positions only
+        # (HL clearinghouseState / Binance positionRisk omit flat ones), so a venue-reported
+        # value has no refresh path after a close — drop it, and its flag, on going flat.
+        if not self.is_open():
+            self.maint_margin = 0.0
+            self._maint_margin_external = False
+            return
+
         # Skip recalculation if margin is managed externally (live trading with exchange-provided values)
         if self._maint_margin_external:
             return
@@ -1554,6 +1564,12 @@ class Position:
             self.maint_margin = 0.0
 
     def _update_initial_margin(self) -> None:
+        # Same flat guard as _update_maint_margin: a venue-reported value has no refresh path once flat.
+        if not self.is_open():
+            self.initial_margin = 0.0
+            self._initial_margin_external = False
+            return
+
         # Skip recalculation if margin is managed externally (live trading with exchange-provided values)
         if self._initial_margin_external:
             return

--- a/tests/qubx/core/account_manager/reducer_test.py
+++ b/tests/qubx/core/account_manager/reducer_test.py
@@ -73,13 +73,19 @@ def _fill(trade_id: str = "t1", amount: float = 0.5, price: float = 100.0) -> De
     return Deal(trade_id=trade_id, order_id="v1", time=T0, amount=amount, price=price, aggressive=True)
 
 
-def _order(state: AccountState, cid: str = "c1", status: OrderStatus = OrderStatus.SUBMITTED, venue_id=None) -> Order:
+def _order(
+    state: AccountState,
+    cid: str = "c1",
+    status: OrderStatus = OrderStatus.SUBMITTED,
+    venue_id=None,
+    side: OrderSide = OrderSide.BUY,
+) -> Order:
     order = Order(
         client_order_id=cid,
         type=OrderType.LIMIT,
         instrument=BTC,
         quantity=1.0,
-        side=OrderSide.BUY,
+        side=side,
         time_in_force="gtc",
         status=status,
         venue_order_id=venue_id,
@@ -606,6 +612,31 @@ def test_futures_fee_debits_settle_balance():
     apply(state, OrderFilledEvent(instrument=None, client_order_id="c1", fill=deal), T1)
     # futures: settle (USDT) += realized_pnl - fee = 0 - 2
     assert _present(state.get_balance("USDT")).total == 998.0
+
+
+def test_closing_fill_clears_venue_reported_margins():
+    # Venues report margins for OPEN positions only, so a value a snapshot stamped on the
+    # position (set_external_*_margin) has no refresh path once the deal ledger books the size
+    # to zero. The closing fill itself must drop it — otherwise total_maint_margin() and
+    # margin_ratio() keep reporting a maintenance requirement with no position behind it.
+    state = _state()
+    _seed_usdt(state, 1000.0)
+    _order(state, status=OrderStatus.ACCEPTED)
+    apply(state, OrderFilledEvent(instrument=None, client_order_id="c1", fill=_fill("t1", 0.5, 50_000.0)), T1)
+
+    pos = _present(state.get_position(BTC))
+    pos.set_external_maint_margin(107.40)  # as reconcile_position_from_snapshot does
+    pos.set_external_initial_margin(268.5)
+    assert state.total_maint_margin() == 107.40
+    assert state.margin_ratio() < 100.0
+
+    _order(state, cid="c2", status=OrderStatus.ACCEPTED, side=OrderSide.SELL)
+    apply(state, OrderFilledEvent(instrument=None, client_order_id="c2", fill=_fill("t2", -0.5, 51_000.0)), T1)
+
+    assert pos.quantity == 0.0
+    assert state.total_maint_margin() == 0.0
+    assert state.total_initial_margin() == 0.0
+    assert state.margin_ratio() == 100.0
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/qubx/core/test_position_initial_margin.py
+++ b/tests/qubx/core/test_position_initial_margin.py
@@ -6,10 +6,17 @@ account processors can write the exchange-reported value and the framework
 won't recompute it on price updates.
 """
 
-from qubx.core.basics import Instrument, MarketType, Position
+import numpy as np
+import pytest
+
+from qubx.core.basics import DEFAULT_MAINTENANCE_MARGIN, Instrument, MarketType, Position
+
+T0 = np.datetime64("2026-05-28T00:00:00", "ns")
+T1 = np.datetime64("2026-05-28T00:01:00", "ns")
+T2 = np.datetime64("2026-05-28T00:02:00", "ns")
 
 
-def _make_instrument() -> Instrument:
+def _make_instrument(initial_margin: float = 0.0) -> Instrument:
     return Instrument(
         symbol="ETHUSDT",
         market_type=MarketType.SWAP,
@@ -22,6 +29,7 @@ def _make_instrument() -> Instrument:
         lot_size=0.001,
         min_size=0.001,
         contract_size=1.0,
+        initial_margin=initial_margin,
     )
 
 
@@ -74,3 +82,113 @@ def test_reset_by_position_copies_initial_margin_state():
     dst.reset_by_position(src)
     assert dst.initial_margin == 99.9
     assert dst._initial_margin_external is True
+
+
+# --------------------------------------------------------------------------- #
+# Venue-reported margins must not outlive the position.
+#
+# Venues report margins for OPEN positions only (Hyperliquid clearinghouseState,
+# Binance positionRisk both omit flat ones), so once the deal ledger books a
+# position to zero there is no snapshot left to refresh a value stamped via
+# set_external_*_margin. The close itself has to drop the value AND the sticky
+# flag, or AccountState.total_maint_margin()/margin_ratio() keep reading a
+# maintenance requirement for risk that no longer exists.
+# --------------------------------------------------------------------------- #
+
+
+def test_full_close_clears_venue_reported_margins():
+    pos = Position(instrument=_make_instrument())
+    pos.update_position(T0, 100.0, 2000.0)
+    pos.set_external_maint_margin(15.35693)
+    pos.set_external_initial_margin(26.85)
+
+    pos.update_position(T1, 0.0, 2010.0)
+
+    assert pos.is_open() is False
+    assert pos.maint_margin == 0.0
+    assert pos._maint_margin_external is False
+    assert pos.initial_margin == 0.0
+    assert pos._initial_margin_external is False
+
+
+def test_partial_close_keeps_venue_reported_margins():
+    # the guard must fire only on going flat — a reduced position still carries the
+    # venue value until the next snapshot re-reports it
+    pos = Position(instrument=_make_instrument())
+    pos.update_position(T0, 100.0, 2000.0)
+    pos.set_external_maint_margin(15.35693)
+    pos.set_external_initial_margin(26.85)
+
+    pos.update_position(T1, 40.0, 2010.0)
+
+    assert pos.is_open() is True
+    assert pos.maint_margin == 15.35693
+    assert pos._maint_margin_external is True
+    assert pos.initial_margin == 26.85
+    assert pos._initial_margin_external is True
+
+
+def test_reopen_after_close_derives_margins_until_venue_reports_again():
+    pos = Position(instrument=_make_instrument(initial_margin=0.1))
+    pos.update_position(T0, 100.0, 2000.0)
+    pos.set_external_maint_margin(15.35693)
+    pos.set_external_initial_margin(26.85)
+    pos.update_position(T1, 0.0, 2010.0)
+
+    # reopen with no venue snapshot in between: framework-derived, not the stale value, not zero
+    pos.update_position(T2, 2.0, 2020.0)
+    assert pos.maint_margin == pytest.approx(DEFAULT_MAINTENANCE_MARGIN * 2.0 * 2020.0)
+    assert pos._maint_margin_external is False
+    assert pos.initial_margin == pytest.approx(0.1 * 2.0 * 2020.0)
+    assert pos._initial_margin_external is False
+
+    # the next snapshot carrying the instrument takes over again
+    pos.set_external_maint_margin(14.9)
+    pos.set_external_initial_margin(29.8)
+    assert pos.maint_margin == 14.9
+    assert pos._maint_margin_external is True
+    assert pos.initial_margin == 29.8
+    assert pos._initial_margin_external is True
+
+
+def test_flatten_clears_external_flags_so_reopen_derives_margins():
+    # flatten() (settle_position / missed-close recovery) zeroes the values; it must drop the
+    # flags too, otherwise a reopen with no quote in between is an OPEN position reading
+    # zero margin — an account that looks maximally safe with real risk on.
+    pos = Position(instrument=_make_instrument(initial_margin=0.1))
+    pos.update_position(T0, 100.0, 2000.0)
+    pos.set_external_maint_margin(15.35693)
+    pos.set_external_initial_margin(26.85)
+
+    pos.flatten()
+    assert pos.maint_margin == 0.0
+    assert pos._maint_margin_external is False
+    assert pos.initial_margin == 0.0
+    assert pos._initial_margin_external is False
+
+    pos.update_position(T1, 2.0, 2020.0)
+    assert pos.is_open() is True
+    assert pos.maint_margin == pytest.approx(DEFAULT_MAINTENANCE_MARGIN * 2.0 * 2020.0)
+    assert pos.maint_margin > 0.0
+    assert pos.initial_margin == pytest.approx(0.1 * 2.0 * 2020.0)
+    assert pos.initial_margin > 0.0
+
+
+def test_derived_margins_open_close_cycle_without_venue_values():
+    # simulated / backtester path: the external flags are never set, so margins are derived
+    # while open and zero once flat — the flat guard changes nothing here
+    pos = Position(instrument=_make_instrument(initial_margin=0.1))
+
+    pos.update_position(T0, 100.0, 2000.0)
+    assert pos.maint_margin == pytest.approx(DEFAULT_MAINTENANCE_MARGIN * 100.0 * 2000.0)
+    assert pos.initial_margin == pytest.approx(0.1 * 100.0 * 2000.0)
+
+    pos.update_position(T1, 40.0, 2010.0)
+    assert pos.maint_margin == pytest.approx(DEFAULT_MAINTENANCE_MARGIN * 40.0 * 2010.0)
+    assert pos.initial_margin == pytest.approx(0.1 * 40.0 * 2010.0)
+
+    pos.update_position(T2, 0.0, 2020.0)
+    assert pos.maint_margin == 0.0
+    assert pos._maint_margin_external is False
+    assert pos.initial_margin == 0.0
+    assert pos._initial_margin_external is False


### PR DESCRIPTION
## What happens

A closed position keeps the maintenance/initial margin the venue last reported for it, so the account keeps counting margin for positions that no longer exist.

Dev bot `c9d223f3` (funding-arb, BINANCE.UM + HYPERLIQUID.F) read a HYPERLIQUID.F maintenance margin of **107.40** and MMR **6.89** with **zero open positions**. Its `MarginRatioRebalancer` saw a margin emergency that closing could never relieve, and liquidated all 8 pairs instead of the 3 that correct numbers required. Also visible on BINANCE.UM (maint 11.54 at zero positions) — not venue-specific.

## Why

Connectors stamp per-position margins from an account snapshot via `set_external_*_margin()`, which sets `_*_margin_external = True`. That flag makes `_update_*_margin()` early-return forever, so the only remaining refresh path is another snapshot carrying that instrument. But venues report margins for **open** positions only (Hyperliquid `clearinghouseState.assetPositions`, Binance v3 `positionRisk`) — so once the deal ledger books the quantity to 0 the instrument disappears from snapshots and the last value is frozen, while `total_maint_margin()` keeps summing it and `margin_ratio()` keeps dividing by it.

It bites only on the *healthy* path. A **missed** close would have gone through `LocalPositionMissing` → `flatten()` and zeroed the margins. Booking the close correctly is exactly what hides the position from both loops of `Differ._diff_positions`: the venue no longer lists it, and the local-side loop is gated on `_material_pos`.

## Fix — `src/qubx/core/basics.py`, 16 lines

Guard both margin recalcs on the canonical flat predicate `is_open()`, clearing the value **and** the sticky flag on going flat. `update_market_price()` is the single chokepoint every flat transition passes through — the deal path, `reconcile_size` via snapshot reconcile, and every quote.

`flatten()` also clears the two flags next to the values it already zeroes. Required, not cosmetic: otherwise it leaves `external=True` holding `0.0`, and a reopen with no quote in between is an **open** position reading zero maintenance margin — an account that looks maximally safe with real risk on.

Deliberately not fixed in `Differ._diff_positions` (routing flat positions through `LocalPositionMissing` would spawn pointless missed-deal recovery for every flat position on every snapshot) or at the summing site in `AccountState` (masks it; the per-position value stays stale for consumers that read it directly). No connector changes — connectors report correctly; the venue simply has nothing to report once flat.

Behaviour note: sub-lot dust (`0 < |qty| < lot_size`) now reads zero margin, consistent with the differ's own "less than half a lot is effectively flat" convention.

## Verified

Six new tests in `test_position_initial_margin.py` (Position level) and `account_manager/reducer_test.py` (deal path end-to-end).

**Pre-fix: 4 failed, 2 passed.** The failures reproduce the incident — including the reducer case asserting `total_maint_margin() == 0.0` and getting `107.4`. The two that pass are the negative controls, and must keep passing: a **partial** close has to *keep* the venue value, and the simulated/backtester path (flags never set) has to be bit-identical.

**Post-fix:** 379 passed across the account-manager and margin suites; 35 passed on `-k margin`; full `-m "not integration and not e2e"` suite 3076 passed, 5 skipped (pre-existing).