### PR TITLE
feat(account): prefer venue-reported margin totals over position sums

### DIFF
--- a/docs/account-management/design.md
+++ b/docs/account-management/design.md
@@ -138,17 +138,29 @@ legality, runs no reconcile rules, fires no callbacks, depends on no clock.
 ### Venue-reported figures (option 2)
 
 `AccountState` holds an optional `VenueAccountFigures{equity, available_margin,
-margin_ratio, withdrawable, as_of}`. Each metric prefers its venue counterpart when
-present, else derives. The figures ride **flat on `AccountSnapshot`** (optional fields
-next to `as_of`/orders/positions/balances) and are set only by snapshot reconcile; the
-connector extracts them via the `_extract_venue_figures` seam (Binance and OKX wired;
-Bitfinex documented derive-only — `fetch_balance` carries no account figures; other
-venues return None and always derive — as does sim).
+margin_ratio, withdrawable, total_maint_margin, total_initial_margin, as_of}`. Each
+metric prefers its venue counterpart when present, else derives. The figures ride
+**flat on `AccountSnapshot`** (optional fields next to `as_of`/orders/positions/
+balances) and are set only by snapshot reconcile; the connector extracts them via the
+`_extract_venue_figures` seam — a positional 6-tuple in that field order (Binance and
+OKX wired; Bitfinex documented derive-only — `fetch_balance` carries no account
+figures; other venues return None and always derive — as does sim).
 
 - `withdrawable` maps Binance fapi `maxWithdrawAmount`; OKX exposes max-withdrawal only
   on a separate endpoint (outside the snapshot seam) so it stays None there. The derived
   fallback equals available margin (withdrawable ≤ available conceptually; equality is
   the documented sim/no-venue simplification).
+- `total_maint_margin` / `total_initial_margin` map Binance fapi `totalMaintMargin` /
+  `totalInitialMargin` (PM: `accountMaintMargin` / `accountInitialMargin`) and OKX
+  `mmr` / `imr`. The venue total may be scoped differently from a position sum
+  (cross-only on some venues, or including open-order margin): it is the venue's
+  requirement, not a re-sum of our positions. In single-asset mode Binance UM's totals
+  cover the USDT asset only, so a non-USDT-margined position reads as zero there; the
+  reconciler logs a WARNING when a venue reports zero maintenance margin on a book with
+  open positions (a signal only — the reported 0.0 is still used). The derived fallback
+  sums the per-position margins. On PM the venue total is also what makes
+  `total_capital / total_maint_margin` equal `uniMMR` — `accountEquity` spans
+  um/cm/margin while the position sum is UM-only.
 
 - **Freshness = WS liveness, not a TTL.** Venue figures arrive in lockstep with the
   events that would change them; the only staleness is a dead WS, which the liveness →

--- a/src/qubx/connectors/ccxt/connector.py
+++ b/src/qubx/connectors/ccxt/connector.py
@@ -1712,7 +1712,9 @@ class CcxtConnector(ChannelEmitter):
             positions = ccxt_convert_positions(raw_positions, ex.name, ex.markets)
             await self._fill_leverage_settings(positions)
             balances = self._convert_balances(raw_balance)
-            equity, available_margin, margin_ratio, withdrawable = self._extract_venue_figures(raw_balance)
+            equity, available_margin, margin_ratio, withdrawable, total_maint_margin, total_initial_margin = (
+                self._extract_venue_figures(raw_balance)
+            )
         except Exception as e:  # noqa: BLE001 — AM retries on its next snapshot tick
             # Venue exception text goes in as a positional arg (may contain HTML/markup that
             # loguru's colorizer rejects when it appears in the format string).
@@ -1737,6 +1739,8 @@ class CcxtConnector(ChannelEmitter):
                     available_margin=available_margin,
                     margin_ratio=margin_ratio,
                     withdrawable=withdrawable,
+                    total_maint_margin=total_maint_margin,
+                    total_initial_margin=total_initial_margin,
                 ),
             )
         )
@@ -1751,27 +1755,33 @@ class CcxtConnector(ChannelEmitter):
 
     def _extract_venue_figures(
         self, raw_balance: dict[str, Any]
-    ) -> tuple[float | None, float | None, float | None, float | None]:
-        """(equity, available_margin, margin_ratio, withdrawable) from the venue's raw
-        account payload.
+    ) -> tuple[float | None, float | None, float | None, float | None, float | None, float | None]:
+        """Venue account figures from the raw account payload, as the positional 6-tuple
+        ``(equity, available_margin, margin_ratio, withdrawable, total_maint_margin,
+        total_initial_margin)`` — overrides must keep exactly this order.
 
         ccxt has no unified account-figures schema, so the base impl reads the
         Binance-futures account fields carried through in ``info`` (both fapi v2 and
         v3 account payloads carry them top-level): ``totalMarginBalance`` (wallet +
         unrealized PnL = account equity), ``availableBalance`` (margin available for
-        new positions) and ``maxWithdrawAmount`` (maximum amount for transfer out).
-        Binance reports no direct margin ratio — left None so AM derives it. Venues
-        whose payload lacks these keys yield all-None and AM derives every metric;
-        subclasses override for venue-specific payloads.
+        new positions), ``maxWithdrawAmount`` (maximum amount for transfer out),
+        ``totalMaintMargin`` and ``totalInitialMargin`` (account-level margin
+        requirements; the initial figure includes open-order margin, and in single-asset
+        mode both cover the USDT asset only — a non-USDT-margined position reads as zero
+        there). Binance reports no direct margin ratio — left None so AM derives it.
+        Venues whose payload lacks these keys yield all-None and AM derives every
+        metric; subclasses override for venue-specific payloads.
         """
         info = raw_balance.get("info")
         if not isinstance(info, dict):
-            return None, None, None, None
+            return None, None, None, None, None, None
         return (
             info_float(info, "totalMarginBalance"),
             info_float(info, "availableBalance"),
             None,
             info_float(info, "maxWithdrawAmount"),
+            info_float(info, "totalMaintMargin"),
+            info_float(info, "totalInitialMargin"),
         )
 
     # ------------------------------------------------------------------ #

--- a/src/qubx/connectors/ccxt/exchanges/binance/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/binance/connector.py
@@ -73,13 +73,16 @@ class BinancePmCcxtConnector(CcxtConnector):
 
     def _extract_venue_figures(
         self, raw_balance: dict[str, Any]
-    ) -> tuple[float | None, float | None, float | None, float | None]:
-        """(equity, available_margin, margin_ratio, withdrawable) from ``papiGetAccount``:
+    ) -> tuple[float | None, float | None, float | None, float | None, float | None, float | None]:
+        """(equity, available_margin, margin_ratio, withdrawable, total_maint_margin,
+        total_initial_margin) from ``papiGetAccount``:
         ``accountEquity`` (collateral + uPnL across um/cm/margin, USD),
         ``totalAvailableBalance`` (margin available for new positions),
         ``uniMMR`` (accountEquity / accountMaintMargin — same shape as AM's derived
         ratio; reported as a 99999999 sentinel when maint margin is 0, mapped to None
-        so AM applies its own no-positions handling) and ``virtualMaxWithdrawAmount``."""
+        so AM applies its own no-positions handling), ``virtualMaxWithdrawAmount``,
+        ``accountMaintMargin`` and ``accountInitialMargin`` (account-wide margin
+        requirements across um/cm/margin — the same scope as ``accountEquity``)."""
         account = _account_figures(raw_balance)
         maint = info_float(account, "accountMaintMargin")
         margin_ratio = info_float(account, "uniMMR") if maint is not None and maint > 0 else None
@@ -88,6 +91,8 @@ class BinancePmCcxtConnector(CcxtConnector):
             info_float(account, "totalAvailableBalance"),
             margin_ratio,
             info_float(account, "virtualMaxWithdrawAmount"),
+            maint,
+            info_float(account, "accountInitialMargin"),
         )
 
     async def _fill_leverage_settings(self, positions: list[Position]) -> None:

--- a/src/qubx/connectors/ccxt/exchanges/bitfinex/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/bitfinex/connector.py
@@ -16,7 +16,7 @@ class BitfinexCcxtConnector(_TwoStreamCcxtConnector):
 
     def _extract_venue_figures(
         self, raw_balance: dict[str, Any]
-    ) -> tuple[float | None, float | None, float | None, float | None]:
+    ) -> tuple[float | None, float | None, float | None, float | None, float | None, float | None]:
         """Deliberately all-None: Bitfinex's ``fetch_balance`` carries no account figures.
 
         Its raw ``info`` is the bare wallets *list* from ``auth/r/wallets`` (the
@@ -25,4 +25,4 @@ class BitfinexCcxtConnector(_TwoStreamCcxtConnector):
         snapshot seam's reach. All-None → AM derives every metric from balances +
         positions.
         """
-        return None, None, None, None
+        return None, None, None, None, None, None

--- a/src/qubx/connectors/ccxt/exchanges/okx/connector.py
+++ b/src/qubx/connectors/ccxt/exchanges/okx/connector.py
@@ -12,7 +12,7 @@ Adds the OKX-specific behavior on top of the generic ``CcxtConnector``:
 - **Balance extraction**: ccxt's OKX balance mapping is wrong for the framework — see
   ``_convert_balances``.
 - **Venue account figures**: OKX's trading-balance payload carries account-level
-  figures (``totalEq`` / ``mgnRatio`` / ``adjEq`` / ``imr`` in ``info.data[0]``) — see
+  figures (``totalEq`` / ``mgnRatio`` / ``adjEq`` / ``imr`` / ``mmr`` in ``info.data[0]``) — see
   ``_extract_venue_figures``; AM prefers them per metric over its derived values.
 - **make_client_id / cid_framework_prefix**: OKX clOrdId is case-sensitive
   alphanumeric only, 1-32 chars — the underscore in ``qubx_`` is stripped, so origin
@@ -185,7 +185,7 @@ class OkxCcxtConnector(_TwoStreamCcxtConnector):
 
     def _extract_venue_figures(
         self, raw_balance: dict[str, Any]
-    ) -> tuple[float | None, float | None, float | None, float | None]:
+    ) -> tuple[float | None, float | None, float | None, float | None, float | None, float | None]:
         """OKX account-level figures from ``info.data[0]`` of the trading-balance payload.
 
         - equity: ``totalEq`` — total account equity. USD-denominated; reported as-is
@@ -197,6 +197,9 @@ class OkxCcxtConnector(_TwoStreamCcxtConnector):
         - withdrawable: deliberately None — OKX reports max-withdrawal only on a
           separate ``account/max-withdrawal`` endpoint, outside the snapshot seam,
           so AM derives it (= available).
+        - total_maint_margin / total_initial_margin: ``mmr`` / ``imr`` — account-level
+          maintenance / initial margin requirements (cross positions + pending orders),
+          populated only in multi-currency/portfolio margin modes like ``adjEq``.
 
         Not-applicable fields arrive as ``""`` → None → AM derives that metric.
         """
@@ -206,7 +209,7 @@ class OkxCcxtConnector(_TwoStreamCcxtConnector):
         adj_eq = info_float(acct, "adjEq")
         imr = info_float(acct, "imr")
         available_margin = adj_eq - imr if adj_eq is not None and imr is not None else None
-        return equity, available_margin, margin_ratio, None
+        return equity, available_margin, margin_ratio, None, info_float(acct, "mmr"), imr
 
     def make_client_id(self, suggested: str) -> str:
         """OKX clOrdId: case-sensitive alphanumeric only, 1-32 chars.

--- a/src/qubx/core/account_manager/reconciler.py
+++ b/src/qubx/core/account_manager/reconciler.py
@@ -504,7 +504,17 @@ class Reconciler:
 
         # - venue-reported figures (equity/margins): prefer-venue-else-derive per metric in
         #   AccountState. Absence = "not observed" -> keep the previous capture, never clear.
-        if any(v is not None for v in (snap.equity, snap.available_margin, snap.margin_ratio, snap.withdrawable)):
+        if any(
+            v is not None
+            for v in (
+                snap.equity,
+                snap.available_margin,
+                snap.margin_ratio,
+                snap.withdrawable,
+                snap.total_maint_margin,
+                snap.total_initial_margin,
+            )
+        ):
             state.set_venue_figures(
                 VenueAccountFigures(
                     as_of=snap.as_of,
@@ -512,8 +522,21 @@ class Reconciler:
                     available_margin=snap.available_margin,
                     margin_ratio=snap.margin_ratio,
                     withdrawable=snap.withdrawable,
+                    total_maint_margin=snap.total_maint_margin,
+                    total_initial_margin=snap.total_initial_margin,
                 )
             )
+        # - diagnostic only, changes no value: a venue claiming zero maintenance margin on a
+        #   live book is the false-safe signature (Binance UM single-asset mode reports
+        #   USDT-only totals, so a non-USDT-margined position reads as zero). The reported
+        #   0.0 is still used as-is — it is a value, not "unreported".
+        if snap.total_maint_margin == 0.0 and snap.positions:
+            open_count = sum(1 for p in snap.positions if p.is_open())
+            if open_count:
+                _log.warning(
+                    f"[{state.exchange}] reconcile: venue reports total_maint_margin=0.0 with {open_count} open "
+                    "position(s) — check the margin asset/mode of those positions"
+                )
 
         return actions + self._dispatch(SnapshotIn(snap), state, now)
 

--- a/src/qubx/core/account_manager/state.py
+++ b/src/qubx/core/account_manager/state.py
@@ -41,6 +41,8 @@ class VenueAccountFigures:
     available_margin: float | None = None
     margin_ratio: float | None = None
     withdrawable: float | None = None
+    total_maint_margin: float | None = None
+    total_initial_margin: float | None = None
 
 
 def _notional(position: Position) -> float:
@@ -241,9 +243,21 @@ class AccountState:
         return cash + sum(p.market_value_funds for p in list(self._positions.values()))
 
     def total_initial_margin(self) -> float:
+        """Venue total when reported — it may be scoped differently from a position sum
+        (cross-only on some venues, or including open-order margin), so it is the venue's
+        requirement rather than a re-sum of our positions — else the sum over positions."""
+        venue = self._venue_figures
+        if venue is not None and venue.total_initial_margin is not None:
+            return venue.total_initial_margin
         return sum(p.initial_margin for p in list(self._positions.values()))
 
     def total_maint_margin(self) -> float:
+        """Venue total when reported — it may be scoped differently from a position sum
+        (cross-only on some venues, or including open-order margin), so it is the venue's
+        requirement rather than a re-sum of our positions — else the sum over positions."""
+        venue = self._venue_figures
+        if venue is not None and venue.total_maint_margin is not None:
+            return venue.total_maint_margin
         return sum(p.maint_margin for p in list(self._positions.values()))
 
     def available_margin(self) -> float:

--- a/src/qubx/core/events.py
+++ b/src/qubx/core/events.py
@@ -194,6 +194,8 @@ class AccountSnapshot:
     available_margin: float | None = None
     margin_ratio: float | None = None
     withdrawable: float | None = None
+    total_maint_margin: float | None = None
+    total_initial_margin: float | None = None
 
 
 @msg

--- a/src/qubx/core/interfaces.py
+++ b/src/qubx/core/interfaces.py
@@ -464,6 +464,12 @@ class IAccountViewer:
         (depends on the per-instrument leverage tier and margin mode).
         Useful for "can I open more?" sizing decisions.
 
+        In live this is the venue-reported account total when the venue provides
+        one (e.g. Binance ``totalInitialMargin``, OKX ``imr``); otherwise it is
+        summed over ``Position.initial_margin``. The venue total may be scoped
+        differently from a position sum (cross-only on some venues, or including
+        open-order margin) — it is the venue's requirement, not a re-sum of positions.
+
         Returns:
             float: Total initial margin
         """
@@ -475,6 +481,12 @@ class IAccountViewer:
         Maintenance margin is the threshold below which positions get
         liquidated (typically lower than initial margin).  Useful for
         liquidation-distance / risk dashboards.
+
+        In live this is the venue-reported account total when the venue provides
+        one (e.g. Binance ``totalMaintMargin``, OKX ``mmr``); otherwise it is
+        summed over ``Position.maint_margin``. The venue total may be scoped
+        differently from a position sum (cross-only on some venues, or including
+        open-order margin) — it is the venue's requirement, not a re-sum of positions.
 
         Returns:
             float: Total maintenance margin

--- a/tests/qubx/connectors/ccxt/test_binance_pm.py
+++ b/tests/qubx/connectors/ccxt/test_binance_pm.py
@@ -12,7 +12,8 @@ Pins the PM routing fix and the PM-specific connector subclass:
 3. ``parse_position_risk`` defaults marginMode to cross (papi payloads carry neither
    marginType nor isolatedMargin; PM is always cross).
 4. ``BinancePmCcxtConnector._extract_venue_figures`` reads the papiGetAccount dict the
-   exchange class grafts into fetch_balance's ``info`` (uniMMR sentinel mapped to None).
+   exchange class grafts into fetch_balance's ``info`` (uniMMR sentinel mapped to None,
+   account-wide margin totals passed through).
 5. The factory resolves ``CUSTOM_CONNECTORS`` by venue name first, canonical second.
 6. ``ccxt_extract_leverage_settings`` accepts papi's ``maxNotional`` spelling.
 
@@ -198,12 +199,13 @@ class TestBinancePmVenueFigures:
                         "totalAvailableBalance": "359.52",
                         "uniMMR": "731.2",
                         "accountMaintMargin": "0.55",
+                        "accountInitialMargin": "44.99",
                         "virtualMaxWithdrawAmount": "358.0",
                     },
                 }
             }
         )
-        assert figures == (404.51, 359.52, 731.2, 358.0)
+        assert figures == (404.51, 359.52, 731.2, 358.0, 0.55, 44.99)
 
     def test_unimmr_sentinel_maps_to_none(self):
         # no positions: accountMaintMargin 0 and uniMMR is a 99999999 sentinel
@@ -216,16 +218,18 @@ class TestBinancePmVenueFigures:
                         "totalAvailableBalance": "404.51",
                         "uniMMR": "99999999",
                         "accountMaintMargin": "0.0",
+                        "accountInitialMargin": "0.0",
                         "virtualMaxWithdrawAmount": "404.51",
                     },
                 }
             }
         )
-        assert figures == (404.51, 404.51, None, 404.51)
+        # the 0.0 margin totals are real venue values (no positions), not "unreported"
+        assert figures == (404.51, 404.51, None, 404.51, 0.0, 0.0)
 
     def test_missing_graft_degrades_to_none(self):
         # raw papiGetBalance list info (graft failed) must not sink the snapshot
-        assert self._connector()._extract_venue_figures({"info": [{"asset": "USDT"}]}) == (None, None, None, None)
+        assert self._connector()._extract_venue_figures({"info": [{"asset": "USDT"}]}) == (None,) * 6
 
 
 DOGE_MARKET = {

--- a/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
+++ b/tests/qubx/connectors/ccxt/test_ccxt_exchange_connectors.py
@@ -376,7 +376,7 @@ async def test_okx_snapshot_extracts_cashbal_balances() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# OKX venue account figures (totalEq / mgnRatio / adjEq − imr from info.data[0])
+# OKX venue account figures (totalEq / mgnRatio / adjEq − imr / mmr / imr from info.data[0])
 # --------------------------------------------------------------------------- #
 @pytest.mark.asyncio
 async def test_okx_snapshot_extracts_venue_figures_multi_ccy() -> None:
@@ -391,6 +391,7 @@ async def test_okx_snapshot_extracts_venue_figures_multi_ccy() -> None:
                         "totalEq": "50000.5",
                         "adjEq": "49000.0",
                         "imr": "1200.0",
+                        "mmr": "600.0",
                         "mgnRatio": "35.5",
                         "details": [
                             {"ccy": "USDT", "cashBal": "40000.0", "frozenBal": "1200.0"},
@@ -408,6 +409,8 @@ async def test_okx_snapshot_extracts_venue_figures_multi_ccy() -> None:
     assert snap.available_margin == pytest.approx(47800.0)  # adjEq - imr
     assert snap.margin_ratio == 35.5  # mgnRatio
     assert snap.withdrawable is None  # max-withdrawal lives on a separate OKX endpoint
+    assert snap.total_maint_margin == 600.0  # mmr
+    assert snap.total_initial_margin == 1200.0  # imr
 
     # End-to-end: the snapshot lands in AM and the venue figures win over derived metrics.
     am = SimulatedAccountManager(
@@ -421,6 +424,8 @@ async def test_okx_snapshot_extracts_venue_figures_multi_ccy() -> None:
     assert am.get_margin_ratio("OKX.F") == 35.5
     # no venue withdrawable -> falls back to the (venue-preferred) available figure
     assert am.get_withdrawable_balance("OKX.F") == pytest.approx(47800.0)
+    assert am.get_total_maint_margin("OKX.F") == 600.0
+    assert am.get_total_initial_margin("OKX.F") == 1200.0
 
 
 @pytest.mark.asyncio
@@ -437,6 +442,7 @@ async def test_okx_snapshot_single_ccy_empty_fields_yield_none() -> None:
                         "totalEq": "1918.55678",
                         "adjEq": "",
                         "imr": "",
+                        "mmr": "",
                         "mgnRatio": "",
                         "details": [{"ccy": "BTC", "cashBal": "0.049", "frozenBal": "0"}],
                     }
@@ -451,6 +457,8 @@ async def test_okx_snapshot_single_ccy_empty_fields_yield_none() -> None:
     assert snap.available_margin is None
     assert snap.margin_ratio is None
     assert snap.withdrawable is None
+    assert snap.total_maint_margin is None
+    assert snap.total_initial_margin is None
 
 
 @pytest.mark.asyncio
@@ -476,6 +484,8 @@ async def test_okx_snapshot_survives_malformed_balance_payload(info) -> None:
     assert snap.available_margin is None
     assert snap.margin_ratio is None
     assert snap.withdrawable is None
+    assert snap.total_maint_margin is None
+    assert snap.total_initial_margin is None
     # The good legs still made it into the snapshot.
     assert snap.open_orders == []
     assert snap.positions == []
@@ -485,7 +495,8 @@ async def test_okx_snapshot_survives_malformed_balance_payload(info) -> None:
 async def test_base_snapshot_extracts_binance_figures_incl_withdrawable() -> None:
     # Base extractor maps the Binance fapi account payload (v2 and v3 both carry these
     # top-level): totalMarginBalance -> equity, availableBalance -> available_margin,
-    # maxWithdrawAmount -> withdrawable; Binance reports no margin ratio -> None.
+    # maxWithdrawAmount -> withdrawable, totalMaintMargin / totalInitialMargin -> the
+    # account margin totals; Binance reports no margin ratio -> None.
     exchange = _snapshot_exchange(
         {
             "total": {"USDT": 111.02},
@@ -494,6 +505,8 @@ async def test_base_snapshot_extracts_binance_figures_incl_withdrawable() -> Non
                 "totalMarginBalance": "111.02007243",
                 "availableBalance": "11.39894857",
                 "maxWithdrawAmount": "10.50000000",
+                "totalMaintMargin": "1.23456789",
+                "totalInitialMargin": "99.62112386",
             },
         }
     )
@@ -504,6 +517,8 @@ async def test_base_snapshot_extracts_binance_figures_incl_withdrawable() -> Non
     assert snap.available_margin == 11.39894857
     assert snap.margin_ratio is None
     assert snap.withdrawable == 10.5
+    assert snap.total_maint_margin == 1.23456789
+    assert snap.total_initial_margin == 99.62112386
 
 
 @pytest.mark.asyncio
@@ -579,6 +594,8 @@ async def test_bitfinex_snapshot_venue_figures_pinned_all_none() -> None:
     assert snap.available_margin is None
     assert snap.margin_ratio is None
     assert snap.withdrawable is None
+    assert snap.total_maint_margin is None
+    assert snap.total_initial_margin is None
     assert len(snap.balances) == 1
     assert snap.balances[0].currency == "USDT"
     assert snap.balances[0].total == 50.0

--- a/tests/qubx/core/account_manager/state_metrics_test.py
+++ b/tests/qubx/core/account_manager/state_metrics_test.py
@@ -80,6 +80,59 @@ def test_total_margins_from_positions():
     assert state.total_maint_margin() == 4.0
 
 
+def test_total_margins_prefer_venue():
+    state = _state()
+    pos = Position(_instrument())
+    pos.initial_margin = 10.0
+    pos.maint_margin = 4.0
+    state.set_position(pos.instrument, pos)
+    state.set_venue_figures(_venue(total_initial_margin=143.4, total_maint_margin=11.5))
+    assert state.total_initial_margin() == 143.4
+    assert state.total_maint_margin() == 11.5
+
+
+def test_total_margins_fall_back_per_metric():
+    # Per-metric preference: a venue reporting only one total leaves the other summed.
+    state = _state()
+    pos = Position(_instrument())
+    pos.initial_margin = 10.0
+    pos.maint_margin = 4.0
+    state.set_position(pos.instrument, pos)
+    state.set_venue_figures(_venue(total_maint_margin=11.5))
+    assert state.total_initial_margin() == 10.0
+    assert state.total_maint_margin() == 11.5
+
+
+def test_venue_zero_maint_margin_is_authoritative():
+    # A reported 0.0 is a value, not "unreported": it wins over the position sum and
+    # margin_ratio takes its no-maint branch.
+    state = _state(1000.0)
+    pos = Position(_instrument())
+    pos.maint_margin = 4.0
+    state.set_position(pos.instrument, pos)
+    state.set_venue_figures(_venue(total_maint_margin=0.0))
+    assert state.total_maint_margin() == 0.0
+    assert state.margin_ratio() == 100.0
+
+
+def test_available_margin_derives_from_venue_initial_margin_total():
+    state = _state(1000.0)
+    pos = Position(_instrument())
+    pos.initial_margin = 10.0
+    state.set_position(pos.instrument, pos)
+    state.set_venue_figures(_venue(total_initial_margin=150.0))
+    assert state.available_margin() == 850.0
+
+
+def test_margin_ratio_derives_from_venue_maint_total():
+    state = _state(1000.0)
+    pos = Position(_instrument())
+    pos.maint_margin = 100.0
+    state.set_position(pos.instrument, pos)
+    state.set_venue_figures(_venue(total_maint_margin=50.0))
+    assert state.margin_ratio() == 20.0
+
+
 def test_available_margin_derived():
     state = _state(1000.0)
     pos = Position(_instrument())

--- a/tests/qubx/core/test_account_manager_snapshot.py
+++ b/tests/qubx/core/test_account_manager_snapshot.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
+from qubx import logger
 from qubx.connectors.ccxt.utils import ccxt_convert_order_info
 from qubx.core.account_manager import AccountManager, AccountManagerConfig
 from qubx.core.basics import (
@@ -82,6 +83,8 @@ def _snap_event(
     available_margin=None,
     margin_ratio=None,
     withdrawable=None,
+    total_maint_margin=None,
+    total_initial_margin=None,
 ):
     return AccountSnapshotEvent(
         instrument=None,
@@ -95,6 +98,8 @@ def _snap_event(
             available_margin=available_margin,
             margin_ratio=margin_ratio,
             withdrawable=withdrawable,
+            total_maint_margin=total_maint_margin,
+            total_initial_margin=total_initial_margin,
         ),
     )
 
@@ -694,6 +699,86 @@ def test_snapshot_sets_venue_figures_and_metrics_prefer_them():
     assert am.get_available_margin("binance") == 4000.0
     assert am.get_margin_ratio("binance") == 42.0
     assert am.get_withdrawable_balance("binance") == 3500.0
+
+
+def test_snapshot_margin_totals_round_trip_and_prefer_venue():
+    # The venue's account-level margin totals ride the snapshot into VenueAccountFigures
+    # (a snapshot carrying only them still sets the capture) and win over the position sums.
+    am = _am()
+    state = am._states["binance"]
+    pos = Position(_instrument())
+    pos.initial_margin = 10.0
+    pos.maint_margin = 4.0
+    state.set_position(pos.instrument, pos)
+    am.apply(_snap_event(total_maint_margin=11.5, total_initial_margin=143.4))
+    figures = state.get_venue_figures()
+    assert figures is not None
+    assert figures.total_maint_margin == 11.5
+    assert figures.total_initial_margin == 143.4
+    assert am.get_total_maint_margin("binance") == 11.5
+    assert am.get_total_initial_margin("binance") == 143.4
+
+
+def test_snapshot_zero_margin_totals_are_trusted_end_to_end():
+    # The production incident: the venue reports account-level margin totals of 0.0 while
+    # the local position still carries stale non-zero per-position margins. 0.0 is a
+    # reported value, not "unreported": it must survive the reconciler's is-not-None guard
+    # (a truthiness regression would silently drop exactly this case) and win.
+    am = _am()
+    state = am._states["binance"]
+    pos = Position(_instrument())
+    pos.initial_margin = 143.4
+    pos.maint_margin = 11.539
+    state.set_position(pos.instrument, pos)
+    am.apply(_snap_event(total_maint_margin=0.0, total_initial_margin=0.0))
+    assert am.get_total_maint_margin("binance") == 0.0
+    assert am.get_total_initial_margin("binance") == 0.0
+    assert am.get_margin_ratio("binance") == 100.0
+
+
+def test_snapshot_zero_maint_margin_on_live_book_warns_but_changes_nothing():
+    # Diagnostic only: a venue claiming zero maintenance margin while its own snapshot
+    # carries an open position is the false-safe signature (Binance UM single-asset mode
+    # reports USDT-only totals). It logs a WARNING naming the exchange; the value still wins.
+    am = _am()
+    state = am._states["binance"]
+    inst = _instrument()
+    state.set_position(inst, Position(instrument=inst, quantity=1.0, pos_average_price=50_000.0))
+    snap_pos = Position(instrument=inst, quantity=1.0, pos_average_price=50_000.0)
+    am._time.t = np.datetime64("2026-05-28T01:00:00")
+
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(m), level="WARNING")
+    try:
+        am.apply(_snap_event(as_of="2026-05-28T01:00:00", positions=[snap_pos], total_maint_margin=0.0))
+    finally:
+        logger.remove(sink_id)
+
+    assert any(
+        m.record["level"].name == "WARNING" and "[binance]" in m and "total_maint_margin=0.0" in m for m in messages
+    )
+    assert am.get_total_maint_margin("binance") == 0.0
+
+
+def test_snapshot_zero_maint_margin_warning_stays_silent_otherwise():
+    # No open position in the snapshot (flat book) or a non-zero venue total: no warning.
+    am = _am()
+    state = am._states["binance"]
+    inst = _instrument()
+    state.set_position(inst, Position(instrument=inst, quantity=1.0, pos_average_price=50_000.0))
+    open_pos = Position(instrument=inst, quantity=1.0, pos_average_price=50_000.0)
+    am._time.t = np.datetime64("2026-05-28T01:00:00")
+
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(m), level="WARNING")
+    try:
+        am.apply(_snap_event(as_of="2026-05-28T01:00:00", positions=[open_pos], total_maint_margin=25.0))
+        am.apply(_snap_event(as_of="2026-05-28T01:01:00", total_maint_margin=0.0))  # positions not observed
+        am.apply(_snap_event(as_of="2026-05-28T01:02:00", positions=[], total_maint_margin=0.0))  # flat book
+    finally:
+        logger.remove(sink_id)
+
+    assert not [m for m in messages if "total_maint_margin=0.0" in m]
 
 
 def test_snapshot_without_figures_keeps_previous_capture():


### PR DESCRIPTION
## Problem

`AccountState.total_maint_margin()` / `total_initial_margin()` always summed per-position values, even when the venue reports authoritative account-level totals — while `equity`, `available_margin`, `margin_ratio` and `withdrawable` already prefer the venue figure.

Live numbers: Binance `papiGetAccount` returns `accountMaintMargin = 0.0` / `accountInitialMargin = 0.0` while Qubx reports 11.539 / 143.40; Hyperliquid reports `crossMaintenanceMarginUsed: 0.0` while Qubx reports 107.40.

Cause: `_extract_venue_figures` returned a fixed 4-tuple with no slot for the totals, so BINANCE.PM read `accountMaintMargin` (to gate `uniMMR`) and discarded it.

## Fix

- Two new fields, `total_maint_margin` / `total_initial_margin`, on `AccountSnapshot` and `VenueAccountFigures`, carried through the reconciler.
- The two accessors prefer the venue value, else sum positions — same shape as `total_capital()`. A reported `0.0` is trusted: it is a value, not "unreported".
- `_extract_venue_figures` widened 4→6; populated in base Binance (`totalMaintMargin`/`totalInitialMargin`), BINANCE.PM (`accountMaintMargin`/`accountInitialMargin`), OKX (`mmr`/`imr`); Bitfinex stays all-None.
- Diagnostic WARNING (changes no value) when a venue reports zero maintenance margin on a snapshot that carries open positions.

Coherence: on PM `accountEquity` already spans um/cm/margin — the same pool `total_capital()` reports — so `total_capital / total_maint_margin` is now `uniMMR` exactly; pairing account-wide equity with a UM-only position sum was the incoherent combination.

## What to watch

- Venue totals may be scoped differently from a position sum: cross-only (OKX), including open-order margin (Binance/OKX), and USDT-asset-only in Binance UM single-asset mode — a non-USDT-margined position reads as zero there (the WARNING above covers that signature; both prod BINANCE.UM configs are USDT-margined today).
- Venue totals refresh on the 30s REST snapshot, not per fill.
- **Breaking for out-of-tree connectors:** any `CcxtConnector` subclass overriding `_extract_venue_figures` must now return 6 values — a stale 4-tuple raises inside `_snapshot_async`, is swallowed, and the bot silently never reconciles. No such override exists in-tree or in the `exchanges` repo today.
- Ships with #423 (`fix/flat-position-margins`, unmerged): disjoint files. The Hyperliquid leg keeps stale per-position sums until #423 lands, since the HL plugin does not populate the totals yet (separate PR in `exchanges`).
