### PR TITLE
fix(pandaz): resolve NameErrors in bands_signals (np.isscalar, prices)

### DIFF
--- a/src/qubx/pandaz/utils.py
+++ b/src/qubx/pandaz/utils.py
@@ -357,7 +357,7 @@ def bands_signals(
     exit,
     stop: float | None = np.inf,
     entry_method="cross-out",  # 'cross-in', 'revert-to-band'
-    position_sizes_fn=lambda time, score, prices, side: np.zeros(len(p)),
+    position_sizes_fn=lambda time, score, prices, side: np.zeros(len(prices)),
 ) -> pd.DataFrame:
     """
     Generate trading signals using score and entry / exit thresholds
@@ -365,7 +365,7 @@ def bands_signals(
     if not isinstance(prices, pd.DataFrame):
         raise ValueError("Prices must be a pandas DataFrame")
 
-    _as_series = lambda xs, index, name: pd.Series(xs, index=index, name=name) if isscalar(xs) else xs
+    _as_series = lambda xs, index, name: pd.Series(xs, index=index, name=name) if np.isscalar(xs) else xs
 
     # - entry function
     ent_fn: Callable[[float, float, float, float], int] = lambda t, s2, s1, s0: 0


### PR DESCRIPTION
### Problem

`bands_signals()` in `src/qubx/pandaz/utils.py` contains two references to names that don't exist in scope, so the function raises `NameError` when used.

**1. `isscalar` is not defined** (`utils.py:368`)

```python
_as_series = lambda xs, index, name: pd.Series(xs, index=index, name=name) if isscalar(xs) else xs
```

The module imports NumPy as `import numpy as np` (there is no `from numpy import isscalar` / star import), so the bare name `isscalar` is undefined. `_as_series` is invoked unconditionally a few lines later:

```python
entry = abs(_as_series(entry, score.index, "entry"))
exit = _as_series(exit, score.index, "exit")
stop = abs(_as_series(stop, score.index, "stop"))
```

so **any** call to `bands_signals` raises `NameError: name 'isscalar' is not defined` (e.g. `stop` defaults to `np.inf`, a scalar, which routes straight through the `isscalar(...)` branch).

**2. `p` is not defined** in the default `position_sizes_fn` (`utils.py:360`)

```python
position_sizes_fn=lambda time, score, prices, side: np.zeros(len(p)),
```

The lambda's parameter is `prices`, not `p`; `p` is undefined. This default is later called at `utils.py:412` (`position_sizes_fn(t, s0, pi, side)`), so relying on the default sizing function raises `NameError: name 'p' is not defined`.

### Fix

```diff
-    position_sizes_fn=lambda time, score, prices, side: np.zeros(len(p)),
+    position_sizes_fn=lambda time, score, prices, side: np.zeros(len(prices)),
...
-    _as_series = lambda xs, index, name: pd.Series(xs, index=index, name=name) if isscalar(xs) else xs
+    _as_series = lambda xs, index, name: pd.Series(xs, index=index, name=name) if np.isscalar(xs) else xs
```

Both fixes are unambiguous: `np` is the module's NumPy alias, and `prices` is the lambda's own parameter. No behavior change beyond making the function runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
